### PR TITLE
fix: restore ZeroProvisionerType constant to "tidb_zero"

### DIFF
--- a/server/internal/tenant/zero.go
+++ b/server/internal/tenant/zero.go
@@ -153,7 +153,7 @@ func (p *ZeroProvisioner) Provision(ctx context.Context) (*ClusterInfo, error) {
 	}, nil
 }
 
-const ZeroProvisionerType = "zero"
+const ZeroProvisionerType = "tidb_zero"
 
 // ProviderType returns the provider identifier.
 func (p *ZeroProvisioner) ProviderType() string {


### PR DESCRIPTION
## Summary

- `902a2c5` introduced `const ZeroProvisionerType = "zero"`, changing the value from the original `"tidb_zero"` that has been stored in the `provider` column of the `tenants` table since `17997e6`.
- This broke `TestZeroProvisioner_ProviderType` (which correctly asserted `"tidb_zero"`) and would have caused a DB compat issue: existing tenants provisioned before this commit have `provider = "tidb_zero"` in the DB, while new tenants would get `provider = "zero"`.
- Fix: restore the constant to `"tidb_zero"`.