### PR TITLE
test(e2e): add session storage smoke test for PR #103

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -8,7 +8,7 @@ This directory contains live end-to-end tests for server and CRDT behavior. Thes
 
 ## Smoke tests — quick reference
 
-Both `api-smoke-test.sh` and `api-smoke-test-round2.sh` support v1alpha1 and v1alpha2
+`api-smoke-test.sh` and `api-smoke-test-round2.sh` support v1alpha1 and v1alpha2
 via `MNEMO_API_VERSION`. Default is `v1alpha1`.
 
 ```bash
@@ -22,15 +22,20 @@ MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-round2.sh
 MNEMO_BASE=$DEV bash e2e/api-smoke-test-v1alpha2.sh
 MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-round2-v1alpha2.sh
 
+# Session storage tests (both API versions)
+MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-sessions.sh
+MNEMO_BASE=$DEV MNEMO_API_VERSION=v1alpha2 POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-sessions.sh
+
 # Existing-tenant backward-compat check (requires a pre-existing tenant ID)
 MNEMO_BASE=$DEV MNEMO_EXISTING_TENANT_ID=<id> POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-existing-tenant.sh
 
-# All five — full smoke suite
+# Full smoke suite
 for script in \
   "e2e/api-smoke-test.sh" \
   "e2e/api-smoke-test-v1alpha2.sh" \
   "POLL_TIMEOUT_S=60 e2e/api-smoke-test-round2.sh" \
-  "POLL_TIMEOUT_S=60 e2e/api-smoke-test-round2-v1alpha2.sh"; do
+  "POLL_TIMEOUT_S=60 e2e/api-smoke-test-round2-v1alpha2.sh" \
+  "POLL_TIMEOUT_S=60 e2e/api-smoke-test-sessions.sh"; do
   eval "MNEMO_BASE=$DEV bash $script"
 done
 MNEMO_BASE=$DEV MNEMO_EXISTING_TENANT_ID=<id> POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-existing-tenant.sh
@@ -77,6 +82,29 @@ concurrent async ingest bumps.
 | 8 | Get after delete | `GET /memories/{id}` returns 404 |
 | 9 | Idempotent re-delete | Second `DELETE` on already-deleted ID returns 204 (no-op, not 404) |
 
+### Session storage (`api-smoke-test-sessions.sh`)
+
+Regression tests for raw session storage (PR #103). Provisions a fresh tenant,
+ingests messages, and verifies all session-specific behaviors: unified search,
+`memory_type` filtering, metadata projection, no-query exclusion, and deduplication.
+Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
+
+| # | Case | What is verified |
+|---|------|-----------------|
+| 1 | Provision tenant | `POST /v1alpha1/mem9s` returns 201 |
+| 2 | Session write via messages | `POST /memories {messages}` returns 202 `accepted` |
+| 3 | Poll until sessions appear | `GET /memories?memory_type=session&q=` polled until results appear |
+| 4 | Unified search includes sessions | `GET /memories?q=` returns rows with `memory_type=session` |
+| 5 | `memory_type=session` filter | All results have `memory_type=session`; no other types |
+| 6 | `memory_type=insight` excludes sessions | No `memory_type=session` rows when insight filter applied |
+| 7 | Session metadata projection | First session result has `role`, `seq`, `content_type` in `metadata` |
+| 8 | No-query list excludes sessions | `GET /memories` (no `?q=`) returns no `memory_type=session` rows |
+| 9 | `session_id` scoped filter | All results belong to the expected `session_id` |
+| 10 | Deduplication | Re-sending identical messages does not increase row count |
+| 11 | Existing tenant: session write | `POST /memories {messages}` on pre-existing tenant returns 202 (requires `MNEMO_EXISTING_TENANT_ID`) |
+| 12 | Existing tenant: lazy migration | Poll + retry writes until sessions appear — proves `EnsureSessionsTable` creates table in flight |
+| 13 | Existing tenant: filter after migration | `memory_type=session` filter works correctly after lazy migration |
+
 ### Existing-tenant compat (`api-smoke-test-existing-tenant.sh`)
 
 Backward-compatibility check: exercises a **pre-existing tenant** (created before the
@@ -102,9 +130,12 @@ memories. Covers both v1alpha1 and v1alpha2 auth in every operation.
 ## Commands
 
 ```bash
