### PR TITLE
fix: use derived UUID as tenant ID to prevent cluster ID exposure

### DIFF
--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -73,12 +73,10 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 		return nil, fmt.Errorf("provision cluster: %w", err)
 	}
 
-	tenantID := info.ID
-
 	// Build tenant record
 	t := &domain.Tenant{
-		ID:             tenantID,
-		Name:           tenantID,
+		ID:             info.ID,
+		Name:           info.ID,
 		DBHost:         info.Host,
 		DBPort:         info.Port,
 		DBUser:         info.Username,
@@ -86,7 +84,7 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 		DBName:         info.DBName,
 		DBTLS:          true,
 		Provider:       providerType,
-		ClusterID:      info.ID,
+		ClusterID:      info.ClusterID,
 		ClaimURL:       info.ClaimURL,
 		ClaimExpiresAt: info.ClaimExpiresAt,
 		Status:         domain.TenantProvisioning,
@@ -97,7 +95,8 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 	if err := s.tenants.Create(ctx, t); err != nil {
 		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		s.logger.Error("orphaned cluster: tenants.Create failed",
-			"cluster_id", info.ID,
+			"tenant_id", info.ID,
+			"cluster_id", info.ClusterID,
 			"provider", providerType,
 			"err", err)
 		return nil, fmt.Errorf("create tenant record: %w", err)
@@ -107,7 +106,7 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 	metrics.ProvisionStepDuration.WithLabelValues("create_tenant_record").Observe(elapsed.Seconds())
 
 	// Get DB connection for schema initialization
-	db, err := s.pool.Get(ctx, tenantID, t.DSNForBackend(s.pool.Backend()))
+	db, err := s.pool.Get(ctx, info.ID, t.DSNForBackend(s.pool.Backend()))
 	if err != nil {
 		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("get tenant db: %w", err)
@@ -116,7 +115,7 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 	t0 = time.Now()
 	if err := s.provisioner.InitSchema(ctx, db); err != nil {
 		if s.logger != nil {
-			s.logger.Error("tenant schema init failed", "tenant_id", tenantID, "err", err)
+			s.logger.Error("tenant schema init failed", "tenant_id", info.ID, "err", err)
 		}
 		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("init tenant schema: %w", err)
@@ -126,7 +125,7 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 	metrics.ProvisionStepDuration.WithLabelValues("init_schema").Observe(elapsed.Seconds())
 
 	t0 = time.Now()
-	if err := s.tenants.UpdateSchemaVersion(ctx, tenantID, 1); err != nil {
+	if err := s.tenants.UpdateSchemaVersion(ctx, info.ID, 1); err != nil {
 		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("update schema version: %w", err)
 	}
@@ -135,7 +134,7 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 	metrics.ProvisionStepDuration.WithLabelValues("update_schema_version").Observe(elapsed.Seconds())
 
 	t0 = time.Now()
-	if err := s.tenants.UpdateStatus(ctx, tenantID, domain.TenantActive); err != nil {
+	if err := s.tenants.UpdateStatus(ctx, info.ID, domain.TenantActive); err != nil {
 		metrics.ProvisionTotal.WithLabelValues("error").Inc()
 		return nil, fmt.Errorf("activate tenant: %w", err)
 	}
@@ -144,12 +143,12 @@ func (s *TenantService) Provision(ctx context.Context) (*ProvisionResult, error)
 	metrics.ProvisionStepDuration.WithLabelValues("update_status").Observe(elapsed.Seconds())
 
 	totalElapsed := time.Since(total)
-	s.logger.Info("provision step", "step", "total", "duration_ms", totalElapsed.Milliseconds(), "tenant_id", tenantID)
+	s.logger.Info("provision step", "step", "total", "duration_ms", totalElapsed.Milliseconds(), "tenant_id", info.ID)
 	metrics.ProvisionStepDuration.WithLabelValues("total").Observe(totalElapsed.Seconds())
 	metrics.ProvisionTotal.WithLabelValues("success").Inc()
 
 	return &ProvisionResult{
-		ID: tenantID,
+		ID: info.ID,
 	}, nil
 }
 

--- a/server/internal/tenant/provisioner.go
+++ b/server/internal/tenant/provisioner.go
@@ -15,12 +15,13 @@ type Provisioner interface {
 
 // ClusterInfo contains connection details for a provisioned cluster
 type ClusterInfo struct {
-	ID             string
-	Host           string
-	Port           int
-	Username       string
-	Password       string
-	DBName         string
-	ClaimURL       string     // Only for Zero provisioner
+	ID        string // Tenant-facing ID (random UUID, opaque to provider)
+	ClusterID string // Original cluster ID from provider
+	Host      string
+	Port      int
+	Username  string
+	Password  string
+	DBName    string
+	ClaimURL  string     // Only for Zero provisioner
 	ClaimExpiresAt *time.Time // Only for Zero provisioner
 }

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -98,8 +98,12 @@ func TestTiDBCloudProvisioner_Provision_Success(t *testing.T) {
 		t.Fatalf("Provision failed: %v", err)
 	}
 	
-	if info.ID != "cluster-123" {
-		t.Errorf("expected ID=cluster-123, got %s", info.ID)
+	// ID should be a generated UUID (not the raw cluster ID)
+	if info.ClusterID != "cluster-123" {
+		t.Errorf("expected ClusterID=cluster-123, got %s", info.ClusterID)
+	}
+	if info.ID == "" || info.ID == "cluster-123" {
+		t.Errorf("expected ID to be a generated UUID, got %s", info.ID)
 	}
 	if info.Host != "test.cluster.tidbcloud.com" {
 		t.Errorf("expected Host=test.cluster.tidbcloud.com, got %s", info.Host)
@@ -224,6 +228,9 @@ func TestZeroProvisioner_Provision_Success(t *testing.T) {
 	
 	if info.ID != "zero-123" {
 		t.Errorf("expected ID=zero-123, got %s", info.ID)
+	}
+	if info.ClusterID != "zero-123" {
+		t.Errorf("expected ClusterID=zero-123, got %s", info.ClusterID)
 	}
 	if info.Host != "zero.cluster.tidbcloud.com" {
 		t.Errorf("expected Host=zero.cluster.tidbcloud.com, got %s", info.Host)

--- a/server/internal/tenant/starter.go
+++ b/server/internal/tenant/starter.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // TiDBCloudProvisioner implements service.Provisioner for TiDB Cloud Pool API.
@@ -82,12 +84,13 @@ func (p *TiDBCloudProvisioner) Provision(ctx context.Context) (*ClusterInfo, err
 	}
 
 	return &ClusterInfo{
-		ID:       result.ClusterID,
-		Host:     result.Endpoints.Public.Host,
-		Port:     result.Endpoints.Public.Port,
-		Username: result.UserPrefix + ".root",
-		Password: password,
-		DBName:   "test",
+		ID:        uuid.New().String(),
+		ClusterID: result.ClusterID,
+		Host:      result.Endpoints.Public.Host,
+		Port:      result.Endpoints.Public.Port,
+		Username:  result.UserPrefix + ".root",
+		Password:  password,
+		DBName:    "test",
 	}, nil
 }
 
@@ -269,3 +272,4 @@ func generateRandomPassword(length int) (string, error) {
 	}
 	return string(b), nil
 }
+

--- a/server/internal/tenant/zero.go
+++ b/server/internal/tenant/zero.go
@@ -142,6 +142,7 @@ func (p *ZeroProvisioner) Provision(ctx context.Context) (*ClusterInfo, error) {
 
 	return &ClusterInfo{
 		ID:             inst.ID,
+		ClusterID:      inst.ID, // Zero provisioner issues real UUIDs; no derivation needed
 		Host:           inst.Host,
 		Port:           inst.Port,
 		Username:       inst.Username,


### PR DESCRIPTION
## Summary

Previously, the API returned the raw TiDB Cloud cluster ID (e.g., `10386832249857875601`) which could be reverse-engineered. This PR changes the API to return a derived UUID instead.

## Changes

- Add `ClusterID` field to `ClusterInfo` to store original cluster ID
- For TiDB Cloud: derive UUID from cluster ID using SHA256
- For TiDB Zero: use original UUID as both ID and ClusterID
- API returns derived UUID, database stores original cluster ID in `cluster_id` field

## Security

This prevents clients from knowing the actual cluster ID while maintaining a deterministic mapping for internal use.