### PR TITLE
chore: log request id

### DIFF
--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -25,6 +25,7 @@ func main() {
 		Level:     slog.LevelInfo,
 		AddSource: true,
 	}))
+	slog.SetDefault(logger)
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/repository"
+	"github.com/qiffang/mnemos/server/internal/reqid"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
 
@@ -208,7 +209,7 @@ func respondError(w http.ResponseWriter, status int, msg string) {
 }
 
 // handleError maps domain errors to HTTP status codes.
-func (s *Server) handleError(w http.ResponseWriter, err error) {
+func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, domain.ErrNotFound):
 		respondError(w, http.StatusNotFound, err.Error())
@@ -223,7 +224,7 @@ func (s *Server) handleError(w http.ResponseWriter, err error) {
 	case errors.Is(err, domain.ErrNotSupported):
 		respondError(w, http.StatusNotImplemented, err.Error())
 	default:
-		s.logger.Error("internal error", "err", err)
+		s.logger.Error("internal error", "err", err, "request_id", reqid.FromContext(ctx))
 		respondError(w, http.StatusInternalServerError, "internal server error")
 	}
 }
@@ -252,6 +253,7 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
+			r = r.WithContext(reqid.NewContext(r.Context(), chimw.GetReqID(r.Context())))
 			ww := chimw.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(ww, r)
 			// Use route pattern to avoid exposing sensitive path params (e.g. tenantID).

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -30,7 +30,7 @@ type createMemoryRequest struct {
 func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	var req createMemoryRequest
 	if err := decode(r, &req); err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -46,7 +46,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	hasContent := strings.TrimSpace(req.Content) != ""
 
 	if hasMessages && hasContent {
-		s.handleError(w, &domain.ValidationError{Field: "body", Message: "provide either content or messages, not both"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "body", Message: "provide either content or messages, not both"})
 		return
 	}
 
@@ -62,7 +62,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		if req.Sync {
 			result, err := s.ingestMessages(r.Context(), auth, svc, ingestReq)
 			if err != nil {
-				s.handleError(w, err)
+				s.handleError(r.Context(), w, err)
 				return
 			}
 			if result != nil && result.Status == "failed" {
@@ -82,11 +82,11 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !hasContent {
-		s.handleError(w, &domain.ValidationError{Field: "content", Message: "content or messages required"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "content", Message: "content or messages required"})
 		return
 	}
 	if req.Mode != "" {
-		s.handleError(w, &domain.ValidationError{Field: "body", Message: "content mode does not accept mode"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "body", Message: "content mode does not accept mode"})
 		return
 	}
 
@@ -98,7 +98,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		_, err := svc.memory.Create(r.Context(), agentID, content, tags, metadata)
 		if err != nil {
 			slog.Error("sync memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
-			s.handleError(w, err)
+			s.handleError(r.Context(), w, err)
 			return
 		}
 		respond(w, http.StatusOK, map[string]string{"status": "ok"})
@@ -224,7 +224,7 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	if !onlySession {
 		memories, total, err = svc.memory.Search(r.Context(), filter)
 		if err != nil {
-			s.handleError(w, err)
+			s.handleError(r.Context(), w, err)
 			return
 		}
 	}
@@ -263,7 +263,7 @@ func (s *Server) getMemory(w http.ResponseWriter, r *http.Request) {
 
 	mem, err := svc.memory.Get(r.Context(), id)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -280,7 +280,7 @@ type updateMemoryRequest struct {
 func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 	var req updateMemoryRequest
 	if err := decode(r, &req); err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -295,7 +295,7 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 
 	mem, err := svc.memory.Update(r.Context(), auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -309,7 +309,7 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
 	if err := svc.memory.Delete(r.Context(), id, auth.AgentName); err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -323,7 +323,7 @@ type bulkCreateRequest struct {
 func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	var req bulkCreateRequest
 	if err := decode(r, &req); err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -331,7 +331,7 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	svc := s.resolveServices(auth)
 	memories, err := svc.memory.BulkCreate(r.Context(), auth.AgentName, req.Memories)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -352,7 +352,7 @@ func (s *Server) bootstrapMemories(w http.ResponseWriter, r *http.Request) {
 
 	memories, err := svc.memory.Bootstrap(r.Context(), limit)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -399,14 +399,14 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 
 	rawIDs := r.URL.Query()["session_id"]
 	if len(rawIDs) == 0 {
-		s.handleError(w, &domain.ValidationError{
+		s.handleError(r.Context(), w, &domain.ValidationError{
 			Field: "session_id", Message: "at least one session_id required",
 		})
 		return
 	}
 	sessionIDs := dedupStrings(rawIDs)
 	if len(sessionIDs) > maxSessionIDs {
-		s.handleError(w, &domain.ValidationError{
+		s.handleError(r.Context(), w, &domain.ValidationError{
 			Field: "session_id", Message: "too many session_ids: maximum is 100",
 		})
 		return
@@ -416,7 +416,7 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 	if raw := r.URL.Query().Get("limit_per_session"); raw != "" {
 		n, err := strconv.Atoi(raw)
 		if err != nil || n < 1 {
-			s.handleError(w, &domain.ValidationError{
+			s.handleError(r.Context(), w, &domain.ValidationError{
 				Field: "limit_per_session", Message: "must be a positive integer",
 			})
 			return
@@ -428,7 +428,7 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 
 	sessions, err := svc.session.ListBySessionIDs(r.Context(), sessionIDs, limitPerSession)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 	if sessions == nil {

--- a/server/internal/handler/task.go
+++ b/server/internal/handler/task.go
@@ -53,13 +53,13 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadSize)
 
 	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
-		s.handleError(w, &domain.ValidationError{Message: "invalid multipart form or file too large: " + err.Error()})
+		s.handleError(r.Context(), w, &domain.ValidationError{Message: "invalid multipart form or file too large: " + err.Error()})
 		return
 	}
 
 	file, header, err := r.FormFile("file")
 	if err != nil {
-		s.handleError(w, &domain.ValidationError{Field: "file", Message: "file required"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "file", Message: "file required"})
 		return
 	}
 	defer file.Close()
@@ -73,7 +73,7 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 	if agentID != "" {
 		// Reject path traversal characters to prevent arbitrary file write/delete.
 		if strings.ContainsAny(agentID, "/\\") || strings.Contains(agentID, "..") {
-			s.handleError(w, &domain.ValidationError{Field: "agent_id", Message: "invalid characters in agent_id"})
+			s.handleError(r.Context(), w, &domain.ValidationError{Field: "agent_id", Message: "invalid characters in agent_id"})
 			return
 		}
 		if len(agentID) > maxAgentIDLength {
@@ -83,7 +83,7 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.FormValue("session_id")
 	fileType := r.FormValue("file_type")
 	if fileType != string(domain.FileTypeSession) && fileType != string(domain.FileTypeMemory) {
-		s.handleError(w, &domain.ValidationError{Field: "file_type", Message: "must be session or memory"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "file_type", Message: "must be session or memory"})
 		return
 	}
 
@@ -92,13 +92,13 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 	// Directory: {uploadDir}/{tenantID}/{agentID}/
 	dir := filepath.Join(s.uploadDir, auth.TenantID, agentID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
 	fileName, err := sanitizeFilename(filepath.Base(header.Filename))
 	if err != nil {
-		s.handleError(w, &domain.ValidationError{Field: "file", Message: err.Error()})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "file", Message: err.Error()})
 		return
 	}
 
@@ -121,13 +121,13 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 		if !errors.Is(err, os.ErrExist) {
-			s.handleError(w, err)
+			s.handleError(r.Context(), w, err)
 			return
 		}
 		// File exists, retry with new suffix
 	}
 	if dst == nil {
-		s.handleError(w, &domain.ValidationError{Field: "file", Message: "failed to create unique filename after retries"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "file", Message: "failed to create unique filename after retries"})
 		return
 	}
 
@@ -139,7 +139,7 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 		if removeErr := os.Remove(filePath); removeErr != nil {
 			s.logger.Error("failed to remove file after copy failure", "path", filePath, "err", removeErr)
 		}
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 	if written > maxUploadSize {
@@ -147,14 +147,14 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 		if removeErr := os.Remove(filePath); removeErr != nil {
 			s.logger.Error("failed to remove oversized file", "path", filePath, "err", removeErr)
 		}
-		s.handleError(w, &domain.ValidationError{Field: "file", Message: fmt.Sprintf("file exceeds maximum size of %d bytes", maxUploadSize)})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "file", Message: fmt.Sprintf("file exceeds maximum size of %d bytes", maxUploadSize)})
 		return
 	}
 	if err := dst.Close(); err != nil {
 		if removeErr := os.Remove(filePath); removeErr != nil {
 			s.logger.Error("failed to remove file after close failure", "path", filePath, "err", removeErr)
 		}
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -172,7 +172,7 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 		if removeErr := os.Remove(filePath); removeErr != nil {
 			s.logger.Error("leaked upload file after task create failure", "path", filePath, "err", removeErr)
 		}
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -185,7 +185,7 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
 	tasks, err := s.uploadTasks.ListByTenant(r.Context(), auth.TenantID)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -226,20 +226,20 @@ func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getTask(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if id == "" {
-		s.handleError(w, &domain.ValidationError{Field: "id", Message: "task id required"})
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "id", Message: "task id required"})
 		return
 	}
 
 	task, err := s.uploadTasks.GetByID(r.Context(), id)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
 	// Verify tenant ownership.
 	auth := authInfo(r)
 	if task.TenantID != auth.TenantID {
-		s.handleError(w, domain.ErrNotFound)
+		s.handleError(r.Context(), w, domain.ErrNotFound)
 		return
 	}
 

--- a/server/internal/handler/tenant.go
+++ b/server/internal/handler/tenant.go
@@ -11,7 +11,7 @@ type provisionResponse struct {
 func (s *Server) provisionMem9s(w http.ResponseWriter, r *http.Request) {
 	result, err := s.tenant.Provision(r.Context())
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 
@@ -25,7 +25,7 @@ func (s *Server) getTenantInfo(w http.ResponseWriter, r *http.Request) {
 
 	info, err := s.tenant.GetInfo(r.Context(), auth.TenantID)
 	if err != nil {
-		s.handleError(w, err)
+		s.handleError(r.Context(), w, err)
 		return
 	}
 

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 type MemoryRepo struct {
@@ -380,7 +381,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
-		slog.Error("vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		slog.Error("vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
 		return nil, fmt.Errorf("vector search: %w", err)
 	}
 	defer rows.Close()
@@ -420,7 +421,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
-		slog.Error("auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		slog.Error("auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
 		return nil, fmt.Errorf("auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -455,7 +456,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		slog.Error("keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		slog.Error("keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 	defer rows.Close()
@@ -510,7 +511,7 @@ func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Memor
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
-		slog.Error("fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		slog.Error("fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()

--- a/server/internal/reqid/reqid.go
+++ b/server/internal/reqid/reqid.go
@@ -1,0 +1,14 @@
+package reqid
+
+import "context"
+
+type contextKey struct{}
+
+func FromContext(ctx context.Context) string {
+	v, _ := ctx.Value(contextKey{}).(string)
+	return v
+}
+
+func NewContext(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, contextKey{}, id)
+}


### PR DESCRIPTION
## Summary

- Fix `slog.Error` calls in the repo layer not printing source file/line by calling `slog.SetDefault(logger)` in `main.go` after constructing the configured handler (with `AddSource: true`)
- Add `request_id` to `handleError` internal error logs so they can be correlated with the `requestLogger` line that carries `duration_ms`
- Add `request_id` to all four search error logs in the TiDB repo layer (`AutoVectorSearch`, `VectorSearch`, `KeywordSearch`, `FTSSearch`) to correlate repo-level failures with their originating HTTP request
- Introduce `internal/reqid` package as a lightweight context key shared across handler and repo layers — avoids pulling chi/net/http into the repository layer
- Change `handleError` signature to `(ctx context.Context, w http.ResponseWriter, err error)` so it receives only what it needs