### PR TITLE
fix: improve session search quality and observability

### DIFF
--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -188,6 +188,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		// SessionService.Search preserves SessionID/Source filters from the caller — intentional:
 		// session-scoped filtering is meaningful for the sessions table. MemoryService.Search
 		// resets these fields to broaden memory recall; the asymmetry is by design.
+		// session.Search is all-or-nothing: returns (results, nil) or (nil, err), never partial results + err.
+		// total is only incremented on success, so the response total stays consistent with the slice length.
 		sessionMems, sessErr := svc.session.Search(r.Context(), filter)
 		if sessErr != nil {
 			slog.Warn("session search failed", "cluster_id", auth.ClusterID, "err", sessErr)

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -82,6 +82,8 @@ func (s *SessionService) Search(ctx context.Context, f domain.MemoryFilter) ([]d
 	if err != nil {
 		return nil, err
 	}
+	// All search paths return results sorted by score descending; dedupByContent
+	// therefore retains the highest-scored occurrence for each unique content string.
 	return dedupByContent(results), nil
 }
 
@@ -201,7 +203,7 @@ func dedupByContent(mems []domain.Memory) []domain.Memory {
 // each message N times. Identical messages in different sessions or roles are always
 // distinct (session_id and role are part of the input).
 //
-// TODO: migrate to SHA-256(role+content) — dropping sessionID from the hash keeps
+// TODO(content-hash-migration): migrate to SHA-256(role+content) — dropping sessionID from the hash keeps
 // the same write-time dedup guarantee (the unique index is (session_id, content_hash),
 // so cross-session collisions are still impossible) while making content_hash
 // comparable across sessions. That would let the search path dedup by content_hash


### PR DESCRIPTION
## Summary

- **Dedup session results by content** — when multiple sessions contain an identical message, `SessionService.Search` now returns only the highest-scored occurrence. This avoids sending redundant tokens to plugins with no information gain.
- **Align default search limit** — handler and service now both use `service.DefaultSessionLimit` (10) so the default is defined once and consistent.
- **Improve log observability** — session search failure log now includes `cluster_id`, matching the pattern used everywhere else in the handler.

## Changes

### `server/internal/service/session.go`
- Export `DefaultSessionLimit = 10` const
- Refactor `Search` to single result variable so `dedupByContent` applies on all search paths
- Add `dedupByContent` helper: keeps first (highest-scored) occurrence per unique content string
- Add TODO on `sessionContentHash` to migrate to `SHA-256(role+content)` for future SQL-level dedup

### `server/internal/handler/memory.go`
- `slog.Warn("session search failed", ...)` now includes `"cluster_id", auth.ClusterID`
- Default limit uses `service.DefaultSessionLimit` instead of hard-coded `50`