### PR TITLE
chore(site): align netlify monorepo build detection

### DIFF
--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -35,7 +35,7 @@ cd site && npx tsc --noEmit
 - TypeScript config extends `astro/tsconfigs/strict`.
 - Current content model is centralized in `src/content/site.ts`; copy changes usually belong there, not inline in components.
 - Output is static (`output: 'static'`).
-- Netlify currently builds from the `site/` base directory. `netlify.toml` lives here and calls `scripts/netlify-build.sh` to build both `site/` and `dashboard/app/`, then copies dashboard assets into `dist/your-memory/`.
+- Netlify should keep `site/` as the package directory with the base directory unset. `netlify.toml` still lives here, but its build paths resolve from the repo root so it can build both `site/` and `dashboard/app/`, then copy dashboard assets into `site/dist/your-memory/`.
 - Locale and theme state use typed string unions and storage keys defined in `src/content/site.ts`.
 - Locale switching is runtime-driven via `data-i18n` attributes plus `src/scripts/site-ui.ts`; new locales usually touch `site.ts`, `site-ui.ts`, and `Layout.astro` together.
 - `public/SKILL.md` and `public/beta/SKILL.md` are served verbatim as onboarding documents.

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,6 +1,9 @@
+# Keep `site` as the Netlify package directory and leave the base directory unset.
+# Netlify will load this file from `site/`, but resolve build paths from the repo root.
 [build]
-  command = "bash ./scripts/netlify-build.sh"
-  publish = "dist"
+  command = "bash ./site/scripts/netlify-build.sh"
+  publish = "site/dist"
+  ignore = "if [ -z \"$CACHED_COMMIT_REF\" ]; then exit 1; fi; git diff --quiet \"$CACHED_COMMIT_REF\" \"$COMMIT_REF\" -- site dashboard/app"
 
 [[redirects]]
   from = "/your-memory/api/*"


### PR DESCRIPTION
## Summary
- keep `site/netlify.toml` in the site package while resolving build paths from the repo root
- make Netlify rebuild when either `site` or `dashboard/app` changes in PRs
- document the expected monorepo Netlify setup for this site

## Notes
- update Netlify UI to leave Base directory unset
- set Package directory to `site`