### PR TITLE
refine(dashboard): track memory farm entry and feedback clicks

### DIFF
--- a/dashboard/app/src/components/pixel-farm/feedback-dialog.test.tsx
+++ b/dashboard/app/src/components/pixel-farm/feedback-dialog.test.tsx
@@ -1,0 +1,21 @@
+import "@/i18n";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import i18n from "@/i18n";
+import { PixelFarmFeedbackDialog } from "./feedback-dialog";
+
+describe("PixelFarmFeedbackDialog", () => {
+  it("adds Mixpanel metadata to the feedback trigger button", () => {
+    const { container } = render(<PixelFarmFeedbackDialog />);
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[data-mp-event="Dashboard/MemoryFarm/FeedbackOpenClicked"]',
+    );
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("data-mp-page-name", "memory-farm");
+
+    fireEvent.click(button!);
+    expect(screen.getByText(i18n.t("pixel_farm.feedback.title"))).toBeInTheDocument();
+  });
+});

--- a/dashboard/app/src/components/pixel-farm/feedback-dialog.tsx
+++ b/dashboard/app/src/components/pixel-farm/feedback-dialog.tsx
@@ -54,6 +54,8 @@ export function PixelFarmFeedbackDialog() {
       <button
         type="button"
         onClick={handleOpen}
+        data-mp-event="Dashboard/MemoryFarm/FeedbackOpenClicked"
+        data-mp-page-name="memory-farm"
         className="absolute bottom-4 left-4 z-20 flex cursor-pointer items-center gap-2 rounded-md border-[2px] border-[#3f3322] bg-[#f6dca6] px-3 py-2 text-[11px] font-bold uppercase tracking-wider text-[#3f3322] shadow-[2px_2px_0px_0px_#3f3322] transition-all hover:bg-[#ffe8b6] active:translate-y-[2px] active:shadow-none"
       >
         <MessageSquareWarning className="h-3.5 w-3.5" />

--- a/dashboard/app/src/components/space/memory-farm-promo-card.test.tsx
+++ b/dashboard/app/src/components/space/memory-farm-promo-card.test.tsx
@@ -1,0 +1,28 @@
+import "@/i18n";
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryFarmPromoCard } from "./memory-farm-promo-card";
+
+describe("MemoryFarmPromoCard", () => {
+  it("adds Mixpanel metadata to the CTA button", () => {
+    const onAction = vi.fn();
+    const { container } = render(
+      <MemoryFarmPromoCard
+        status="ready"
+        onAction={onAction}
+      />,
+    );
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[data-mp-event="Dashboard/MemoryFarm/EnterClicked"]',
+    );
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("data-mp-page-name", "space");
+    expect(button).toHaveAttribute("data-mp-entry-point", "promo-card");
+    expect(button).toHaveAttribute("data-mp-status", "ready");
+
+    fireEvent.click(button!);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/app/src/components/space/memory-farm-promo-card.tsx
+++ b/dashboard/app/src/components/space/memory-farm-promo-card.tsx
@@ -63,6 +63,10 @@ export function MemoryFarmPromoCard({
           </p>
           <button 
             onClick={onAction}
+            data-mp-event="Dashboard/MemoryFarm/EnterClicked"
+            data-mp-page-name="space"
+            data-mp-entry-point="promo-card"
+            data-mp-status={status}
             className={`flex shrink-0 items-center gap-1.5 border-2 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider transition-all active:translate-y-[2px] active:shadow-none ${
               status === "ready" 
                 ? "border-[#294c34] bg-[#5fa861] text-[#fff0c6] shadow-[2px_2px_0px_0px_#294c34] hover:bg-[#6cba6e]" 


### PR DESCRIPTION
## Summary
- add `Dashboard/MemoryFarm/EnterClicked` to the Space promo CTA
- add `Dashboard/MemoryFarm/FeedbackOpenClicked` to the Memory Farm feedback button
- add lightweight component tests for both buttons