### PR TITLE
fix(dashboard): restore remembered-aware memory farm entry

### DIFF
--- a/dashboard/app/src/components/space/memory-farm-promo-card.test.tsx
+++ b/dashboard/app/src/components/space/memory-farm-promo-card.test.tsx
@@ -1,28 +1,58 @@
 import "@/i18n";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { MemoryFarmPromoCard } from "./memory-farm-promo-card";
 
 describe("MemoryFarmPromoCard", () => {
-  it("adds Mixpanel metadata to the CTA button", () => {
+  it("renders a split CTA with a remembered-only new-tab option", async () => {
     const onAction = vi.fn();
     const { container } = render(
       <MemoryFarmPromoCard
+        canOpenInNewTab
+        href="/your-memory/labs/memory-farm"
         status="ready"
         onAction={onAction}
       />,
     );
 
-    const button = container.querySelector<HTMLButtonElement>(
+    const cta = container.querySelector<HTMLButtonElement>(
       'button[data-mp-event="Dashboard/MemoryFarm/EnterClicked"]',
     );
 
-    expect(button).toBeInTheDocument();
-    expect(button).toHaveAttribute("data-mp-page-name", "space");
-    expect(button).toHaveAttribute("data-mp-entry-point", "promo-card");
-    expect(button).toHaveAttribute("data-mp-status", "ready");
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute("data-mp-page-name", "space");
+    expect(cta).toHaveAttribute("data-mp-entry-point", "promo-card");
+    expect(cta).toHaveAttribute("data-mp-status", "ready");
+    expect(screen.queryByText("New tab:")).not.toBeInTheDocument();
 
-    fireEvent.click(button!);
+    fireEvent.click(cta!);
     expect(onAction).toHaveBeenCalledTimes(1);
+
+    const menuTrigger = screen.getByRole("button", { name: "More options" });
+    menuTrigger.focus();
+    fireEvent.keyDown(menuTrigger, { key: "Enter" });
+
+    const menuItem = await screen.findByRole("menuitem", {
+      name: "Enter Farm in new tab",
+    });
+
+    expect(menuItem).toBeInTheDocument();
+    expect(menuItem).toHaveAttribute("href", "/your-memory/labs/memory-farm");
+    expect(menuItem).toHaveAttribute("target", "_blank");
+    expect(menuItem).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(menuItem).toHaveAttribute("data-mp-page-name", "space");
+    expect(menuItem).toHaveAttribute("data-mp-entry-point", "promo-card-menu");
+    expect(menuItem).toHaveTextContent("Enter Farm");
+    expect(menuItem).toHaveTextContent("(new tab)");
+  });
+
+  it("keeps a single current-tab CTA when new-tab access is unavailable", () => {
+    render(
+      <MemoryFarmPromoCard status="ready" onAction={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Enter Farm" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "More options" })).not.toBeInTheDocument();
+    expect(screen.queryByText("new tab")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/app/src/components/space/memory-farm-promo-card.tsx
+++ b/dashboard/app/src/components/space/memory-farm-promo-card.tsx
@@ -1,12 +1,23 @@
 import type { MemoryFarmEntryStatus } from "./use-memory-farm-entry-state";
-import { Loader2 } from "lucide-react";
+import { ChevronDown, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ButtonGroup } from "@/components/ui/button-group";
 
 export function MemoryFarmPromoCard({
   status,
+  canOpenInNewTab = false,
+  href,
   onAction,
 }: {
   status: MemoryFarmEntryStatus;
+  canOpenInNewTab?: boolean;
+  href?: string;
   onAction: () => void;
 }) {
   const { t } = useTranslation();
@@ -23,6 +34,19 @@ export function MemoryFarmPromoCard({
     statusText = t("memory_farm_preview.status.unavailable");
     ctaLabel = t("memory_farm_preview.cta.unavailable");
   }
+
+  const hasNewTabMenu = status === "ready" && canOpenInNewTab && typeof href === "string";
+  const ctaClassName = `flex shrink-0 items-center gap-1.5 border-2 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider transition-all active:translate-y-[2px] active:shadow-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
+    status === "ready"
+      ? "border-primary bg-primary text-primary-foreground shadow-[2px_2px_0px_0px_rgba(0,0,0,0.2)] hover:opacity-90"
+      : "border-border bg-muted text-foreground shadow-[2px_2px_0px_0px_rgba(0,0,0,0.1)] hover:bg-accent"
+  }`;
+  const splitButtonGroupClassName =
+    "border-2 border-primary bg-primary text-primary-foreground shadow-[2px_2px_0px_0px_rgba(0,0,0,0.2)]";
+  const splitButtonActionClassName =
+    "flex items-center gap-1.5 bg-primary px-2.5 py-1.5 text-[11px] font-bold uppercase tracking-wider transition-all hover:bg-primary/90 focus-visible:relative focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50";
+  const splitButtonMenuClassName =
+    "relative flex items-center justify-center bg-primary/82 px-1.5 transition-all hover:bg-primary/74 focus-visible:relative focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 before:absolute before:left-0 before:top-1 before:bottom-1 before:w-[2px] before:bg-primary-foreground/60";
 
   // Use a fallback if the image doesn't exist, though spec says to use a committed static image
   const promoImageUrl = new URL("../../assets/promo/memory-farm-preview-card.png", import.meta.url).href;
@@ -58,24 +82,87 @@ export function MemoryFarmPromoCard({
         </p>
 
         <div className="mt-4 flex items-center justify-between gap-3">
-          <p className="text-[10px] font-bold uppercase tracking-wider text-soft-foreground flex-1">
-            {statusText}
-          </p>
-          <button
-            onClick={onAction}
-            data-mp-event="Dashboard/MemoryFarm/EnterClicked"
-            data-mp-page-name="space"
-            data-mp-entry-point="promo-card"
-            data-mp-status={status}
-            className={`flex shrink-0 items-center gap-1.5 border-2 px-3 py-1.5 text-[11px] font-bold uppercase tracking-wider transition-all active:translate-y-[2px] active:shadow-none ${
-              status === "ready"
-                ? "border-primary bg-primary text-primary-foreground shadow-[2px_2px_0px_0px_rgba(0,0,0,0.2)] hover:opacity-90"
-                : "border-border bg-muted text-foreground shadow-[2px_2px_0px_0px_rgba(0,0,0,0.1)] hover:bg-accent"
-            }`}
-          >
-            {status === "preparing" && <Loader2 className="size-3 animate-spin" />}
-            {ctaLabel}
-          </button>
+          <div className="flex-1">
+            <p className="text-[10px] font-bold uppercase tracking-wider text-soft-foreground">
+              {statusText}
+            </p>
+          </div>
+          {hasNewTabMenu ? (
+            <ButtonGroup
+              aria-label={t("memory_farm_preview.cta.ready")}
+              className={splitButtonGroupClassName}
+            >
+              <button
+                type="button"
+                onClick={onAction}
+                data-mp-event="Dashboard/MemoryFarm/EnterClicked"
+                data-mp-page-name="space"
+                data-mp-entry-point="promo-card"
+                data-mp-status={status}
+                className={splitButtonActionClassName}
+              >
+                {ctaLabel}
+              </button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={t("memory_farm_preview.cta.more_actions")}
+                    className={splitButtonMenuClassName}
+                  >
+                    <ChevronDown className="size-3.5" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  sideOffset={6}
+                  className="min-w-[156px] rounded-none border-2 border-border bg-card p-1 text-foreground shadow-[2px_2px_0px_0px_rgba(0,0,0,0.12)]"
+                  style={{ fontFamily: '"Ark Pixel Mono", monospace' }}
+                >
+                  <DropdownMenuItem
+                    asChild
+                    className="cursor-pointer rounded-none px-3 py-2 text-[11px] font-bold tracking-wide text-foreground focus:bg-muted focus:text-foreground"
+                  >
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      data-mp-event="Dashboard/MemoryFarm/OpenInNewTabClicked"
+                      data-mp-page-name="space"
+                      data-mp-entry-point="promo-card-menu"
+                      data-mp-status={status}
+                      aria-label={t("memory_farm_preview.cta.enter_in_new_tab")}
+                      className="inline-flex items-center gap-1.5"
+                    >
+                      <span>{ctaLabel}</span>
+                      <span className="text-[10px] font-medium tracking-[0.08em] text-soft-foreground">
+                        (
+                      </span>
+                      <span className="text-[10px] font-medium tracking-[0.08em] text-soft-foreground">
+                        {t("memory_farm_preview.cta.new_tab")}
+                      </span>
+                      <span className="text-[10px] font-medium tracking-[0.08em] text-soft-foreground">
+                        )
+                      </span>
+                    </a>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </ButtonGroup>
+          ) : (
+            <button
+              type="button"
+              onClick={onAction}
+              data-mp-event="Dashboard/MemoryFarm/EnterClicked"
+              data-mp-page-name="space"
+              data-mp-entry-point="promo-card"
+              data-mp-status={status}
+              className={ctaClassName}
+            >
+              {status === "preparing" && <Loader2 className="size-3 animate-spin" />}
+              {ctaLabel}
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/dashboard/app/src/components/space/space-page-layout.tsx
+++ b/dashboard/app/src/components/space/space-page-layout.tsx
@@ -50,6 +50,7 @@ interface SpacePageLayoutProps {
   routeState: SpaceRouteState;
   dataModel: SpaceDataModel;
   t: TFunction;
+  canOpenFarmInNewTab: boolean;
   addOpen: boolean;
   setAddOpen: Dispatch<SetStateAction<boolean>>;
   editTarget: Memory | null;
@@ -79,6 +80,7 @@ export function SpacePageLayout({
   routeState,
   dataModel,
   t,
+  canOpenFarmInNewTab,
   addOpen,
   setAddOpen,
   editTarget,
@@ -549,6 +551,8 @@ export function SpacePageLayout({
             <div className="w-full shrink-0 py-8 xl:order-1 xl:py-8 xl:w-[312px] 2xl:w-[320px]">
               <MemoryFarmPromoCard
                 status={dataModel.farmEntryStatus}
+                canOpenInNewTab={canOpenFarmInNewTab}
+                href="/your-memory/labs/memory-farm"
                 onAction={onHandleFarmAction}
               />
               <AnalysisPanel

--- a/dashboard/app/src/components/ui/button-group.tsx
+++ b/dashboard/app/src/components/ui/button-group.tsx
@@ -1,0 +1,48 @@
+import type * as React from "react";
+import { cn } from "@/lib/utils";
+
+function ButtonGroup({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<"div"> & {
+  orientation?: "horizontal" | "vertical";
+}) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(
+        "inline-flex shrink-0 items-stretch overflow-hidden",
+        orientation === "vertical" ? "flex-col" : "flex-row",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"span"> & {
+  orientation?: "horizontal" | "vertical";
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      data-slot="button-group-separator"
+      data-orientation={orientation}
+      className={cn(
+        "shrink-0 bg-current/20",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { ButtonGroup, ButtonGroupSeparator };

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -539,7 +539,10 @@
     "cta": {
       "ready": "Enter Farm",
       "preparing": "Preparing",
-      "unavailable": "View Status"
+      "unavailable": "View Status",
+      "new_tab": "new tab",
+      "enter_in_new_tab": "Enter Farm in new tab",
+      "more_actions": "More options"
     },
     "dialog": {
       "preparing_title": "Preparing Memory Farm Preview",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -539,7 +539,10 @@
     "cta": {
       "ready": "进入农场",
       "preparing": "准备中",
-      "unavailable": "查看状态"
+      "unavailable": "查看状态",
+      "new_tab": "新标签页",
+      "enter_in_new_tab": "在新标签页进入农场",
+      "more_actions": "更多选项"
     },
     "dialog": {
       "preparing_title": "正在准备 Memory Farm 预览",

--- a/dashboard/app/src/lib/session.ts
+++ b/dashboard/app/src/lib/session.ts
@@ -87,6 +87,14 @@ export function getActiveSpaceId(): string | null {
   return getSpaceId() ?? restoreRememberedSpace();
 }
 
+export function isRememberedSpace(spaceId: string): boolean {
+  if (!spaceId) {
+    return false;
+  }
+
+  return readRememberedSpace()?.spaceId === spaceId;
+}
+
 export function maskSpaceId(id: string): string {
   if (id.length <= 8) return id;
   return `${id.slice(0, 4)}…${id.slice(-4)}`;

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -11,6 +11,7 @@ import { shouldCompactMemoryOverview } from "./space";
 
 const mocks = vi.hoisted(() => ({
   clearSpace: vi.fn(),
+  isRememberedSpace: vi.fn(() => false),
   retry: vi.fn(),
   useStats: vi.fn(),
   useSourceMemories: vi.fn(),
@@ -67,6 +68,22 @@ function getTimelineBucket(index: number): Element {
   }
 
   return bucket;
+}
+
+function getFarmCta(): HTMLElement {
+  const cta = document.querySelector<HTMLElement>(
+    '[data-mp-event="Dashboard/MemoryFarm/EnterClicked"]',
+  );
+
+  if (!cta) {
+    throw new Error("Missing Memory Farm CTA");
+  }
+
+  return cta;
+}
+
+function getFarmMoreActionsTrigger(): HTMLButtonElement {
+  return screen.getByRole("button", { name: "More options" });
 }
 
 function createMemory(
@@ -276,6 +293,7 @@ vi.mock("@/lib/memory-insight-background", async () => {
 vi.mock("@/lib/session", () => ({
   getActiveSpaceId: () => "space-1",
   getSpaceId: () => "space-1",
+  isRememberedSpace: mocks.isRememberedSpace,
   setSpaceId: vi.fn(),
   clearSpace: mocks.clearSpace,
   maskSpaceId: (id: string) => id,
@@ -485,6 +503,8 @@ describe("SpacePage", () => {
     vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW.getTime());
     window.innerWidth = 1440;
     window.dispatchEvent(new Event("resize"));
+    mocks.isRememberedSpace.mockReset();
+    mocks.isRememberedSpace.mockReturnValue(false);
     mocks.useStats.mockClear();
     mocks.useSourceMemories.mockClear();
     mocks.useMemories.mockClear();
@@ -560,6 +580,61 @@ describe("SpacePage", () => {
     await waitFor(() => {
       expect(mocks.useStats).toHaveBeenCalledWith("space-1", undefined, true);
     });
+  });
+
+  it("navigates to memory farm in the current tab when remember is off", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderSpacePage();
+
+    expect(screen.queryByRole("button", { name: "More options" })).not.toBeInTheDocument();
+
+    fireEvent.click(getFarmCta());
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/labs/memory-farm");
+    });
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("shows a remembered-only new-tab menu for memory farm", async () => {
+    mocks.isRememberedSpace.mockReturnValue(true);
+
+    renderSpacePage();
+
+    expect(screen.queryByText("New tab:")).not.toBeInTheDocument();
+    expect(getFarmMoreActionsTrigger()).toBeInTheDocument();
+
+    const menuTrigger = getFarmMoreActionsTrigger();
+    menuTrigger.focus();
+    fireEvent.keyDown(menuTrigger, { key: "Enter" });
+
+    const menuItem = await screen.findByRole("menuitem", { name: "Enter Farm in new tab" });
+
+    expect(menuItem).toHaveAttribute("href", "/your-memory/labs/memory-farm");
+    expect(menuItem).toHaveAttribute("target", "_blank");
+    expect(menuItem).toHaveTextContent("Enter Farm");
+    expect(menuItem).toHaveTextContent("(new tab)");
+  });
+
+  it("keeps current-tab enter as the primary CTA when remember is on", async () => {
+    mocks.isRememberedSpace.mockReturnValue(true);
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    renderSpacePage();
+
+    const cta = getFarmCta();
+
+    expect(cta.tagName).toBe("BUTTON");
+
+    fireEvent.click(cta);
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/labs/memory-farm");
+    });
+
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it("keeps the detail panel closed after the user closes it in analysis mode", async () => {

--- a/dashboard/app/src/pages/space.tsx
+++ b/dashboard/app/src/pages/space.tsx
@@ -8,7 +8,7 @@ import { patchSyncState } from "@/api/local-cache";
 import { SpacePageLayout } from "@/components/space/space-page-layout";
 import { useSpaceDataModel } from "@/components/space/use-space-data-model";
 import { useSpaceRouteState } from "@/components/space/use-space-route-state";
-import { getActiveSpaceId } from "@/lib/session";
+import { getActiveSpaceId, isRememberedSpace } from "@/lib/session";
 import type { Memory } from "@/types/memory";
 import { shouldCompactMemoryOverview } from "@/components/space/space-selectors";
 
@@ -19,6 +19,7 @@ export function SpacePage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const spaceId = getActiveSpaceId() ?? "";
+  const canOpenFarmInNewTab = isRememberedSpace(spaceId);
   const routeState = useSpaceRouteState(spaceId);
   const [addOpen, setAddOpen] = useState(false);
   const [editTarget, setEditTarget] = useState<Memory | null>(null);
@@ -179,6 +180,7 @@ export function SpacePage() {
       routeState={routeState}
       dataModel={dataModel}
       t={t}
+      canOpenFarmInNewTab={canOpenFarmInNewTab}
       addOpen={addOpen}
       setAddOpen={setAddOpen}
       editTarget={editTarget}


### PR DESCRIPTION
## Summary
- restore Memory Farm entry to TanStack Router navigation in the current tab
- only expose a new-tab affordance when the current space is remembered
- replace the promo card hint copy with a remembered-only split CTA and pixel-styled menu

## Testing
- pnpm test -- src/components/space/memory-farm-promo-card.test.tsx src/pages/space.test.tsx