### PR TITLE
fix(server): honor proxy headers in rate limiting

### DIFF
--- a/server/internal/middleware/ratelimit.go
+++ b/server/internal/middleware/ratelimit.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -47,10 +48,7 @@ func (rl *RateLimiter) Stop() {
 func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-			if ip == "" {
-				ip = r.RemoteAddr
-			}
+			ip := clientIP(r)
 
 			if !rl.getLimiter(ip).Allow() {
 				writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
@@ -67,6 +65,29 @@ func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		for _, part := range strings.Split(xff, ",") {
+			ip := strings.TrimSpace(part)
+			if parsed := net.ParseIP(ip); parsed != nil {
+				return parsed.String()
+			}
+		}
+	}
+
+	if xri := strings.TrimSpace(r.Header.Get("X-Real-IP")); xri != "" {
+		if parsed := net.ParseIP(xri); parsed != nil {
+			return parsed.String()
+		}
+	}
+
+	if host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr)); err == nil && host != "" {
+		return host
+	}
+
+	return strings.TrimSpace(r.RemoteAddr)
 }
 
 func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {

--- a/server/internal/middleware/ratelimit_test.go
+++ b/server/internal/middleware/ratelimit_test.go
@@ -1,0 +1,95 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		want       string
+	}{
+		{
+			name:       "uses forwarded for first valid ip",
+			remoteAddr: "10.0.0.1:8080",
+			headers: map[string]string{
+				"X-Forwarded-For": "203.0.113.10, 10.0.0.1",
+			},
+			want: "203.0.113.10",
+		},
+		{
+			name:       "falls back to real ip when forwarded for invalid",
+			remoteAddr: "10.0.0.1:8080",
+			headers: map[string]string{
+				"X-Forwarded-For": "unknown",
+				"X-Real-IP":       "198.51.100.7",
+			},
+			want: "198.51.100.7",
+		},
+		{
+			name:       "falls back to remote addr host",
+			remoteAddr: "192.0.2.44:9000",
+			want:       "192.0.2.44",
+		},
+		{
+			name:       "keeps remote addr when not hostport",
+			remoteAddr: "192.0.2.55",
+			want:       "192.0.2.55",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+
+			if got := clientIP(req); got != tt.want {
+				t.Fatalf("clientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimiterUsesForwardedIPBuckets(t *testing.T) {
+	t.Parallel()
+
+	rl := NewRateLimiter(0, 1)
+	defer rl.Stop()
+
+	handler := rl.Middleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	makeRequest := func(forwardedFor string) int {
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		req.RemoteAddr = "10.0.0.1:8080"
+		if forwardedFor != "" {
+			req.Header.Set("X-Forwarded-For", forwardedFor)
+		}
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	if got := makeRequest("203.0.113.10"); got != http.StatusOK {
+		t.Fatalf("first forwarded request status = %d, want %d", got, http.StatusOK)
+	}
+	if got := makeRequest("198.51.100.7"); got != http.StatusOK {
+		t.Fatalf("second forwarded request with different client ip status = %d, want %d", got, http.StatusOK)
+	}
+	if got := makeRequest("203.0.113.10"); got != http.StatusTooManyRequests {
+		t.Fatalf("third forwarded request with repeated client ip status = %d, want %d", got, http.StatusTooManyRequests)
+	}
+}


### PR DESCRIPTION
Fixes #19

## Summary
- derive the client identity from X-Forwarded-For and X-Real-IP before falling back to RemoteAddr
- keep the existing tenant-level limiter behavior unchanged
- add regression coverage for proxy-aware client IP selection and rate-limit buckets

## Verification
- cd server && GOROOT=/usr/local/opt/go/libexec GO111MODULE=on /usr/local/opt/go/libexec/bin/go test ./internal/middleware -run 'Test(ClientIP|RateLimiterUsesForwardedIPBuckets)' -count=1