### PR TITLE
e2e: update session smoke test to reflect recall exclusion of session rows

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -85,8 +85,8 @@ concurrent async ingest bumps.
 ### Session storage (`api-smoke-test-sessions.sh`)
 
 Regression tests for raw session storage (PR #103). Provisions a fresh tenant,
-ingests messages, and verifies all session-specific behaviors: unified search,
-`memory_type` filtering, metadata projection, no-query exclusion, and deduplication.
+ingests messages, and verifies all session-specific behaviors: session exclusion from
+unified recall, `memory_type` filtering, metadata projection, no-query exclusion, and deduplication.
 Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
 
 | # | Case | What is verified |
@@ -94,7 +94,7 @@ Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
 | 1 | Provision tenant | `POST /v1alpha1/mem9s` returns 201 |
 | 2 | Session write via messages | `POST /memories {messages}` returns 202 `accepted` |
 | 3 | Poll until sessions appear | `GET /memories?memory_type=session&q=` polled until results appear |
-| 4 | Unified search includes sessions | `GET /memories?q=` returns rows with `memory_type=session` |
+| 4 | Unified search excludes sessions | `GET /memories?q=` returns no `memory_type=session` rows (recall omits sessions by design) |
 | 5 | `memory_type=session` filter | All results have `memory_type=session`; no other types |
 | 6 | `memory_type=insight` excludes sessions | No `memory_type=session` rows when insight filter applied |
 | 7 | Session metadata projection | First session result has `role`, `seq`, `content_type` in `metadata` |

--- a/e2e/api-smoke-test-sessions.sh
+++ b/e2e/api-smoke-test-sessions.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # api-smoke-test-sessions.sh
 # Session storage smoke test: verifies raw session write, deduplication,
-# unified search, memory_type filtering, and metadata projection.
+# memory_type filtering, and metadata projection.
 #
 # Tests covered:
 #   1. Provision tenant
 #   2. Session write via messages — expect 202
-#   3. Poll until sessions appear in unified search
-#   4. Unified search returns memory_type=session rows
+#   3. Poll until sessions appear via memory_type=session filter
+#   4. Unified search (no memory_type) excludes session rows
 #   5. memory_type=session filter returns only sessions
 #   6. memory_type=insight filter excludes sessions
 #   7. Session metadata projection (role, seq, content_type in metadata field)
@@ -157,9 +157,9 @@ check "POST /memories (messages) returns 202" "$code" "202"
 check_contains "response has status=accepted" "$bdy" '"accepted"'
 
 # ============================================================================
-# TEST 3 — Poll until sessions appear in unified search
+# TEST 3 — Poll until sessions appear via memory_type=session filter
 # ============================================================================
-step "3" "Poll until sessions appear in unified search (timeout=${POLL_TIMEOUT_S}s)"
+step "3" "Poll until sessions appear via memory_type=session filter (timeout=${POLL_TIMEOUT_S}s)"
 SESSION_APPEARED=false
 ELAPSED=0
 while [ "$ELAPSED" -lt "$POLL_TIMEOUT_S" ]; do
@@ -203,9 +203,9 @@ if [ "$SESSION_APPEARED" = "false" ]; then
 fi
 
 # ============================================================================
-# TEST 4 — Unified search returns memory_type=session rows
+# TEST 4 — Unified search (no memory_type) excludes session rows
 # ============================================================================
-step "4" "Unified search: GET /memories?q= returns session rows"
+step "4" "Unified search (no memory_type): GET /memories?q= must exclude session rows"
 resp=$(curl_mem_json "$MEM_BASE?q=${UNIQUE_MARKER}&limit=20")
 code=$(http_code "$resp")
 bdy=$(body "$resp")
@@ -216,7 +216,7 @@ import sys, json
 mems = json.load(sys.stdin).get('memories', [])
 print('yes' if any(m.get('memory_type') == 'session' for m in mems) else 'no')
 " 2>/dev/null || true)
-check "unified search includes memory_type=session rows" "$HAS_SESSION" "yes"
+check "unified search excludes memory_type=session rows" "$HAS_SESSION" "no"
 
 # ============================================================================
 # TEST 5 — memory_type=session filter returns ONLY sessions


### PR DESCRIPTION
## What

Update `api-smoke-test-sessions.sh` and `e2e/AGENTS.md` to match the behavior change introduced in #174: unified recall (`?q=` without `memory_type`) no longer returns `memory_type=session` rows.

## Why

Test 4 was asserting that a unified search includes session rows. After #174 changed `handler/memory.go` line 232 from:

```go
if filter.Query != "" && (onlySession || filter.MemoryType == "") {
```

to:

```go
if filter.Query != "" && onlySession {
```

sessions are excluded from unified recall by design and must be queried explicitly via `?memory_type=session`. The old assertion was a false failure, not a bug.

## Changes

- `api-smoke-test-sessions.sh` test 3/4: update step descriptions and flip test 4 assertion from "includes sessions" → "excludes sessions"
- `e2e/AGENTS.md`: update session coverage table row 3/4 and the section description to match