### PR TITLE
ingest: recover from LLM flattened-fact JSON corruption

### DIFF
--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -348,10 +348,14 @@ func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agen
 }
 
 // normalizeParsedFacts converts []ExtractedFact from a successful parse into a
-// clean slice, and falls back to legacy string-array format when the primary
-// parse succeeded structurally but produced no facts (which happens when the
-// model returns the old {"facts":["text"]} schema — json.Unmarshal silently
-// produces Facts:nil on a type mismatch inside a slice element).
+// clean slice, and falls back to progressively looser formats when the primary
+// parse succeeded structurally but produced no facts:
+//
+//  1. Legacy string-array: {"facts":["text"]} — json.Unmarshal silently
+//     produces Facts:nil on a type mismatch inside a slice element.
+//  2. Flattened-fact: {"facts":":[{","text":"...","tags":[...]} — a recurring
+//     model glitch where the array opening bleeds into the key's string value
+//     and the intended fact fields are emitted as top-level keys instead.
 func normalizeParsedFacts(raw string, parsed []ExtractedFact) []ExtractedFact {
 	var out []ExtractedFact
 	for _, f := range parsed {
@@ -367,11 +371,14 @@ func normalizeParsedFacts(raw string, parsed []ExtractedFact) []ExtractedFact {
 	if len(out) > 0 {
 		return out
 	}
+
+	cleaned := llm.StripMarkdownFences(raw)
+
+	// Fallback 1: legacy string-array {"facts":["text1","text2"]}.
 	type legacyResponse struct {
 		Facts []string `json:"facts"`
 	}
 	var legacy legacyResponse
-	cleaned := llm.StripMarkdownFences(raw)
 	if err := json.Unmarshal([]byte(cleaned), &legacy); err == nil {
 		for _, t := range legacy.Facts {
 			t = strings.TrimSpace(t)
@@ -382,6 +389,26 @@ func normalizeParsedFacts(raw string, parsed []ExtractedFact) []ExtractedFact {
 		if len(legacy.Facts) > 0 && len(out) == 0 {
 			slog.Warn("normalizeParsedFacts: legacy facts array had entries but all were empty after trim",
 				"legacy_count", len(legacy.Facts))
+		}
+	}
+	if len(out) > 0 {
+		return out
+	}
+
+	// Fallback 2: flattened-fact corruption pattern.
+	// The model emits {"facts":":[{","text":"...","tags":[...]} — "facts" is a
+	// garbage string, but the actual fact fields are top-level keys.  Recover
+	// the fact when a top-level "text" field is present.
+	type flattenedFact struct {
+		Facts interface{} `json:"facts"`
+		Text  string      `json:"text"`
+		Tags  []string    `json:"tags"`
+	}
+	var flat flattenedFact
+	if err := json.Unmarshal([]byte(cleaned), &flat); err == nil {
+		if t := strings.TrimSpace(flat.Text); t != "" {
+			slog.Warn("normalizeParsedFacts: recovered fact from flattened-fact corruption", "text", t)
+			out = append(out, ExtractedFact{Text: t, Tags: flat.Tags})
 		}
 	}
 	return out
@@ -436,7 +463,7 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 	lastRaw := raw
 	if err != nil {
 		raw2, retryErr := s.llm.CompleteJSON(ctx, systemPrompt,
-			"Your previous response was not valid JSON. Return ONLY the JSON object.\n\n"+userPrompt)
+			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt)
 		if retryErr != nil {
 			return nil, fmt.Errorf("extraction retry: %w", retryErr)
 		}
@@ -534,7 +561,7 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 	lastRaw := raw
 	if err != nil {
 		raw2, retryErr := s.llm.CompleteJSON(ctx, systemPrompt,
-			"Your previous response was not valid JSON. Return ONLY the JSON object.\n\n"+userPrompt)
+			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt)
 		if retryErr != nil {
 			return nil, nil, fmt.Errorf("extraction retry: %w", retryErr)
 		}

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1865,6 +1865,100 @@ func TestExtractFactsAlternativeKeyReturnsZero(t *testing.T) {
 	}
 }
 
+func makeFlattenedFactServer(raw string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": raw}},
+			},
+		})
+	}))
+}
+
+func TestExtractFactsFlattenedFactNoTextNoTags(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"facts":":[{",": ":", "}`
+	srv := makeFlattenedFactServer(raw)
+	defer srv.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: srv.URL, Model: "test-model"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	_, err := svc.extractFacts(context.Background(), "User: hello")
+	if err == nil {
+		t.Fatal("expected error for unrecoverable junk response, got nil")
+	}
+}
+
+func TestExtractFactsFlattenedFactTagsOnly(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"facts":":[{","tags":["mnemos","api","testing"]}`
+	srv := makeFlattenedFactServer(raw)
+	defer srv.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: srv.URL, Model: "test-model"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	_, err := svc.extractFacts(context.Background(), "User: hello")
+	if err == nil {
+		t.Fatal("expected error when flattened-fact has tags but no text, got nil")
+	}
+}
+
+func TestExtractFactsFlattenedFactWithText(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"facts":":[{","text":"mnemos API smoke test round-2 uses a poll loop to wait for async memory creation","tags":["mnemos","api","testing"]}`
+	srv := makeFlattenedFactServer(raw)
+	defer srv.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: srv.URL, Model: "test-model"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	facts, err := svc.extractFacts(context.Background(), "User: hello")
+	if err != nil {
+		t.Fatalf("extractFacts() error = %v", err)
+	}
+	if len(facts) != 1 {
+		t.Fatalf("expected 1 recovered fact, got %d", len(facts))
+	}
+	want := "mnemos API smoke test round-2 uses a poll loop to wait for async memory creation"
+	if facts[0].Text != want {
+		t.Fatalf("expected text %q, got %q", want, facts[0].Text)
+	}
+	if len(facts[0].Tags) != 3 || facts[0].Tags[0] != "mnemos" {
+		t.Fatalf("expected tags [mnemos api testing], got %v", facts[0].Tags)
+	}
+}
+
+func TestExtractPhase1FlattenedFactWithText(t *testing.T) {
+	t.Parallel()
+
+	raw := `{"facts":":[{","text":"mnemos API smoke test round-2 uses a poll loop to wait for async memory creation","tags":["mnemos","api","testing"]}`
+	srv := makeFlattenedFactServer(raw)
+	defer srv.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: srv.URL, Model: "test-model"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	result, err := svc.ExtractPhase1(context.Background(), []IngestMessage{
+		{Role: "user", Content: "User: hello"},
+	})
+	if err != nil {
+		t.Fatalf("ExtractPhase1() error = %v", err)
+	}
+	if len(result.Facts) != 1 {
+		t.Fatalf("expected 1 recovered fact, got %d", len(result.Facts))
+	}
+	want := "mnemos API smoke test round-2 uses a poll loop to wait for async memory creation"
+	if result.Facts[0].Text != want {
+		t.Fatalf("expected text %q, got %q", want, result.Facts[0].Text)
+	}
+}
+
 func TestReconcileTagsClampedViaReconcilePath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

The dev LLM (Kimi-K2.5 on Azure) intermittently emits malformed JSON during fact
extraction. All observed failures share the same corruption pattern — the array
opening syntax bleeds into the `facts` key's string value, and the actual fact
fields appear as top-level keys:

\`\`\`json
{"facts":":[{","text":"<fact>","tags":["tag1","tag2"]}
\`\`\`

Because the retry prompt never showed the model its own bad output, both the
initial call and the retry failed identically, causing the entire ingest job to
error out and the memory to never materialise.

## Changes

**Better retry prompt** (`extractFacts` + `extractFactsAndTags`)

The retry now includes the model's bad response so it can self-correct:

> "Your previous response was invalid JSON:\n{bad_raw}\n\nFix it and return ONLY the corrected JSON object."

**New fallback in `normalizeParsedFacts`**

Added a third recovery tier for the flattened-fact corruption pattern. When
`facts` is a string (not an array), the fallback unmarshals with
`Facts interface{}` to absorb the corrupt value and recovers the fact from
top-level `text`/`tags` fields if present. Cases with no `text` field remain
errors — nothing to recover.

**Tests** — 4 new cases covering all observed malformed shapes:

| Test | Input | Expected |
|------|-------|----------|
| `TestExtractFactsFlattenedFactNoTextNoTags` | `{"facts":":[{",": ":","}"` | error (unrecoverable) |
| `TestExtractFactsFlattenedFactTagsOnly` | `{"facts":":[{","tags":[...]}` | error (no text field) |
| `TestExtractFactsFlattenedFactWithText` | `{"facts":":[{","text":"...","tags":[...]}` | 1 fact recovered |
| `TestExtractPhase1FlattenedFactWithText` | same via `ExtractPhase1` path | 1 fact recovered |