### PR TITLE
fix: add missing slog.Error before returning search and list errors in repository layer

### DIFF
--- a/server/internal/repository/db9/memory.go
+++ b/server/internal/repository/db9/memory.go
@@ -215,6 +215,7 @@ func (r *DB9MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, 
 
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
+		slog.Error("auto vector search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("db9 auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -271,6 +272,7 @@ func (r *DB9MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Me
 			r.jiebaDisabled.Store(true)
 			return r.MemoryRepo.FTSSearch(ctx, query, f, limit)
 		}
+		slog.Error("fts search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("db9 fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -190,6 +190,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	var total int
 	countQuery := "SELECT COUNT(*) FROM memories WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		slog.Error("list memories: count failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("count memories: %w", err)
 	}
 
@@ -212,6 +213,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
+		slog.Error("list memories: query failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("list memories: %w", err)
 	}
 	defer rows.Close()
@@ -233,6 +235,7 @@ func (r *MemoryRepo) Count(ctx context.Context) (int, error) {
 		`SELECT COUNT(*) FROM memories WHERE state = 'active'`,
 	).Scan(&count)
 	if err != nil {
+		slog.Error("count memories failed", "cluster_id", r.clusterID, "err", err)
 		return 0, fmt.Errorf("count memories: %w", err)
 	}
 	return count, nil
@@ -247,6 +250,7 @@ func (r *MemoryRepo) ListBootstrap(ctx context.Context, limit int) ([]domain.Mem
 		limit,
 	)
 	if err != nil {
+		slog.Error("list bootstrap failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("list bootstrap: %w", err)
 	}
 	defer rows.Close()
@@ -319,6 +323,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
+		slog.Error("vector search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("vector search: %w", err)
 	}
 	defer rows.Close()
@@ -356,6 +361,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
+		slog.Error("keyword search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 	defer rows.Close()
@@ -390,6 +396,7 @@ func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Memor
 
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
+		slog.Error("fts search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -221,6 +221,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	var total int
 	countQuery := "SELECT COUNT(*) FROM memories WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		slog.Error("list memories: count failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("count memories: %w", err)
 	}
 
@@ -243,6 +244,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
+		slog.Error("list memories: query failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("list memories: %w", err)
 	}
 	defer rows.Close()
@@ -264,6 +266,7 @@ func (r *MemoryRepo) Count(ctx context.Context) (int, error) {
 		`SELECT COUNT(*) FROM memories WHERE state = 'active'`,
 	).Scan(&count)
 	if err != nil {
+		slog.Error("count memories failed", "cluster_id", r.clusterID, "err", err)
 		return 0, fmt.Errorf("count memories: %w", err)
 	}
 	return count, nil
@@ -278,6 +281,7 @@ func (r *MemoryRepo) ListBootstrap(ctx context.Context, limit int) ([]domain.Mem
 		limit,
 	)
 	if err != nil {
+		slog.Error("list bootstrap failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("list bootstrap: %w", err)
 	}
 	defer rows.Close()
@@ -373,6 +377,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
+		slog.Error("vector search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("vector search: %w", err)
 	}
 	defer rows.Close()
@@ -407,6 +412,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
+		slog.Error("auto vector search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -436,6 +442,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
+		slog.Error("keyword search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 	defer rows.Close()
@@ -485,6 +492,7 @@ func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Memor
 
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
+		slog.Error("fts search failed", "cluster_id", r.clusterID, "err", err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()


### PR DESCRIPTION
## Problem

All search and list functions in the repository layer were returning errors silently — no `slog.Error` was emitted before the `return nil, err`. This made DB failures invisible in log aggregators: the only trace was buried inside the error string itself (e.g., `cluster_id` was embedded in the error message but never a structured field).

## Changes

Added `slog.Error` with `cluster_id` as a structured field before every error return in the three repository backends, covering:

**Search functions** (`tidb`, `postgres`, `db9`):
- `VectorSearch` — query failure
- `AutoVectorSearch` — query failure
- `KeywordSearch` — query failure
- `FTSSearch` — query failure

**Read functions** (`tidb`, `postgres`):
- `List` — count query failure
- `List` — data query failure
- `Count` — query failure
- `ListBootstrap` — query failure

`db9` needs no changes for read functions as it delegates to the embedded `postgres.MemoryRepo`.

## Why only these functions?

CRUD write operations (`Create`, `Update`, `SoftDelete`, `ArchiveAndCreate`, `BulkCreate`) are intentionally left without repo-level logs — they are typically observed at the service/handler layer where richer business context (agent ID, session ID, etc.) is available. Read/search failures on the other hand can happen silently on the hot path with no other log site above them.