### PR TITLE
fix: format memory values and enhance composition chart layout

### DIFF
--- a/dashboard/app/src/components/space/memory-composition-chart.tsx
+++ b/dashboard/app/src/components/space/memory-composition-chart.tsx
@@ -223,21 +223,21 @@ export function MemoryCompositionChart({
                 onMouseEnter={() => setActiveKey(segment.key)}
                 onMouseLeave={() => setActiveKey(null)}
                 className={cn(
-                  "rounded-xl border px-3 py-2 text-left transition-colors",
+                  "rounded-xl border px-3 py-2 text-left transition-colors min-w-0 overflow-hidden",
                   isActive
                     ? "border-foreground/12 bg-foreground/[0.04]"
                     : "border-transparent bg-secondary/45 hover:border-foreground/8 hover:bg-secondary/70",
                 )}
               >
-                <div className="flex items-center justify-between gap-3">
-                  <span className="inline-flex items-center gap-2 text-sm text-foreground">
+                <div className="flex items-center justify-between gap-2 min-w-0">
+                  <span className="inline-flex min-w-0 items-center gap-2 text-xs text-foreground">
                     <span
-                      className="size-2 rounded-full"
+                      className="size-2 shrink-0 rounded-full"
                       style={{ backgroundColor: `var(${segment.colorToken})` }}
                     />
-                    {t(segment.labelKey)}
+                    <span className="truncate">{t(segment.labelKey)}</span>
                   </span>
-                  <span className="font-mono text-xs text-soft-foreground">
+                  <span className="shrink-0 font-mono text-xs text-soft-foreground">
                     {compactFormatter.format(segment.value)}
                   </span>
                 </div>


### PR DESCRIPTION
before:
![img_v3_02vv_69235ce2-53b3-4505-9c6d-5bc76d2e470g](https://github.com/user-attachments/assets/f7e821c2-ec01-443b-8a4a-7669b4ef4325)

after:
<img width="1206" height="1108" alt="image" src="https://github.com/user-attachments/assets/5f9eca18-18b5-48b6-9eb8-5ee6e7ef9472" />
<img width="906" height="1074" alt="image" src="https://github.com/user-attachments/assets/46dff032-37f6-49cc-b30c-9874367496a3" />
