### PR TITLE
enhancemnet(skill): Add memory tools to tools whitelit

### DIFF
--- a/site/public/SKILL.md
+++ b/site/public/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mem9
-version: 1.0.7
+version: 1.0.8
 description: |
   Persistent cloud memory for OpenClaw agents.
 


### PR DESCRIPTION
Env:
- openclaw v2026.3.28
- mem9 0.3.5

Problem:

memory_store, memory_update and memory_update tools will be blocked without the following config

```
  "tools": {
     "profile": "coding"
  }
```

When the user asks OpenCLAW to remember, it can not call the tool to proactively save it to the database. I think it is better to set this configuration when setting up mem9


Needs to add to `alsoAllow `when the user has configured the tools profile, like this

```
  "tools": {
     "profile": "coding"
     "alsoAllow": ["memory_store", "memory_update", "memory_delete"]
  }
```


Test:

has manually tested,  the change works for all the following situation

```
"tools": {
    "alsoAllow": [
      "tools1"
    ]
  }
```

```
"tools": {
    "alsoAllow": [
    ]
  }
```
```
"tools": {
  }
```

// no tools
```

```