### PR TITLE
metrics: add provision step duration and result metrics

### DIFF
--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -34,6 +34,30 @@ var (
 		},
 		[]string{"method", "route"},
 	)
+
+	// ProvisionStepDuration observes the duration of each step in the provision flow.
+	// step labels: tidb_zero_create_instance, create_tenant_record,
+	//              init_schema_create_table, init_schema_vector_index,
+	//              init_schema_fts_index, update_status, update_schema_version, total
+	ProvisionStepDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mnemo",
+			Name:      "provision_step_duration_seconds",
+			Help:      "Duration of each step in the provision flow.",
+			Buckets:   []float64{0.05, 0.1, 0.5, 1, 2, 5, 10, 20, 30},
+		},
+		[]string{"step"},
+	)
+
+	// ProvisionTotal counts provision attempts by result (success or error).
+	ProvisionTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "provision_total",
+			Help:      "Total number of provision attempts.",
+		},
+		[]string{"result"}, // "success" | "error"
+	)
 )
 
 // Middleware records HTTP request count and duration for each request.

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/repository"
 	"github.com/qiffang/mnemos/server/internal/tenant"
 )
@@ -95,10 +96,13 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 
 	t0 := time.Now()
 	instance, err := s.zero.CreateInstance(ctx, "mem9s")
+	elapsed := time.Since(t0)
+	s.logger.Info("provision step", "step", "tidb_zero_create_instance", "duration_ms", elapsed.Milliseconds())
+	metrics.ProvisionStepDuration.WithLabelValues("tidb_zero_create_instance").Observe(elapsed.Seconds())
 	if err != nil {
+		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("provision TiDB Zero instance: %w", err)
 	}
-	s.logger.Info("provision step", "step", "tidb_zero_create_instance", "duration_ms", time.Since(t0).Milliseconds())
 
 	// Use the TiDB Zero instance ID as the tenant ID.
 	tenantID := instance.ID
@@ -122,32 +126,47 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 
 	t0 = time.Now()
 	if err := s.tenants.Create(ctx, t); err != nil {
+		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("create tenant record: %w", err)
 	}
-	s.logger.Info("provision step", "step", "create_tenant_record", "duration_ms", time.Since(t0).Milliseconds())
+	elapsed = time.Since(t0)
+	s.logger.Info("provision step", "step", "create_tenant_record", "duration_ms", elapsed.Milliseconds())
+	metrics.ProvisionStepDuration.WithLabelValues("create_tenant_record").Observe(elapsed.Seconds())
 
 	t0 = time.Now()
 	if err := s.initSchema(ctx, t); err != nil {
 		if s.logger != nil {
 			s.logger.Error("tenant schema init failed", "tenant_id", tenantID, "err", err)
 		}
+		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("init tenant schema: %w", err)
 	}
-	s.logger.Info("provision step", "step", "init_schema", "duration_ms", time.Since(t0).Milliseconds())
+	elapsed = time.Since(t0)
+	s.logger.Info("provision step", "step", "init_schema", "duration_ms", elapsed.Milliseconds())
+	metrics.ProvisionStepDuration.WithLabelValues("init_schema").Observe(elapsed.Seconds())
 
 	t0 = time.Now()
 	if err := s.tenants.UpdateStatus(ctx, tenantID, domain.TenantActive); err != nil {
+		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("activate tenant: %w", err)
 	}
-	s.logger.Info("provision step", "step", "update_status", "duration_ms", time.Since(t0).Milliseconds())
+	elapsed = time.Since(t0)
+	s.logger.Info("provision step", "step", "update_status", "duration_ms", elapsed.Milliseconds())
+	metrics.ProvisionStepDuration.WithLabelValues("update_status").Observe(elapsed.Seconds())
 
 	t0 = time.Now()
 	if err := s.tenants.UpdateSchemaVersion(ctx, tenantID, 1); err != nil {
+		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("update schema version: %w", err)
 	}
-	s.logger.Info("provision step", "step", "update_schema_version", "duration_ms", time.Since(t0).Milliseconds())
+	elapsed = time.Since(t0)
+	s.logger.Info("provision step", "step", "update_schema_version", "duration_ms", elapsed.Milliseconds())
+	metrics.ProvisionStepDuration.WithLabelValues("update_schema_version").Observe(elapsed.Seconds())
 
