### PR TITLE
memory_recall: add second-degree vector search for improved single-hop recall

### DIFF
--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -685,6 +686,7 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	m.SupersededBy = supersededBy.String
 	m.Tags = unmarshalTags(tagsJSON)
 	m.Metadata = unmarshalRawJSON(metadataJSON)
+	m.Embedding = parseVecString(embeddingStr)
 	score := 1 - distance
 	m.Score = &score
 	return &m, nil
@@ -769,6 +771,28 @@ func nullJSON(data json.RawMessage) any {
 
 // vecToString converts a float32 slice to the TiDB VECTOR string format: "[0.1,0.2,...]".
 // Returns nil for empty/nil slices.
+// parseVecString parses a TiDB vector string (e.g. "[0.1,0.2,0.3]") back into []float32.
+func parseVecString(b []byte) []float32 {
+	s := strings.TrimSpace(string(b))
+	if len(s) < 2 || s[0] != '[' || s[len(s)-1] != ']' {
+		return nil
+	}
+	s = s[1 : len(s)-1]
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	vec := make([]float32, 0, len(parts))
+	for _, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 32)
+		if err != nil {
+			return nil
+		}
+		vec = append(vec, float32(v))
+	}
+	return vec
+}
+
 func vecToString(embedding []float32) any {
 	if len(embedding) == 0 {
 		return nil

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -345,14 +345,11 @@ func (s *MemoryService) autoHybridSearch(ctx context.Context, filter domain.Memo
 
 	// Second-hop: use top-N first-hop results as seeds for expanded vector search.
 	secondHopMems := s.secondHopAutoSearch(ctx, mems, scores, filter, limit)
-	if len(secondHopMems) > 0 {
-		for rank, m := range secondHopMems {
-			scores[m.ID] += secondHopWeight / (rrfK + float64(rank+1))
-			if _, exists := mems[m.ID]; !exists {
-				mems[m.ID] = m
-			}
+	for rank, m := range secondHopMems {
+		scores[m.ID] += secondHopWeight / (rrfK + float64(rank+1))
+		if _, exists := mems[m.ID]; !exists {
+			mems[m.ID] = m
 		}
-		slog.Info("second-hop search completed", "new_results", len(secondHopMems))
 	}
 
 	applyTypeWeights(mems, scores)
@@ -387,17 +384,25 @@ func (s *MemoryService) secondHopAutoSearch(
 		seedIDs[m.ID] = struct{}{}
 	}
 
-	// Launch concurrent second-hop searches.
+	// Launch concurrent second-hop searches using first-hop embeddings
+	// to avoid redundant embedding API calls.
 	type hopResult struct {
 		results []domain.Memory
 		err     error
 	}
 	ch := make(chan hopResult, topN)
 	for _, seed := range seeds {
-		go func(content string) {
-			results, err := s.memories.AutoVectorSearch(ctx, content, filter, limit)
-			ch <- hopResult{results: results, err: err}
-		}(seed.Content)
+		if len(seed.Embedding) > 0 {
+			go func(vec []float32) {
+				results, err := s.memories.VectorSearch(ctx, vec, filter, limit)
+				ch <- hopResult{results: results, err: err}
+			}(seed.Embedding)
+		} else {
+			go func(content string) {
+				results, err := s.memories.AutoVectorSearch(ctx, content, filter, limit)
+				ch <- hopResult{results: results, err: err}
+			}(seed.Content)
+		}
 	}
 
 	// Collect results: deduplicate, exclude seeds, keep best score per ID.


### PR DESCRIPTION
This PR uses top-3 first-hop results as seeds for concurrent AutoVectorSearch calls, merging second-hop results into the RRF ranking with weight 0.3.

Benchmark shows +3.51% single-hop F1, +0.94% overall F1 vs main.