### PR TITLE
fix(server): remove unbounded handler service cache

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -3,10 +3,8 @@ package handler
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -34,7 +32,6 @@ type Server struct {
 	ingestMode  service.IngestMode
 	dbBackend   string
 	logger      *slog.Logger
-	svcCache    sync.Map
 }
 
 // NewServer creates a new HTTP handler server.
@@ -71,34 +68,13 @@ type resolvedSvc struct {
 	ingest *service.IngestService
 }
 
-type tenantSvcKey string
-
 // resolveServices returns the correct services for a request.
 func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
-	if auth.TenantID == "" {
-		key := tenantSvcKey(fmt.Sprintf("db-%p", auth.TenantDB))
-		if cached, ok := s.svcCache.Load(key); ok {
-			return cached.(resolvedSvc)
-		}
-		memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled)
-		svc := resolvedSvc{
-			memory: service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-			ingest: service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-		}
-		s.svcCache.Store(key, svc)
-		return svc
-	}
-	key := tenantSvcKey(fmt.Sprintf("%s-%p", auth.TenantID, auth.TenantDB))
-	if cached, ok := s.svcCache.Load(key); ok {
-		return cached.(resolvedSvc)
-	}
 	memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled)
-	svc := resolvedSvc{
+	return resolvedSvc{
 		memory: service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 		ingest: service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 	}
-	s.svcCache.Store(key, svc)
-	return svc
 }
 
 // Router builds the chi router with all routes and middleware.

--- a/server/internal/handler/handler_test.go
+++ b/server/internal/handler/handler_test.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/service"
+)
+
+func TestResolveServicesReturnsFreshInstances(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		dbBackend:  "tidb",
+		ingestMode: service.ModeSmart,
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	auth := &domain.AuthInfo{}
+
+	first := srv.resolveServices(auth)
+	second := srv.resolveServices(auth)
+
+	if first.memory == nil || first.ingest == nil || second.memory == nil || second.ingest == nil {
+		t.Fatal("resolveServices() returned nil service")
+	}
+	if first.memory == second.memory {
+		t.Fatal("resolveServices() reused cached memory service; want fresh instance")
+	}
+	if first.ingest == second.ingest {
+		t.Fatal("resolveServices() reused cached ingest service; want fresh instance")
+	}
+}


### PR DESCRIPTION
Fixes #20

## Summary
- stop caching request-scoped service wrappers in Server
- construct fresh memory and ingest services on each request using the resolved tenant DB
- add a regression test that fails if resolveServices starts reusing cached instances again

## Verification
- cd server && GOROOT=/usr/local/opt/go/libexec GO111MODULE=on /usr/local/opt/go/libexec/bin/go test ./internal/handler -run TestResolveServicesReturnsFreshInstances -count=1