### PR TITLE
fix(server): register memory utility routes

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -129,6 +129,9 @@ func (s *Server) Router(tenantMW, rateLimitMW func(http.Handler) http.Handler) h
 		// Memory CRUD.
 		r.Post("/memories", s.createMemory)
 		r.Get("/memories", s.listMemories)
+		// Static subroutes must be registered explicitly alongside /{id}.
+		r.Post("/memories/bulk", s.bulkCreateMemories)
+		r.Get("/memories/bootstrap", s.bootstrapMemories)
 		r.Get("/memories/{id}", s.getMemory)
 		r.Put("/memories/{id}", s.updateMemory)
 		r.Delete("/memories/{id}", s.deleteMemory)

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestRouterRegistersMemoryUtilityRoutes(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	identity := func(next http.Handler) http.Handler { return next }
+
+	router := srv.Router(identity, identity)
+	mux, ok := router.(*chi.Mux)
+	if !ok {
+		t.Fatalf("Router() returned %T, want *chi.Mux", router)
+	}
+
+	routes := make(map[string]struct{})
+	if err := chi.Walk(mux, func(method, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		routes[method+" "+route] = struct{}{}
+		return nil
+	}); err != nil {
+		t.Fatalf("chi.Walk() error = %v", err)
+	}
+
+	for _, route := range []string{
+		"POST /v1alpha1/mem9s/{tenantID}/memories/bulk",
+		"GET /v1alpha1/mem9s/{tenantID}/memories/bootstrap",
+	} {
+		if _, ok := routes[route]; !ok {
+			t.Fatalf("missing route %q", route)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #22

## Summary
- register the missing /memories/bulk and /memories/bootstrap routes
- add a router regression test for these memory utility endpoints

## Verification
- cd server && GOROOT=/usr/local/opt/go/libexec GO111MODULE=on /usr/local/opt/go/libexec/bin/go test ./internal/handler -run TestRouterRegistersMemoryUtilityRoutes -count=1