### PR TITLE
fix(log): redact tenant ID from request logs using chi route pattern

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -194,15 +194,25 @@ func authInfo(r *http.Request) *domain.AuthInfo {
 }
 
 // requestLogger returns a middleware that logs each request.
+// It uses the chi route pattern (e.g. /v1alpha1/mem9s/{tenantID}/memories)
+// instead of the raw URL path to avoid logging sensitive tenant IDs.
 func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 			ww := chimw.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(ww, r)
+			// Use route pattern to avoid exposing sensitive path params (e.g. tenantID).
+			routeCtx := chi.RouteContext(r.Context())
+			path := r.URL.Path
+			if routeCtx != nil {
+				if pattern := routeCtx.RoutePattern(); pattern != "" {
+					path = pattern
+				}
+			}
 			logger.Info("request",
 				"method", r.Method,
-				"path", r.URL.Path,
+				"path", path,
 				"status", ww.Status(),
 				"duration_ms", time.Since(start).Milliseconds(),
 				"request_id", chimw.GetReqID(r.Context()),


### PR DESCRIPTION
## Problem

The `requestLogger` middleware was logging `r.URL.Path` directly, which includes the raw `tenantID` (Space ID) in the path:

```
path: /v1alpha1/mem9s/jhIuzTGvhHajvoCmfyxDebvfGTo3mEIH/memories
```

Tenant IDs are sensitive identifiers and should not appear in plain-text logs.

## Solution

Use `chi.RouteContext(r.Context()).RoutePattern()` to log the route template instead of the raw path:

```
path: /v1alpha1/mem9s/{tenantID}/memories
```

This is the same approach already used in the `metrics` middleware to avoid high cardinality from tenant IDs in Prometheus labels.

## Behavior

- **Matched routes**: logs the chi route pattern (e.g. `/v1alpha1/mem9s/{tenantID}/memories`)
- **Unmatched routes** (e.g. `/healthz`, 404s): falls back to `r.URL.Path` since there is no route pattern available

## Changes

- `server/internal/handler/handler.go`: updated `requestLogger` to use `RoutePattern()` with fallback to `r.URL.Path`