### PR TITLE
middleware: log duration_ms on tenant pool connection failure

### DIFF
--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -57,9 +58,10 @@ func ResolveTenant(
 			}
 			t.DBPassword = decryptedPassword
 
+			poolStart := time.Now()
 			db, err := pool.Get(r.Context(), t.ID, t.DSNForBackend(pool.Backend()))
 			if err != nil {
-				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "err", err)
+				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", time.Since(poolStart).Milliseconds(), "err", err)
 				writeError(w, http.StatusServiceUnavailable, "cannot connect to tenant database")
 				return
 			}
@@ -113,9 +115,10 @@ func ResolveApiKey(
 			}
 			t.DBPassword = decryptedPassword
 
+			poolStart := time.Now()
 			db, err := pool.Get(r.Context(), t.ID, t.DSNForBackend(pool.Backend()))
 			if err != nil {
-				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "err", err)
+				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", time.Since(poolStart).Milliseconds(), "err", err)
 				writeError(w, http.StatusServiceUnavailable, "cannot connect to tenant database")
 				return
 			}


### PR DESCRIPTION
Add `duration_ms` to the "cannot connect to tenant database" error log in
both `ResolveTenant` and `ResolveApiKey` middleware.

This makes it easier to diagnose `context canceled` failures by showing
how long `pool.Get` spent before timing out, correlating with the
`duration_ms` already logged by the request logger.