### PR TITLE
feat: add GET /session-messages batch read API (TiDB only)

### DIFF
--- a/server/internal/domain/errors.go
+++ b/server/internal/domain/errors.go
@@ -26,3 +26,6 @@ func (e *ValidationError) Error() string {
 func (e *ValidationError) Unwrap() error {
 	return ErrValidation
 }
+
+// ErrNotImplemented is returned by repository methods not supported by the current backend.
+var ErrNotImplemented = errors.New("not implemented")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -167,6 +167,9 @@ func (s *Server) Router(
 		r.Get("/imports", s.listTasks)
 		r.Get("/imports/{id}", s.getTask)
 
+		// Session messages (TiDB backend only).
+		r.Get("/session-messages", s.handleListSessionMessages)
+
 	})
 
 	r.Route("/v1alpha2/mem9s", func(r chi.Router) {
@@ -181,6 +184,9 @@ func (s *Server) Router(
 		r.Post("/imports", s.createTask)
 		r.Get("/imports", s.listTasks)
 		r.Get("/imports/{id}", s.getTask)
+
+		// Session messages (TiDB backend only).
+		r.Get("/session-messages", s.handleListSessionMessages)
 	})
 
 	return r

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -323,4 +324,44 @@ func tagsAtIndex(tags [][]string, i int) []string {
 		return tags[i]
 	}
 	return []string{}
+}
+
+// handleListSessionMessages handles GET /session-messages
+// Returns raw session messages for one or more session_id values.
+// Query params:
+//   - session_id (repeatable, required)
+//   - limit_per_session (optional positive integer)
+func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	svc := s.resolveServices(auth)
+
+	sessionIDs := r.URL.Query()["session_id"]
+	if len(sessionIDs) == 0 {
+		s.handleError(w, &domain.ValidationError{Field: "session_id", Message: "at least one session_id is required"})
+		return
+	}
+
+	limitPerSession := 0
+	if raw := r.URL.Query().Get("limit_per_session"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			s.handleError(w, &domain.ValidationError{Field: "limit_per_session", Message: "must be a positive integer"})
+			return
+		}
+		limitPerSession = n
+	}
+
+	messages, err := svc.session.ListBySessionIDs(r.Context(), sessionIDs, limitPerSession)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotImplemented) {
+			respondError(w, http.StatusNotImplemented, "session-messages API not supported on this backend")
+			return
+		}
+		s.handleError(w, err)
+		return
+	}
+	if messages == nil {
+		messages = []*domain.Session{}
+	}
+	respond(w, http.StatusOK, map[string]any{"messages": messages})
 }

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -71,4 +71,10 @@ type SessionRepo interface {
 	FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error)
 	KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error)
 	FTSAvailable() bool
+
+	// ListBySessionIDs returns raw session messages for the given session IDs.
+	// If limitPerSession > 0, at most that many messages are returned per session.
+	// Results are ordered by created_at ASC, seq ASC, id ASC.
+	// Returns domain.ErrNotImplemented for backends that do not support this operation.
+	ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error)
 }

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -378,3 +378,95 @@ func fillSessionMemory(m *domain.Memory, sessionID, agentID, source, role, conte
 	m.Metadata = metaBytes
 	return m
 }
