### PR TITLE
feat: add LLM token consumption Prometheus metrics

### DIFF
--- a/server/internal/llm/client.go
+++ b/server/internal/llm/client.go
@@ -85,6 +85,12 @@ type chatResponse struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 		TotalTokens      int `json:"total_tokens"`
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details,omitempty"`
+		// Anthropic-style cache fields (used by some OpenAI-compatible proxies).
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
 	} `json:"usage,omitempty"`
 	Error *struct {
 		Message string `json:"message"`
@@ -213,8 +219,22 @@ func (c *Client) doRequest(ctx context.Context, cr chatRequest) (string, error) 
 
 	metrics.LLMRequestDuration.WithLabelValues(c.model, "success").Observe(duration)
 	if chatResp.Usage != nil {
-		metrics.LLMTokensTotal.WithLabelValues(c.model, "prompt").Add(float64(chatResp.Usage.PromptTokens))
-		metrics.LLMTokensTotal.WithLabelValues(c.model, "completion").Add(float64(chatResp.Usage.CompletionTokens))
+		u := chatResp.Usage
+		metrics.LLMTokensTotal.WithLabelValues(c.model, "input").Add(float64(u.PromptTokens))
+		metrics.LLMTokensTotal.WithLabelValues(c.model, "output").Add(float64(u.CompletionTokens))
+		metrics.LLMTokensTotal.WithLabelValues(c.model, "total").Add(float64(u.TotalTokens))
+
+		// Cache tokens: try OpenAI-style (prompt_tokens_details.cached_tokens), then Anthropic-style.
+		cacheRead := u.CacheReadInputTokens
+		if cacheRead == 0 && u.PromptTokensDetails != nil {
+			cacheRead = u.PromptTokensDetails.CachedTokens
+		}
+		if cacheRead > 0 {
+			metrics.LLMTokensTotal.WithLabelValues(c.model, "cache_read").Add(float64(cacheRead))
+		}
+		if u.CacheCreationInputTokens > 0 {
+			metrics.LLMTokensTotal.WithLabelValues(c.model, "cache_creation").Add(float64(u.CacheCreationInputTokens))
+		}
 	}
 	return content, nil
 }

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -83,6 +83,8 @@ var (
 	)
 
 	// LLMTokensTotal counts LLM token consumption by model and type (prompt/completion).
+	// LLMTokensTotal counts LLM token consumption by model and type.
+	// type: "input" | "output" | "total" | "cache_read" | "cache_creation"
 	LLMTokensTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "mnemo",


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                
                                                                                                                                                                                                                                            
  - Add a new `mnemo_llm_tokens_total` Prometheus counter to track LLM token consumption, broken down by model and type (`input`, `output`, `total`, `cache_read`, `cache_creation`).                                                       
  - Parse the `usage` field from OpenAI-compatible chat completion responses in `llm/client.go` and record token counts after each successful request.                                                                                      
  - Support both OpenAI-style (`prompt_tokens_details.cached_tokens`) and Anthropic-style (`cache_read_input_tokens`, `cache_creation_input_tokens`) cache token reporting.                                                                 
                                                                                                                                                                                                                                            
                                                                                                                                                                                                             