-	s.logger.Info("provision step", "step", "total", "duration_ms", time.Since(total).Milliseconds(), "tenant_id", tenantID)
+	totalElapsed := time.Since(total)
+	s.logger.Info("provision step", "step", "total", "duration_ms", totalElapsed.Milliseconds(), "tenant_id", tenantID)
+	metrics.ProvisionStepDuration.WithLabelValues("total").Observe(totalElapsed.Seconds())
+	metrics.ProvisionTotal.WithLabelValues("success").Inc()
 
 	return &ProvisionResult{
 		ID: tenantID,
@@ -192,23 +211,39 @@ func (s *TenantService) initSchema(ctx context.Context, t *domain.Tenant) error 
 	if err != nil {
 		return err
 	}
+
+	t0 := time.Now()
 	if _, err := db.ExecContext(ctx, buildMemorySchema(s.autoModel, s.autoDims)); err != nil {
 		return fmt.Errorf("init tenant schema: memories: %w", err)
 	}
+	elapsed := time.Since(t0)
+	s.logger.Info("provision step", "step", "init_schema_create_table", "duration_ms", elapsed.Milliseconds())
+	metrics.ProvisionStepDuration.WithLabelValues("init_schema_create_table").Observe(elapsed.Seconds())
+
 	if s.autoModel != "" {
+		t0 = time.Now()
 		_, err := db.ExecContext(ctx,
 			`ALTER TABLE memories ADD VECTOR INDEX idx_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`)
+		elapsed = time.Since(t0)
 		if err != nil && !isIndexExistsError(err) {
 			return fmt.Errorf("init tenant schema: vector index: %w", err)
 		}
+		s.logger.Info("provision step", "step", "init_schema_vector_index", "duration_ms", elapsed.Milliseconds())
+		metrics.ProvisionStepDuration.WithLabelValues("init_schema_vector_index").Observe(elapsed.Seconds())
 	}
+
 	if s.ftsEnabled {
+		t0 = time.Now()
 		_, err := db.ExecContext(ctx,
 			`ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`)
+		elapsed = time.Since(t0)
 		if err != nil && !isIndexExistsError(err) {
 			return fmt.Errorf("init tenant schema: fulltext index: %w", err)
 		}
+		s.logger.Info("provision step", "step", "init_schema_fts_index", "duration_ms", elapsed.Milliseconds())
+		metrics.ProvisionStepDuration.WithLabelValues("init_schema_fts_index").Observe(elapsed.Seconds())
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

The `POST /mem9s` provision API takes ~10s end-to-end but there was no visibility into which step was responsible. This PR adds fine-grained Prometheus metrics to track per-step latency and overall outcome.

## New Metrics

### `mnemo_provision_step_duration_seconds` (Histogram)
Tracks the duration of each sub-step in the provision flow via a `step` label:

| Step | Description |
|------|-------------|
| `tidb_zero_create_instance` | HTTP call to TiDB Zero API to create a new serverless instance |
| `create_tenant_record` | Insert tenant record into meta DB |
| `init_schema` | Total time for all DDL on the new instance |
| `init_schema_create_table` | `CREATE TABLE memories` (with vector column) |
| `init_schema_vector_index` | `ALTER TABLE ... ADD VECTOR INDEX` |
| `init_schema_fts_index` | `ALTER TABLE ... ADD FULLTEXT INDEX` |
| `update_status` | Update tenant status to active |
| `update_schema_version` | Update schema version to 1 |
| `total` | End-to-end provision duration |

Buckets are tuned for slow operations: `0.05, 0.1, 0.5, 1, 2, 5, 10, 20, 30` seconds.

### `mnemo_provision_total` (Counter)
Counts provision attempts by `result` label (`success` or `error`), with the error counter incremented at the failing step.

## Changes
- `server/internal/metrics/metrics.go`: added `ProvisionStepDuration` and `ProvisionTotal`
- `server/internal/service/tenant.go`: instrument each step; `initSchema` DDL steps broken out individually

Existing `slog` timing logs are **preserved** alongside the new metrics.