+
+// ListBySessionIDs returns raw session messages for the given session IDs.
+// If limitPerSession > 0, at most that many rows are returned per session_id,
+// using a window function (ROW_NUMBER). Results are ordered by
+// created_at ASC, seq ASC, id ASC.
+func (r *SessionRepo) ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+
+	// Deduplicate session IDs.
+	seen := make(map[string]struct{}, len(sessionIDs))
+	unique := sessionIDs[:0:len(sessionIDs)]
+	unique = unique[:0]
+	for _, id := range sessionIDs {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+	}
+
+	placeholders := make([]string, len(unique))
+	args := make([]any, len(unique))
+	for i, id := range unique {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	inClause := strings.Join(placeholders, ", ")
+
+	const cols = `id, session_id, agent_id, source, seq, role, content, content_type,
+		content_hash, tags, state, created_at, updated_at`
+
+	var sqlQuery string
+	if limitPerSession > 0 {
+		sqlQuery = fmt.Sprintf(`
+			SELECT %s FROM (
+				SELECT %s,
+					ROW_NUMBER() OVER (
+						PARTITION BY session_id
+						ORDER BY created_at ASC, seq ASC, id ASC
+					) AS rn
+				FROM sessions
+				WHERE session_id IN (%s) AND state = 'active'
+			) t WHERE rn <= ?
+			ORDER BY session_id ASC, created_at ASC, seq ASC, id ASC`,
+			cols, cols, inClause)
+		args = append(args, limitPerSession)
+	} else {
+		sqlQuery = fmt.Sprintf(`
+			SELECT %s
+			FROM sessions
+			WHERE session_id IN (%s) AND state = 'active'
+			ORDER BY session_id ASC, created_at ASC, seq ASC, id ASC`,
+			cols, inClause)
+	}
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return nil, nil
+		}
+		slog.Error("list by session ids failed", "cluster_id", r.clusterID, "err", err)
+		return nil, fmt.Errorf("list by session ids: cluster_id=%s: %w", r.clusterID, err)
+	}
+	defer rows.Close()
+
+	var results []*domain.Session
+	for rows.Next() {
+		var s domain.Session
+		var tagsJSON []byte
+		var agentID, source, contentType sql.NullString
+		if err := rows.Scan(
+			&s.ID, &s.SessionID, &agentID, &source,
+			&s.Seq, &s.Role, &s.Content, &contentType,
+			&s.ContentHash, &tagsJSON, &s.State,
+			&s.CreatedAt, &s.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("list by session ids scan: %w", err)
+		}
+		s.AgentID = agentID.String
+		s.Source = source.String
+		s.ContentType = contentType.String
+		if len(tagsJSON) > 0 {
+			_ = json.Unmarshal(tagsJSON, &s.Tags)
+		}
+		results = append(results, &s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list by session ids rows: %w", err)
+	}
+	return results, nil
+}

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -49,6 +49,11 @@ func (s *SessionService) BulkCreate(ctx context.Context, agentName string, req I
 	}
 	return nil
 }
+// ListBySessionIDs returns raw session messages for the given session IDs.
+// If limitPerSession > 0, at most that many messages are returned per session.
+func (s *SessionService) ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error) {
+	return s.sessions.ListBySessionIDs(ctx, sessionIDs, limitPerSession)
+}
 
 func (s *SessionService) Search(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
 	limit := f.Limit

--- a/server/internal/service/session_test.go
+++ b/server/internal/service/session_test.go
@@ -62,6 +62,10 @@ func (s *stubSessionRepo) KeywordSearch(_ context.Context, _ string, _ domain.Me
 
 func (s *stubSessionRepo) FTSAvailable() bool { return s.ftsAvail }
 
+func (s *stubSessionRepo) ListBySessionIDs(_ context.Context, _ []string, _ int) ([]*domain.Session, error) {
+	return nil, nil
+}
+
 func newTestSessionService(repo *stubSessionRepo) *SessionService {
 	return NewSessionService(repo, nil, "")
 }
@@ -293,3 +297,7 @@ func (c *capturingSessionRepo) KeywordSearch(ctx context.Context, q string, f do
 	return c.stub.KeywordSearch(ctx, q, f, limit)
 }
 func (c *capturingSessionRepo) FTSAvailable() bool { return c.stub.FTSAvailable() }
+
+func (c *capturingSessionRepo) ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error) {
+	return c.stub.ListBySessionIDs(ctx, sessionIDs, limitPerSession)
+}


### PR DESCRIPTION
## Summary

Adds a new read endpoint to retrieve raw session messages by one or more `session_id` values.

Closes #110

## API

```
GET /session-messages?session_id=a&session_id=b&limit_per_session=2
```

**Params:**
- `session_id` — repeatable, required; at least one must be provided
- `limit_per_session` — optional positive integer; when set, returns at most N messages per session using `ROW_NUMBER() OVER (PARTITION BY session_id)`

**Response:**
```json
{"messages": [{"id": "...", "session_id": "...", "role": "user", "content": "...", ...}]}
```

- Flat `messages[]` array; `session_id` included on every item
- Ordered by `session_id ASC, created_at ASC, seq ASC, id ASC`
- Only `state = 'active'` rows returned

## Changes

| Layer | File | Change |
|---|---|---|
| Domain | `domain/errors.go` | Add `ErrNotImplemented` sentinel |
| Repository | `repository/repository.go` | Add `ListBySessionIDs` to `SessionRepo` interface |
| Repository | `repository/tidb/sessions.go` | Implement `ListBySessionIDs` with window-function for `limit_per_session` |
| Service | `service/session.go` | Thin pass-through `ListBySessionIDs` |
| Handler | `handler/memory.go` | `handleListSessionMessages` handler |
| Router | `handler/handler.go` | Register route on both `v1alpha1` and `v1alpha2` |
| Tests | `service/session_test.go` | Add `ListBySessionIDs` to test stubs |

## Backend support

- **TiDB**: fully implemented
- **postgres / db9**: returns `ErrNotImplemented` → HTTP 501 (per interface contract; can opt in later)