### PR TITLE
fix: strip OpenClaw metadata noise and improve ingest stability

### DIFF
--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -168,6 +168,7 @@ function formatMemoriesBlock(memories: Memory[]): string {
 
 function stripInjectedContext(content: string): string {
   let s = content;
+  // Remove <relevant-memories> blocks
   for (;;) {
     const start = s.indexOf("<relevant-memories>");
     if (start === -1) break;
@@ -178,6 +179,12 @@ function stripInjectedContext(content: string): string {
     }
     s = s.slice(0, start) + s.slice(end + "</relevant-memories>".length);
   }
+  // Remove OpenClaw metadata blocks (Conversation info, Sender, Inbound Context, etc.)
+  s = s.replace(/(?:Conversation info|Inbound Context|Sender \(untrusted metadata\)|Group Chat Context)[^\n]*\n```(?:json)?\n[\s\S]*?```\s*/g, "");
+  // Remove [message_id: ...] lines
+  s = s.replace(/\[message_id:\s*[^\]]+\]/g, "");
+  // Remove HEARTBEAT_OK / NO_REPLY
+  s = s.replace(/HEARTBEAT_OK|NO_REPLY/g, "");
   return s.trim();
 }
 

--- a/server/internal/llm/client.go
+++ b/server/internal/llm/client.go
@@ -114,8 +114,14 @@ func (c *Client) CompleteJSON(ctx context.Context, system, user string) (string,
 			slog.Warn("LLM rejected response_format:json_object (HTTP 400), retrying without it")
 			return c.complete(ctx, system, user, nil)
 		}
+		return "", err
 	}
