### PR TITLE
feat(import): accept markdown/plain-text for file_type=memory uploads

### DIFF
--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -240,12 +240,9 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 		}
 
 	case domain.FileTypeMemory:
-		var file MemoryFile
-		if err := json.Unmarshal(data, &file); err != nil {
+		file, err := parseMemoryFile(data, task.AgentID)
+		if err != nil {
 			return w.failTask(ctx, task, fmt.Errorf("parse memory file: %w", err), logger)
-		}
-		if file.AgentID == "" {
-			file.AgentID = task.AgentID
 		}
 
 		// Handle empty file: mark done immediately
@@ -366,6 +363,32 @@ func marshalMetadata(metadata map[string]any) (json.RawMessage, error) {
 		return nil, err
 	}
 	return json.RawMessage(b), nil
+}
+
+// parseMemoryFile parses upload data as a MemoryFile.
+// It accepts two formats:
+//   - JSON: {"agent_id":"...","memories":[{"content":"..."},...]}
+//   - Markdown/plain-text: the entire file becomes a single memory entry.
+func parseMemoryFile(data []byte, fallbackAgentID string) (MemoryFile, error) {
+	var file MemoryFile
+	if err := json.Unmarshal(data, &file); err == nil && len(file.Memories) > 0 {
+		if file.AgentID == "" {
+			file.AgentID = fallbackAgentID
+		}
+		return file, nil
+	}
+
+	// Fall back: treat the entire payload as Markdown / plain-text.
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return MemoryFile{AgentID: fallbackAgentID}, nil
+	}
+	return MemoryFile{
+		AgentID: fallbackAgentID,
+		Memories: []MemoryFileEntry{
+			{Content: content},
+		},
+	}, nil
 }
 
 // parseSessionFile tries to parse data as a JSON SessionFile first.

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -151,8 +151,8 @@ func TestParseSessionFile(t *testing.T) {
 			wantMsgs: 2, // only user + assistant, not toolResult
 		},
 		{
-			name: "OpenClaw JSONL with multi-block content",
-			data: `{"type":"message","id":"msg1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"let me think"},{"type":"text","text":"first part"},{"type":"text","text":"second part"}]}}`,
+			name:     "OpenClaw JSONL with multi-block content",
+			data:     `{"type":"message","id":"msg1","message":{"role":"assistant","content":[{"type":"thinking","thinking":"let me think"},{"type":"text","text":"first part"},{"type":"text","text":"second part"}]}}`,
 			wantMsgs: 1,
 		},
 		{
@@ -178,6 +178,74 @@ func TestParseSessionFile(t *testing.T) {
 			}
 			if len(file.Messages) != tt.wantMsgs {
 				t.Errorf("got %d messages, want %d", len(file.Messages), tt.wantMsgs)
+			}
+		})
+	}
+}
+
+func TestParseMemoryFile(t *testing.T) {
+	tests := []struct {
+		name            string
+		data            string
+		fallbackAgentID string
+		wantAgentID     string
+		wantMemories    int
+		wantContent     string
+	}{
+		{
+			name:         "valid JSON memory file",
+			data:         `{"agent_id":"a1","memories":[{"content":"fact one"},{"content":"fact two"}]}`,
+			wantAgentID:  "a1",
+			wantMemories: 2,
+		},
+		{
+			name:            "JSON missing agent_id uses fallback",
+			data:            `{"memories":[{"content":"fact"}]}`,
+			fallbackAgentID: "fallback",
+			wantAgentID:     "fallback",
+			wantMemories:    1,
+		},
+		{
+			name:         "markdown plain text",
+			data:         "# My Notes\n\nThis is a memory stored as markdown.",
+			wantMemories: 1,
+			wantContent:  "# My Notes\n\nThis is a memory stored as markdown.",
+		},
+		{
+			name:            "markdown uses fallback agent_id",
+			data:            "some plain text memory",
+			fallbackAgentID: "agent-x",
+			wantAgentID:     "agent-x",
+			wantMemories:    1,
+			wantContent:     "some plain text memory",
+		},
+		{
+			name:         "empty file yields zero memories",
+			data:         "   \n  ",
+			wantMemories: 0,
+		},
+		{
+			name:         "JSON with empty memories array falls back to plaintext",
+			data:         `{"memories":[]}`,
+			wantMemories: 1,
+			wantContent:  `{"memories":[]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := parseMemoryFile([]byte(tt.data), tt.fallbackAgentID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(file.Memories) != tt.wantMemories {
+				t.Errorf("got %d memories, want %d", len(file.Memories), tt.wantMemories)
+			}
+			if tt.wantAgentID != "" && file.AgentID != tt.wantAgentID {
+				t.Errorf("agentID = %q, want %q", file.AgentID, tt.wantAgentID)
+			}
+			if tt.wantContent != "" && tt.wantMemories == 1 && file.Memories[0].Content != tt.wantContent {
+				t.Errorf("content = %q, want %q", file.Memories[0].Content, tt.wantContent)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The import API previously required `file_type=memory` uploads to be valid JSON
(`{"agent_id":"...","memories":[...]}` format). Uploading a plain `.md` file
would fail with a JSON parse error.

## Change

`parseMemoryFile` now tries JSON first (existing behaviour). If the payload
does not parse as a valid JSON memory file (or has an empty `memories` array),
it falls back to treating the entire file content as a single `insight` memory
entry.

**Accepted formats for `file_type=memory`:**

| Input | Behaviour |
|---|---|
| Valid JSON `{"memories":[...]}` | Each entry stored as a separate memory (unchanged) |
| Markdown / plain-text `.md` | Entire file stored as one insight memory |
| Empty / whitespace-only file | Zero memories written; task marked done |

`file_type=session` is unaffected.

## Testing

Added `TestParseMemoryFile` with 6 cases covering JSON, markdown, fallback
agent ID, empty input, and the JSON-with-empty-array edge case.