### PR TITLE
fix(dashboard): remove unused modules

### DIFF
--- a/dashboard/app/src/pages/space.tsx
+++ b/dashboard/app/src/pages/space.tsx
@@ -255,12 +255,6 @@ export function SpacePage() {
         : "",
     [i18n.language, timelineSelection],
   );
-  const compactOverview = shouldCompactMemoryOverview(
-    selected,
-    isDesktopViewport,
-    selectedDetailMode,
-  );
-
   useEffect(() => {
     if (!spaceId) navigate({ to: "/", replace: true });
   }, [spaceId, navigate]);


### PR DESCRIPTION
## Summary
- remove the unused `compactOverview` variable in `dashboard/app/src/pages/space.tsx`
- restore `pnpm typecheck` and `pnpm build` on `main`
- keep the PR scoped to the main-branch regression only

## Verification
- cd dashboard/app && pnpm typecheck
- cd dashboard/app && pnpm build