### PR TITLE
Page LoCoMo ingest wait across memory list results

### DIFF
--- a/benchmark/locomo/src/ingest.ts
+++ b/benchmark/locomo/src/ingest.ts
@@ -51,11 +51,24 @@ const formatContent = (sampleId: string, sessionNo: number, turnIndex: number, d
 
 const sleep = async (ms: number): Promise<void> => await new Promise(resolve => setTimeout(resolve, ms))
 
+const countSessionMemories = async (sessionId: string): Promise<number> => {
+  const limit = 200
+  let offset = 0
+  let total = 0
+
+  while (true) {
+    const memories = await searchMemories({ session_id: sessionId, agent_id: getAgentId(), limit, offset })
+    total += memories.length
+    if (memories.length < limit) return total
+    offset += limit
+  }
+}
+
 const waitForSessionMemories = async (sessionId: string, expectedCount: number): Promise<void> => {
   const deadline = Date.now() + 60_000
   while (Date.now() < deadline) {
-    const memories = await searchMemories({ session_id: sessionId, agent_id: getAgentId(), limit: expectedCount })
-    if (memories.length >= expectedCount) return
+    const count = await countSessionMemories(sessionId)
+    if (count >= expectedCount) return
     await sleep(1000)
   }
   throw new Error(`Timed out waiting for mem9 writes for session ${sessionId}`)


### PR DESCRIPTION
  ## Summary
  - page through session-scoped memory list results while waiting for LoCoMo
  ingest writes
  - count all matching memories instead of assuming a single list request can
  observe every write

  ## Why
  The LoCoMo harness waits for all raw memory writes for a sample to become
  searchable
  before evaluation continues. The server caps `/memories` list results, but the
  wait
  logic previously requested `limit=expectedCount` and compared only that single
  page.

  For larger samples like `conv-26`, the expected write count exceeds the API
  page size,
  so the harness would time out even after writes succeeded.

  ## Verification
  - cd benchmark/locomo && npm run typecheck
  - reproduced the timeout on `conv-26` before the fix
  - verified the new wait logic pages through results instead of stalling at the
  API cap