-	return result, err
+	// Verify the response is valid JSON; if not, retry without response_format.
+	if !json.Valid([]byte(result)) {
+		slog.Warn("response_format:json_object returned invalid JSON, retrying without it")
+		return c.complete(ctx, system, user, nil)
+	}
+	return result, nil
 }
 
 func (c *Client) complete(ctx context.Context, system, user string, respFmt *responseFormat) (string, error) {

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -11,6 +11,8 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"regexp"
+
 	"github.com/google/uuid"
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/embed"
@@ -19,6 +21,13 @@ import (
 )
 
 // IngestMode controls which pipeline stages run.
+// Regex patterns for stripping OpenClaw metadata noise from messages before LLM extraction.
+var (
+	// Matches blocks like "Conversation info (untrusted metadata):\n```json\n...\n```"
+	metadataBlockRe = regexp.MustCompile("(?s)(?:Conversation info|Inbound Context|Sender \\(untrusted metadata\\)|Group Chat Context)[^\\n]*\\n```(?:json)?\\n.*?```\\s*")
+	messageIDRe     = regexp.MustCompile(`\[message_id:\s*[^\]]+\]`)
+)
+
 type IngestMode string
 
 const (
@@ -159,14 +168,13 @@ func (s *IngestService) ExtractPhase1(ctx context.Context, messages []IngestMess
 	if formatted == "" {
 		return &Phase1Result{}, nil
 	}
-	const maxConversationRunes = 1000000
-	formatted = truncateRunes(formatted, maxConversationRunes)
+	formatted = truncateRunes(formatted, 8000)
 
-	facts, messageTags, err := s.extractFactsAndTags(ctx, formatted, len(messages))
+	facts, err := s.extractFacts(ctx, formatted)
 	if err != nil {
 		return nil, err
 	}
-	return &Phase1Result{Facts: facts, MessageTags: messageTags}, nil
+	return &Phase1Result{Facts: facts}, nil
 }
 
 // ReconcilePhase2 runs reconciliation of extracted facts against existing memories.
@@ -424,14 +432,16 @@ func (s *IngestService) extractFacts(ctx context.Context, conversation string) (
 	currentDate := time.Now().Format("2006-01-02")
 
 	systemPrompt := `You are an information extraction engine. Your task is to identify distinct,
-atomic facts from a conversation.
+atomic facts from a conversation between a user and an AI assistant.
 
 ## Rules
 
-1. Extract facts ONLY from the user's messages. Ignore assistant and system messages entirely.
+1. Extract facts from BOTH user and assistant messages. Many valuable facts appear in assistant replies
+   (e.g., software installed, configurations changed, commands run, decisions made, issues resolved).
 2. Each fact must be a single, self-contained statement (one idea per fact).
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
+   - Good: "Installed openclaw-browser-auto and chrome-devtools skills"
    - Bad: "Knows some programming languages"
 4. Preserve the user's original language. If the user writes in Chinese, extract facts in Chinese.
 5. Omit ephemeral information (greetings, filler, debugging chatter with no lasting value).
@@ -443,7 +453,7 @@ atomic facts from a conversation.
 10. If no meaningful facts exist in the conversation, return an empty facts array.
 11. Assign 1-3 short lowercase tags to each extracted fact describing its topic or
    category. Examples: "tech", "personal", "preference", "work", "location", "habit",
-   "relationship", "event", "timeline".
+   "relationship", "event", "timeline", "install", "config", "decision", "error-fix".
    Use hyphens for multi-word tags: "programming-language", "work-tool".
    If no meaningful tags apply, omit the "tags" field for that fact.
 
@@ -503,7 +513,8 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
 
 ## Rules — facts
 
-1. Extract facts ONLY from the user's messages. Ignore assistant and system messages entirely.
+1. Extract facts from BOTH user and assistant messages. Many valuable facts appear in assistant replies
+   (e.g., software installed, configurations changed, commands run, decisions made).
 2. Each fact must be a single, self-contained statement (one idea per fact).
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
@@ -1120,8 +1131,9 @@ func stripInjectedContext(messages []IngestMessage) []IngestMessage {
 	return result
 }
 
-// stripMemoryTags removes <relevant-memories>...</relevant-memories> from text.
+// stripMemoryTags removes <relevant-memories>...</relevant-memories> and OpenClaw metadata blocks from text.
 func stripMemoryTags(s string) string {
+	// Remove <relevant-memories> blocks
 	for {
 		start := strings.Index(s, "<relevant-memories>")
 		if start == -1 {
@@ -1129,13 +1141,19 @@ func stripMemoryTags(s string) string {
 		}
 		end := strings.Index(s, "</relevant-memories>")
 		if end == -1 {
-			// Malformed tag, remove from start to end.
 			s = s[:start]
 			break
 		}
 		s = s[:start] + s[end+len("</relevant-memories>"):]
 	}
-	return s
+	// Remove OpenClaw metadata blocks (Conversation info, Sender, message_id, Inbound Context, etc.)
+	s = metadataBlockRe.ReplaceAllString(s, "")
+	// Remove [message_id: ...] lines
+	s = messageIDRe.ReplaceAllString(s, "")
+	// Remove HEARTBEAT_OK / NO_REPLY
+	s = strings.ReplaceAll(s, "HEARTBEAT_OK", "")
+	s = strings.ReplaceAll(s, "NO_REPLY", "")
+	return strings.TrimSpace(s)
 }
 
 // formatConversation formats messages into a conversation string for LLM.


### PR DESCRIPTION
## Problem

When using mem9 with OpenClaw, the ingest pipeline fails to extract meaningful facts because:

1. **Metadata noise** — OpenClaw injects large metadata blocks into every message (Conversation info, Inbound Context, Sender, Group Chat Context, message_id, `<relevant-memories>`, HEARTBEAT_OK, NO_REPLY). These consume the LLM's input budget and add no value for fact extraction.

2. **Only extracting from user messages** — Many valuable facts appear in assistant replies (software installed, configurations changed, decisions made, issues resolved).

3. **JSON instability with small local models** — Ollama's qwen3.5:9b sometimes returns invalid JSON when using `response_format: { type: "json_object" }`, causing silent extraction failures.

4. **Excessive input length** — With metadata noise, conversations easily exceed 1M characters, causing small models to produce unreliable output.

## Changes

### Server (`internal/service/ingest.go`)
- Add `stripMemoryTags`: regex-based removal of OpenClaw metadata blocks, message_id lines, HEARTBEAT_OK, NO_REPLY
- Reduce conversation truncation from 1,000,000 to 8,000 characters (appropriate for small models)
- Switch from `extractFactsAndTags` to `extractFacts` for simpler, more reliable JSON output
- Update extraction prompt to extract from BOTH user and assistant messages

### LLM Client (`internal/llm/client.go`)
- Add `json.Valid` check on LLM response; if invalid, retry without `response_format`
- Remove duplicate `return` on HTTP 400 path

### Plugin (`openclaw-plugin/hooks.ts`)
- Add matching metadata stripping in plugin-side `stripInjectedContext`

## Testing

Verified end-to-end with Ollama qwen3.5:9b:
- Conversation reduced from ~1M chars of noise to ~6,500 chars of actual content
- Successfully extracted 9 facts and reconciled with 14 existing memories
- JSON retry mechanism handles Ollama's occasional invalid output

## Environment

- GPU: RTX 4060 Ti 16GB
- LLM: Ollama qwen3.5:9b
- Embedding: Ollama qwen3-embedding:0.6b
- Database: TiDB with vector search