### PR TITLE
Preserve session_id for raw memory creates

### DIFF
--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -95,7 +95,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	content := req.Content
 
 	if req.Sync {
-		_, err := svc.memory.Create(r.Context(), agentID, content, tags, metadata)
+		_, err := svc.memory.Create(r.Context(), agentID, req.SessionID, content, tags, metadata)
 		if err != nil {
 			slog.Error("sync memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
 			s.handleError(w, err)
@@ -103,8 +103,8 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		respond(w, http.StatusOK, map[string]string{"status": "ok"})
 	} else {
-		go func(agentName, actorAgentID, content string, tags []string, metadata json.RawMessage) {
-			mem, err := svc.memory.Create(context.Background(), actorAgentID, content, tags, metadata)
+		go func(agentName, actorAgentID, sessionID, content string, tags []string, metadata json.RawMessage) {
+			mem, err := svc.memory.Create(context.Background(), actorAgentID, sessionID, content, tags, metadata)
 			if err != nil {
 				slog.Error("async memory create failed", "agent", actorAgentID, "actor", agentName, "err", err)
 				return
@@ -114,7 +114,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			slog.Info("async memory create complete", "agent", actorAgentID, "actor", agentName, "memory_id", "")
-		}(auth.AgentName, agentID, content, tags, metadata)
+		}(auth.AgentName, agentID, req.SessionID, content, tags, metadata)
 
 		respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 	}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -37,8 +37,8 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 	return nil, domain.ErrNotFound
 }
 func (m *testMemoryRepo) UpdateOptimistic(context.Context, *domain.Memory, int) error { return nil }
-func (m *testMemoryRepo) SoftDelete(context.Context, string, string) error             { return nil }
-func (m *testMemoryRepo) ArchiveMemory(context.Context, string, string) error          { return nil }
+func (m *testMemoryRepo) SoftDelete(context.Context, string, string) error            { return nil }
+func (m *testMemoryRepo) ArchiveMemory(context.Context, string, string) error         { return nil }
 func (m *testMemoryRepo) ArchiveAndCreate(_ context.Context, _, _ string, mem *domain.Memory) error {
 	m.createCalls = append(m.createCalls, mem)
 	return nil
@@ -47,8 +47,8 @@ func (m *testMemoryRepo) SetState(context.Context, string, domain.MemoryState) e
 func (m *testMemoryRepo) List(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
 	return nil, 0, nil
 }
-func (m *testMemoryRepo) Count(context.Context) (int, error)                     { return 0, nil }
-func (m *testMemoryRepo) BulkCreate(context.Context, []*domain.Memory) error     { return nil }
+func (m *testMemoryRepo) Count(context.Context) (int, error)                 { return 0, nil }
+func (m *testMemoryRepo) BulkCreate(context.Context, []*domain.Memory) error { return nil }
 func (m *testMemoryRepo) VectorSearch(context.Context, []float32, domain.MemoryFilter, int) ([]domain.Memory, error) {
 	return nil, nil
 }
@@ -61,8 +61,8 @@ func (m *testMemoryRepo) KeywordSearch(context.Context, string, domain.MemoryFil
 func (m *testMemoryRepo) FTSSearch(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
 	return nil, nil
 }
-func (m *testMemoryRepo) FTSAvailable() bool                                                  { return false }
-func (m *testMemoryRepo) ListBootstrap(context.Context, int) ([]domain.Memory, error)         { return nil, nil }
+func (m *testMemoryRepo) FTSAvailable() bool                                          { return false }
+func (m *testMemoryRepo) ListBootstrap(context.Context, int) ([]domain.Memory, error) { return nil, nil }
 
 // testSessionRepo is a minimal SessionRepo mock for handler tests.
 type testSessionRepo struct {
@@ -130,11 +130,13 @@ func makeRequest(t *testing.T, method, path string, body any) *http.Request {
 }
 
 func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
-	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
 
 	body := map[string]any{
-		"content": "test memory content",
-		"sync":    true,
+		"content":    "test memory content",
+		"session_id": "test-session",
+		"sync":       true,
 	}
 	req := makeRequest(t, http.MethodPost, "/memories", body)
 	rr := httptest.NewRecorder()
@@ -143,6 +145,12 @@ func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("expected 1 create call, got %d", len(memRepo.createCalls))
+	}
+	if memRepo.createCalls[0].SessionID != "test-session" {
+		t.Fatalf("expected session ID propagated, got %q", memRepo.createCalls[0].SessionID)
 	}
 }
 

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -40,7 +40,7 @@ func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, emb
 	}
 }
 
-func (s *MemoryService) Create(ctx context.Context, agentID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, error) {
+func (s *MemoryService) Create(ctx context.Context, agentID, sessionID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, error) {
 	if err := validateMemoryInput(content, tags); err != nil {
 		return nil, err
 	}
@@ -72,6 +72,7 @@ func (s *MemoryService) Create(ctx context.Context, agentID, content string, tag
 			Embedding:  embedding,
 			MemoryType: domain.TypeInsight,
 			AgentID:    agentID,
+			SessionID:  sessionID,
 			State:      domain.StateActive,
 			Version:    1,
 			UpdatedBy:  agentID,

--- a/server/internal/service/memory_test.go
+++ b/server/internal/service/memory_test.go
@@ -461,7 +461,7 @@ func TestCreateFallsBackToRawWhenLLMUnavailable(t *testing.T) {
 	repo := &memoryRepoMock{}
 	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
 
-	mem, err := svc.Create(context.Background(), "agent-1", "user prefers dark mode", []string{"prefs"}, json.RawMessage(`{"source":"manual"}`))
+	mem, err := svc.Create(context.Background(), "agent-1", "session-123", "user prefers dark mode", []string{"prefs"}, json.RawMessage(`{"source":"manual"}`))
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
@@ -476,6 +476,9 @@ func TestCreateFallsBackToRawWhenLLMUnavailable(t *testing.T) {
 	}
 	if mem.MemoryType != domain.TypeInsight {
 		t.Fatalf("expected insight memory type, got %s", mem.MemoryType)
+	}
+	if mem.SessionID != "session-123" {
+		t.Fatalf("expected session ID propagated, got %q", mem.SessionID)
 	}
 }
 
@@ -500,7 +503,7 @@ func TestCreateRunsReconcilePipeline(t *testing.T) {
 	repo := &memoryRepoMock{}
 	svc := NewMemoryService(repo, llmClient, nil, "auto-model", ModeSmart)
 
-	mem, err := svc.Create(context.Background(), "agent-1", "I use Go 1.22", nil, nil)
+	mem, err := svc.Create(context.Background(), "agent-1", "session-123", "I use Go 1.22", nil, nil)
 	if err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}


### PR DESCRIPTION
  ## Summary
  - pass `session_id` through raw content memory creates
  - persist `SessionID` in the no-LLM raw create path
  - add handler/service regression coverage

  ## Why
  LoCoMo writes raw memories with `session_id` and then polls/searches by that
  same session.
  The server accepted `session_id` on `POST /memories` but dropped it in the raw
  content path,
  so writes succeeded but session-scoped reads never found them.

  ## Verification
  - go test ./...
  - go vet ./...