### PR TITLE
test(e2e): add relative_age assertions to smoke tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ cd server && MNEMO_DSN="user:pass@tcp(host:4000)/db?parseTime=true" go run ./cmd
 - `INSERT ... ON DUPLICATE KEY UPDATE` is the expected upsert pattern.
 - Atomic version bump happens in SQL: `SET version = version + 1`.
 - `X-Mnemo-Agent-Id` is the per-agent identity header for memory requests.
+- Always use `make` targets for building and Docker image operations — never construct raw `go build` or `docker build` commands from scratch. Use `make build-linux` for the server binary and `REGISTRY=<ecr> COMMIT=<tag> make docker` for images.
 
 ## Go style
 

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -47,8 +47,8 @@ any memories by the time the list runs.
 | 3 | Ingest via messages | `POST /memories` with `messages[]` returns 202 `accepted` |
 | 4 | Ingest via content | `POST /memories` with `content` field returns 202 `accepted` |
 | 5 | Validation errors | `content+messages` → 400; `content+tags` → 202; empty body → 400 |
-| 6 | List memories | `GET /memories` returns 200 with `memories` array and `total` field |
-| 7 | Search by query | `GET /memories?q=TiDB` and no-match query both return 200 |
+| 6 | List memories | `GET /memories` returns 200 with `memories` array and `total` field; `relative_age` non-empty on first memory (if any) |
+| 7 | Search by query | `GET /memories?q=TiDB` and no-match query both return 200; `relative_age` non-empty on first result (if any) |
 | 8 | Search by tags | `GET /memories?tags=tidb` returns 200 with `memories` array |
 | 9 | Get by ID | `GET /memories/{id}` returns 200 with matching `id` field |
 | 10 | Update memory | `PUT /memories/{id}` returns 200, version bumps, tag change reflected |

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -9,7 +9,7 @@
 #   4. Ingest via content (async reconcile, expect 202)
 #   5. Validation errors (bad request shapes)
 #   6. List memories
-#   7. Search by query (?q=)
+#   7. Search by query (?q=) — includes relative_age check on results
 #   8. Search by tags (?tags=)
 #   9. Get memory by ID (uses first ID from list, if any)
 #  10. Update memory (PUT /{id})
@@ -219,6 +219,22 @@ mems = json.load(sys.stdin).get('memories', [])
 print(mems[0]['id'] if mems else '')
 " 2>/dev/null || true)
 
+if [ -n "$FIRST_MEM_ID" ]; then
+  FIRST_RELATIVE_AGE=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print(mems[0].get('relative_age', '') if mems else '')
+" 2>/dev/null || true)
+  TOTAL=$((TOTAL+1))
+  if [ -n "$FIRST_RELATIVE_AGE" ]; then
+    ok "list: first memory has relative_age (got='$FIRST_RELATIVE_AGE')"
+    PASS=$((PASS+1))
+  else
+    fail "list: first memory missing relative_age field"
+    FAIL=$((FAIL+1))
+  fi
+fi
+
 # ============================================================================
 # TEST 7 — Search by query
 # ============================================================================
@@ -239,6 +255,23 @@ if [ "$SEARCH_OK" = "true" ]; then
   code=$(http_code "$resp")
   bdy=$(body "$resp")
   check "GET /memories?q=TiDB returns 200" "$code" "200"
+  SEARCH_RELATIVE_AGE=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print(mems[0].get('relative_age', '') if mems else 'no-results')
+" 2>/dev/null || true)
+  if [ "$SEARCH_RELATIVE_AGE" = "no-results" ]; then
+    info "search: no results yet — relative_age check skipped"
+  else
+    TOTAL=$((TOTAL+1))
+    if [ -n "$SEARCH_RELATIVE_AGE" ]; then
+      ok "search: first result has relative_age (got='$SEARCH_RELATIVE_AGE')"
+      PASS=$((PASS+1))
+    else
+      fail "search: first result missing relative_age field"
+      FAIL=$((FAIL+1))
+    fi
+  fi
 
   info "Searching: q=xyzzy_nonexistent_term_abc123"
   resp=$(curl_mem_json "$MEM_BASE?q=xyzzy_nonexistent_term_abc123&limit=10")


### PR DESCRIPTION
## Summary

- Assert `relative_age` is non-empty on list (test 6) and search (test 7) responses in `api-smoke-test.sh` — the only paths where the server populates the field (`populateRelativeAge` is called in `List`, `ListByTags`, and both `Search` variants)
- Search result check is skipped gracefully when no results exist yet (fresh tenant, async ingest not complete)
- Update `e2e/AGENTS.md` coverage tables to document the new assertions
- Add make-targets convention to `AGENTS.md` global conventions: always use `make build-linux` / `REGISTRY=<ecr> COMMIT=<tag> make docker` — never construct raw build commands from scratch

## Verified

Full smoke suite run against both dev and prod — 4/4 scripts, all checks passed.