### PR TITLE
Fix TiDB auto-embedding fallback and migration

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -92,6 +92,11 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		actual, loaded := s.svcCache.LoadOrStore(key, svc)
 		if !loaded {
 			go func() {
+				if err := s.tenant.EnsureMemoriesAutoEmbedding(context.Background(), auth.TenantDB); err != nil {
+					s.logger.Warn("memories auto-embedding migration failed",
+						"cluster_id", auth.ClusterID,
+						"err", err)
+				}
 				if err := s.tenant.EnsureSessionsTable(context.Background(), auth.TenantDB); err != nil {
 					s.logger.Warn("sessions table migration failed",
 						"cluster_id", auth.ClusterID,
@@ -115,6 +120,12 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	actual, loaded := s.svcCache.LoadOrStore(key, svc)
 	if !loaded {
 		go func() {
+			if err := s.tenant.EnsureMemoriesAutoEmbedding(context.Background(), auth.TenantDB); err != nil {
+				s.logger.Warn("memories auto-embedding migration failed",
+					"cluster_id", auth.ClusterID,
+					"tenant", auth.TenantID,
+					"err", err)
+			}
 			if err := s.tenant.EnsureSessionsTable(context.Background(), auth.TenantDB); err != nil {
 				s.logger.Warn("sessions table migration failed",
 					"cluster_id", auth.ClusterID,

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -300,7 +301,17 @@ func (s *MemoryService) autoHybridSearch(ctx context.Context, filter domain.Memo
 
 	vecResults, vecErr := s.memories.AutoVectorSearch(ctx, filter.Query, filter, fetchLimit)
 	if vecErr != nil {
-		return nil, 0, fmt.Errorf("auto vector search: %w", vecErr)
+		// When the embedding column is not yet GENERATED ALWAYS AS (EMBED_TEXT(...)) STORED,
+		// TiDB rejects the query. Degrade gracefully to keyword/FTS search so that reads
+		// still succeed while the background schema migration (EnsureMemoriesAutoEmbedding)
+		// runs. The error is logged so operators can track when this happens.
+		if isEmbedColumnSchemaError(vecErr) {
+			slog.Warn("auto vector search unavailable: embedding column not EMBED_TEXT-generated; degrading to keyword search",
+				"err", vecErr)
+			vecResults = nil
+		} else {
+			return nil, 0, fmt.Errorf("auto vector search: %w", vecErr)
+		}
 	}
 
 	minScore := filter.MinScore
@@ -580,6 +591,14 @@ type BulkMemoryInput struct {
 	Content  string          `json:"content"`
 	Tags     []string        `json:"tags,omitempty"`
 	Metadata json.RawMessage `json:"metadata,omitempty"`
+}
+
+// isEmbedColumnSchemaError returns true when TiDB rejects a VEC_EMBED_COSINE_DISTANCE
+// call because the embedding column is not GENERATED ALWAYS AS (EMBED_TEXT(...)) STORED.
+// This happens when the schema was created from schema.sql (plain VECTOR NULL column)
+// rather than from BuildMemorySchema with autoModel set.
+func isEmbedColumnSchemaError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "EMBED_TEXT")
 }
 
 func validateMemoryInput(content string, tags []string) error {

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
@@ -183,12 +184,87 @@ func (s *TenantService) GetInfo(ctx context.Context, tenantID string) (*domain.T
 	}, nil
 }
 
+// EnsureMemoriesAutoEmbedding migrates the memories.embedding column to
+// GENERATED ALWAYS AS (EMBED_TEXT(...)) STORED when MNEMO_EMBED_AUTO_MODEL is set
+// but the column is still a plain VECTOR NULL column (e.g. created from schema.sql).
+// This is a no-op when autoModel is not configured or the column is already GENERATED.
+func (s *TenantService) EnsureMemoriesAutoEmbedding(ctx context.Context, db *sql.DB) error {
+	if s.autoModel == "" || s.autoDims == 0 {
+		return nil
+	}
+
+	var extra string
+	err := db.QueryRowContext(ctx,
+		`SELECT EXTRA FROM INFORMATION_SCHEMA.COLUMNS
+		 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'memories' AND COLUMN_NAME = 'embedding'`,
+	).Scan(&extra)
+	if err == sql.ErrNoRows {
+		slog.Warn("memories.embedding column not found; skipping auto-embedding migration")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("check embedding column: %w", err)
+	}
+
+	// Already a generated column — nothing to do.
+	if strings.Contains(strings.ToUpper(extra), "GENERATED") {
+		return nil
+	}
+
+	slog.Warn("memories.embedding is a plain VECTOR column; migrating to EMBED_TEXT-generated column",
+		"model", s.autoModel, "dims", s.autoDims)
+
+	// First try the simple in-place ALTER path.
+	_, _ = db.ExecContext(ctx, `ALTER TABLE memories DROP INDEX idx_cosine`)
+
+	sanitizedModel := strings.ReplaceAll(s.autoModel, "'", "''")
+	alterSQL := fmt.Sprintf(
+		`ALTER TABLE memories MODIFY COLUMN embedding VECTOR(%d) GENERATED ALWAYS AS (EMBED_TEXT('%s', content, '{"dimensions": %d}')) STORED`,
+		s.autoDims, sanitizedModel, s.autoDims,
+	)
+	if _, err := db.ExecContext(ctx, alterSQL); err != nil {
+		// Some TiDB versions reject changing a plain column into a generated column in-place.
+		// Rebuild the table into the correct shape and swap it in.
+		if strings.Contains(err.Error(), "newCol IsGenerated true, oldCol IsGenerated false") {
+			if rebuildErr := s.rebuildMemoriesTableWithAutoEmbedding(ctx, db); rebuildErr != nil {
+				return fmt.Errorf("migrate embedding column via rebuild: %w (original alter error: %v)", rebuildErr, err)
+			}
+		} else {
+			return fmt.Errorf(
+				"migrate embedding column: run manually: ALTER TABLE memories MODIFY COLUMN embedding VECTOR(%d) GENERATED ALWAYS AS (EMBED_TEXT('%s', content, '{\"dimensions\": %d}')) STORED: %w",
+				s.autoDims, s.autoModel, s.autoDims, err,
+			)
+		}
+	}
+
+	_, err = db.ExecContext(ctx,
+		`ALTER TABLE memories ADD VECTOR INDEX idx_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`)
+	if err != nil && !tenant.IsIndexExistsError(err) {
+		slog.Warn("failed to add vector index after embedding migration (non-fatal)", "err", err)
+	}
+
+	slog.Info("memories.embedding column migrated to EMBED_TEXT-generated", "model", s.autoModel, "dims", s.autoDims)
+	return nil
+}
+
 func (s *TenantService) EnsureSessionsTable(ctx context.Context, db *sql.DB) error {
 	if _, err := db.ExecContext(ctx, tenant.BuildSessionsSchema(s.autoModel, s.autoDims)); err != nil {
 		return fmt.Errorf("ensure sessions table: create: %w", err)
 	}
 	if s.autoModel != "" {
-		_, err := db.ExecContext(ctx,
+		var extra string
+		err := db.QueryRowContext(ctx,
+			`SELECT EXTRA FROM INFORMATION_SCHEMA.COLUMNS
+			 WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'sessions' AND COLUMN_NAME = 'embedding'`,
+		).Scan(&extra)
+		if err == nil && !strings.Contains(strings.ToUpper(extra), "GENERATED") {
+			slog.Warn("sessions.embedding is a plain VECTOR column; rebuilding table to EMBED_TEXT-generated",
+				"model", s.autoModel, "dims", s.autoDims)
+			if rebuildErr := s.rebuildSessionsTableWithAutoEmbedding(ctx, db); rebuildErr != nil {
+				return fmt.Errorf("ensure sessions table: rebuild: %w", rebuildErr)
+			}
+		}
+		_, err = db.ExecContext(ctx,
 			`ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`)
 		if err != nil && !tenant.IsIndexExistsError(err) {
 			return fmt.Errorf("ensure sessions table: vector index: %w", err)
@@ -200,6 +276,48 @@ func (s *TenantService) EnsureSessionsTable(ctx context.Context, db *sql.DB) err
 		if err != nil && !tenant.IsIndexExistsError(err) {
 			return fmt.Errorf("ensure sessions table: fts index: %w", err)
 		}
+	}
+	return nil
+}
+
+func (s *TenantService) rebuildMemoriesTableWithAutoEmbedding(ctx context.Context, db *sql.DB) error {
+	tmp := "memories_auto_tmp"
+	backup := fmt.Sprintf("memories_backup_%d", time.Now().Unix())
+	createSQL := strings.Replace(tenant.BuildMemorySchema(s.autoModel, s.autoDims), "CREATE TABLE IF NOT EXISTS memories", "CREATE TABLE "+tmp, 1)
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS `+tmp); err != nil {
+		return fmt.Errorf("drop temp memories table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, createSQL); err != nil {
+		return fmt.Errorf("create temp memories table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO `+tmp+` (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, superseded_by, created_at, updated_at)
+		SELECT id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, superseded_by, created_at, updated_at FROM memories`); err != nil {
+		return fmt.Errorf("copy memories data: %w", err)
+	}
+	renameSQL := fmt.Sprintf("RENAME TABLE memories TO %s, %s TO memories", backup, tmp)
+	if _, err := db.ExecContext(ctx, renameSQL); err != nil {
+		return fmt.Errorf("swap memories tables: %w", err)
+	}
+	return nil
+}
+
+func (s *TenantService) rebuildSessionsTableWithAutoEmbedding(ctx context.Context, db *sql.DB) error {
+	tmp := "sessions_auto_tmp"
+	backup := fmt.Sprintf("sessions_backup_%d", time.Now().Unix())
+	createSQL := strings.Replace(tenant.BuildSessionsSchema(s.autoModel, s.autoDims), "CREATE TABLE IF NOT EXISTS sessions", "CREATE TABLE "+tmp, 1)
+	if _, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS `+tmp); err != nil {
+		return fmt.Errorf("drop temp sessions table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, createSQL); err != nil {
+		return fmt.Errorf("create temp sessions table: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `INSERT INTO `+tmp+` (id, session_id, agent_id, source, seq, role, content, content_type, content_hash, tags, state, created_at, updated_at)
+		SELECT id, session_id, agent_id, source, seq, role, content, content_type, content_hash, tags, state, created_at, updated_at FROM sessions`); err != nil {
+		return fmt.Errorf("copy sessions data: %w", err)
+	}
+	renameSQL := fmt.Sprintf("RENAME TABLE sessions TO %s, %s TO sessions", backup, tmp)
+	if _, err := db.ExecContext(ctx, renameSQL); err != nil {
+		return fmt.Errorf("swap sessions tables: %w", err)
 	}
 	return nil
 }

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -69,16 +69,22 @@ CREATE TABLE IF NOT EXISTS memories (
 -- ALTER TABLE memories ADD VECTOR INDEX idx_cosine ((VEC_COSINE_DISTANCE(embedding)));
 
 -- Auto-embedding variant (TiDB Cloud Serverless only):
--- Replace the embedding column above with a generated column:
+-- Replace the embedding column above with a generated column.
+-- Note: use single-quotes for the model name and include the dimensions JSON option.
+-- The server auto-migrates this column on first use when MNEMO_EMBED_AUTO_MODEL is set,
+-- but you can also run the migration manually:
 --
---   embedding VECTOR(1024) GENERATED ALWAYS AS (
---     EMBED_TEXT("tidbcloud_free/amazon/titan-embed-text-v2", content)
---   ) STORED,
+--   ALTER TABLE memories MODIFY COLUMN embedding
+--     VECTOR(1024) GENERATED ALWAYS AS (
+--       EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{"dimensions": 1024}')
+--     ) STORED;
 --
 -- Then add vector index:
---   VECTOR INDEX idx_cosine ((VEC_COSINE_DISTANCE(embedding)))
+--   ALTER TABLE memories ADD VECTOR INDEX idx_cosine ((VEC_COSINE_DISTANCE(embedding)))
+--     ADD_COLUMNAR_REPLICA_ON_DEMAND;
 --
--- Set MNEMO_EMBED_AUTO_MODEL=tidbcloud_free/amazon/titan-embed-text-v2 to enable.
+-- Set MNEMO_EMBED_AUTO_MODEL=tidbcloud_free/amazon/titan-embed-text-v2
+-- and MNEMO_EMBED_AUTO_DIMS=1024 to enable.
 
 
 -- Migration: tombstone -> state (4-step plan).


### PR DESCRIPTION
## Summary

This PR fixes TiDB auto-embedding schema drift and makes search degrade gracefully instead of surfacing hard 500 errors.

## Problem

In the TiDB auto-embedding flow, a tenant can end up with a plain `VECTOR` column instead of a proper `EMBED_TEXT()` generated column.

When that happens:

- memory writes may still succeed
- semantic search can fail at query time with errors like:
  - `VEC_EMBED_COSINE_DISTANCE() first argument must be a vector embedding column generated by EMBED_TEXT()`

So the broken state is subtle: data appears to be written correctly, but recall/search fails later.

## What changed

- detect when `memories.embedding` / `sessions.embedding` are not `EMBED_TEXT()` generated columns
- rebuild the affected tables into the correct TiDB auto-embedding shape when in-place migration is not supported
- recreate vector indexes against the repaired schema
- degrade search gracefully when auto vector search is unavailable instead of returning a hard failure

## Why rebuild is needed

TiDB does not always allow converting a plain vector column into a generated `EMBED_TEXT()` column in place.

For that reason, the repair path falls back to:

1. creating a correctly-shaped replacement table
2. copying the data
3. swapping the tables in place

This keeps the fix practical for already-drifted tenants.

## Scope

This PR does **not** change the overall tenant model or TiDB provisioning flow.
It only repairs schema drift for TiDB auto-embedding tables and prevents search from failing hard while the schema is not yet usable for vector search.

## Validation

Validated against TiDB Cloud with auto embedding enabled:

- `mnemo-server` starts successfully
- memory creation succeeds
- auto-embedding schema is repaired into `STORED GENERATED`
- hybrid search succeeds again after migration
- OpenClaw -> mem9 -> TiDB flow was verified end to end
