### PR TITLE
feat(ingest): add temporal age context to memory reconciliation

### DIFF
--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -465,6 +465,11 @@ Example 5 — Age as tiebreaker for ambiguous conflicts:
   New facts: ["Prefers VS Code", "Works at company Y"]
   Result: {"memory": [{"id": "0", "text": "Prefers VS Code", "event": "UPDATE", "old_memory": "Prefers vim"}, {"id": "1", "text": "Works at company Y", "event": "UPDATE", "old_memory": "Works at startup X"}]}
 
+Example 6 — Age does NOT trigger UPDATE without content conflict:
+  Existing memories: [{"id": 0, "text": "Likes coffee", "age": "2 years ago"}]
+  New facts: ["Enjoys coffee"]
+  Result: {"memory": [{"id": "0", "text": "Likes coffee", "event": "NOOP"}]}
+
 ## Output Format
 
 Return ONLY valid JSON. No markdown fences.

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1027,25 +1027,21 @@ func TestReconcileContentValidatesInput(t *testing.T) {
 func TestReconcileIncludesMemoryAge(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
 	var reconcileBody string
 	var mu sync.Mutex
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		callCount++
-		current := callCount
-		if current == 2 {
-			reconcileBody = string(body)
-		}
-		mu.Unlock()
+		bodyStr := string(body)
 
 		var resp string
-		if current == 1 {
-			resp = `{"facts": ["Lives in Shanghai"]}`
-		} else {
+		if strings.Contains(bodyStr, "Current memory contents:") {
+			mu.Lock()
+			reconcileBody = bodyStr
+			mu.Unlock()
 			resp = `{"memory": [{"id": "0", "text": "Lives in Shanghai", "event": "UPDATE", "old_memory": "Lives in Beijing"}]}`
+		} else {
+			resp = `{"facts": ["Lives in Shanghai"]}`
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
@@ -1110,25 +1106,21 @@ func TestReconcileIncludesMemoryAge(t *testing.T) {
 func TestReconcileOmitsAgeForZeroTimestamp(t *testing.T) {
 	t.Parallel()
 
-	callCount := 0
 	var reconcileBody string
 	var mu sync.Mutex
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		callCount++
-		current := callCount
-		if current == 2 {
-			reconcileBody = string(body)
-		}
-		mu.Unlock()
+		bodyStr := string(body)
 
 		var resp string
-		if current == 1 {
-			resp = `{"facts": ["Prefers dark mode"]}`
-		} else {
+		if strings.Contains(bodyStr, "Current memory contents:") {
+			mu.Lock()
+			reconcileBody = bodyStr
+			mu.Unlock()
 			resp = `{"memory": [{"id": "0", "text": "Prefers dark mode", "event": "NOOP"}]}`
+		} else {
+			resp = `{"facts": ["Prefers dark mode"]}`
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{


### PR DESCRIPTION
## Summary

- Add `age` field (e.g. "1 year ago") to existing memories sent to the reconciliation LLM, giving it temporal context to resolve conflicts between new facts and stale memories
- Age acts as a **tiebreaker**, not a primary decision factor — content must conflict or supersede for UPDATE/DELETE
- Omit age when `UpdatedAt` is zero (graceful handling of legacy data)

## Changes

**`server/internal/service/ingest.go`**
- `memoryRef` struct gains `Age string` field with `json:"age,omitempty"`
- Populate via existing `relativeAge(m.UpdatedAt)` — zero check skips
- Rule 8 added to reconciliation prompt: age as tiebreaker for ambiguous conflicts
- Example 5 added: preference conflict scenario (vim→VS Code, startup X→company Y)
- Examples 1-4 updated with consistent `age` fields

**`server/internal/service/ingest_test.go`**
- `TestReconcileIncludesMemoryAge` — verifies age appears in LLM prompt + ArchiveAndCreate executes
- `TestReconcileOmitsAgeForZeroTimestamp` — verifies age omitted when UpdatedAt is zero

## Before → After

```json
// Before: LLM has no temporal context
[{"id": 0, "text": "Lives in Beijing"}]

// After: LLM knows the memory is stale
[{"id": 0, "text": "Lives in Beijing", "age": "1 year ago"}]
```

## Token cost

~600 tokens increase at max capacity (60 existing memories). Acceptable tradeoff for better reconciliation quality.