-# Original tenant API smoke tests
+# CRUD smoke tests
 bash e2e/api-smoke-test.sh
 bash e2e/api-smoke-test-round2.sh
+
+# Session storage regression tests
+bash e2e/api-smoke-test-sessions.sh
 
 # Existing-tenant backward-compat check
 MNEMO_EXISTING_TENANT_ID=<id> bash e2e/api-smoke-test-existing-tenant.sh
@@ -128,6 +159,7 @@ python3 e2e/concurrent-real-doc-test.py
 
 - `api-smoke-test.sh` / `api-smoke-test-v1alpha2.sh` — CRUD smoke, ingest, search, tag filter (tests 1–11)
 - `api-smoke-test-round2.sh` / `api-smoke-test-round2-v1alpha2.sh` — per-ID ops: GET, PUT, If-Match LWW, DELETE, idempotent re-delete (tests 1–9)
+- `api-smoke-test-sessions.sh` — session storage: write, dedup, unified search, type filter, metadata, no-query exclusion, lazy migration (tests 1–13; tests 11–13 require `MNEMO_EXISTING_TENANT_ID`)
 - `api-smoke-test-existing-tenant.sh` — backward-compat: pre-existing tenant read/write/search across v1alpha1 and v1alpha2 (tests 1–12)
 - `crdt-*` and `plugin-crdt-*` use the CRDT branch `/api/users`, `/api/spaces/provision`, `/api/memories` surface.
 - Check the server branch/API shape before mixing the two sets.
@@ -137,9 +169,9 @@ python3 e2e/concurrent-real-doc-test.py
 | Variable | Default | Used by |
 |----------|---------|---------|
 | `MNEMO_BASE` | `https://api.mem9.ai` | all smoke scripts |
-| `MNEMO_API_VERSION` | `v1alpha1` | `api-smoke-test*.sh`, `api-smoke-test-round2.sh` |
-| `POLL_TIMEOUT_S` | `20` | `api-smoke-test-round2*.sh`, `api-smoke-test-existing-tenant.sh` |
-| `MNEMO_EXISTING_TENANT_ID` | — | `api-smoke-test-existing-tenant.sh` |
+| `MNEMO_API_VERSION` | `v1alpha1` | `api-smoke-test.sh`, `api-smoke-test-round2.sh`, `api-smoke-test-sessions.sh` |
+| `POLL_TIMEOUT_S` | `20` (round2), `30` (sessions) | `api-smoke-test-round2*.sh`, `api-smoke-test-sessions.sh`, `api-smoke-test-existing-tenant.sh` |
+| `MNEMO_EXISTING_TENANT_ID` | — | `api-smoke-test-existing-tenant.sh`, `api-smoke-test-sessions.sh` (tests 11–13) |
 | `MNEMO_TEST_BASE` | `http://127.0.0.1:18081` | CRDT scripts |
 | `MNEMO_TEST_USER_TOKEN` | — | CRDT scripts |
 
@@ -151,6 +183,7 @@ python3 e2e/concurrent-real-doc-test.py
 | `api-smoke-test-v1alpha2.sh` | v1alpha2 | One-liner wrapper — sets `MNEMO_API_VERSION=v1alpha2` |
 | `api-smoke-test-round2.sh` | v1alpha1 (default) or v1alpha2 | Per-ID ops: GET, PUT, If-Match LWW, DELETE, idempotent re-delete |
 | `api-smoke-test-round2-v1alpha2.sh` | v1alpha2 | One-liner wrapper — sets `MNEMO_API_VERSION=v1alpha2` |
+| `api-smoke-test-sessions.sh` | v1alpha1 (default) or v1alpha2 | Session storage: write, dedup, unified search, type filter, metadata |
 | `api-smoke-test-existing-tenant.sh` | v1alpha1 + v1alpha2 | Backward-compat: pre-existing tenant full lifecycle, both auth modes |
 | `crdt-e2e-tests.sh` | CRDT branch | Core CRDT server behavior |
 | `plugin-crdt-e2e.py` | CRDT branch | Plugin clock propagation |
@@ -162,6 +195,7 @@ python3 e2e/concurrent-real-doc-test.py
 - Each script provisions its own tenant / keys; runs are repeatable and isolated.
 - These scripts validate live behavior, so failures may be env/data issues rather than local code regressions.
 - `crdt-server-merge-e2e.py` is the primary regression signal for section merge logic.
