### PR TITLE
docs(AGENTS): clarify site/ Netlify deployment and SKILL.md ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,13 @@ It is hosted on Netlify and **automatically deployed from the `main` branch**.
 | `site/public/SKILL.md` | **Production** SKILL.md — served at `https://mem9.ai/SKILL.md` |
 | `site/public/beta/SKILL.md` | **Beta** SKILL.md — served at `https://mem9.ai/beta/SKILL.md` |
 
-When updating the SKILL.md that agents fetch, edit these files (not any other copy).
-Do **not** edit `clawhub-skill/mem9/SKILL.md` — that directory has been removed.
+When updating the SKILL.md that agents fetch, edit **only** these two files:
+
+- `site/public/SKILL.md` — production, changes go live within seconds after merging to `main`
+- `site/public/beta/SKILL.md` — beta, same deployment pipeline
+
+Do **not** edit any other copy (e.g. `clawhub-skill/mem9/SKILL.md` has been removed).
+Do **not** manually sync to clawhub — Netlify handles publishing automatically.
 
 ## Hierarchical AGENTS.md files
 


### PR DESCRIPTION
## Summary

Add explicit documentation about the `site/` directory and SKILL.md ownership rules.

### Changes
- Update `site/` description in module table: "deployed to Netlify from `main` branch"
- Add `site/public/SKILL.md` and `site/public/beta/SKILL.md` to the file reference table
- Add new **`## site/ — Netlify deployment`** section explaining:
  - `/site/` is auto-deployed to mem9.ai from `main`
  - Production SKILL.md → `site/public/SKILL.md` (served at `https://mem9.ai/SKILL.md`)
  - Beta SKILL.md → `site/public/beta/SKILL.md` (served at `https://mem9.ai/beta/SKILL.md`)
  - Agents should edit these files, not any other copy
  - The removed `clawhub-skill/mem9/SKILL.md` should no longer be edited

### Why
Prevents agents from editing the wrong SKILL.md copy, and makes the Netlify deployment relationship explicit.