### PR TITLE
Memory Insight: bubble relation mesh and richer bubble animations

### DIFF
--- a/dashboard/app/src/components/space/memory-insight-overview.tsx
+++ b/dashboard/app/src/components/space/memory-insight-overview.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/space/memory-insight-layout";
 import {
   formatInsightCategoryLabel,
+  normalizeInsightCategoryKey,
   type MemoryInsightEntityNode,
   type MemoryInsightMemoryNode,
   type MemoryInsightNodeKind,
@@ -83,6 +84,15 @@ type PanState = {
 type PositionedNode = LaneRenderableItem & {
   position: InsightPoint;
   muted?: boolean;
+};
+
+type RootBubbleRelationEdge = {
+  id: string;
+  sourceId: string;
+  targetId: string;
+  sharedMemoryCount: number;
+  sharedTagCount: number;
+  strength: number;
 };
 
 const DRIFT_SEEDS = [
@@ -252,6 +262,105 @@ function sortMemoryNodes(memoryNodes: MemoryInsightMemoryNode[]): MemoryInsightM
   );
 }
 
+function buildRootBubbleRelationEdges(input: {
+  cards: AnalysisCategoryCard[];
+  memories: Memory[];
+  matchMap: Map<string, MemoryAnalysisMatch>;
+}): RootBubbleRelationEdge[] {
+  const { cards, memories, matchMap } = input;
+  if (cards.length < 2 || memories.length === 0) {
+    return [];
+  }
+
+  const cardByCategory = new Map<string, string>();
+  cards.forEach((card) => {
+    cardByCategory.set(normalizeInsightCategoryKey(card.category), `card:${card.category}`);
+  });
+  const cardIDs = new Set(cardByCategory.values());
+
+  const tagSetsByCardID = new Map<string, Set<string>>();
+  const aggregateByPair = new Map<string, Omit<RootBubbleRelationEdge, "id" | "strength">>();
+  const pairKey = (left: string, right: string) => {
+    return left < right ? `${left}=>${right}` : `${right}=>${left}`;
+  };
+
+  memories.forEach((memory) => {
+    const match = matchMap.get(memory.id);
+    if (!match || match.categories.length === 0) {
+      return;
+    }
+
+    const cardIDsForMemory = Array.from(new Set(
+      match.categories
+        .map((category) => cardByCategory.get(normalizeInsightCategoryKey(category)))
+        .filter((value): value is string => typeof value === "string"),
+    ));
+
+    if (cardIDsForMemory.length < 2) {
+      return;
+    }
+
+    const normalizedTags = new Set(
+      memory.tags
+        .map((tag) => tag.trim().toLowerCase())
+        .filter((tag) => tag.length > 0),
+    );
+
+    cardIDsForMemory.forEach((cardID) => {
+      if (!cardIDs.has(cardID)) {
+        return;
+      }
+      let tagSet = tagSetsByCardID.get(cardID);
+      if (!tagSet) {
+        tagSet = new Set<string>();
+        tagSetsByCardID.set(cardID, tagSet);
+      }
+      normalizedTags.forEach((tag) => tagSet.add(tag));
+    });
+
+    for (let index = 0; index < cardIDsForMemory.length; index += 1) {
+      for (let compareIndex = index + 1; compareIndex < cardIDsForMemory.length; compareIndex += 1) {
+        const sourceId = cardIDsForMemory[index]!;
+        const targetId = cardIDsForMemory[compareIndex]!;
+        const key = pairKey(sourceId, targetId);
+        const previous = aggregateByPair.get(key);
+        aggregateByPair.set(key, {
+          sourceId: sourceId < targetId ? sourceId : targetId,
+          targetId: sourceId < targetId ? targetId : sourceId,
+          sharedMemoryCount: (previous?.sharedMemoryCount ?? 0) + 1,
+          sharedTagCount: previous?.sharedTagCount ?? 0,
+        });
+      }
+    }
+  });
+
+  aggregateByPair.forEach((aggregate, key) => {
+    const sourceTags = tagSetsByCardID.get(aggregate.sourceId) ?? new Set<string>();
+    const targetTags = tagSetsByCardID.get(aggregate.targetId) ?? new Set<string>();
+    let sharedTagCount = 0;
+    sourceTags.forEach((tag) => {
+      if (targetTags.has(tag)) {
+        sharedTagCount += 1;
+      }
+    });
+    aggregateByPair.set(key, {
+      ...aggregate,
+      sharedTagCount,
+    });
+  });
+
+  const edges = Array.from(aggregateByPair.values())
+    .map((edge) => ({
+      ...edge,
+      strength: edge.sharedMemoryCount + Math.min(edge.sharedTagCount, 10) * 0.4,
+      id: `${edge.sourceId}=>${edge.targetId}`,
+    }))
+    .filter((edge) => edge.sharedMemoryCount > 0 || edge.sharedTagCount >= 2)
+    .sort((left, right) => right.strength - left.strength || right.sharedMemoryCount - left.sharedMemoryCount);
+
+  return edges;
+}
+
 function omitKeys<T extends Record<string, unknown>>(record: T, keys: string[]): T {
   if (keys.length === 0) {
     return record;
@@ -373,19 +482,20 @@ function InsightNodeButton({
       {bubble ? (
         <>
           <span
-            className="memory-insight-bubble-core"
+            className={cn(
+              "memory-insight-bubble-core",
+              active ? "memory-insight-bubble-core-paused" : "",
+            )}
             style={{
               width: diameter,
               height: diameter,
+              ...(active ? undefined : driftStyle),
             }}
           >
+            <span className="memory-insight-bubble-halo absolute inset-[-16px] rounded-full" />
             <span className="memory-insight-bubble-shell absolute inset-0 rounded-full" />
             <span
-              className={cn(
-                "memory-insight-bubble-visual absolute inset-[3px] rounded-full",
-                active ? "memory-insight-bubble-visual-paused" : "",
-              )}
-              style={active ? undefined : driftStyle}
+              className="memory-insight-bubble-visual absolute inset-[3px] rounded-full"
             />
           </span>
           <span className="memory-insight-bubble-label mt-2 block w-full px-1">
@@ -1230,6 +1340,51 @@ function MemoryInsightCanvas({
     [canvasNodes, laneAnchors.positions, laneHeights, laneWidth, poolLayout.height, rootRegionOffsetX, rootRegionWidth, safeViewportWidth, viewportMinHeight],
   );
 
+  const rootRelationEdges = useMemo(() => {
+    const edges = buildRootBubbleRelationEdges({
+      cards: poolCards,
+      memories,
+      matchMap,
+    });
+    if (edges.length === 0) {
+      return [];
+    }
+
+    const maxStrength = edges[0]?.strength ?? 1;
+    return edges
+      .map((edge) => {
+        const sourcePosition = poolLayout.positions[edge.sourceId];
+        const targetPosition = poolLayout.positions[edge.targetId];
+        if (!sourcePosition || !targetPosition) {
+          return null;
+        }
+        const sourceCard = poolCards.find((card) => `card:${card.category}` === edge.sourceId);
+        const targetCard = poolCards.find((card) => `card:${card.category}` === edge.targetId);
+        if (!sourceCard || !targetCard) {
+          return null;
+        }
+        const sourceDiameter = bubbleDiameter(sourceCard.count, maxCardCount, compact);
+        const targetDiameter = bubbleDiameter(targetCard.count, maxCardCount, compact);
+        const intensity = Math.min(edge.strength / Math.max(maxStrength, 1), 1);
+        const sourceX = rootRegionOffsetX + sourcePosition.x + sourceDiameter / 2;
+        const sourceY = sourcePosition.y + sourceDiameter / 2;
+        const targetX = rootRegionOffsetX + targetPosition.x + targetDiameter / 2;
+        const targetY = targetPosition.y + targetDiameter / 2;
+
+        return {
+          ...edge,
+          sourceX,
+          sourceY,
+          targetX,
+          targetY,
+          intensity,
+          strokeWidth: 1 + intensity * 3.8,
+          opacity: 0.12 + intensity * 0.5,
+        };
+      })
+      .filter((edge): edge is NonNullable<typeof edge> => edge !== null);
+  }, [compact, matchMap, maxCardCount, memories, poolCards, poolLayout.positions, rootRegionOffsetX]);
+
   const summaryParts = useMemo(() => {
     const parts = [t("memory_insight.summary_root", { count: graph.cards.length })];
     if (expandedCards.length > 0) {
@@ -1358,6 +1513,31 @@ function MemoryInsightCanvas({
               >
                 {t("memory_insight.canvas_hint")}
               </div>
+
+              {rootRelationEdges.length > 0 ? (
+                <svg
+                  aria-hidden
+                  className="pointer-events-none absolute inset-0 z-[1]"
+                  width={canvasBounds.width}
+                  height={canvasBounds.height}
+                  viewBox={`0 0 ${canvasBounds.width} ${canvasBounds.height}`}
+                  preserveAspectRatio="none"
+                >
+                  {rootRelationEdges.map((edge) => (
+                    <line
+                      key={edge.id}
+                      x1={edge.sourceX}
+                      y1={edge.sourceY}
+                      x2={edge.targetX}
+                      y2={edge.targetY}
+                      stroke="color-mix(in srgb, var(--type-insight) 76%, transparent)"
+                      strokeWidth={edge.strokeWidth}
+                      strokeLinecap="round"
+                      opacity={edge.opacity}
+                    />
+                  ))}
+                </svg>
+              ) : null}
 
               {canvasNodes.map((node, index) => {
                 const isRootBubble = node.kind === "card" && !expandedCardSet.has(node.id);

--- a/dashboard/app/src/index.css
+++ b/dashboard/app/src/index.css
@@ -205,6 +205,12 @@ h1, h2, h3, h4 {
   box-shadow: none;
   transform-origin: center;
   will-change: transform, box-shadow, filter;
+  animation: insight-bubble-drift var(--insight-drift-duration, 22s) ease-in-out infinite alternate;
+  animation-delay: var(--insight-drift-delay, 0s);
+  transition:
+    transform 280ms ease,
+    box-shadow 280ms ease,
+    filter 280ms ease;
 }
 
 .memory-insight-bubble-core::before,
@@ -229,6 +235,21 @@ h1, h2, h3, h4 {
   filter: blur(12px);
 }
 
+.memory-insight-bubble-halo {
+  z-index: 0;
+  opacity: 0.42;
+  background:
+    radial-gradient(circle at 42% 38%, color-mix(in srgb, white 78%, transparent) 0%, transparent 36%),
+    radial-gradient(circle, color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 24%, transparent) 0%, transparent 74%);
+  filter: blur(11px);
+  transform: scale(0.9);
+  transition:
+    opacity 300ms ease,
+    transform 300ms ease,
+    filter 300ms ease;
+  animation: insight-bubble-halo-pulse 5.8s ease-in-out infinite;
+}
+
 .memory-insight-bubble-core::after {
   inset: 0;
   z-index: 1;
@@ -243,21 +264,19 @@ h1, h2, h3, h4 {
 
 .memory-insight-bubble-visual {
   z-index: 2;
-  animation: insight-bubble-drift var(--insight-drift-duration, 22s) ease-in-out infinite alternate;
-  animation-delay: var(--insight-drift-delay, 0s);
   background: color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 18%, var(--background));
   box-shadow: none;
   transform-origin: center;
-  will-change: transform, box-shadow, filter;
+  will-change: box-shadow, filter;
   transition:
-    transform 260ms ease,
     box-shadow 260ms ease,
     filter 260ms ease,
     background 260ms ease;
+  animation: insight-bubble-sheen 8s ease-in-out infinite alternate;
 }
 
-.memory-insight-bubble:active .memory-insight-bubble-visual,
-.memory-insight-bubble-visual-paused {
+.memory-insight-bubble:active .memory-insight-bubble-core,
+.memory-insight-bubble-core-paused {
   animation-play-state: paused;
 }
 
@@ -272,16 +291,26 @@ h1, h2, h3, h4 {
 }
 
 .memory-insight-bubble:hover .memory-insight-bubble-core {
-  box-shadow: 0 0 24px color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 16%, transparent);
+  transform: scale(1.05);
+  box-shadow: 0 0 30px color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 24%, transparent);
+  filter: saturate(1.1);
 }
 
 .memory-insight-bubble:hover .memory-insight-bubble-visual {
-  background: color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 24%, var(--background));
-  filter: saturate(1.08);
+  background: color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 30%, var(--background));
+  filter: saturate(1.16);
   box-shadow: none;
 }
 
+.memory-insight-bubble:hover .memory-insight-bubble-halo,
+.memory-insight-bubble[data-active="true"] .memory-insight-bubble-halo {
+  opacity: 0.75;
+  transform: scale(1.05);
+  filter: blur(12px);
+}
+
 .memory-insight-bubble[data-active="true"] .memory-insight-bubble-core {
+  transform: scale(1.03);
   box-shadow: 0 0 20px color-mix(in srgb, var(--insight-bubble-color, var(--type-insight)) 14%, transparent);
 }
 
@@ -308,8 +337,12 @@ h1, h2, h3, h4 {
 
 .memory-insight-bubble[data-dragging="true"] .memory-insight-bubble-visual {
   animation: none;
-  transform: none;
   filter: none;
+}
+
+.memory-insight-bubble[data-dragging="true"] .memory-insight-bubble-core {
+  animation: none;
+  transform: none;
 }
 
 [data-testid^="insight-node-"].memory-insight-bubble > span.relative {
@@ -354,4 +387,15 @@ h1, h2, h3, h4 {
       0
     ) scale(0.996);
   }
+}
+
+@keyframes insight-bubble-halo-pulse {
+  0%,
+  100% { opacity: 0.38; transform: scale(0.88); }
+  50% { opacity: 0.64; transform: scale(1.04); }
+}
+
+@keyframes insight-bubble-sheen {
+  0% { filter: brightness(0.98) saturate(0.96); }
+  100% { filter: brightness(1.08) saturate(1.08); }
 }


### PR DESCRIPTION
### Motivation
- Surface cross-category relationships between root bubbles so users can see a network (mesh) of related categories inferred from shared memory hits and overlapping tags. 
- Fix visual drift artifacts where inner and outer bubble layers moved independently and make bubble motion and hover interactions feel more expressive and discoverable. 
- Improve discovery in the browse view by giving relationship signals (lines) and stronger hover/active feedback so users can better explore memory topology at a glance.

### Description
- Added a relation inference routine `buildRootBubbleRelationEdges` that aggregates co-hit categories and shared tags from `Memory` + `MemoryAnalysisMatch` data to produce weighted edges between root bubbles. 
- Computed `rootRelationEdges` in the canvas with positions, intensity, `strokeWidth` and `opacity` and rendered them as an SVG layer so stronger relations appear darker/thicker and form a mesh. 
- Reworked bubble motion so the whole `.memory-insight-bubble-core` now animates (drift seeds applied to the core) to eliminate split/overlapping double-circle movement, and paused animation during drag/active states. 
- Added a visual halo/aura element and sheen animation (`insight-bubble-halo`, `insight-bubble-sheen`) plus stronger hover/active scale, glow and saturation rules to make bubbles more expressive. 
- Minor DOM/CSS adjustments in `InsightNodeButton` to include the halo and updated class usage, and imported `normalizeInsightCategoryKey` for category-to-card mapping.
- Files changed: `dashboard/app/src/components/space/memory-insight-overview.tsx` and `dashboard/app/src/index.css`.

### Testing
- Ran TypeScript build check with `cd dashboard/app && pnpm typecheck`, which completed successfully. 
- Ran unit tests for the modified component with `cd dashboard/app && pnpm vitest run src/components/space/memory-insight-overview.test.tsx`, and all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf30d581f88324b7dea527599e48ed)