### PR TITLE
Remove hooks in plugin.json

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -6,6 +6,5 @@
     "name": "mem9-ai"
   },
   "repository": "https://github.com/mem9-ai/mem9-claude-plugin",
-  "license": "Apache-2.0",
-  "hooks": "./hooks/hooks.json"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
```
 error:
    Failed to load hooks from $HOME/.claude/plugins/cache/mem9/mem9/0.2.0/hooks/hooks.json: Duplicate hooks file detected:
    ./hooks/hooks.json resolves to already-loaded file $HOME/.claude/plugins/cache/mem9/mem9/0.2.0/hooks/hooks.json. The standard
    hooks/hooks.json is loaded automatically, so manifest.hooks should only reference additional hook files.
```