### PR TITLE
feat(dashboard): refine analysis facets and tag filters

### DIFF
--- a/dashboard/app/src/api/analysis-helpers.test.ts
+++ b/dashboard/app/src/api/analysis-helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { AnalysisApiError } from "./analysis-client";
 import {
+  buildFacetStats,
   buildCreateJobRequest,
   chunkAnalysisMemories,
   createMemoryFingerprint,
@@ -190,6 +191,72 @@ describe("analysis helpers", () => {
     expect(merged.aggregate.categoryCounts.identity).toBe(1);
     expect(merged.batchSummaries[0]?.status).toBe("SUCCEEDED");
     expect(merged.topTags).toEqual(["ai"]);
+    expect(merged.topTopics).toEqual(["ai"]);
+    expect(merged.topTagStats).toEqual([{ value: "ai", count: 1 }]);
+    expect(merged.topTopicStats).toEqual([{ value: "ai", count: 1 }]);
+  });
+
+  it("builds facet stats with stable sorting and a 50 item limit", () => {
+    const counts: Record<string, number> = Object.fromEntries(
+      Array.from({ length: 51 }, (_, index) => [
+        `term-${index.toString().padStart(2, "0")}`,
+        1,
+      ]),
+    );
+
+    counts.priority = 53;
+    counts.beta = 5;
+    counts.alpha = 5;
+
+    const stats = buildFacetStats(counts);
+
+    expect(stats).toHaveLength(50);
+    expect(stats[0]).toEqual({ value: "priority", count: 53 });
+    expect(stats[1]).toEqual({ value: "alpha", count: 5 });
+    expect(stats[2]).toEqual({ value: "beta", count: 5 });
+    expect(stats[49]).toEqual({ value: "term-46", count: 1 });
+  });
+
+  it("keeps snapshot facet stats when snapshot is at least as new as updates", () => {
+    const snapshot = createSnapshot();
+    snapshot.progress.resultVersion = 3;
+    snapshot.aggregate.resultVersion = 3;
+    snapshot.topTagStats = [
+      { value: "priority", count: 7 },
+      { value: "alpha", count: 5 },
+    ];
+    snapshot.topTopicStats = [
+      { value: "project", count: 9 },
+      { value: "roadmap", count: 9 },
+    ];
+    snapshot.topTags = ["priority", "alpha"];
+    snapshot.topTopics = ["project", "roadmap"];
+    snapshot.aggregate.tagCounts = { priority: 7, alpha: 5 };
+    snapshot.aggregate.topicCounts = { project: 9, roadmap: 9 };
+
+    const updates: AnalysisJobUpdatesResponse = {
+      cursor: 0,
+      nextCursor: 2,
+      events: [],
+      completedBatchResults: [],
+      aggregate: {
+        ...snapshot.aggregate,
+        resultVersion: 2,
+        tagCounts: { stale: 1 },
+        topicCounts: { stale: 1 },
+      },
+      progress: {
+        ...snapshot.progress,
+        resultVersion: 2,
+      },
+    };
+
+    const merged = mergeSnapshotWithUpdates(snapshot, updates);
+
+    expect(merged.topTagStats).toEqual(snapshot.topTagStats);
+    expect(merged.topTopicStats).toEqual(snapshot.topTopicStats);
+    expect(merged.topTags).toEqual(["priority", "alpha"]);
+    expect(merged.topTopics).toEqual(["project", "roadmap"]);
   });
 
   it("stores cached job ids per space and range", async () => {

--- a/dashboard/app/src/api/analysis-helpers.ts
+++ b/dashboard/app/src/api/analysis-helpers.ts
@@ -1,6 +1,7 @@
 import type {
   AggregateSnapshot,
   AnalysisCategory,
+  AnalysisFacetStat,
   AnalysisJobSnapshotResponse,
   AnalysisJobUpdatesResponse,
   AnalysisMemoryInput,
@@ -21,6 +22,7 @@ export const TERMINAL_JOB_STATUSES: JobStatus[] = [
 ];
 
 export const DEFAULT_TAXONOMY_VERSION = "v2";
+export const MAX_ANALYSIS_FACETS = 50;
 
 const EMPTY_AGGREGATE: AggregateSnapshot = {
   categoryCounts: {
@@ -156,6 +158,8 @@ export function createPendingSnapshot(
     },
     aggregate: EMPTY_AGGREGATE,
     aggregateCards: [],
+    topTagStats: [],
+    topTopicStats: [],
     topTags: [],
     topTopics: [],
     batchSummaries: makeBatchSummaries(input.batchSize, memories),
@@ -201,6 +205,74 @@ function toAggregateCards(
     .sort((left, right) => right.count - left.count);
 }
 
+function compareFacetValues(left: string, right: string): number {
+  return left.localeCompare(right, "en");
+}
+
+function normalizeFacetStats(stats: AnalysisFacetStat[]): AnalysisFacetStat[] {
+  return [...stats]
+    .filter((stat) => stat.count > 0)
+    .sort(
+      (left, right) =>
+        right.count - left.count || compareFacetValues(left.value, right.value),
+    )
+    .slice(0, MAX_ANALYSIS_FACETS);
+}
+
+export function buildFacetStats(
+  counts: Record<string, number>,
+  limit = MAX_ANALYSIS_FACETS,
+): AnalysisFacetStat[] {
+  return Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .sort((left, right) => right[1] - left[1] || compareFacetValues(left[0], right[0]))
+    .slice(0, limit)
+    .map(([value, count]) => ({
+      value,
+      count,
+    }));
+}
+
+function toFacetStatsFromLegacyValues(
+  values: string[] | undefined,
+  counts: Record<string, number>,
+): AnalysisFacetStat[] {
+  if (!Array.isArray(values) || values.length === 0) {
+    return buildFacetStats(counts);
+  }
+
+  const stats = values
+    .map((value) => ({
+      value,
+      count: counts[value] ?? 0,
+    }))
+    .filter((stat) => stat.count > 0);
+
+  return stats.length > 0 ? normalizeFacetStats(stats) : buildFacetStats(counts);
+}
+
+function toFacetValues(stats: AnalysisFacetStat[]): string[] {
+  return stats.map((stat) => stat.value);
+}
+
+function getMoreRecentProgress(
+  snapshot: AnalysisJobSnapshotResponse,
+  updates: AnalysisJobUpdatesResponse,
+) {
+  return snapshot.progress.resultVersion >= updates.progress.resultVersion
+    ? snapshot.progress
+    : updates.progress;
+}
+
+function getMoreRecentAggregate(
+  snapshot: AnalysisJobSnapshotResponse,
+  updates: AnalysisJobUpdatesResponse,
+) {
+  return snapshot.aggregate.resultVersion >= updates.aggregate.resultVersion
+    ? snapshot.aggregate
+    : updates.aggregate;
+}
+
 function mergeBatchSummaries(
   base: BatchSummary[],
   completed: BatchSummary[],
@@ -219,22 +291,30 @@ export function mergeSnapshotWithUpdates(
   snapshot: AnalysisJobSnapshotResponse,
   updates: AnalysisJobUpdatesResponse,
 ): AnalysisJobSnapshotResponse {
+  const progress = getMoreRecentProgress(snapshot, updates);
+  const aggregate = getMoreRecentAggregate(snapshot, updates);
+  const usesSnapshotAggregate =
+    snapshot.aggregate.resultVersion >= aggregate.resultVersion;
+  const topTagStats = usesSnapshotAggregate
+    ? snapshot.topTagStats !== undefined
+      ? normalizeFacetStats(snapshot.topTagStats)
+      : toFacetStatsFromLegacyValues(snapshot.topTags, aggregate.tagCounts)
+    : buildFacetStats(aggregate.tagCounts);
+  const topTopicStats = usesSnapshotAggregate
+    ? snapshot.topTopicStats !== undefined
+      ? normalizeFacetStats(snapshot.topTopicStats)
+      : toFacetStatsFromLegacyValues(snapshot.topTopics, aggregate.topicCounts)
+    : buildFacetStats(aggregate.topicCounts);
+
   return {
     ...snapshot,
-    progress: updates.progress,
-    aggregate: updates.aggregate,
-    aggregateCards: toAggregateCards(
-      updates.aggregate,
-      updates.progress.processedMemories,
-    ),
-    topTags: Object.entries(updates.aggregate.tagCounts)
-      .sort((left, right) => right[1] - left[1])
-      .slice(0, 5)
-      .map(([tag]) => tag),
-    topTopics: Object.entries(updates.aggregate.topicCounts)
-      .sort((left, right) => right[1] - left[1])
-      .slice(0, 5)
-      .map(([topic]) => topic),
+    progress,
+    aggregate,
+    aggregateCards: toAggregateCards(aggregate, progress.processedMemories),
+    topTagStats,
+    topTopicStats,
+    topTags: toFacetValues(topTagStats),
+    topTopics: toFacetValues(topTopicStats),
     batchSummaries: mergeBatchSummaries(
       snapshot.batchSummaries,
       updates.completedBatchResults,

--- a/dashboard/app/src/api/analysis-queries.test.ts
+++ b/dashboard/app/src/api/analysis-queries.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { shouldStopPollingSnapshot } from "./analysis-queries";
+import type { AnalysisJobSnapshotResponse, BatchStatus } from "@/types/analysis";
+
+function createSnapshot(
+  overrides: Partial<AnalysisJobSnapshotResponse> = {},
+): AnalysisJobSnapshotResponse {
+  return {
+    jobId: "aj_1",
+    status: "PROCESSING",
+    expectedTotalMemories: 4,
+    expectedTotalBatches: 2,
+    batchSize: 2,
+    pipelineVersion: "v1",
+    taxonomyVersion: "v2",
+    llmEnabled: true,
+    createdAt: "2026-03-03T00:00:00Z",
+    startedAt: "2026-03-03T00:00:01Z",
+    completedAt: null,
+    expiresAt: null,
+    progress: {
+      expectedTotalBatches: 2,
+      uploadedBatches: 2,
+      completedBatches: 1,
+      failedBatches: 0,
+      processedMemories: 2,
+      resultVersion: 1,
+    },
+    aggregate: {
+      categoryCounts: {
+        identity: 1,
+        emotion: 0,
+        preference: 1,
+        experience: 0,
+        activity: 0,
+      },
+      tagCounts: { priority: 3 },
+      topicCounts: { agents: 2 },
+      summarySnapshot: ["identity:1", "preference:1"],
+      resultVersion: 1,
+    },
+    aggregateCards: [
+      { category: "identity", count: 1, confidence: 0.5 },
+      { category: "preference", count: 1, confidence: 0.5 },
+    ],
+    topTagStats: [{ value: "priority", count: 3 }],
+    topTopicStats: [{ value: "agents", count: 2 }],
+    topTags: ["priority"],
+    topTopics: ["agents"],
+    batchSummaries: [
+      {
+        batchIndex: 1,
+        status: "SUCCEEDED",
+        memoryCount: 2,
+        processedMemories: 2,
+        topCategories: [{ category: "identity", count: 1, confidence: 0.5 }],
+        topTags: ["priority"],
+      },
+      {
+        batchIndex: 2,
+        status: "SUCCEEDED",
+        memoryCount: 2,
+        processedMemories: 2,
+        topCategories: [{ category: "preference", count: 1, confidence: 0.5 }],
+        topTags: ["priority"],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function createBatchSummaries(
+  secondStatus: BatchStatus,
+): AnalysisJobSnapshotResponse["batchSummaries"] {
+  return [
+    {
+      batchIndex: 1,
+      status: "SUCCEEDED",
+      memoryCount: 2,
+      processedMemories: 2,
+      topCategories: [{ category: "identity", count: 1, confidence: 0.5 }],
+      topTags: ["priority"],
+    },
+    {
+      batchIndex: 2,
+      status: secondStatus,
+      memoryCount: 2,
+      processedMemories: secondStatus === "SUCCEEDED" ? 2 : 0,
+      topCategories: [],
+      topTags: [],
+    },
+  ];
+}
+
+describe("shouldStopPollingSnapshot", () => {
+  it("stops polling when the snapshot status is terminal", () => {
+    expect(
+      shouldStopPollingSnapshot(createSnapshot({ status: "COMPLETED" })),
+    ).toBe(true);
+  });
+
+  it("stops polling when all uploaded batches are terminal even if the job status lags", () => {
+    expect(
+      shouldStopPollingSnapshot(
+        createSnapshot({
+          status: "PROCESSING",
+          progress: {
+            expectedTotalBatches: 2,
+            uploadedBatches: 2,
+            completedBatches: 1,
+            failedBatches: 1,
+            processedMemories: 2,
+            resultVersion: 2,
+          },
+          batchSummaries: createBatchSummaries("FAILED"),
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each(["QUEUED", "RUNNING", "RETRYING"] as const)(
+    "keeps polling while a batch is still %s",
+    (status) => {
+      expect(
+        shouldStopPollingSnapshot(
+          createSnapshot({
+            progress: {
+              expectedTotalBatches: 2,
+              uploadedBatches: 2,
+              completedBatches: 1,
+              failedBatches: 0,
+              processedMemories: 2,
+              resultVersion: 2,
+            },
+            batchSummaries: createBatchSummaries(status),
+          }),
+        ),
+      ).toBe(false);
+    },
+  );
+});

--- a/dashboard/app/src/api/analysis-queries.ts
+++ b/dashboard/app/src/api/analysis-queries.ts
@@ -36,6 +36,7 @@ import { features } from "@/config/features";
 import { filterMemoriesForView, sortMemoriesByUpdatedAtDesc } from "@/lib/memory-filters";
 import type {
   AnalysisCategoryCard,
+  AnalysisJobSnapshotResponse,
   MemoryAnalysisMatch,
   SpaceAnalysisState,
   TaxonomyResponse,
@@ -45,6 +46,7 @@ import type { TimeRangePreset } from "@/types/time-range";
 import { presetToParams } from "@/types/time-range";
 
 const PAGE_SIZE = 200;
+const TERMINAL_BATCH_STATUSES = new Set(["SUCCEEDED", "FAILED", "DLQ"]);
 
 const INITIAL_STATE: SpaceAnalysisState = {
   phase: "idle",
@@ -58,6 +60,26 @@ const INITIAL_STATE: SpaceAnalysisState = {
   pollAfterMs: getDefaultPollMs(),
   isRetrying: false,
 };
+
+export function shouldStopPollingSnapshot(
+  snapshot: AnalysisJobSnapshotResponse,
+): boolean {
+  if (isTerminalJobStatus(snapshot.status)) {
+    return true;
+  }
+
+  if (snapshot.expectedTotalBatches === 0) {
+    return false;
+  }
+
+  return (
+    snapshot.progress.uploadedBatches >= snapshot.expectedTotalBatches &&
+    snapshot.batchSummaries.length >= snapshot.expectedTotalBatches &&
+    snapshot.batchSummaries.every((batch) =>
+      TERMINAL_BATCH_STATUSES.has(batch.status),
+    )
+  );
+}
 
 async function syncAllMemories(spaceId: string): Promise<Memory[]> {
   const all: Memory[] = [];
@@ -313,6 +335,7 @@ export function useSpaceAnalysis(
         if (cancelled || runRef.current !== currentRun) return;
 
         const mergedSnapshot = mergeSnapshotWithUpdates(snapshot, updates);
+        const shouldStop = shouldStopPollingSnapshot(mergedSnapshot);
         await persistAnalysisSnapshot(
           spaceId,
           range,
@@ -323,7 +346,7 @@ export function useSpaceAnalysis(
 
         updateState((current) => ({
           ...current,
-          phase: isTerminalJobStatus(snapshot.status) ? "completed" : "processing",
+          phase: shouldStop ? "completed" : "processing",
           snapshot: mergedSnapshot,
           events: trimEvents([...updates.events].reverse(), 8),
           cursor: updates.nextCursor,
@@ -335,7 +358,7 @@ export function useSpaceAnalysis(
           isRetrying: false,
         }));
 
-        if (isTerminalJobStatus(snapshot.status)) return;
+        if (shouldStop) return;
 
         timer = window.setTimeout(() => {
           void poll(jobId, fingerprint, updates.nextCursor, delayMs);
@@ -387,11 +410,10 @@ export function useSpaceAnalysis(
         cached.snapshot
       ) {
         const cachedSnapshot = cached.snapshot;
+        const shouldStop = shouldStopPollingSnapshot(cachedSnapshot);
         updateState((current) => ({
           ...current,
-          phase: isTerminalJobStatus(cachedSnapshot.status)
-            ? "completed"
-            : "processing",
+          phase: shouldStop ? "completed" : "processing",
           snapshot: cachedSnapshot,
           events: current.events,
           cursor: current.cursor,
@@ -403,7 +425,7 @@ export function useSpaceAnalysis(
           isRetrying: false,
         }));
 
-        if (!isTerminalJobStatus(cachedSnapshot.status)) {
+        if (!shouldStop) {
           await poll(cached.jobId, fingerprint, 0, getDefaultPollMs());
         }
         return;
@@ -509,7 +531,7 @@ export function useSpaceAnalysis(
 
         updateState((current) => ({
           ...current,
-          phase: isTerminalJobStatus(snapshot.status) ? "completed" : "processing",
+          phase: shouldStopPollingSnapshot(snapshot) ? "completed" : "processing",
           snapshot,
           error: null,
           warning: taxonomyUnavailable ? "taxonomy_unavailable" : null,
@@ -518,7 +540,7 @@ export function useSpaceAnalysis(
           pollAfterMs: createResponse.pollAfterMs,
         }));
 
-        if (!isTerminalJobStatus(snapshot.status)) {
+        if (!shouldStopPollingSnapshot(snapshot)) {
           await poll(
             createResponse.jobId,
             fingerprint,

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -121,6 +121,7 @@ export const httpProvider: DashboardProvider = {
   ): Promise<MemoryListResponse> {
     const qs = new URLSearchParams();
     if (params.q) qs.set("q", params.q);
+    if (params.tags?.length) qs.set("tags", params.tags.join(","));
     if (params.memory_type) qs.set("memory_type", params.memory_type);
     if (params.updated_from) qs.set("updated_from", params.updated_from);
     if (params.updated_to) qs.set("updated_to", params.updated_to);

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -114,6 +114,14 @@ function mockList(params: MemoryListParams): MemoryListResponse {
     );
   }
 
+  if (params.tags?.length) {
+    result = result.filter((m) =>
+      params.tags?.every((tag) =>
+        m.tags.some((memoryTag) => memoryTag.toLowerCase() === tag.toLowerCase()),
+      ),
+    );
+  }
+
   if (params.memory_type) {
     result = result.filter((m) => m.memory_type === params.memory_type);
   }

--- a/dashboard/app/src/api/queries.ts
+++ b/dashboard/app/src/api/queries.ts
@@ -31,6 +31,7 @@ export function useMemories(
   spaceId: string,
   params: {
     q?: string;
+    tag?: string;
     memory_type?: MemoryType;
     range?: TimeRangePreset;
     facet?: MemoryFacet;
@@ -42,6 +43,7 @@ export function useMemories(
     queryFn: ({ pageParam }) =>
       api.listMemories(spaceId, {
         q: params.q,
+        tags: params.tag ? [params.tag] : undefined,
         memory_type: params.memory_type,
         facet: params.facet,
         ...timeParams,

--- a/dashboard/app/src/components/space/analysis-panel.test.tsx
+++ b/dashboard/app/src/components/space/analysis-panel.test.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from "i18next";
 import { describe, expect, it, vi } from "vitest";
 import { AnalysisPanel } from "./analysis-panel";
 import type {
+  AnalysisFacetStat,
   AnalysisJobSnapshotResponse,
   SpaceAnalysisState,
 } from "@/types/analysis";
@@ -18,9 +19,21 @@ const t = vi.fn((key: string, options?: Record<string, unknown>) => {
   return key;
 }) as unknown as TFunction;
 
+function createFacetStats(
+  entries: Array<[string, number]>,
+): AnalysisFacetStat[] {
+  return entries.map(([value, count]) => ({
+    value,
+    count,
+  }));
+}
+
 function createSnapshot(
   overrides: Partial<AnalysisJobSnapshotResponse> = {},
 ): AnalysisJobSnapshotResponse {
+  const topTagStats = createFacetStats([["priority", 3]]);
+  const topTopicStats = createFacetStats([["agents", 2]]);
+
   return {
     jobId: "aj_1",
     status: "PROCESSING",
@@ -50,7 +63,7 @@ function createSnapshot(
         experience: 0,
         activity: 0,
       },
-      tagCounts: { ai: 2 },
+      tagCounts: { priority: 3 },
       topicCounts: { agents: 2 },
       summarySnapshot: ["identity:1", "preference:1"],
       resultVersion: 1,
@@ -59,8 +72,10 @@ function createSnapshot(
       { category: "identity", count: 1, confidence: 0.5 },
       { category: "preference", count: 1, confidence: 0.5 },
     ],
-    topTags: ["ai"],
-    topTopics: ["agents"],
+    topTagStats,
+    topTopicStats,
+    topTags: topTagStats.map((stat) => stat.value),
+    topTopics: topTopicStats.map((stat) => stat.value),
     batchSummaries: [
       {
         batchIndex: 1,
@@ -68,7 +83,7 @@ function createSnapshot(
         memoryCount: 2,
         processedMemories: 2,
         topCategories: [{ category: "identity", count: 1, confidence: 0.5 }],
-        topTags: ["ai"],
+        topTags: ["priority"],
       },
       {
         batchIndex: 2,
@@ -131,6 +146,8 @@ describe("AnalysisPanel", () => {
     expect(screen.getByText("analysis.phase.uploading")).toBeInTheDocument();
     expect(screen.getByText("analysis.cards")).toBeInTheDocument();
     expect(screen.getByText("analysis.top_topics")).toBeInTheDocument();
+    expect(screen.getByText("agents(2)")).toBeInTheDocument();
+    expect(screen.getByText("priority(3)")).toBeInTheDocument();
     expect(
       screen.getByText("analysis.batch_summary.syncing:2/2"),
     ).toBeInTheDocument();
@@ -142,6 +159,42 @@ describe("AnalysisPanel", () => {
       }),
     );
     expect(onSelectCategory).toHaveBeenCalledWith("preference");
+  });
+
+  it("uses uploaded batches for uploading progress", () => {
+    const { container } = render(
+      <AnalysisPanel
+        state={createState({
+          phase: "uploading",
+          snapshot: createSnapshot({
+            progress: {
+              expectedTotalBatches: 2,
+              uploadedBatches: 1,
+              completedBatches: 0,
+              failedBatches: 0,
+              processedMemories: 0,
+              resultVersion: 1,
+            },
+          }),
+        })}
+        sourceCount={4}
+        sourceLoading={false}
+        taxonomy={null}
+        taxonomyUnavailable={false}
+        cards={createSnapshot().aggregateCards}
+        onSelectCategory={() => {}}
+        onRetry={() => {}}
+        t={t}
+      />,
+    );
+
+    expect(screen.getByText("analysis.batch_summary.syncing:1/2")).toBeInTheDocument();
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-slot="progress-indicator"]'),
+    ).toHaveStyle({
+      transform: "translateX(-50%)",
+    });
   });
 
   it("renders completed state with recent updates", () => {
@@ -193,7 +246,9 @@ describe("AnalysisPanel", () => {
     );
 
     expect(screen.getByText("analysis.degraded_title")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "analysis.retry" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "analysis.retry" }),
+    ).toBeInTheDocument();
   });
 
   it("renders empty state when there are no memories in range", () => {
@@ -218,5 +273,132 @@ describe("AnalysisPanel", () => {
     );
 
     expect(screen.getByText("analysis.empty")).toBeInTheDocument();
+  });
+
+  it("shows 8 facet items by default and expands to the full list", async () => {
+    const topicStats = createFacetStats([
+      ["topic-1", 9],
+      ["topic-2", 8],
+      ["topic-3", 7],
+      ["topic-4", 6],
+      ["topic-5", 5],
+      ["topic-6", 4],
+      ["topic-7", 3],
+      ["topic-8", 2],
+      ["topic-9", 1],
+    ]);
+
+    render(
+      <AnalysisPanel
+        state={createState({
+          snapshot: createSnapshot({
+            aggregate: {
+              categoryCounts: {
+                identity: 1,
+                emotion: 0,
+                preference: 1,
+                experience: 0,
+                activity: 0,
+              },
+              tagCounts: {},
+              topicCounts: Object.fromEntries(
+                topicStats.map((stat) => [stat.value, stat.count]),
+              ),
+              summarySnapshot: ["identity:1", "preference:1"],
+              resultVersion: 1,
+            },
+            topTagStats: [],
+            topTopicStats: topicStats,
+            topTags: [],
+            topTopics: topicStats.map((stat) => stat.value),
+          }),
+        })}
+        sourceCount={4}
+        sourceLoading={false}
+        taxonomy={null}
+        taxonomyUnavailable={false}
+        cards={createSnapshot().aggregateCards}
+        onSelectCategory={() => {}}
+        onRetry={() => {}}
+        t={t}
+      />,
+    );
+
+    const container = screen.getByTestId("analysis-facets-topics");
+    const expandButton = await screen.findByRole("button", {
+      name: "analysis.more",
+    });
+
+    expect(expandButton).toBeInTheDocument();
+    expect(screen.getByText("topic-8(2)")).toBeInTheDocument();
+    expect(screen.queryByText("topic-9(1)")).not.toBeInTheDocument();
+    expect(container.children).toHaveLength(8);
+
+    fireEvent.click(expandButton);
+    expect(
+      screen.getByRole("button", { name: "analysis.less" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("topic-9(1)")).toBeInTheDocument();
+    expect(container.children).toHaveLength(9);
+
+    fireEvent.click(screen.getByRole("button", { name: "analysis.less" }));
+    expect(
+      screen.getByRole("button", { name: "analysis.more" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("topic-9(1)")).not.toBeInTheDocument();
+    expect(container.children).toHaveLength(8);
+  });
+
+  it("does not show more when facet count is 8 or fewer", () => {
+    const topicStats = createFacetStats([
+      ["topic-1", 9],
+      ["topic-2", 8],
+      ["topic-3", 7],
+      ["topic-4", 6],
+      ["topic-5", 5],
+      ["topic-6", 4],
+      ["topic-7", 3],
+      ["topic-8", 2],
+    ]);
+
+    render(
+      <AnalysisPanel
+        state={createState({
+          snapshot: createSnapshot({
+            aggregate: {
+              categoryCounts: {
+                identity: 1,
+                emotion: 0,
+                preference: 1,
+                experience: 0,
+                activity: 0,
+              },
+              tagCounts: {},
+              topicCounts: Object.fromEntries(
+                topicStats.map((stat) => [stat.value, stat.count]),
+              ),
+              summarySnapshot: ["identity:1", "preference:1"],
+              resultVersion: 1,
+            },
+            topTagStats: [],
+            topTopicStats: topicStats,
+            topTags: [],
+            topTopics: topicStats.map((stat) => stat.value),
+          }),
+        })}
+        sourceCount={4}
+        sourceLoading={false}
+        taxonomy={null}
+        taxonomyUnavailable={false}
+        cards={createSnapshot().aggregateCards}
+        onSelectCategory={() => {}}
+        onRetry={() => {}}
+        t={t}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "analysis.more" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/dashboard/app/src/components/space/analysis-panel.tsx
+++ b/dashboard/app/src/components/space/analysis-panel.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import type { TFunction } from "i18next";
 import {
   AlertTriangle,
@@ -6,15 +7,26 @@ import {
   Loader2,
   RefreshCcw,
 } from "lucide-react";
+import { buildFacetStats } from "@/api/analysis-helpers";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import type {
   AnalysisCategory,
   AnalysisCategoryCard,
+  AnalysisFacetStat,
   AnalysisJobSnapshotResponse,
   SpaceAnalysisState,
   TaxonomyResponse,
 } from "@/types/analysis";
+
+const TERMINAL_SNAPSHOT_STATUSES = new Set([
+  "COMPLETED",
+  "PARTIAL_FAILED",
+  "FAILED",
+  "CANCELLED",
+  "EXPIRED",
+]);
+const COLLAPSED_FACET_LIMIT = 8;
 
 function formatCategoryLabel(t: TFunction, category: AnalysisCategory): string {
   return t(`analysis.category.${category}`);
@@ -24,17 +36,91 @@ function formatPhaseLabel(t: TFunction, phase: SpaceAnalysisState["phase"]): str
   return t(`analysis.phase.${phase}`);
 }
 
-function getCompletionRatio(snapshot: AnalysisJobSnapshotResponse): number {
-  if (snapshot.expectedTotalBatches === 0) return 0;
-  return Math.round(
-    ((snapshot.progress.completedBatches + snapshot.progress.failedBatches) /
-      snapshot.expectedTotalBatches) *
-      100,
-  );
+function getFacetStats(
+  snapshot: AnalysisJobSnapshotResponse,
+  kind: "tags" | "topics",
+): AnalysisFacetStat[] {
+  if (kind === "tags") {
+    if (snapshot.topTagStats !== undefined) {
+      return snapshot.topTagStats;
+    }
+
+    if (snapshot.topTags.length > 0) {
+      return snapshot.topTags
+        .map((value) => ({
+          value,
+          count: snapshot.aggregate.tagCounts[value] ?? 0,
+        }))
+        .filter((stat) => stat.count > 0);
+    }
+
+    return buildFacetStats(snapshot.aggregate.tagCounts);
+  }
+
+  if (snapshot.topTopicStats !== undefined) {
+    return snapshot.topTopicStats;
+  }
+
+  if (snapshot.topTopics.length > 0) {
+    return snapshot.topTopics
+      .map((value) => ({
+        value,
+        count: snapshot.aggregate.topicCounts[value] ?? 0,
+      }))
+      .filter((stat) => stat.count > 0);
+  }
+
+  return buildFacetStats(snapshot.aggregate.topicCounts);
 }
 
-function getBatchProgressCount(snapshot: AnalysisJobSnapshotResponse): number {
-  return snapshot.progress.completedBatches + snapshot.progress.failedBatches;
+function getDisplayedBatchProgress(
+  phase: SpaceAnalysisState["phase"],
+  snapshot: AnalysisJobSnapshotResponse,
+): { current: number; total: number; ratio: number } {
+  const total = snapshot.expectedTotalBatches;
+
+  if (total === 0) {
+    return {
+      current: 0,
+      total: 0,
+      ratio: 0,
+    };
+  }
+
+  if (phase === "completed" || TERMINAL_SNAPSHOT_STATUSES.has(snapshot.status)) {
+    return {
+      current: total,
+      total,
+      ratio: 100,
+    };
+  }
+
+  if (phase === "uploading") {
+    const current = Math.min(snapshot.progress.uploadedBatches, total);
+    return {
+      current,
+      total,
+      ratio: Math.round((current / total) * 100),
+    };
+  }
+
+  if (phase === "processing") {
+    const current = Math.min(
+      snapshot.progress.completedBatches + snapshot.progress.failedBatches,
+      total,
+    );
+    return {
+      current,
+      total,
+      ratio: Math.round((current / total) * 100),
+    };
+  }
+
+  return {
+    current: 0,
+    total,
+    ratio: 0,
+  };
 }
 
 function formatBatchSummary(
@@ -42,26 +128,25 @@ function formatBatchSummary(
   phase: SpaceAnalysisState["phase"],
   snapshot: AnalysisJobSnapshotResponse,
 ): string {
-  const progressed = getBatchProgressCount(snapshot);
-  const total = snapshot.expectedTotalBatches;
+  const progress = getDisplayedBatchProgress(phase, snapshot);
 
   if (phase === "creating" || phase === "uploading") {
     return t("analysis.batch_summary.syncing", {
-      current: snapshot.progress.uploadedBatches,
-      total,
+      current: progress.current,
+      total: progress.total,
     });
   }
 
   if (phase === "processing") {
     return t("analysis.batch_summary.processing", {
-      current: progressed,
-      total,
+      current: progress.current,
+      total: progress.total,
     });
   }
 
   return t("analysis.batch_summary.completed", {
-    current: progressed,
-    total,
+    current: progress.current,
+    total: progress.total,
   });
 }
 
@@ -109,6 +194,17 @@ export function AnalysisPanel({
   t: TFunction;
 }) {
   const snapshot = state.snapshot;
+  const progress = snapshot
+    ? getDisplayedBatchProgress(state.phase, snapshot)
+    : null;
+  const topTopicStats = useMemo(
+    () => (snapshot ? getFacetStats(snapshot, "topics") : []),
+    [snapshot],
+  );
+  const topTagStats = useMemo(
+    () => (snapshot ? getFacetStats(snapshot, "tags") : []),
+    [snapshot],
+  );
 
   return (
     <aside className="w-full shrink-0 xl:w-[360px]">
@@ -192,12 +288,9 @@ export function AnalysisPanel({
               <div className="space-y-2">
                 <div className="flex items-center justify-between text-xs text-muted-foreground">
                   <span>{t("analysis.progress")}</span>
-                  <span>
-                    {getBatchProgressCount(snapshot)}/
-                    {snapshot.expectedTotalBatches}
-                  </span>
+                  <span>{progress?.current ?? 0}/{progress?.total ?? 0}</span>
                 </div>
-                <Progress value={getCompletionRatio(snapshot)} />
+                <Progress value={progress?.ratio ?? 0} />
                 <p className="text-xs text-soft-foreground">
                   {formatBatchSummary(t, state.phase, snapshot)}
                 </p>
@@ -297,23 +390,23 @@ export function AnalysisPanel({
                 </section>
               )}
 
-              {(snapshot.topTags.length > 0 || snapshot.topTopics.length > 0) && (
+              {(topTagStats.length > 0 || topTopicStats.length > 0) && (
                 <section className="space-y-3">
-                  {snapshot.topTopics.length > 0 && (
-                    <div>
-                      <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-ring">
-                        {t("analysis.top_topics")}
-                      </h3>
-                      <ChipRow items={snapshot.topTopics} />
-                    </div>
+                  {topTopicStats.length > 0 && (
+                    <FacetSection
+                      kind="topics"
+                      title={t("analysis.top_topics")}
+                      stats={topTopicStats}
+                      t={t}
+                    />
                   )}
-                  {snapshot.topTags.length > 0 && (
-                    <div>
-                      <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-ring">
-                        {t("analysis.top_tags")}
-                      </h3>
-                      <ChipRow items={snapshot.topTags.map((tag) => `#${tag}`)} />
-                    </div>
+                  {topTagStats.length > 0 && (
+                    <FacetSection
+                      kind="tags"
+                      title={t("analysis.top_tags")}
+                      stats={topTagStats}
+                      t={t}
+                    />
                   )}
                 </section>
               )}
@@ -362,17 +455,56 @@ function MetricCard({ label, value }: { label: string; value: string }) {
   );
 }
 
-function ChipRow({ items }: { items: string[] }) {
+function FacetSection({
+  kind,
+  title,
+  stats,
+  t,
+}: {
+  kind: "topics" | "tags";
+  title: string;
+  stats: AnalysisFacetStat[];
+  t: TFunction;
+}) {
+  const items = useMemo(() => stats.slice(0, 50), [stats]);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const isOverflowing = items.length > COLLAPSED_FACET_LIMIT;
+  const displayedItems =
+    isExpanded || !isOverflowing
+      ? items
+      : items.slice(0, COLLAPSED_FACET_LIMIT);
+
   return (
-    <div className="mt-2 flex flex-wrap gap-2">
-      {items.map((item) => (
-        <span
-          key={item}
-          className="rounded-full bg-secondary px-2.5 py-1 text-xs text-muted-foreground"
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-ring">
+        {title}
+      </h3>
+      <div
+        data-testid={`analysis-facets-${kind}`}
+        className="mt-2 flex flex-wrap gap-2"
+      >
+        {displayedItems.map((stat) => (
+          <span
+            key={stat.value}
+            className="rounded-full bg-secondary px-2.5 py-1 text-xs text-muted-foreground"
+          >
+            {stat.value}({stat.count})
+          </span>
+        ))}
+      </div>
+      {isOverflowing && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setIsExpanded((current) => !current);
+          }}
+          aria-expanded={isExpanded}
+          className="-ml-2 mt-1 h-auto px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
         >
-          {item}
-        </span>
-      ))}
+          {isExpanded ? t("analysis.less") : t("analysis.more")}
+        </Button>
+      )}
     </div>
   );
 }

--- a/dashboard/app/src/components/space/tag-strip.tsx
+++ b/dashboard/app/src/components/space/tag-strip.tsx
@@ -1,0 +1,49 @@
+import type { TFunction } from "i18next";
+
+export interface TagSummary {
+  tag: string;
+  count: number;
+}
+
+export function TagStrip({
+  tags,
+  activeTag,
+  onSelect,
+  t,
+}: {
+  tags: TagSummary[];
+  activeTag?: string;
+  onSelect: (tag: string | undefined) => void;
+  t: TFunction;
+}) {
+  if (tags.length === 0) return null;
+
+  return (
+    <div>
+      <div className="mb-2 text-xs font-medium text-muted-foreground">
+        {t("tag_strip.label")}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {tags.map(({ tag, count }) => {
+          const isActive = activeTag === tag;
+          return (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => onSelect(isActive ? undefined : tag)}
+              aria-label={t("tag_strip.filter_label", { tag, count })}
+              className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-all ${
+                isActive
+                  ? "border-foreground/20 bg-foreground/[0.05] text-foreground"
+                  : "border-border bg-background text-muted-foreground hover:border-foreground/15 hover:text-foreground"
+              }`}
+            >
+              <span className="font-medium">#{tag}</span>
+              <span className="text-xs text-soft-foreground">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -157,6 +157,10 @@
   "topics": {
     "label": "Browse by topic"
   },
+  "tag_strip": {
+    "label": "Browse by tag",
+    "filter_label": "Filter by tag {{tag}} ({{count}})"
+  },
   "facet": {
     "about_you": "About You",
     "preferences": "Preferences",
@@ -194,6 +198,8 @@
     "summary": "Summary",
     "top_topics": "Top topics",
     "top_tags": "Top tags",
+    "more": "More",
+    "less": "Less",
     "batch_progress": "Batch progress",
     "recent_updates": "Recent updates",
     "retry": "Retry analysis",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -157,6 +157,10 @@
   "topics": {
     "label": "按主题浏览"
   },
+  "tag_strip": {
+    "label": "按标签浏览",
+    "filter_label": "按标签 {{tag}} 筛选（{{count}}）"
+  },
   "facet": {
     "about_you": "关于你",
     "preferences": "偏好",
@@ -194,6 +198,8 @@
     "summary": "摘要",
     "top_topics": "高频主题",
     "top_tags": "高频标签",
+    "more": "更多",
+    "less": "收起",
     "batch_progress": "批次进度",
     "recent_updates": "最近更新",
     "retry": "重试分析",

--- a/dashboard/app/src/lib/memory-filters.ts
+++ b/dashboard/app/src/lib/memory-filters.ts
@@ -29,6 +29,14 @@ export function memoryMatchesQuery(memory: Memory, query?: string): boolean {
   );
 }
 
+export function memoryMatchesTag(memory: Memory, tag?: string): boolean {
+  if (!tag) return true;
+  const normalized = tag.trim().toLowerCase();
+  if (!normalized) return true;
+
+  return memory.tags.some((memoryTag) => memoryTag.toLowerCase() === normalized);
+}
+
 export function memoryMatchesType(
   memory: Memory,
   memoryType?: MemoryType,
@@ -41,6 +49,7 @@ export function filterMemoriesForView(
   memories: Memory[],
   params: {
     q?: string;
+    tag?: string;
     memoryType?: MemoryType;
     range?: TimeRangePreset;
   },
@@ -49,6 +58,7 @@ export function filterMemoriesForView(
     memories.filter(
       (memory) =>
         memoryMatchesQuery(memory, params.q) &&
+        memoryMatchesTag(memory, params.tag) &&
         memoryMatchesType(memory, params.memoryType) &&
         (!params.range || memoryMatchesRange(memory, params.range)),
     ),

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -10,6 +10,7 @@ import type { SpaceAnalysisState } from "@/types/analysis";
 const mocks = vi.hoisted(() => ({
   clearSpace: vi.fn(),
   retry: vi.fn(),
+  useMemories: vi.fn(),
 }));
 
 function createMemory(
@@ -17,13 +18,14 @@ function createMemory(
   content: string,
   updatedAt: string,
   memoryType: Memory["memory_type"] = "insight",
+  tags: string[] = [],
 ): Memory {
   return {
     id,
     content,
     memory_type: memoryType,
     source: "agent",
-    tags: [],
+    tags,
     metadata: null,
     agent_id: "agent",
     session_id: "",
@@ -39,16 +41,22 @@ const activityNewest = createMemory(
   "mem-activity-1",
   "Deploy dashboard status update",
   "2026-03-03T00:00:00Z",
+  "insight",
+  ["launch", "release"],
 );
 const preferenceMemory = createMemory(
   "mem-preference-1",
   "Prefer Neovim for edits",
   "2026-03-02T00:00:00Z",
+  "insight",
+  ["editor"],
 );
 const activityOlder = createMemory(
   "mem-activity-2",
   "Weekly activity planning notes",
   "2026-03-01T00:00:00Z",
+  "insight",
+  ["launch"],
 );
 
 const analysisState: SpaceAnalysisState = {
@@ -121,22 +129,31 @@ vi.mock("@/api/queries", () => ({
       insight: 3,
     },
   }),
-  useMemories: () => ({
-    data: {
-      pages: [
-        {
-          memories: [activityNewest, preferenceMemory, activityOlder],
-          total: 3,
-          limit: 50,
-          offset: 0,
-        },
-      ],
-    },
-    fetchNextPage: vi.fn(),
-    hasNextPage: false,
-    isFetchingNextPage: false,
-    isLoading: false,
-  }),
+  useMemories: (_spaceId: string, params: { tag?: string }) => {
+    mocks.useMemories(params);
+    const memories = [activityNewest, preferenceMemory, activityOlder].filter(
+      (memory) =>
+        !params.tag ||
+        memory.tags.some((tag) => tag.toLowerCase() === params.tag?.toLowerCase()),
+    );
+
+    return {
+      data: {
+        pages: [
+          {
+            memories,
+            total: memories.length,
+            limit: 50,
+            offset: 0,
+          },
+        ],
+      },
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      isLoading: false,
+    };
+  },
   useCreateMemory: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useDeleteMemory: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateMemory: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -212,6 +229,7 @@ vi.mock("@/api/analysis-queries", () => ({
 
 describe("SpacePage", () => {
   beforeEach(async () => {
+    mocks.useMemories.mockClear();
     await i18n.changeLanguage("en");
     window.history.pushState({}, "", "/your-memory/space");
     await act(async () => {
@@ -231,5 +249,23 @@ describe("SpacePage", () => {
     expect(screen.getAllByText("Deploy dashboard status update")).toHaveLength(2);
     expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Delete this memory" })).toBeInTheDocument();
+  });
+
+  it("shows tag chips and filters the list by tag", async () => {
+    render(<RouterProvider router={router} />);
+
+    expect(screen.getByText("Browse by tag")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: /filter by tag launch/i }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.useMemories).toHaveBeenLastCalledWith(
+        expect.objectContaining({ tag: "launch" }),
+      );
+    });
+
+    expect(screen.getByRole("button", { name: /^#launch$/ })).toBeInTheDocument();
+    expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
   });
 });

--- a/dashboard/app/src/pages/space.tsx
+++ b/dashboard/app/src/pages/space.tsx
@@ -37,6 +37,7 @@ import { EditMemoryDialog } from "@/components/space/edit-dialog";
 import { DeleteDialog } from "@/components/space/delete-dialog";
 import { TimeRangeSelector } from "@/components/space/time-range";
 import { TopicStrip } from "@/components/space/topic-strip";
+import { TagStrip, type TagSummary } from "@/components/space/tag-strip";
 import { AnalysisPanel } from "@/components/space/analysis-panel";
 import { ExportDialog } from "@/components/space/export-dialog";
 import { ImportDialog } from "@/components/space/import-dialog";
@@ -69,6 +70,7 @@ export function SpacePage() {
   const range: TimeRangePreset = search.range ?? "all";
   const facet: MemoryFacet | undefined = search.facet;
   const analysisCategory: AnalysisCategory | undefined = search.analysisCategory;
+  const tag = search.tag;
 
   useEffect(() => {
     if (!spaceId) navigate({ to: "/", replace: true });
@@ -88,6 +90,7 @@ export function SpacePage() {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useMemories(spaceId, {
       q: search.q,
+      tag,
       memory_type: search.type,
       range,
       facet,
@@ -128,13 +131,20 @@ export function SpacePage() {
     search.q,
     search.type,
   ]);
+  const tagFilteredAnalysisMemories = useMemo(
+    () =>
+      filterMemoriesForView(analysisFilteredMemories, {
+        tag,
+      }),
+    [analysisFilteredMemories, tag],
+  );
 
   const usingLocalAnalysisList = !!analysisCategory;
   const displayedMemories = usingLocalAnalysisList
-    ? analysisFilteredMemories.slice(0, localVisibleCount)
+    ? tagFilteredAnalysisMemories.slice(0, localVisibleCount)
     : memories;
   const hasMoreMemories = usingLocalAnalysisList
-    ? analysisFilteredMemories.length > localVisibleCount
+    ? tagFilteredAnalysisMemories.length > localVisibleCount
     : hasNextPage;
   const isMemoryLoading = usingLocalAnalysisList
     ? analysis.sourceLoading
@@ -143,27 +153,60 @@ export function SpacePage() {
   const displayedFirstPageSize = usingLocalAnalysisList
     ? Math.min(displayedMemories.length, LOCAL_PAGE_SIZE)
     : firstPageSize;
+  const tagOptions = useMemo<TagSummary[]>(() => {
+    const source = usingLocalAnalysisList ? analysisFilteredMemories : displayedMemories;
+    const counts = new Map<string, number>();
+
+    for (const memory of source) {
+      for (const memoryTag of memory.tags) {
+        const normalized = memoryTag.trim();
+        if (!normalized) continue;
+        counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
+      }
+    }
+
+    return [...counts.entries()]
+      .sort((left, right) => right[1] - left[1] || left[0].localeCompare(right[0], "en"))
+      .slice(0, 24)
+      .map(([value, count]) => ({
+        tag: value,
+        count,
+      }));
+  }, [analysisFilteredMemories, displayedMemories, usingLocalAnalysisList]);
 
   useEffect(() => {
     if (!usingLocalAnalysisList || isMemoryLoading) return;
 
-    if (analysisFilteredMemories.length === 0) {
+    if (displayedMemories.length === 0) {
       setSelected(null);
       return;
     }
 
     if (
       !selected ||
-      !analysisFilteredMemories.some((memory) => memory.id === selected.id)
+      !displayedMemories.some((memory) => memory.id === selected.id)
     ) {
-      setSelected(analysisFilteredMemories[0] ?? null);
+      setSelected(displayedMemories[0] ?? null);
     }
   }, [
-    analysisFilteredMemories,
+    displayedMemories,
     isMemoryLoading,
     selected,
     usingLocalAnalysisList,
   ]);
+
+  useEffect(() => {
+    if (isMemoryLoading || !selected) return;
+
+    if (displayedMemories.length === 0) {
+      setSelected(null);
+      return;
+    }
+
+    if (!displayedMemories.some((memory) => memory.id === selected.id)) {
+      setSelected(displayedMemories[0] ?? null);
+    }
+  }, [displayedMemories, isMemoryLoading, selected]);
 
   if (!spaceId) return null;
 
@@ -197,7 +240,14 @@ export function SpacePage() {
   function handleFacetChange(f: MemoryFacet | undefined) {
     navigate({
       to: "/space",
-      search: { ...search, facet: f },
+      search: { ...search, facet: f, tag: undefined },
+    });
+  }
+
+  function handleTagChange(nextTag: string | undefined) {
+    navigate({
+      to: "/space",
+      search: { ...search, tag: nextTag },
     });
   }
 
@@ -300,6 +350,7 @@ export function SpacePage() {
     !isMemoryLoading &&
     displayedMemories.length === 0 &&
     !search.q &&
+    !tag &&
     !search.type &&
     !facet &&
     !analysisCategory;
@@ -307,6 +358,7 @@ export function SpacePage() {
     (search.type ? 1 : 0) +
     (facet ? 1 : 0) +
     (search.q ? 1 : 0) +
+    (tag ? 1 : 0) +
     (analysisCategory ? 1 : 0);
 
   return (
@@ -467,7 +519,7 @@ export function SpacePage() {
             </div>
 
             {/* Active filters indicator (right below search) */}
-            {(search.type || facet || search.q || analysisCategory) && (
+            {(search.type || facet || search.q || tag || analysisCategory) && (
               <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                 <span>{t("filter.active")}</span>
                 {search.q && (
@@ -514,6 +566,15 @@ export function SpacePage() {
                     <X className="size-3" />
                   </button>
                 )}
+                {tag && (
+                  <button
+                    onClick={() => handleTagChange(undefined)}
+                    className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-foreground hover:bg-secondary/80"
+                  >
+                    #{tag}
+                    <X className="size-3" />
+                  </button>
+                )}
                 {analysisCategory && (
                   <button
                     onClick={() => handleAnalysisCategoryChange(undefined)}
@@ -537,6 +598,17 @@ export function SpacePage() {
                     {t("filter.clear_all")}
                   </button>
                 )}
+              </div>
+            )}
+
+            {tagOptions.length > 0 && (
+              <div className="mt-4">
+                <TagStrip
+                  tags={tagOptions}
+                  activeTag={tag}
+                  onSelect={handleTagChange}
+                  t={t}
+                />
               </div>
             )}
 

--- a/dashboard/app/src/router.tsx
+++ b/dashboard/app/src/router.tsx
@@ -45,6 +45,7 @@ const VALID_FACETS = [
 
 export interface SpaceSearch {
   q?: string;
+  tag?: string;
   type?: MemoryType;
   range?: TimeRangePreset;
   facet?: MemoryFacet;
@@ -57,6 +58,7 @@ const spaceRoute = createRoute({
   component: SpacePage,
   validateSearch: (search: Record<string, unknown>): SpaceSearch => ({
     q: typeof search.q === "string" ? search.q || undefined : undefined,
+    tag: typeof search.tag === "string" ? search.tag || undefined : undefined,
     type: VALID_TYPES.includes(search.type as string)
       ? (search.type as MemoryType)
       : undefined,

--- a/dashboard/app/src/test/setup.ts
+++ b/dashboard/app/src/test/setup.ts
@@ -2,6 +2,10 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+declare global {
+  var __triggerResizeObserver__: (() => void) | undefined;
+}
+
 class MemoryStorage implements Storage {
   private readonly store = new Map<string, string>();
 
@@ -51,8 +55,62 @@ function ensureStorage(name: "localStorage" | "sessionStorage"): void {
 ensureStorage("localStorage");
 ensureStorage("sessionStorage");
 
+class ResizeObserverMock implements ResizeObserver {
+  private static instances: ResizeObserverMock[] = [];
+
+  public readonly targets = new Set<Element>();
+
+  public constructor(private readonly callback: ResizeObserverCallback) {
+    ResizeObserverMock.instances.push(this);
+  }
+
+  public disconnect(): void {
+    this.targets.clear();
+  }
+
+  public observe(target: Element): void {
+    this.targets.add(target);
+  }
+
+  public unobserve(target: Element): void {
+    this.targets.delete(target);
+  }
+
+  public trigger(): void {
+    const entries = [...this.targets].map(
+      (target) =>
+        ({
+          target,
+          contentRect: target.getBoundingClientRect(),
+        }) as ResizeObserverEntry,
+    );
+
+    this.callback(entries, this);
+  }
+
+  public static triggerAll(): void {
+    for (const instance of ResizeObserverMock.instances) {
+      instance.trigger();
+    }
+  }
+
+  public static reset(): void {
+    ResizeObserverMock.instances = [];
+  }
+}
+
+Object.defineProperty(globalThis, "ResizeObserver", {
+  value: ResizeObserverMock,
+  configurable: true,
+});
+
+globalThis.__triggerResizeObserver__ = () => {
+  ResizeObserverMock.triggerAll();
+};
+
 afterEach(() => {
   cleanup();
   localStorage.clear();
   sessionStorage.clear();
+  ResizeObserverMock.reset();
 });

--- a/dashboard/app/src/types/analysis.ts
+++ b/dashboard/app/src/types/analysis.ts
@@ -104,6 +104,11 @@ export interface AnalysisCategoryCard {
   confidence: number;
 }
 
+export interface AnalysisFacetStat {
+  value: string;
+  count: number;
+}
+
 export interface MemoryAnalysisMatch {
   memoryId: string;
   categories: AnalysisCategory[];
@@ -156,6 +161,8 @@ export interface AnalysisJobSnapshotResponse {
   progress: JobProgressSnapshot;
   aggregate: AggregateSnapshot;
   aggregateCards: AnalysisCategoryCard[];
+  topTagStats?: AnalysisFacetStat[];
+  topTopicStats?: AnalysisFacetStat[];
   topTags: string[];
   topTopics: string[];
   batchSummaries: BatchSummary[];

--- a/dashboard/app/src/types/memory.ts
+++ b/dashboard/app/src/types/memory.ts
@@ -60,6 +60,7 @@ export interface ApiError {
 
 export interface MemoryListParams {
   q?: string;
+  tags?: string[];
   memory_type?: MemoryType;
   limit?: number;
   offset?: number;


### PR DESCRIPTION
## Summary
- restore tag browsing and filtering on the dashboard space page
- improve analysis panel facet handling and add fixed collapsed top tags/topics sections
- add/update dashboard tests for analysis caching, tag filters, and facet expansion

## Verification
- cd dashboard/app && pnpm test -- --run src/components/space/analysis-panel.test.tsx
- cd dashboard/app && pnpm test -- --run src/pages/space.test.tsx
- cd dashboard/app && pnpm typecheck