+- `api-smoke-test-sessions.sh` is the primary regression signal for raw session storage.
 - `MNEMO_TEST_USER_TOKEN` is a one-time setup input for the CRDT scripts; those scripts provision spaces afterward.
 - Version checks in round2 use `>` (version advanced), not exact equality — the async ingest pipeline may bump versions concurrently.
 

--- a/e2e/api-smoke-test-sessions.sh
+++ b/e2e/api-smoke-test-sessions.sh
@@ -1,0 +1,496 @@
+#!/bin/bash
+# api-smoke-test-sessions.sh
+# Session storage smoke test: verifies raw session write, deduplication,
+# unified search, memory_type filtering, and metadata projection.
+#
+# Tests covered:
+#   1. Provision tenant
+#   2. Session write via messages — expect 202
+#   3. Poll until sessions appear in unified search
+#   4. Unified search returns memory_type=session rows
+#   5. memory_type=session filter returns only sessions
+#   6. memory_type=insight filter excludes sessions
+#   7. Session metadata projection (role, seq, content_type in metadata field)
+#   8. No-query list excludes sessions
+#   9. session_id scoped filter
+#  10. Deduplication — same messages sent twice produce no extra rows
+#  11. Existing tenant: session write triggers lazy migration (requires MNEMO_EXISTING_TENANT_ID)
+#  12. Existing tenant: poll + retry until sessions appear after lazy table creation
+#  13. Existing tenant: memory_type=session filter works after migration
+#
+# Usage:
+#   bash e2e/api-smoke-test-sessions.sh
+#   MNEMO_BASE=https://api.mem9.ai bash e2e/api-smoke-test-sessions.sh
+#   MNEMO_API_VERSION=v1alpha2 bash e2e/api-smoke-test-sessions.sh
+#   POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-sessions.sh
+#   MNEMO_EXISTING_TENANT_ID=<id> bash e2e/api-smoke-test-sessions.sh
+set -euo pipefail
+
+BASE="${MNEMO_BASE:-https://api.mem9.ai}"
+API_VERSION="${MNEMO_API_VERSION:-v1alpha1}"
+AGENT_A="smoke-sessions-agent"
+UNIQUE_MARKER="MNEMO_SESS_TEST_$(date +%s)"
+SESSION_ID="smoke-sessions-${UNIQUE_MARKER}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-30}"
+POLL_INTERVAL_S=2
+EXISTING_TENANT_ID="${MNEMO_EXISTING_TENANT_ID:-}"
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}  →${RESET} $*"; }
+ok()    { echo -e "${GREEN}  PASS${RESET} $*"; }
+fail()  { echo -e "${RED}  FAIL${RESET} $*"; }
+step()  { echo -e "\n${YELLOW}[$1]${RESET} $2"; }
+
+curl_json() {
+  curl -s --connect-timeout 5 --max-time 30 -w '\n__HTTP__%{http_code}' "$@"
+}
+
+http_code() { printf '%s' "$1" | grep '__HTTP__' | sed 's/__HTTP__//'; }
+body()      { printf '%s' "$1" | grep -v '__HTTP__'; }
+
+check() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    ok "$desc (got=$got)"
+    PASS=$((PASS+1))
+    return 0
+  else
+    fail "$desc — expected '$want', got '$got'"
+    FAIL=$((FAIL+1))
+    return 1
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  TOTAL=$((TOTAL+1))
+  if printf '%s' "$haystack" | grep -q "$needle"; then
+    ok "$desc (contains '$needle')"
+    PASS=$((PASS+1))
+    return 0
+  else
+    fail "$desc — '$needle' not found in: $haystack"
+    FAIL=$((FAIL+1))
+    return 1
+  fi
+}
+
+curl_mem_json() {
+  local url="$1"
+  shift
+
+  if [ "$API_VERSION" = "v1alpha2" ]; then
+    curl_json "$@" \
+      -H "X-Mnemo-Agent-Id: $AGENT_A" \
+      -H "X-API-Key: $API_KEY" \
+      "$url"
+    return
+  fi
+
+  curl_json "$@" \
+    -H "X-Mnemo-Agent-Id: $AGENT_A" \
+    "$url"
+}
+
+echo "========================================================"
+echo "  mnemos API smoke test — session storage"
+echo "  Base URL      : $BASE"
+echo "  API Mode      : $API_VERSION"
+echo "  Session ID    : $SESSION_ID"
+echo "  Unique marker : $UNIQUE_MARKER"
+echo "  Poll timeout  : ${POLL_TIMEOUT_S}s"
+echo "  Started       : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+
+# ============================================================================
+# TEST 1 — Provision tenant
+# ============================================================================
+step "1" "Provision tenant (POST /v1alpha1/mem9s)"
+resp=$(curl_json -X POST "$BASE/v1alpha1/mem9s")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "POST /v1alpha1/mem9s returns 201" "$code" "201"
+
+TENANT_ID=$(printf '%s' "$bdy" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))" 2>/dev/null || true)
+if [ -z "$TENANT_ID" ]; then
+  fail "Could not extract tenant ID — aborting."
+  exit 1
+fi
+info "Tenant: $TENANT_ID"
+API_KEY="$TENANT_ID"
+
+if [ "$API_VERSION" = "v1alpha2" ]; then
+  MEM_BASE="$BASE/v1alpha2/mem9s/memories"
+  info "Using v1alpha2 header auth with X-API-Key"
+else
+  MEM_BASE="$BASE/v1alpha1/mem9s/$TENANT_ID/memories"
+  info "Using v1alpha1 path auth with tenantID"
+fi
+
+# ============================================================================
+# TEST 2 — Session write via messages
+# ============================================================================
+step "2" "Session write via messages (POST /memories with messages[])"
+resp=$(curl_mem_json "$MEM_BASE" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"messages\": [
+      {\"role\": \"user\",      \"content\": \"$UNIQUE_MARKER what is mnemos?\"},
+      {\"role\": \"assistant\", \"content\": \"mnemos is persistent memory for AI agents.\"},
+      {\"role\": \"user\",      \"content\": \"$UNIQUE_MARKER does it use TiDB?\"},
+      {\"role\": \"assistant\", \"content\": \"Yes, TiDB with hybrid vector and keyword search.\"}
+    ],
+    \"session_id\": \"$SESSION_ID\"
+  }")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "POST /memories (messages) returns 202" "$code" "202"
+check_contains "response has status=accepted" "$bdy" '"accepted"'
+
+# ============================================================================
+# TEST 3 — Poll until sessions appear in unified search
+# ============================================================================
+step "3" "Poll until sessions appear in unified search (timeout=${POLL_TIMEOUT_S}s)"
+SESSION_APPEARED=false
+ELAPSED=0
+while [ "$ELAPSED" -lt "$POLL_TIMEOUT_S" ]; do
+  list_resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&memory_type=session&limit=10")
+  list_code=$(http_code "$list_resp")
+  list_bdy=$(body "$list_resp")
+
+  if [ "$list_code" = "200" ]; then
+    SESSION_COUNT=$(printf '%s' "$list_bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print(len(mems))
+" 2>/dev/null || true)
+
+    if [ -n "$SESSION_COUNT" ] && [ "$SESSION_COUNT" -gt 0 ]; then
+      info "Sessions appeared after ~${ELAPSED}s (count=$SESSION_COUNT)"
+      TOTAL=$((TOTAL+1))
+      ok "Sessions materialised within ${POLL_TIMEOUT_S}s"
+      PASS=$((PASS+1))
+      SESSION_APPEARED=true
+      break
+    fi
+  fi
+
+  sleep "$POLL_INTERVAL_S"
+  ELAPSED=$((ELAPSED+POLL_INTERVAL_S))
+done
+
+if [ "$SESSION_APPEARED" = "false" ]; then
+  TOTAL=$((TOTAL+1))
+  fail "Sessions did NOT appear within ${POLL_TIMEOUT_S}s — skipping session-dependent tests"
+  FAIL=$((FAIL+1))
+  echo ""
+  echo "========================================================"
+  echo "  RESULTS: $PASS / $TOTAL passed, $FAIL failed"
+  echo "  Tenant : $TENANT_ID"
+  echo -e "  ${RED}$FAIL test(s) failed.${RESET}"
+  echo "  Finished : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "========================================================"
+  exit "$FAIL"
+fi
+
+# ============================================================================
+# TEST 4 — Unified search returns memory_type=session rows
+# ============================================================================
+step "4" "Unified search: GET /memories?q= returns session rows"
+resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&limit=20")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories?q= returns 200" "$code" "200"
+
+HAS_SESSION=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print('yes' if any(m.get('memory_type') == 'session' for m in mems) else 'no')
+" 2>/dev/null || true)
+check "unified search includes memory_type=session rows" "$HAS_SESSION" "yes"
+
+# ============================================================================
+# TEST 5 — memory_type=session filter returns ONLY sessions
+# ============================================================================
+step "5" "memory_type=session filter returns only sessions"
+resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&memory_type=session&limit=20")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories?memory_type=session returns 200" "$code" "200"
+
+SESSION_ONLY=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+if not mems:
+    print('no-results')
+elif all(m.get('memory_type') == 'session' for m in mems):
+    print('yes')
+else:
+    non = [m.get('memory_type') for m in mems if m.get('memory_type') != 'session']
+    print('no: found ' + str(non))
+" 2>/dev/null || true)
+check "all results have memory_type=session" "$SESSION_ONLY" "yes"
+
+# ============================================================================
+# TEST 6 — memory_type=insight filter excludes sessions
+# ============================================================================
+step "6" "memory_type=insight filter excludes sessions"
+resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&memory_type=insight&limit=20")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories?memory_type=insight returns 200" "$code" "200"
+
+HAS_SESSION_IN_INSIGHT=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print('yes' if any(m.get('memory_type') == 'session' for m in mems) else 'no')
+" 2>/dev/null || true)
+check "insight filter has no memory_type=session rows" "$HAS_SESSION_IN_INSIGHT" "no"
+
+# ============================================================================
+# TEST 7 — Session metadata projection (role, seq, content_type)
+# ============================================================================
+step "7" "Session metadata projection: role, seq, content_type present"
+resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&memory_type=session&limit=10")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories?memory_type=session returns 200" "$code" "200"
+
+META_CHECK=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+if not mems:
+    print('no-results')
+    sys.exit()
+m = mems[0]
+meta = m.get('metadata')
+if meta is None:
+    print('no-metadata')
+    sys.exit()
+if isinstance(meta, str):
+    import json as j
+    meta = j.loads(meta)
+missing = [f for f in ('role', 'seq', 'content_type') if f not in meta]
+print('missing:' + ','.join(missing) if missing else 'ok')
+" 2>/dev/null || true)
+check "first session has role, seq, content_type in metadata" "$META_CHECK" "ok"
+
+# ============================================================================
+# TEST 8 — No-query list excludes sessions
+# ============================================================================
+step "8" "No-query list (GET /memories) excludes sessions"
+resp=$(curl_mem_json "$MEM_BASE?limit=50")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories (no ?q=) returns 200" "$code" "200"
+
+HAS_SESSION_IN_LIST=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print('yes' if any(m.get('memory_type') == 'session' for m in mems) else 'no')
+" 2>/dev/null || true)
+check "list without query has no memory_type=session rows" "$HAS_SESSION_IN_LIST" "no"
+
+# ============================================================================
+# TEST 9 — session_id scoped filter
+# ============================================================================
+step "9" "session_id scoped filter: GET /memories?session_id=&memory_type=session"
+resp=$(curl_mem_json "$MEM_BASE?session_id=${SESSION_ID}&memory_type=session&q=${UNIQUE_MARKER}&limit=20")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories?session_id=&memory_type=session returns 200" "$code" "200"
+
+SESSION_SCOPED=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+if not mems:
+    print('no-results')
+    sys.exit()
+wrong = [m.get('session_id') for m in mems if m.get('session_id') != '$SESSION_ID']
+print('ok' if not wrong else 'wrong-sessions:' + str(wrong))
+" 2>/dev/null || true)
+check "all session_id-filtered results belong to session" "$SESSION_SCOPED" "ok"
+
+# ============================================================================
+# TEST 10 — Deduplication: sending the same messages twice produces no extra rows
+# ============================================================================
+step "10" "Deduplication: same messages sent twice produce no extra session rows"
+
+resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&memory_type=session&limit=100")
+COUNT_BEFORE=$(body "$resp" | python3 -c "
+import sys, json
+print(len(json.load(sys.stdin).get('memories', [])))
+" 2>/dev/null || true)
+info "Session rows before re-send: $COUNT_BEFORE"
+
+resp=$(curl_mem_json "$MEM_BASE" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"messages\": [
+      {\"role\": \"user\",      \"content\": \"$UNIQUE_MARKER what is mnemos?\"},
+      {\"role\": \"assistant\", \"content\": \"mnemos is persistent memory for AI agents.\"},
+      {\"role\": \"user\",      \"content\": \"$UNIQUE_MARKER does it use TiDB?\"},
+      {\"role\": \"assistant\", \"content\": \"Yes, TiDB with hybrid vector and keyword search.\"}
+    ],
+    \"session_id\": \"$SESSION_ID\"
+  }")
+code=$(http_code "$resp")
+check "second POST /memories (same messages) returns 202" "$code" "202"
+
+sleep 3
+
+resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&memory_type=session&limit=100")
+COUNT_AFTER=$(body "$resp" | python3 -c "
+import sys, json
+print(len(json.load(sys.stdin).get('memories', [])))
+" 2>/dev/null || true)
+info "Session rows after re-send: $COUNT_AFTER"
+
+check "row count unchanged after duplicate send (dedup via content hash)" "$COUNT_AFTER" "$COUNT_BEFORE"
+
+# ============================================================================
+# TESTS 11-13 — Existing tenant: lazy sessions table migration
+# Only runs when MNEMO_EXISTING_TENANT_ID is set.
+# The tenant database must NOT have a sessions table yet (created before PR #103).
+# On first request, EnsureSessionsTable fires in background (error 1146 is
+# swallowed); subsequent writes succeed once the table exists. The test retries
+# the write until sessions appear, proving the lazy migration path works end-to-end.
+# ============================================================================
+if [ -n "$EXISTING_TENANT_ID" ]; then
+  echo ""
+  echo "========================================================"
+  echo "  Existing-tenant lazy migration tests"
+  echo "  Tenant ID : $EXISTING_TENANT_ID"
+  echo "========================================================"
+
+  if [ "$API_VERSION" = "v1alpha2" ]; then
+    EXIST_MEM_BASE="$BASE/v1alpha2/mem9s/memories"
+  else
+    EXIST_MEM_BASE="$BASE/v1alpha1/mem9s/$EXISTING_TENANT_ID/memories"
+  fi
+
+  curl_exist_json() {
+    local url="$1"
+    shift
+    if [ "$API_VERSION" = "v1alpha2" ]; then
+      curl_json "$@" \
+        -H "X-Mnemo-Agent-Id: $AGENT_A" \
+        -H "X-API-Key: $EXISTING_TENANT_ID" \
+        "$url"
+      return
+    fi
+    curl_json "$@" \
+      -H "X-Mnemo-Agent-Id: $AGENT_A" \
+      "$url"
+  }
+
+  EXIST_UNIQUE_MARKER="MNEMO_EXIST_SESS_$(date +%s)"
+  EXIST_SESSION_ID="smoke-exist-sessions-${EXIST_UNIQUE_MARKER}"
+
+  step "11" "Existing tenant: session write triggers lazy migration (POST /memories)"
+  resp=$(curl_exist_json "$EXIST_MEM_BASE" -X POST \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"messages\": [
+        {\"role\": \"user\",      \"content\": \"$EXIST_UNIQUE_MARKER lazy migration test\"},
+        {\"role\": \"assistant\", \"content\": \"sessions table should be created in flight.\"}
+      ],
+      \"session_id\": \"$EXIST_SESSION_ID\"
+    }")
+  code=$(http_code "$resp")
+  bdy=$(body "$resp")
+  check "existing tenant POST /memories (messages) returns 202" "$code" "202"
+  check_contains "response has status=accepted" "$bdy" '"accepted"'
+
+  step "12" "Existing tenant: poll + retry writes until sessions appear (lazy table creation)"
+  info "First write may be silently dropped (error 1146 swallowed) — retrying until table is ready"
+  EXIST_SESSION_APPEARED=false
+  ELAPSED=0
+  while [ "$ELAPSED" -lt "$POLL_TIMEOUT_S" ]; do
+    list_resp=$(curl_exist_json "$EXIST_MEM_BASE?q=${EXIST_UNIQUE_MARKER}&memory_type=session&limit=10")
+    list_code=$(http_code "$list_resp")
+    list_bdy=$(body "$list_resp")
+
+    if [ "$list_code" = "200" ]; then
+      EXIST_COUNT=$(printf '%s' "$list_bdy" | python3 -c "
+import sys, json
+print(len(json.load(sys.stdin).get('memories', [])))
+" 2>/dev/null || true)
+      if [ -n "$EXIST_COUNT" ] && [ "$EXIST_COUNT" -gt 0 ]; then
+        info "Sessions appeared after ~${ELAPSED}s (count=$EXIST_COUNT)"
+        TOTAL=$((TOTAL+1))
+        ok "Existing tenant sessions materialised within ${POLL_TIMEOUT_S}s"
+        PASS=$((PASS+1))
+        EXIST_SESSION_APPEARED=true
+        break
+      fi
+    fi
+
+    resp=$(curl_exist_json "$EXIST_MEM_BASE" -X POST \
+      -H "Content-Type: application/json" \
+      -d "{
+        \"messages\": [
+          {\"role\": \"user\",      \"content\": \"$EXIST_UNIQUE_MARKER lazy migration test\"},
+          {\"role\": \"assistant\", \"content\": \"sessions table should be created in flight.\"}
+        ],
+        \"session_id\": \"$EXIST_SESSION_ID\"
+      }")
+
+    sleep "$POLL_INTERVAL_S"
+    ELAPSED=$((ELAPSED+POLL_INTERVAL_S))
+  done
+
+  if [ "$EXIST_SESSION_APPEARED" = "false" ]; then
+    TOTAL=$((TOTAL+1))
+    fail "Existing tenant sessions did NOT appear within ${POLL_TIMEOUT_S}s — lazy migration may have failed"
+    FAIL=$((FAIL+1))
+  fi
+
+  step "13" "Existing tenant: session memory_type=session filter works after migration"
+  resp=$(curl_exist_json "$EXIST_MEM_BASE?q=${EXIST_UNIQUE_MARKER}&memory_type=session&limit=10")
+  code=$(http_code "$resp")
+  bdy=$(body "$resp")
+  check "existing tenant GET /memories?memory_type=session returns 200" "$code" "200"
+
+  EXIST_SESSION_ONLY=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+if not mems:
+    print('no-results')
+elif all(m.get('memory_type') == 'session' for m in mems):
+    print('yes')
+else:
+    non = [m.get('memory_type') for m in mems if m.get('memory_type') != 'session']
+    print('no: found ' + str(non))
+" 2>/dev/null || true)
+  check "existing tenant: all results have memory_type=session" "$EXIST_SESSION_ONLY" "yes"
+else
+  info "MNEMO_EXISTING_TENANT_ID not set — skipping lazy migration tests (11-13)"
+fi
+
+
+echo ""
+echo "========================================================"
+echo "  RESULTS: $PASS / $TOTAL passed, $FAIL failed"
+echo "  Base URL      : $BASE"
+echo "  API Mode      : $API_VERSION"
+echo "  Tenant        : $TENANT_ID"
+echo "  Session       : $SESSION_ID"
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "  ${GREEN}All tests passed.${RESET}"
+else
+  echo -e "  ${RED}$FAIL test(s) failed.${RESET}"
+fi
+echo "  Finished      : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- Adds `e2e/api-smoke-test-sessions.sh` — dedicated regression test for raw session storage introduced in PR #103
- Updates `e2e/AGENTS.md` with new script coverage, env vars table, and quick-reference commands

## Test coverage (13 cases)

| # | Case | Notes |
|---|------|-------|
| 1-2 | Provision + session write | Baseline 202 accepted |
| 3 | Poll until sessions appear | Async wait with `memory_type=session` filter |
| 4 | Unified search includes sessions | `?q=` returns `memory_type=session` rows |
| 5 | `memory_type=session` filter | All results correctly typed |
| 6 | `memory_type=insight` excludes sessions | Filter isolation — checks `memory_type` field, not raw string match |
| 7 | Metadata projection | `role`, `seq`, `content_type` present in `metadata` |
| 8 | No-query list excludes sessions | `GET /memories` (no `?q=`) returns no session rows |
| 9 | `session_id` scoped filter | Results belong to expected session |
| 10 | Deduplication | Same messages twice → row count unchanged (content hash) |
| 11-13 | Existing tenant lazy migration | `MNEMO_EXISTING_TENANT_ID` triggers `EnsureSessionsTable` in-flight; retry-write loop confirms data saved after table creation |

## Verified on dev

All 23/23 tests pass against dev ALB, including lazy migration for both pre-existing tenant types (`tidb_zero` and `tidb_cloud_starter`).

```
RESULTS: 23 / 23 passed, 0 failed  (tidb_zero, ~0s migration)
RESULTS: 23 / 23 passed, 0 failed  (tidb_cloud_starter, ~8s migration)
```