### PR TITLE
feat(dashboard/space): load raw sessions on demand

### DIFF
--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -77,7 +77,7 @@ describe("httpProvider", () => {
     expect(init?.body).toBeInstanceOf(FormData);
   });
 
-  it("requests session preview messages with repeatable session_id params", async () => {
+  it("requests selected-memory session messages without an explicit limit", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -106,8 +106,7 @@ describe("httpProvider", () => {
     );
 
     const result = await httpProvider.listSessionMessages("space-1", {
-      session_ids: ["sess-1", "sess-2"],
-      limit_per_session: 4,
+      session_ids: ["sess-1"],
     });
 
     expect(result.messages).toHaveLength(1);
@@ -115,15 +114,13 @@ describe("httpProvider", () => {
 
     const [url, init] = fetchMock.mock.calls[0] ?? [];
     const headers = init?.headers as Headers;
-    expect(url).toBe(
-      "/your-memory/api/session-messages?session_id=sess-1&session_id=sess-2&limit_per_session=4",
-    );
+    expect(url).toBe("/your-memory/api/session-messages?session_id=sess-1");
     expect(headers.get("X-API-Key")).toBe("space-1");
     expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
-  it("returns an empty session preview result when the endpoint is unavailable", async () => {
+  it("returns an empty session-message result when the endpoint is unavailable", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -164,7 +164,7 @@ function mockList(params: MemoryListParams): MemoryListResponse {
 function mockListSessionMessages(
   params: SessionMessageListParams,
 ): SessionMessageListResponse {
-  const limitPerSession = params.limit_per_session ?? 6;
+  const limitPerSession = params.limit_per_session ?? mockSessionPreviewTemplate.length;
   const requestedSessionIDs = Array.from(
     new Set(
       params.session_ids

--- a/dashboard/app/src/api/queries.test.ts
+++ b/dashboard/app/src/api/queries.test.ts
@@ -1,17 +1,35 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Memory } from "@/types/memory";
+import type { Memory, SessionMessage } from "@/types/memory";
 
-function createMemory(
-  id: string,
-  memoryType: Memory["memory_type"],
-  sessionID = "",
-): Memory {
+const mocks = vi.hoisted(() => ({
+  useQuery: vi.fn((options: unknown) => options),
+  listSessionMessages: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
+    "@tanstack/react-query",
+  );
+
+  return {
+    ...actual,
+    useQuery: (options: unknown) => mocks.useQuery(options),
+  };
+});
+
+vi.mock("./client", () => ({
+  api: {
+    listSessionMessages: (...args: unknown[]) => mocks.listSessionMessages(...args),
+  },
+}));
+
+function createMemory(sessionID = ""): Memory {
   const timestamp = "2026-03-19T00:00:00Z";
 
   return {
-    id,
-    content: `memory-${id}`,
-    memory_type: memoryType,
+    id: "mem-1",
+    content: "memory",
+    memory_type: "insight",
     source: "agent",
     tags: [],
     metadata: null,
@@ -25,56 +43,118 @@ function createMemory(
   };
 }
 
+function createMessage(
+  id: string,
+  createdAt: string,
+  seq: number,
+): SessionMessage {
+  return {
+    id,
+    session_id: "sess-1",
+    agent_id: "agent",
+    source: "agent",
+    seq,
+    role: "user",
+    content: id,
+    content_type: "text/plain",
+    tags: [],
+    state: "active",
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
 async function importQueriesModule() {
   vi.resetModules();
   return import("./queries");
 }
 
-describe("session preview lookup keys", () => {
+describe("linked session helpers", () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
+    vi.clearAllMocks();
     vi.resetModules();
   });
 
-  it("keeps pinned memories out of session preview lookups", async () => {
-    vi.stubEnv("VITE_USE_MOCK", "true");
-    vi.stubEnv("VITE_ENABLE_MOCK_SESSION_PREVIEW", "true");
+  it("derives linked-session presence from the session_id field only", async () => {
+    const { getLinkedSessionID } = await importQueriesModule();
+    const pinnedMemory: Memory = {
+      ...createMemory("sess-2"),
+      memory_type: "pinned",
+    };
 
-    const { getSessionPreviewLookupKey } = await importQueriesModule();
-
-    expect(
-      getSessionPreviewLookupKey(createMemory("mem-full-mock", "pinned", "sess-2")),
-    ).toBe("");
+    expect(getLinkedSessionID(createMemory("  sess-1  "))).toBe("sess-1");
+    expect(getLinkedSessionID(pinnedMemory)).toBe("sess-2");
+    expect(getLinkedSessionID(createMemory(""))).toBe("");
+    expect(getLinkedSessionID(null)).toBe("");
   });
 
-  it("uses insight session ids when mock preview is enabled", async () => {
-    vi.stubEnv("VITE_USE_MOCK", "false");
-    vi.stubEnv("VITE_ENABLE_MOCK_SESSION_PREVIEW", "true");
+  it("sorts session messages by created_at, seq, then id", async () => {
+    const { sortSessionMessages } = await importQueriesModule();
 
-    const { getSessionPreviewLookupKey } = await importQueriesModule();
+    const messages = [
+      createMessage("msg-3", "2026-03-19T00:00:01Z", 2),
+      createMessage("msg-2", "2026-03-19T00:00:01Z", 1),
+      createMessage("msg-1", "2026-03-19T00:00:00Z", 3),
+      createMessage("msg-0", "2026-03-19T00:00:01Z", 2),
+    ];
 
-    expect(
-      getSessionPreviewLookupKey(createMemory("mem-insight", "insight", "sess-1")),
-    ).toBe("sess-1");
-    expect(
-      getSessionPreviewLookupKey(createMemory("mem-no-session", "insight")),
-    ).toBe("");
+    expect(sortSessionMessages(messages).map((message) => message.id)).toEqual([
+      "msg-1",
+      "msg-2",
+      "msg-0",
+      "msg-3",
+    ]);
+  });
+});
+
+describe("useSelectedSessionMessages", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
   });
 
-  it("uses real insight session ids when mock preview is disabled", async () => {
-    vi.stubEnv("VITE_USE_MOCK", "false");
-    vi.stubEnv("VITE_ENABLE_MOCK_SESSION_PREVIEW", "false");
+  it("requests selected-memory session messages with one retry and no explicit limit", async () => {
+    mocks.listSessionMessages.mockResolvedValue({
+      messages: [createMessage("msg-1", "2026-03-19T00:00:00Z", 1)],
+    });
 
-    const { getSessionPreviewLookupKey } = await importQueriesModule();
+    const { useSelectedSessionMessages } = await importQueriesModule();
+    useSelectedSessionMessages("space-1", createMemory(" sess-1 "));
+    const options = mocks.useQuery.mock.calls[0]?.[0] as {
+      enabled: boolean;
+      retry: number;
+      queryKey: string[];
+      queryFn: () => Promise<SessionMessage[]>;
+    };
 
-    expect(
-      getSessionPreviewLookupKey(createMemory("mem-insight", "insight", "sess-real")),
-    ).toBe("sess-real");
-    expect(
-      getSessionPreviewLookupKey(createMemory("mem-pinned", "pinned", "sess-pinned")),
-    ).toBe("");
-    expect(
-      getSessionPreviewLookupKey(createMemory("mem-no-session", "insight")),
-    ).toBe("");
+    expect(mocks.useQuery).toHaveBeenCalledTimes(1);
+    expect(options).toMatchObject({
+      enabled: true,
+      retry: 1,
+      queryKey: ["space", "space-1", "sessionMessages", "sess-1"],
+    });
+
+    const messages = await options.queryFn();
+
+    expect(mocks.listSessionMessages).toHaveBeenCalledWith("space-1", {
+      session_ids: ["sess-1"],
+    });
+    expect(messages).toEqual([createMessage("msg-1", "2026-03-19T00:00:00Z", 1)]);
+  });
+
+  it("stays disabled when the selected memory has no linked session", async () => {
+    const { useSelectedSessionMessages } = await importQueriesModule();
+    useSelectedSessionMessages("space-1", createMemory(""));
+    const options = mocks.useQuery.mock.calls[0]?.[0] as {
+      enabled: boolean;
+      retry: number;
+      queryKey: string[];
+    };
+
+    expect(options).toMatchObject({
+      enabled: false,
+      retry: 1,
+      queryKey: ["space", "space-1", "sessionMessages", ""],
+    });
   });
 });

--- a/dashboard/app/src/api/queries.ts
+++ b/dashboard/app/src/api/queries.ts
@@ -19,27 +19,32 @@ import type { TimeRangePreset } from "@/types/time-range";
 import { presetToParams } from "@/types/time-range";
 
 const PAGE_SIZE = 50;
-const SESSION_PREVIEW_LIMIT = 6;
 
-export function getSessionPreviewLookupKey(memory: Memory): string {
-  if (memory.memory_type !== "insight") return "";
-
-  const sessionID = memory.session_id.trim();
-  if (sessionID) return sessionID;
-
-  return "";
+export function getLinkedSessionID(
+  memory: Pick<Memory, "session_id"> | null | undefined,
+): string {
+  return memory?.session_id.trim() ?? "";
 }
 
-function getSessionPreviewRequestIDs(memories: Memory[]): string[] {
-  const requestIDs = new Set<string>();
-
-  for (const memory of memories) {
-    const requestID = getSessionPreviewLookupKey(memory);
-    if (!requestID) continue;
-    requestIDs.add(requestID);
+function compareSessionMessages(
+  left: SessionMessage,
+  right: SessionMessage,
+): number {
+  const leftTimestamp = Date.parse(left.created_at);
+  const rightTimestamp = Date.parse(right.created_at);
+  const createdAtDiff =
+    (Number.isNaN(leftTimestamp) ? 0 : leftTimestamp) -
+    (Number.isNaN(rightTimestamp) ? 0 : rightTimestamp);
+  if (createdAtDiff !== 0) {
+    return createdAtDiff;
   }
 
-  return [...requestIDs].sort((left, right) => left.localeCompare(right, "en"));
+  const seqDiff = left.seq - right.seq;
+  if (seqDiff !== 0) {
+    return seqDiff;
+  }
+
+  return left.id.localeCompare(right.id, "en");
 }
 
 export function useStats(
@@ -89,42 +94,30 @@ export function useMemories(
   });
 }
 
-export function groupSessionMessagesBySessionID(
+export function sortSessionMessages(
   messages: SessionMessage[],
-): Record<string, SessionMessage[]> {
-  return messages.reduce<Record<string, SessionMessage[]>>((grouped, message) => {
-    const sessionMessages = grouped[message.session_id] ?? [];
-    sessionMessages.push(message);
-    grouped[message.session_id] = sessionMessages;
-    return grouped;
-  }, {});
+): SessionMessage[] {
+  return [...messages].sort(compareSessionMessages);
 }
 
-export function useSessionPreviewMessages(
+export function useSelectedSessionMessages(
   spaceId: string,
-  memories: Memory[],
-  limitPerSession = SESSION_PREVIEW_LIMIT,
+  memory: Memory | null,
 ) {
-  const sessionPreviewRequestIDs = getSessionPreviewRequestIDs(memories);
+  const sessionID = getLinkedSessionID(memory);
 
   return useQuery({
-    queryKey: [
-      "space",
-      spaceId,
-      "sessionPreview",
-      sessionPreviewRequestIDs,
-      limitPerSession,
-    ],
+    queryKey: ["space", spaceId, "sessionMessages", sessionID],
     queryFn: async () => {
       const response = await api.listSessionMessages(spaceId, {
-        session_ids: sessionPreviewRequestIDs,
-        limit_per_session: limitPerSession,
+        session_ids: [sessionID],
       });
-      return groupSessionMessagesBySessionID(response.messages);
+      return sortSessionMessages(
+        response.messages.filter((message) => message.session_id === sessionID),
+      );
     },
-    enabled: !!spaceId && sessionPreviewRequestIDs.length > 0,
-    placeholderData: keepPreviousData,
-    retry: false,
+    enabled: !!spaceId && !!sessionID,
+    retry: 1,
   });
 }
 

--- a/dashboard/app/src/components/space/detail-panel.tsx
+++ b/dashboard/app/src/components/space/detail-panel.tsx
@@ -1,6 +1,14 @@
+import { useEffect, useRef } from "react";
 import type { TFunction } from "i18next";
 import { toast } from "sonner";
-import { Bookmark, Copy, X, Trash2, Pencil, Sparkles } from "lucide-react";
+import {
+  Bookmark,
+  Copy,
+  X,
+  Trash2,
+  Pencil,
+  Sparkles,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Memory, MemoryFacet, SessionMessage } from "@/types/memory";
@@ -11,8 +19,8 @@ import { features } from "@/config/features";
 export function DetailPanel({
   memory: m,
   derivedTags = [],
-  sessionPreview,
-  sessionPreviewLoading,
+  sessionMessages,
+  sessionMessagesLoading,
   onClose,
   onDelete,
   onEdit,
@@ -20,8 +28,8 @@ export function DetailPanel({
 }: {
   memory: Memory;
   derivedTags?: string[];
-  sessionPreview: SessionMessage[];
-  sessionPreviewLoading: boolean;
+  sessionMessages: SessionMessage[];
+  sessionMessagesLoading: boolean;
   onClose: () => void;
   onDelete: () => void;
   onEdit?: () => void;
@@ -36,8 +44,8 @@ export function DetailPanel({
         <DetailPanelContent
           memory={m}
           derivedTags={derivedTags}
-          sessionPreview={sessionPreview}
-          sessionPreviewLoading={sessionPreviewLoading}
+          sessionMessages={sessionMessages}
+          sessionMessagesLoading={sessionMessagesLoading}
           onClose={onClose}
           onDelete={onDelete}
           onEdit={onEdit}
@@ -54,8 +62,8 @@ export function DetailPanel({
 export function DetailPanelContent({
   memory: m,
   derivedTags = [],
-  sessionPreview,
-  sessionPreviewLoading,
+  sessionMessages,
+  sessionMessagesLoading,
   onClose,
   onDelete,
   onEdit,
@@ -66,8 +74,8 @@ export function DetailPanelContent({
 }: {
   memory: Memory;
   derivedTags?: string[];
-  sessionPreview: SessionMessage[];
-  sessionPreviewLoading: boolean;
+  sessionMessages: SessionMessage[];
+  sessionMessagesLoading: boolean;
   onClose: () => void;
   onDelete: () => void;
   onEdit?: () => void;
@@ -78,6 +86,8 @@ export function DetailPanelContent({
 }) {
   const isPinned = m.memory_type === "pinned";
   const tags = m.tags ?? [];
+  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+  const autoScrolledMemoryIDRef = useRef<string | null>(null);
   const facet = features.enableFacet
     ? ((m.metadata as Record<string, unknown> | null)?.facet as
         | MemoryFacet
@@ -89,8 +99,33 @@ export function DetailPanelContent({
     toast.success(t("list.copied"));
   }
 
+  useEffect(() => {
+    autoScrolledMemoryIDRef.current = null;
+  }, [m.id]);
+
+  useEffect(() => {
+    if (sessionMessagesLoading || sessionMessages.length === 0) {
+      return;
+    }
+    if (autoScrolledMemoryIDRef.current === m.id) {
+      return;
+    }
+
+    const scrollArea = scrollAreaRef.current;
+    if (!scrollArea) {
+      return;
+    }
+
+    if (typeof scrollArea.scrollTo === "function") {
+      scrollArea.scrollTo({ top: scrollArea.scrollHeight });
+    } else {
+      scrollArea.scrollTop = scrollArea.scrollHeight;
+    }
+    autoScrolledMemoryIDRef.current = m.id;
+  }, [m.id, sessionMessages, sessionMessagesLoading]);
+
   return (
-    <div className={cn("flex h-full min-h-0 flex-col bg-background/50 backdrop-blur-sm", className)}>
+    <div className={cn("relative flex h-full min-h-0 flex-col bg-background/50 backdrop-blur-sm", className)}>
       <div className="flex items-center justify-between border-b border-border/40 bg-secondary/30 px-6 py-4">
         <div className="flex items-center gap-2">
           <div
@@ -153,6 +188,7 @@ export function DetailPanelContent({
       </div>
 
       <div
+        ref={scrollAreaRef}
         data-testid="detail-scroll-area"
         className={cn("flex-1 overflow-y-auto px-7 py-6", scrollAreaClassName)}
       >
@@ -214,15 +250,15 @@ export function DetailPanelContent({
             </div>
           </div>
 
-          {(sessionPreviewLoading || sessionPreview.length > 0) && (
+          {(sessionMessagesLoading || sessionMessages.length > 0) && (
             <>
               <div className="w-full h-px bg-border/40" />
 
               {/* Session Context */}
-              <div className="pt-2">
+              <div data-testid="detail-session-section" className="pt-2">
                 <DetailSessionPreview
-                  messages={sessionPreview}
-                  loading={sessionPreviewLoading}
+                  messages={sessionMessages}
+                  loading={sessionMessagesLoading}
                   compactMetadata={compactSessionPreview}
                   t={t}
                 />

--- a/dashboard/app/src/components/space/detail-panel.tsx
+++ b/dashboard/app/src/components/space/detail-panel.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from "react";
 import type { TFunction } from "i18next";
 import { toast } from "sonner";
 import {
+  ArrowDownToLine,
+  ArrowUpToLine,
   Bookmark,
   Copy,
   X,
@@ -97,6 +99,32 @@ export function DetailPanelContent({
   function handleCopy() {
     navigator.clipboard.writeText(m.content);
     toast.success(t("list.copied"));
+  }
+
+  function scrollSessionTo(top: number, behavior: ScrollBehavior = "smooth") {
+    const scrollArea = scrollAreaRef.current;
+    if (!scrollArea) {
+      return;
+    }
+
+    if (typeof scrollArea.scrollTo === "function") {
+      scrollArea.scrollTo({ top, behavior });
+    } else {
+      scrollArea.scrollTop = top;
+    }
+  }
+
+  function handleJumpToTop() {
+    scrollSessionTo(0);
+  }
+
+  function handleJumpToLatest() {
+    const scrollArea = scrollAreaRef.current;
+    if (!scrollArea) {
+      return;
+    }
+
+    scrollSessionTo(scrollArea.scrollHeight);
   }
 
   useEffect(() => {
@@ -268,11 +296,39 @@ export function DetailPanelContent({
         </div>
       </div>
 
-      <div className="flex items-center justify-end border-t px-5 py-2.5">
+      <div
+        className={cn(
+          "flex flex-wrap items-center gap-2 border-t px-5 py-2.5",
+          sessionMessages.length > 0 ? "justify-between" : "justify-end",
+        )}
+      >
+        {sessionMessages.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={handleJumpToTop}
+              className="gap-1.5"
+            >
+              <ArrowUpToLine className="size-3" />
+              {t("session_preview.jump_to_start")}
+            </Button>
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={handleJumpToLatest}
+              className="gap-1.5"
+            >
+              <ArrowDownToLine className="size-3" />
+              {t("session_preview.jump_to_latest")}
+            </Button>
+          </div>
+        ) : null}
         <Button
           variant="ghost"
           size="xs"
           onClick={onDelete}
+          aria-label={t("detail.delete_button_label")}
           data-mp-event="Dashboard/Detail/DeleteClicked"
           data-mp-page-name="space"
           data-mp-memory-id={m.id}

--- a/dashboard/app/src/components/space/detail-panel.tsx
+++ b/dashboard/app/src/components/space/detail-panel.tsx
@@ -18,7 +18,7 @@ import { FacetBadge } from "./topic-strip";
 import { DetailSessionPreview } from "./session-preview";
 import { features } from "@/config/features";
 
-export function DetailPanel({
+export const DetailPanel = ({
   memory: m,
   derivedTags = [],
   sessionMessages,
@@ -36,7 +36,7 @@ export function DetailPanel({
   onDelete: () => void;
   onEdit?: () => void;
   t: TFunction;
-}) {
+}) => {
   return (
     <div
       className="w-full shrink-0 py-8 xl:order-3 xl:w-[390px]"
@@ -59,9 +59,9 @@ export function DetailPanel({
       </div>
     </div>
   );
-}
+};
 
-export function DetailPanelContent({
+export const DetailPanelContent = ({
   memory: m,
   derivedTags = [],
   sessionMessages,
@@ -85,7 +85,7 @@ export function DetailPanelContent({
   className?: string;
   scrollAreaClassName?: string;
   t: TFunction;
-}) {
+}) => {
   const isPinned = m.memory_type === "pinned";
   const tags = m.tags ?? [];
   const scrollAreaRef = useRef<HTMLDivElement | null>(null);
@@ -96,12 +96,15 @@ export function DetailPanelContent({
         | undefined)
     : undefined;
 
-  function handleCopy() {
+  const handleCopy = () => {
     navigator.clipboard.writeText(m.content);
     toast.success(t("list.copied"));
-  }
+  };
 
-  function scrollSessionTo(top: number, behavior: ScrollBehavior = "smooth") {
+  const scrollSessionTo = (
+    top: number,
+    behavior: ScrollBehavior = "smooth",
+  ) => {
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea) {
       return;
@@ -112,20 +115,20 @@ export function DetailPanelContent({
     } else {
       scrollArea.scrollTop = top;
     }
-  }
+  };
 
-  function handleJumpToTop() {
+  const handleJumpToTop = () => {
     scrollSessionTo(0);
-  }
+  };
 
-  function handleJumpToLatest() {
+  const handleJumpToLatest = () => {
     const scrollArea = scrollAreaRef.current;
     if (!scrollArea) {
       return;
     }
 
     scrollSessionTo(scrollArea.scrollHeight);
-  }
+  };
 
   useEffect(() => {
     autoScrolledMemoryIDRef.current = null;
@@ -340,13 +343,13 @@ export function DetailPanelContent({
       </div>
     </div>
   );
-}
+};
 
-function MetaCell({ label, value }: { label: string; value: string }) {
+const MetaCell = ({ label, value }: { label: string; value: string }) => {
   return (
     <div>
       <dt className="text-xs text-soft-foreground">{label}</dt>
       <dd className="mt-0.5 text-sm text-foreground/80">{value}</dd>
     </div>
   );
-}
+};

--- a/dashboard/app/src/components/space/memory-card.test.tsx
+++ b/dashboard/app/src/components/space/memory-card.test.tsx
@@ -1,0 +1,60 @@
+import "@/i18n";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import i18n from "@/i18n";
+import { MemoryCard } from "./memory-card";
+import type { Memory } from "@/types/memory";
+
+function createMemory(sessionID = ""): Memory {
+  return {
+    id: "mem-1",
+    content: "Deploy dashboard status update",
+    memory_type: "insight",
+    source: "agent",
+    tags: ["launch"],
+    metadata: null,
+    agent_id: "agent",
+    session_id: sessionID,
+    state: "active",
+    version: 1,
+    updated_by: "agent",
+    created_at: "2026-03-21T04:57:00Z",
+    updated_at: "2026-03-21T04:57:00Z",
+  };
+}
+
+describe("MemoryCard", () => {
+  it("shows linked-session text when the memory has a session_id", () => {
+    render(
+      <MemoryCard
+        memory={createMemory("sess-1")}
+        derivedTags={[]}
+        hasLinkedSession
+        isSelected={false}
+        onClick={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+        delay={0}
+      />,
+    );
+
+    expect(screen.getByText("From a conversation")).toBeInTheDocument();
+  });
+
+  it("omits linked-session text when the memory has no session_id", () => {
+    render(
+      <MemoryCard
+        memory={createMemory("")}
+        derivedTags={[]}
+        hasLinkedSession={false}
+        isSelected={false}
+        onClick={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+        delay={0}
+      />,
+    );
+
+    expect(screen.queryByText("From a conversation")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/app/src/components/space/memory-card.tsx
+++ b/dashboard/app/src/components/space/memory-card.tsx
@@ -1,16 +1,15 @@
 import type { TFunction } from "i18next";
 import { toast } from "sonner";
-import { Bookmark, Copy, Trash2, Sparkles } from "lucide-react";
+import { Bookmark, Copy, MessageSquareQuote, Trash2, Sparkles } from "lucide-react";
 import { formatRelativeTime } from "@/lib/time";
-import type { Memory, MemoryFacet, SessionMessage } from "@/types/memory";
+import type { Memory, MemoryFacet } from "@/types/memory";
 import { FacetBadge } from "./topic-strip";
-import { CardSessionPreview } from "./session-preview";
 import { features } from "@/config/features";
 
 export function MemoryCard({
   memory: m,
   derivedTags = [],
-  sessionPreview,
+  hasLinkedSession,
   isSelected,
   onClick,
   onDelete,
@@ -19,7 +18,7 @@ export function MemoryCard({
 }: {
   memory: Memory;
   derivedTags?: string[];
-  sessionPreview: SessionMessage[];
+  hasLinkedSession: boolean;
   isSelected: boolean;
   onClick: () => void;
   onDelete: () => void;
@@ -80,7 +79,14 @@ export function MemoryCard({
           <p className="line-clamp-3 text-sm leading-relaxed text-foreground/90 font-medium">
             {m.content}
           </p>
-          <CardSessionPreview messages={sessionPreview} t={t} />
+          {hasLinkedSession && (
+            <div className="mt-3">
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/15 bg-primary/[0.07] px-2.5 py-1 text-[11px] font-medium text-primary/90">
+                <MessageSquareQuote className="size-3.5" />
+                {t("list.linked_session")}
+              </span>
+            </div>
+          )}
           <div className="mt-3 flex flex-wrap items-center gap-2.5 text-xs text-soft-foreground">
             <span>{formatRelativeTime(t, m.updated_at)}</span>
             {m.source && (

--- a/dashboard/app/src/components/space/memory-card.tsx
+++ b/dashboard/app/src/components/space/memory-card.tsx
@@ -6,7 +6,7 @@ import type { Memory, MemoryFacet } from "@/types/memory";
 import { FacetBadge } from "./topic-strip";
 import { features } from "@/config/features";
 
-export function MemoryCard({
+export const MemoryCard = ({
   memory: m,
   derivedTags = [],
   hasLinkedSession,
@@ -24,7 +24,7 @@ export function MemoryCard({
   onDelete: () => void;
   t: TFunction;
   delay: number;
-}) {
+}) => {
   const isPinned = m.memory_type === "pinned";
   const tags = m.tags ?? [];
   const facet = features.enableFacet
@@ -33,17 +33,17 @@ export function MemoryCard({
         | undefined)
     : undefined;
 
-  function handleCopy(e: React.MouseEvent) {
+  const handleCopy = (e: React.MouseEvent) => {
     e.stopPropagation();
     navigator.clipboard.writeText(m.content);
     toast.success(t("list.copied"));
-  }
+  };
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key !== "Enter" && e.key !== " ") return;
     e.preventDefault();
     onClick();
-  }
+  };
 
   return (
     <div
@@ -155,4 +155,4 @@ export function MemoryCard({
       </div>
     </div>
   );
-}
+};

--- a/dashboard/app/src/components/space/mobile-detail-sheet.test.tsx
+++ b/dashboard/app/src/components/space/mobile-detail-sheet.test.tsx
@@ -39,23 +39,19 @@ function createSessionMessage(): SessionMessage {
     content: [
       "Conversation info (untrusted metadata):",
       "",
-      "```json",
       "{",
       '  "message_id": "om_x100b54d61dce74a0b21551c196de630",',
       '  "sender": "马圣博",',
       '  "timestamp": "Sat 2026-03-21 04:57 UTC"',
       "}",
-      "```",
       "",
       "Sender (untrusted metadata):",
       "",
-      "```json",
       "{",
       '  "label": "马圣博",',
       '  "id": "ou_e77359a58df929cbfe166f14f37d3281",',
       '  "name": "马圣博"',
       "}",
-      "```",
       "",
       "[message_id: om_x100b54d61dce74a0b21551c196de630]",
       "马圣博: 多少了",
@@ -100,9 +96,6 @@ describe("MobileDetailSheet", () => {
     expect(
       screen.getByTestId("session-metadata-body-conversation-info-untrusted-metadata"),
     ).toHaveTextContent('"message_id": "om_x100b54d61dce74a0b21551c196de630"');
-    expect(
-      screen.getByTestId("session-metadata-body-conversation-info-untrusted-metadata"),
-    ).not.toHaveTextContent("```json");
     expect(screen.getByRole("button", { name: "Collapse" })).toBeInTheDocument();
   });
 
@@ -234,38 +227,4 @@ describe("MobileDetailSheet", () => {
     }
   });
 
-  it("shows quick-jump buttons and uses the shared detail scroll area", () => {
-    vi.mocked(HTMLElement.prototype.scrollTo).mockClear();
-
-    render(
-      <MobileDetailSheet
-        memory={createMemory()}
-        derivedTags={[]}
-        sessionMessages={[createSessionMessage()]}
-        sessionMessagesLoading={false}
-        open
-        onOpenChange={vi.fn()}
-        onDelete={vi.fn()}
-        t={i18n.t}
-      />,
-    );
-
-    const scrollArea = screen.getByTestId("detail-scroll-area");
-    Object.defineProperty(scrollArea, "scrollHeight", {
-      configurable: true,
-      value: 1200,
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Start" }));
-    fireEvent.click(screen.getByRole("button", { name: "Latest" }));
-
-    expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-      top: 0,
-      behavior: "smooth",
-    });
-    expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
-      top: 1200,
-      behavior: "smooth",
-    });
-  });
 });

--- a/dashboard/app/src/components/space/mobile-detail-sheet.test.tsx
+++ b/dashboard/app/src/components/space/mobile-detail-sheet.test.tsx
@@ -1,9 +1,14 @@
 import "@/i18n";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import i18n from "@/i18n";
 import { MobileDetailSheet } from "./mobile-detail-sheet";
 import type { Memory, SessionMessage } from "@/types/memory";
+
+Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+  value: vi.fn(),
+  writable: true,
+});
 
 function createMemory(): Memory {
   return {
@@ -34,19 +39,23 @@ function createSessionMessage(): SessionMessage {
     content: [
       "Conversation info (untrusted metadata):",
       "",
+      "```json",
       "{",
       '  "message_id": "om_x100b54d61dce74a0b21551c196de630",',
       '  "sender": "马圣博",',
       '  "timestamp": "Sat 2026-03-21 04:57 UTC"',
       "}",
+      "```",
       "",
       "Sender (untrusted metadata):",
       "",
+      "```json",
       "{",
       '  "label": "马圣博",',
       '  "id": "ou_e77359a58df929cbfe166f14f37d3281",',
       '  "name": "马圣博"',
       "}",
+      "```",
       "",
       "[message_id: om_x100b54d61dce74a0b21551c196de630]",
       "马圣博: 多少了",
@@ -65,8 +74,8 @@ describe("MobileDetailSheet", () => {
       <MobileDetailSheet
         memory={createMemory()}
         derivedTags={[]}
-        sessionPreview={[createSessionMessage()]}
-        sessionPreviewLoading={false}
+        sessionMessages={[createSessionMessage()]}
+        sessionMessagesLoading={false}
         open
         onOpenChange={vi.fn()}
         onDelete={vi.fn()}
@@ -91,6 +100,9 @@ describe("MobileDetailSheet", () => {
     expect(
       screen.getByTestId("session-metadata-body-conversation-info-untrusted-metadata"),
     ).toHaveTextContent('"message_id": "om_x100b54d61dce74a0b21551c196de630"');
+    expect(
+      screen.getByTestId("session-metadata-body-conversation-info-untrusted-metadata"),
+    ).not.toHaveTextContent("```json");
     expect(screen.getByRole("button", { name: "Collapse" })).toBeInTheDocument();
   });
 
@@ -107,8 +119,8 @@ describe("MobileDetailSheet", () => {
       <MobileDetailSheet
         memory={createMemory()}
         derivedTags={[]}
-        sessionPreview={[createSessionMessage()]}
-        sessionPreviewLoading={false}
+        sessionMessages={[createSessionMessage()]}
+        sessionMessagesLoading={false}
         open
         onOpenChange={vi.fn()}
         onDelete={vi.fn()}
@@ -130,8 +142,8 @@ describe("MobileDetailSheet", () => {
       <MobileDetailSheet
         memory={createMemory()}
         derivedTags={["OpenClaw"]}
-        sessionPreview={[createSessionMessage()]}
-        sessionPreviewLoading={false}
+        sessionMessages={[createSessionMessage()]}
+        sessionMessagesLoading={false}
         open
         onOpenChange={vi.fn()}
         onDelete={vi.fn()}
@@ -141,5 +153,119 @@ describe("MobileDetailSheet", () => {
 
     expect(screen.getByText("Derived tags")).toBeInTheDocument();
     expect(screen.getByText("#OpenClaw")).toBeInTheDocument();
+  });
+
+  it("hides the raw session section when no session messages are available", () => {
+    render(
+      <MobileDetailSheet
+        memory={createMemory()}
+        derivedTags={[]}
+        sessionMessages={[]}
+        sessionMessagesLoading={false}
+        open
+        onOpenChange={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+      />,
+    );
+
+    expect(screen.queryByText("Original Conversation")).not.toBeInTheDocument();
+  });
+
+  it("shows a lightweight loading state while raw session detail is loading", () => {
+    render(
+      <MobileDetailSheet
+        memory={createMemory()}
+        derivedTags={[]}
+        sessionMessages={[]}
+        sessionMessagesLoading
+        open
+        onOpenChange={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+      />,
+    );
+
+    expect(screen.getByText("Original Conversation")).toBeInTheDocument();
+    expect(screen.getByText("Loading conversation...")).toBeInTheDocument();
+  });
+
+  it("scrolls the existing detail scroll area to the newest message once raw session content is ready", async () => {
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight",
+    );
+
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        return 480;
+      },
+    });
+
+    try {
+      vi.mocked(HTMLElement.prototype.scrollTo).mockClear();
+      render(
+        <MobileDetailSheet
+          memory={createMemory()}
+          derivedTags={[]}
+          sessionMessages={[createSessionMessage()]}
+          sessionMessagesLoading={false}
+          open
+          onOpenChange={vi.fn()}
+          onDelete={vi.fn()}
+          t={i18n.t}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
+          top: 480,
+        });
+      });
+    } finally {
+      if (scrollHeightDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollHeightDescriptor,
+        );
+      }
+    }
+  });
+
+  it("shows quick-jump buttons and uses the shared detail scroll area", () => {
+    vi.mocked(HTMLElement.prototype.scrollTo).mockClear();
+
+    render(
+      <MobileDetailSheet
+        memory={createMemory()}
+        derivedTags={[]}
+        sessionMessages={[createSessionMessage()]}
+        sessionMessagesLoading={false}
+        open
+        onOpenChange={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+      />,
+    );
+
+    const scrollArea = screen.getByTestId("detail-scroll-area");
+    Object.defineProperty(scrollArea, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Start" }));
+    fireEvent.click(screen.getByRole("button", { name: "Latest" }));
+
+    expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: "smooth",
+    });
+    expect(HTMLElement.prototype.scrollTo).toHaveBeenCalledWith({
+      top: 1200,
+      behavior: "smooth",
+    });
   });
 });

--- a/dashboard/app/src/components/space/mobile-detail-sheet.test.tsx
+++ b/dashboard/app/src/components/space/mobile-detail-sheet.test.tsx
@@ -64,6 +64,27 @@ function createSessionMessage(): SessionMessage {
   };
 }
 
+function createToolResultMessage(): SessionMessage {
+  return {
+    id: "msg-tool-1",
+    session_id: "session-1",
+    agent_id: "agent",
+    source: "agent",
+    seq: 2,
+    role: "toolResult",
+    content: [
+      "Fetched deployment logs",
+      "",
+      "line-2: timeout stack trace",
+    ].join("\n"),
+    content_type: "text/plain",
+    tags: [],
+    state: "active",
+    created_at: "2026-03-21T04:58:00Z",
+    updated_at: "2026-03-21T04:58:00Z",
+  };
+}
+
 describe("MobileDetailSheet", () => {
   it("renders untrusted metadata as a summary first and expands inline on demand", async () => {
     render(
@@ -225,6 +246,39 @@ describe("MobileDetailSheet", () => {
         );
       }
     }
+  });
+
+  it("keeps tool-result messages collapsed until the user expands them", () => {
+    render(
+      <MobileDetailSheet
+        memory={createMemory()}
+        derivedTags={[]}
+        sessionMessages={[createSessionMessage(), createToolResultMessage()]}
+        sessionMessagesLoading={false}
+        open
+        onOpenChange={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+      />,
+    );
+
+    expect(screen.getByText("Tool result")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("tool-result-preview-msg-tool-1"),
+    ).toHaveTextContent("Fetched deployment logs");
+    expect(
+      screen.getByRole("button", { name: "Show result" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("line-2: timeout stack trace"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("tool-result-toggle-msg-tool-1"));
+
+    expect(
+      screen.getByRole("button", { name: "Hide result" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("line-2: timeout stack trace")).toBeInTheDocument();
   });
 
 });

--- a/dashboard/app/src/components/space/mobile-detail-sheet.tsx
+++ b/dashboard/app/src/components/space/mobile-detail-sheet.tsx
@@ -3,7 +3,7 @@ import { DetailPanelContent } from "@/components/space/detail-panel";
 import { MobilePanelShell } from "@/components/space/mobile-panel-shell";
 import type { Memory, SessionMessage } from "@/types/memory";
 
-export function MobileDetailSheet({
+export const MobileDetailSheet = ({
   memory,
   derivedTags = [],
   sessionMessages,
@@ -23,7 +23,7 @@ export function MobileDetailSheet({
   onDelete: () => void;
   onEdit?: () => void;
   t: TFunction;
-}) {
+}) => {
   if (!memory) return null;
 
   return (
@@ -50,4 +50,4 @@ export function MobileDetailSheet({
       />
     </MobilePanelShell>
   );
-}
+};

--- a/dashboard/app/src/components/space/mobile-detail-sheet.tsx
+++ b/dashboard/app/src/components/space/mobile-detail-sheet.tsx
@@ -6,8 +6,8 @@ import type { Memory, SessionMessage } from "@/types/memory";
 export function MobileDetailSheet({
   memory,
   derivedTags = [],
-  sessionPreview,
-  sessionPreviewLoading,
+  sessionMessages,
+  sessionMessagesLoading,
   open,
   onOpenChange,
   onDelete,
@@ -16,8 +16,8 @@ export function MobileDetailSheet({
 }: {
   memory: Memory | null;
   derivedTags?: string[];
-  sessionPreview: SessionMessage[];
-  sessionPreviewLoading: boolean;
+  sessionMessages: SessionMessage[];
+  sessionMessagesLoading: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDelete: () => void;
@@ -39,8 +39,8 @@ export function MobileDetailSheet({
       <DetailPanelContent
         memory={memory}
         derivedTags={derivedTags}
-        sessionPreview={sessionPreview}
-        sessionPreviewLoading={sessionPreviewLoading}
+        sessionMessages={sessionMessages}
+        sessionMessagesLoading={sessionMessagesLoading}
         onClose={() => onOpenChange(false)}
         onDelete={onDelete}
         onEdit={onEdit}

--- a/dashboard/app/src/components/space/session-preview.tsx
+++ b/dashboard/app/src/components/space/session-preview.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { TFunction } from "i18next";
-import { Loader2, User, MessageCircle, MessageSquare, Bot } from "lucide-react";
+import { Loader2, User, MessageSquare, Bot } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import { cn } from "@/lib/utils";
@@ -20,20 +20,21 @@ type SessionContentBlock =
     };
 
 const UNTRUSTED_METADATA_PATTERN = /^(.+?\(untrusted metadata\)):\s*$/;
+const FENCED_CODE_BLOCK_PATTERN = /^```[\w-]*\s*$/;
 
-function slugifyMetadataLabel(label: string): string {
+const slugifyMetadataLabel = (label: string): string => {
   return label
     .trim()
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
-}
+};
 
-function countToken(value: string, token: "{" | "}"): number {
+const countToken = (value: string, token: "{" | "}"): number => {
   return [...value].filter((char) => char === token).length;
-}
+};
 
-function compactMetadataValue(value: unknown): string {
+const compactMetadataValue = (value: unknown): string => {
   const normalized =
     typeof value === "string"
       ? value.trim()
@@ -44,10 +45,22 @@ function compactMetadataValue(value: unknown): string {
   if (!normalized) return "";
   if (normalized.length <= 30) return normalized;
   return `${normalized.slice(0, 12)}…${normalized.slice(-8)}`;
-}
+};
 
-function summarizeMetadata(raw: string): string {
+const normalizeMetadataRaw = (raw: string): string => {
   const trimmed = raw.trim();
+  if (!trimmed) return "";
+
+  const lines = trimmed.split("\n");
+  if (lines.length < 2) return trimmed;
+  if (!FENCED_CODE_BLOCK_PATTERN.test(lines[0]?.trim() ?? "")) return trimmed;
+  if ((lines[lines.length - 1] ?? "").trim() !== "```") return trimmed;
+
+  return lines.slice(1, -1).join("\n").trim();
+};
+
+const summarizeMetadata = (raw: string): string => {
+  const trimmed = normalizeMetadataRaw(raw);
   if (!trimmed) return "";
 
   try {
@@ -96,14 +109,14 @@ function summarizeMetadata(raw: string): string {
     .split("\n")
     .map((line) => line.trim())
     .find(Boolean) ?? "";
-}
+};
 
-function buildSessionContentBlocks(content: string): SessionContentBlock[] {
+const buildSessionContentBlocks = (content: string): SessionContentBlock[] => {
   const lines = content.split("\n");
   const blocks: SessionContentBlock[] = [];
   const markdownBuffer: string[] = [];
 
-  function flushMarkdownBuffer() {
+  const flushMarkdownBuffer = () => {
     const markdown = markdownBuffer.join("\n").trim();
     markdownBuffer.length = 0;
     if (!markdown) return;
@@ -111,7 +124,7 @@ function buildSessionContentBlocks(content: string): SessionContentBlock[] {
       kind: "markdown",
       content: markdown,
     });
-  }
+  };
 
   let index = 0;
   while (index < lines.length) {
@@ -134,7 +147,16 @@ function buildSessionContentBlocks(content: string): SessionContentBlock[] {
     const metadataLines: string[] = [];
     const firstLine = lines[index]?.trim() ?? "";
 
-    if (firstLine.startsWith("{")) {
+    if (firstLine.startsWith("```")) {
+      while (index < lines.length) {
+        const line = lines[index] ?? "";
+        metadataLines.push(line);
+        index += 1;
+        if (line.trim() === "```" && metadataLines.length > 1) {
+          break;
+        }
+      }
+    } else if (firstLine.startsWith("{")) {
       let depth = 0;
       while (index < lines.length) {
         const line = lines[index] ?? "";
@@ -175,9 +197,9 @@ function buildSessionContentBlocks(content: string): SessionContentBlock[] {
           content,
         },
       ];
-}
+};
 
-function MetadataContent({
+const MetadataContent = ({
   label,
   raw,
   summary,
@@ -189,16 +211,17 @@ function MetadataContent({
   summary: string;
   compact: boolean;
   t: TFunction;
-}) {
+}) => {
   const [expanded, setExpanded] = useState(false);
   const slug = slugifyMetadataLabel(label);
+  const normalizedRaw = normalizeMetadataRaw(raw);
 
   if (!compact) {
     return (
       <div className="my-3 space-y-2">
         <p className="text-[12px] font-medium text-foreground/80">{label}:</p>
         <pre className="whitespace-pre-wrap break-all rounded-xl border border-border/50 bg-secondary/50 px-3 py-3 font-mono text-[12px] leading-6 text-foreground/80">
-          {raw}
+          {normalizedRaw}
         </pre>
       </div>
     );
@@ -237,14 +260,14 @@ function MetadataContent({
           className="mt-3 whitespace-pre-wrap break-all rounded-xl border border-border/50 bg-background/70 px-3 py-3 font-mono text-[11px] leading-6 text-foreground/80"
           data-testid={`session-metadata-body-${slug}`}
         >
-          {raw}
+          {normalizedRaw}
         </pre>
       )}
     </div>
   );
-}
+};
 
-function SessionMessageContent({
+const SessionMessageContent = ({
   content,
   compactMetadata,
   t,
@@ -252,7 +275,7 @@ function SessionMessageContent({
   content: string;
   compactMetadata: boolean;
   t: TFunction;
-}) {
+}) => {
   const blocks = useMemo(() => buildSessionContentBlocks(content), [content]);
 
   return (
@@ -276,13 +299,16 @@ function SessionMessageContent({
       )}
     </div>
   );
-}
+};
 
-function getRoleLabel(t: TFunction, role: SessionMessage["role"]): string {
+const getRoleLabel = (
+  t: TFunction,
+  role: SessionMessage["role"],
+): string => {
   return t(`session_preview.role.${role}`, { defaultValue: role });
-}
+};
 
-function SessionMarkdownContent({ content }: { content: string }) {
+const SessionMarkdownContent = ({ content }: { content: string }) => {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkBreaks]}
@@ -376,9 +402,9 @@ function SessionMarkdownContent({ content }: { content: string }) {
       {content}
     </ReactMarkdown>
   );
-}
+};
 
-export function DetailSessionPreview({
+export const DetailSessionPreview = ({
   messages,
   loading,
   compactMetadata = false,
@@ -388,7 +414,7 @@ export function DetailSessionPreview({
   loading: boolean;
   compactMetadata?: boolean;
   t: TFunction;
-}) {
+}) => {
   if (!loading && messages.length === 0) return null;
 
   return (
@@ -450,41 +476,4 @@ export function DetailSessionPreview({
       )}
     </section>
   );
-}
-
-export function CardSessionPreview({
-  messages,
-  t,
-}: {
-  messages: SessionMessage[];
-  t: TFunction;
-}) {
-  const previewMessages = messages.slice(0, 2);
-
-  if (previewMessages.length === 0) return null;
-
-  return (
-    <div className="mt-3.5 relative pl-3.5 border-l-[2px] border-border/40 transition-colors group-hover:border-border/60">
-      <div className="flex items-center gap-1.5 mb-2">
-        <MessageCircle className="size-3 text-muted-foreground/70" />
-        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
-          {t("session_preview.title")}
-        </span>
-      </div>
-      <div className="space-y-1.5">
-        {previewMessages.map((message) => {
-          return (
-            <div key={message.id} className="flex gap-2 items-start text-xs text-foreground/70 leading-relaxed">
-              <span className="font-semibold text-foreground/40 shrink-0 mt-[1px]">
-                {getRoleLabel(t, message.role)}
-              </span>
-              <span className="line-clamp-1 break-all">
-                {message.content}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
+};

--- a/dashboard/app/src/components/space/session-preview.tsx
+++ b/dashboard/app/src/components/space/session-preview.tsx
@@ -417,20 +417,17 @@ const SessionMarkdownContent = ({ content }: { content: string }) => {
 const ToolResultMessageContent = ({
   message,
   compactMetadata,
+  expanded,
   t,
 }: {
   message: SessionMessage;
   compactMetadata: boolean;
+  expanded: boolean;
   t: TFunction;
 }) => {
-  const [expanded, setExpanded] = useState(false);
   const preview = getToolResultPreview(message.content);
-  const toggleLabel = expanded
-    ? t("session_preview.hide_tool_result")
-    : t("session_preview.show_tool_result");
-
   return (
-    <div className="w-full space-y-2">
+    <div className="w-full">
       {!expanded ? (
         <p
           className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] leading-5 text-muted-foreground"
@@ -439,19 +436,6 @@ const ToolResultMessageContent = ({
           {preview || t("session_preview.tool_result_empty")}
         </p>
       ) : null}
-
-      <div className="flex justify-end">
-        <button
-          type="button"
-          onClick={() => setExpanded((current) => !current)}
-          className="shrink-0 rounded-full border border-border/50 px-2.5 py-1 text-[11px] font-medium text-foreground/70 transition-colors hover:border-border/80 hover:text-foreground"
-          aria-expanded={expanded}
-          aria-label={toggleLabel}
-          data-testid={`tool-result-toggle-${message.id}`}
-        >
-          {toggleLabel}
-        </button>
-      </div>
 
       {expanded ? (
         <div data-testid={`tool-result-body-${message.id}`}>
@@ -462,6 +446,59 @@ const ToolResultMessageContent = ({
           />
         </div>
       ) : null}
+    </div>
+  );
+};
+
+const ToolResultMessageRow = ({
+  message,
+  compactMetadata,
+  t,
+}: {
+  message: SessionMessage;
+  compactMetadata: boolean;
+  t: TFunction;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const toggleLabel = expanded
+    ? t("session_preview.hide_tool_result")
+    : t("session_preview.show_tool_result");
+
+  return (
+    <div className="relative flex gap-4">
+      <div className="relative z-10 flex size-6 shrink-0 items-center justify-center rounded-full border-[3px] border-background bg-primary/10 text-primary">
+        <Bot className="size-3" />
+      </div>
+      <div className="min-w-0 flex-1 pt-0.5 pb-1">
+        <div className="mb-1.5 flex items-center gap-2">
+          <span className="text-[11px] font-medium uppercase tracking-wider text-foreground/70">
+            {getRoleLabel(t, message.role)}
+          </span>
+          <span className="text-[10px] text-muted-foreground/60">
+            {formatRelativeTime(t, message.created_at)}
+          </span>
+          <button
+            type="button"
+            onClick={() => setExpanded((current) => !current)}
+            className="ml-auto shrink-0 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground hover:underline underline-offset-4"
+            aria-expanded={expanded}
+            aria-label={toggleLabel}
+            data-testid={`tool-result-toggle-${message.id}`}
+          >
+            {toggleLabel}
+          </button>
+        </div>
+        <div className="w-full break-words rounded-2xl rounded-tl-sm border border-primary/10 bg-primary/[0.03] px-4 py-2.5 text-[13px] leading-relaxed text-foreground/90">
+          <div className="break-words">
+            <ToolResultMessageContent
+              message={message}
+              compactMetadata={compactMetadata}
+              expanded={expanded}
+              t={t}
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 };
@@ -496,6 +533,18 @@ export const DetailSessionPreview = ({
           {messages.map((message) => {
             const isUser = message.role === "user";
             const isToolResult = message.role === "toolResult";
+
+            if (isToolResult) {
+              return (
+                <ToolResultMessageRow
+                  key={message.id}
+                  message={message}
+                  compactMetadata={compactMetadata}
+                  t={t}
+                />
+              );
+            }
+
             return (
               <div key={message.id} className="relative flex gap-4">
                 <div
@@ -520,26 +569,18 @@ export const DetailSessionPreview = ({
                   <div
                     className={cn(
                       "break-words rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed",
-                      isToolResult ? "w-full" : "inline-block max-w-full",
+                      "inline-block max-w-full",
                       isUser
                         ? "rounded-tl-sm bg-secondary/60 text-foreground/90"
                         : "rounded-tl-sm border border-primary/10 bg-primary/[0.03] text-foreground/90",
                     )}
                   >
                     <div className="break-words">
-                      {isToolResult ? (
-                        <ToolResultMessageContent
-                          message={message}
-                          compactMetadata={compactMetadata}
-                          t={t}
-                        />
-                      ) : (
-                        <SessionMessageContent
-                          content={message.content}
-                          compactMetadata={compactMetadata}
-                          t={t}
-                        />
-                      )}
+                      <SessionMessageContent
+                        content={message.content}
+                        compactMetadata={compactMetadata}
+                        t={t}
+                      />
                     </div>
                   </div>
                 </div>

--- a/dashboard/app/src/components/space/session-preview.tsx
+++ b/dashboard/app/src/components/space/session-preview.tsx
@@ -378,43 +378,6 @@ function SessionMarkdownContent({ content }: { content: string }) {
   );
 }
 
-export function CardSessionPreview({
-  messages,
-  t,
-}: {
-  messages: SessionMessage[];
-  t: TFunction;
-}) {
-  const previewMessages = messages.slice(0, 2);
-
-  if (previewMessages.length === 0) return null;
-
-  return (
-    <div className="mt-3.5 relative pl-3.5 border-l-[2px] border-border/40 transition-colors group-hover:border-border/60">
-      <div className="flex items-center gap-1.5 mb-2">
-        <MessageCircle className="size-3 text-muted-foreground/70" />
-        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
-          {t("session_preview.title")}
-        </span>
-      </div>
-      <div className="space-y-1.5">
-        {previewMessages.map((message) => {
-          return (
-            <div key={message.id} className="flex gap-2 items-start text-xs text-foreground/70 leading-relaxed">
-              <span className="font-semibold text-foreground/40 shrink-0 mt-[1px]">
-                {getRoleLabel(t, message.role)}
-              </span>
-              <span className="line-clamp-1 break-all">
-                {message.content}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 export function DetailSessionPreview({
   messages,
   loading,
@@ -486,5 +449,42 @@ export function DetailSessionPreview({
         </div>
       )}
     </section>
+  );
+}
+
+export function CardSessionPreview({
+  messages,
+  t,
+}: {
+  messages: SessionMessage[];
+  t: TFunction;
+}) {
+  const previewMessages = messages.slice(0, 2);
+
+  if (previewMessages.length === 0) return null;
+
+  return (
+    <div className="mt-3.5 relative pl-3.5 border-l-[2px] border-border/40 transition-colors group-hover:border-border/60">
+      <div className="flex items-center gap-1.5 mb-2">
+        <MessageCircle className="size-3 text-muted-foreground/70" />
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground/80">
+          {t("session_preview.title")}
+        </span>
+      </div>
+      <div className="space-y-1.5">
+        {previewMessages.map((message) => {
+          return (
+            <div key={message.id} className="flex gap-2 items-start text-xs text-foreground/70 leading-relaxed">
+              <span className="font-semibold text-foreground/40 shrink-0 mt-[1px]">
+                {getRoleLabel(t, message.role)}
+              </span>
+              <span className="line-clamp-1 break-all">
+                {message.content}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }

--- a/dashboard/app/src/components/space/session-preview.tsx
+++ b/dashboard/app/src/components/space/session-preview.tsx
@@ -308,6 +308,13 @@ const getRoleLabel = (
   return t(`session_preview.role.${role}`, { defaultValue: role });
 };
 
+const getToolResultPreview = (content: string): string => {
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .find((line) => line !== "" && !line.startsWith("```")) ?? "";
+};
+
 const SessionMarkdownContent = ({ content }: { content: string }) => {
   return (
     <ReactMarkdown
@@ -404,6 +411,55 @@ const SessionMarkdownContent = ({ content }: { content: string }) => {
   );
 };
 
+const ToolResultMessageContent = ({
+  message,
+  compactMetadata,
+  t,
+}: {
+  message: SessionMessage;
+  compactMetadata: boolean;
+  t: TFunction;
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const preview = getToolResultPreview(message.content);
+  const toggleLabel = expanded
+    ? t("session_preview.hide_tool_result")
+    : t("session_preview.show_tool_result");
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-start justify-between gap-3">
+        <p
+          className="min-w-0 flex-1 break-words text-[12px] leading-5 text-muted-foreground"
+          data-testid={`tool-result-preview-${message.id}`}
+        >
+          {preview || t("session_preview.tool_result_empty")}
+        </p>
+        <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          className="shrink-0 rounded-full border border-border/50 px-2.5 py-1 text-[11px] font-medium text-foreground/70 transition-colors hover:border-border/80 hover:text-foreground"
+          aria-expanded={expanded}
+          aria-label={toggleLabel}
+          data-testid={`tool-result-toggle-${message.id}`}
+        >
+          {toggleLabel}
+        </button>
+      </div>
+
+      {expanded ? (
+        <div data-testid={`tool-result-body-${message.id}`}>
+          <SessionMessageContent
+            content={message.content}
+            compactMetadata={compactMetadata}
+            t={t}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
 export const DetailSessionPreview = ({
   messages,
   loading,
@@ -433,6 +489,7 @@ export const DetailSessionPreview = ({
         <div className="relative space-y-5 before:absolute before:inset-y-2 before:left-[11px] before:w-px before:bg-border/40">
           {messages.map((message) => {
             const isUser = message.role === "user";
+            const isToolResult = message.role === "toolResult";
             return (
               <div key={message.id} className="relative flex gap-4">
                 <div
@@ -454,18 +511,28 @@ export const DetailSessionPreview = ({
                       {formatRelativeTime(t, message.created_at)}
                     </span>
                   </div>
-                  <div className={cn(
-                    "rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed inline-block max-w-full break-words",
-                    isUser 
-                      ? "bg-secondary/60 text-foreground/90 rounded-tl-sm" 
-                      : "bg-primary/[0.03] text-foreground/90 rounded-tl-sm border border-primary/10"
-                  )}>
+                  <div
+                    className={cn(
+                      "inline-block max-w-full break-words rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed",
+                      isUser
+                        ? "rounded-tl-sm bg-secondary/60 text-foreground/90"
+                        : "rounded-tl-sm border border-primary/10 bg-primary/[0.03] text-foreground/90",
+                    )}
+                  >
                     <div className="break-words">
-                      <SessionMessageContent
-                        content={message.content}
-                        compactMetadata={compactMetadata}
-                        t={t}
-                      />
+                      {isToolResult ? (
+                        <ToolResultMessageContent
+                          message={message}
+                          compactMetadata={compactMetadata}
+                          t={t}
+                        />
+                      ) : (
+                        <SessionMessageContent
+                          content={message.content}
+                          compactMetadata={compactMetadata}
+                          t={t}
+                        />
+                      )}
                     </div>
                   </div>
                 </div>

--- a/dashboard/app/src/components/space/session-preview.tsx
+++ b/dashboard/app/src/components/space/session-preview.tsx
@@ -312,7 +312,10 @@ const getToolResultPreview = (content: string): string => {
   return content
     .split("\n")
     .map((line) => line.trim())
-    .find((line) => line !== "" && !line.startsWith("```")) ?? "";
+    .filter((line) => line !== "" && !line.startsWith("```"))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
 };
 
 const SessionMarkdownContent = ({ content }: { content: string }) => {
@@ -427,14 +430,17 @@ const ToolResultMessageContent = ({
     : t("session_preview.show_tool_result");
 
   return (
-    <div className="space-y-2">
-      <div className="flex items-start justify-between gap-3">
+    <div className="w-full space-y-2">
+      {!expanded ? (
         <p
-          className="min-w-0 flex-1 break-words text-[12px] leading-5 text-muted-foreground"
+          className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-[12px] leading-5 text-muted-foreground"
           data-testid={`tool-result-preview-${message.id}`}
         >
           {preview || t("session_preview.tool_result_empty")}
         </p>
+      ) : null}
+
+      <div className="flex justify-end">
         <button
           type="button"
           onClick={() => setExpanded((current) => !current)}
@@ -513,7 +519,8 @@ export const DetailSessionPreview = ({
                   </div>
                   <div
                     className={cn(
-                      "inline-block max-w-full break-words rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed",
+                      "break-words rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed",
+                      isToolResult ? "w-full" : "inline-block max-w-full",
                       isUser
                         ? "rounded-tl-sm bg-secondary/60 text-foreground/90"
                         : "rounded-tl-sm border border-primary/10 bg-primary/[0.03] text-foreground/90",

--- a/dashboard/app/src/components/space/space-page-layout.tsx
+++ b/dashboard/app/src/components/space/space-page-layout.tsx
@@ -73,7 +73,7 @@ interface SpacePageLayoutProps {
   onHandleFarmAction: () => void;
 }
 
-export function SpacePageLayout({
+export const SpacePageLayout = ({
   spaceId,
   routeState,
   dataModel,
@@ -100,7 +100,7 @@ export function SpacePageLayout({
   onHandleImport,
   onRefreshMemories,
   onHandleFarmAction,
-}: SpacePageLayoutProps) {
+}: SpacePageLayoutProps) => {
   const isEmpty =
     !dataModel.isMemoryLoading &&
     dataModel.displayedMemories.length === 0 &&
@@ -712,4 +712,4 @@ export function SpacePageLayout({
       />
     </div>
   );
-}
+};

--- a/dashboard/app/src/components/space/space-page-layout.tsx
+++ b/dashboard/app/src/components/space/space-page-layout.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
 } from "lucide-react";
 import type { TFunction } from "i18next";
-import { getSessionPreviewLookupKey } from "@/api/queries";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -504,11 +503,7 @@ export function SpacePageLayout({
                       key={memory.id}
                       memory={memory}
                       derivedTags={dataModel.getActiveDerivedTags(memory)}
-                      sessionPreview={
-                        dataModel.sessionPreviewBySessionID[
-                          getSessionPreviewLookupKey(memory)
-                        ] ?? []
-                      }
+                      hasLinkedSession={memory.session_id.trim() !== ""}
                       isSelected={routeState.selected?.id === memory.id}
                       onClick={() => routeState.openMemoryDetail(memory, "list")}
                       onDelete={() => setDeleteTarget(memory)}
@@ -584,8 +579,8 @@ export function SpacePageLayout({
                 key={routeState.selected.id}
                 memory={routeState.selected}
                 derivedTags={dataModel.getActiveDerivedTags(routeState.selected)}
-                sessionPreview={dataModel.selectedSessionPreview}
-                sessionPreviewLoading={dataModel.selectedSessionPreviewLoading}
+                sessionMessages={dataModel.selectedSessionMessages}
+                sessionMessagesLoading={dataModel.selectedSessionMessagesLoading}
                 onClose={() => routeState.setSelected(null)}
                 onDelete={() => setDeleteTarget(routeState.selected!)}
                 onEdit={
@@ -635,8 +630,8 @@ export function SpacePageLayout({
           <MobileDetailSheet
             memory={routeState.selected}
             derivedTags={dataModel.getActiveDerivedTags(routeState.selected)}
-            sessionPreview={dataModel.selectedSessionPreview}
-            sessionPreviewLoading={dataModel.selectedSessionPreviewLoading}
+            sessionMessages={dataModel.selectedSessionMessages}
+            sessionMessagesLoading={dataModel.selectedSessionMessagesLoading}
             open={!!routeState.selected}
             onOpenChange={(open) => !open && routeState.setSelected(null)}
             onDelete={() => {

--- a/dashboard/app/src/components/space/use-space-data-model.test.tsx
+++ b/dashboard/app/src/components/space/use-space-data-model.test.tsx
@@ -7,7 +7,7 @@ import type { Memory } from "@/types/memory";
 const mocks = vi.hoisted(() => ({
   useStats: vi.fn(),
   useMemories: vi.fn(),
-  useSessionPreviewMessages: vi.fn(),
+  useSelectedSessionMessages: vi.fn(),
   useCreateMemory: vi.fn(),
   useDeleteMemory: vi.fn(),
   useUpdateMemory: vi.fn(),
@@ -48,11 +48,11 @@ const EMPTY_SIGNAL_INDEX: LocalDerivedSignalIndex = {
 };
 
 vi.mock("@/api/queries", () => ({
-  getSessionPreviewLookupKey: (memory: Memory) =>
-    memory.memory_type === "insight" ? memory.session_id : "",
+  getLinkedSessionID: (memory: Pick<Memory, "session_id"> | null | undefined) =>
+    memory?.session_id.trim() ?? "",
   useStats: (...args: unknown[]) => mocks.useStats(...args),
   useMemories: (...args: unknown[]) => mocks.useMemories(...args),
-  useSessionPreviewMessages: (...args: unknown[]) => mocks.useSessionPreviewMessages(...args),
+  useSelectedSessionMessages: (...args: unknown[]) => mocks.useSelectedSessionMessages(...args),
   useCreateMemory: () => mocks.useCreateMemory(),
   useDeleteMemory: () => mocks.useDeleteMemory(),
   useUpdateMemory: () => mocks.useUpdateMemory(),
@@ -103,8 +103,8 @@ function primeMocks(): void {
     isLoading: false,
     isFetching: false,
   });
-  mocks.useSessionPreviewMessages.mockReturnValue({
-    data: {},
+  mocks.useSelectedSessionMessages.mockReturnValue({
+    data: [],
     isLoading: false,
     isFetching: false,
   });
@@ -258,5 +258,82 @@ describe("useSpaceDataModel", () => {
       3,
       expect.objectContaining({ enabled: true }),
     );
+  });
+
+  it("loads raw session data only for the selected memory", () => {
+    const selected = SOURCE_MEMORIES[0]!;
+    mocks.useSelectedSessionMessages.mockReturnValue({
+      data: [
+        {
+          id: "msg-1",
+          session_id: "sess-1",
+          agent_id: "agent",
+          source: "agent",
+          seq: 1,
+          role: "user",
+          content: "hello",
+          content_type: "text/plain",
+          tags: [],
+          state: "active",
+          created_at: "2026-03-28T00:00:00Z",
+          updated_at: "2026-03-28T00:00:00Z",
+        },
+      ],
+      isLoading: false,
+      isFetching: false,
+    });
+
+    const { result } = renderHook(() =>
+      useSpaceDataModel({
+        spaceId: "space-1",
+        q: undefined,
+        range: "all",
+        facet: undefined,
+        analysisCategory: undefined,
+        tag: undefined,
+        memoryTypeFilter: "pinned,insight",
+        timelineSelection: undefined,
+        importStatusOpen: false,
+        exportOpen: false,
+        isDesktopViewport: true,
+        mobileAnalysisOpen: false,
+        selected,
+        localVisibleCount: 50,
+        onSelectedMissing: vi.fn(),
+      }),
+    );
+
+    expect(mocks.useSelectedSessionMessages).toHaveBeenCalledWith("space-1", selected);
+    expect(result.current.selectedSessionMessages).toHaveLength(1);
+    expect(result.current.selectedSessionMessagesLoading).toBe(false);
+  });
+
+  it("does not report selected-session loading when there is no linked session", () => {
+    const { result } = renderHook(() =>
+      useSpaceDataModel({
+        spaceId: "space-1",
+        q: undefined,
+        range: "all",
+        facet: undefined,
+        analysisCategory: undefined,
+        tag: undefined,
+        memoryTypeFilter: "pinned,insight",
+        timelineSelection: undefined,
+        importStatusOpen: false,
+        exportOpen: false,
+        isDesktopViewport: true,
+        mobileAnalysisOpen: false,
+        selected: SOURCE_MEMORIES[1]!,
+        localVisibleCount: 50,
+        onSelectedMissing: vi.fn(),
+      }),
+    );
+
+    expect(mocks.useSelectedSessionMessages).toHaveBeenCalledWith(
+      "space-1",
+      SOURCE_MEMORIES[1]!,
+    );
+    expect(result.current.selectedSessionMessages).toEqual([]);
+    expect(result.current.selectedSessionMessagesLoading).toBe(false);
   });
 });

--- a/dashboard/app/src/components/space/use-space-data-model.ts
+++ b/dashboard/app/src/components/space/use-space-data-model.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useMemo } from "react";
 import {
-  getSessionPreviewLookupKey,
   useStats,
   useMemories,
-  useSessionPreviewMessages,
+  getLinkedSessionID,
+  useSelectedSessionMessages,
   useCreateMemory,
   useDeleteMemory,
   useUpdateMemory,
@@ -62,9 +62,8 @@ export interface SpaceDataModel {
   isFetchingMore: boolean;
   displayedFirstPageSize: number;
   fetchNextPage: ReturnType<typeof useMemories>["fetchNextPage"];
-  sessionPreviewBySessionID: Record<string, SessionMessage[]>;
-  selectedSessionPreview: SessionMessage[];
-  selectedSessionPreviewLoading: boolean;
+  selectedSessionMessages: SessionMessage[];
+  selectedSessionMessagesLoading: boolean;
   tagOptions: TagSummary[];
   analysisTagStats: Array<{
     value: string;
@@ -310,17 +309,7 @@ export function useSpaceDataModel(input: {
       timelineFilteredMemories,
     ],
   );
-  const sessionPreviewMemories = useMemo(() => {
-    if (!input.selected) return displayedSelection.displayedMemories;
-
-    const previewMemories = new Map(
-      displayedSelection.displayedMemories.map((memory) => [memory.id, memory]),
-    );
-    previewMemories.set(input.selected.id, input.selected);
-    return [...previewMemories.values()];
-  }, [displayedSelection.displayedMemories, input.selected]);
-  const sessionPreviewQuery = useSessionPreviewMessages(spaceId, sessionPreviewMemories);
-  const sessionPreviewBySessionID = sessionPreviewQuery.data ?? {};
+  const selectedSessionQuery = useSelectedSessionMessages(spaceId, input.selected);
   const hasMoreMemories = displayedSelection.usingLocalFilteredList
     ? displayedSelection.baseDisplayedMemories.length > input.localVisibleCount
     : hasNextPage;
@@ -350,15 +339,11 @@ export function useSpaceDataModel(input: {
       (derivedTag) => normalizeTagSignal(derivedTag) === activeTagNormalized,
     );
   };
-  const selectedSessionID = input.selected
-    ? getSessionPreviewLookupKey(input.selected)
-    : "";
-  const selectedSessionPreview = selectedSessionID
-    ? (sessionPreviewBySessionID[selectedSessionID] ?? [])
-    : [];
-  const selectedSessionPreviewLoading = !!selectedSessionID &&
-    selectedSessionPreview.length === 0 &&
-    (sessionPreviewQuery.isLoading || sessionPreviewQuery.isFetching);
+  const selectedSessionID = getLinkedSessionID(input.selected);
+  const selectedSessionMessages = selectedSessionQuery.data ?? [];
+  const selectedSessionMessagesLoading = !!selectedSessionID &&
+    selectedSessionMessages.length === 0 &&
+    (selectedSessionQuery.isLoading || selectedSessionQuery.isFetching);
 
   useEffect(() => {
     if (isMemoryLoading || !input.selected) return;
@@ -403,9 +388,8 @@ export function useSpaceDataModel(input: {
     isFetchingMore,
     displayedFirstPageSize,
     fetchNextPage,
-    sessionPreviewBySessionID,
-    selectedSessionPreview,
-    selectedSessionPreviewLoading,
+    selectedSessionMessages,
+    selectedSessionMessagesLoading,
     tagOptions,
     analysisTagStats,
     activeTagNormalized,

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -68,12 +68,16 @@
     "jump_to_latest": "Latest",
     "show_metadata": "Expand",
     "hide_metadata": "Collapse",
+    "show_tool_result": "Show result",
+    "hide_tool_result": "Hide result",
+    "tool_result_empty": "Tool result",
     "metadata_summary_empty": "Tap to view metadata",
     "role": {
       "user": "User",
       "assistant": "Assistant",
       "system": "System",
-      "tool": "Tool"
+      "tool": "Tool",
+      "toolResult": "Tool result"
     }
   },
   "add": {

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -38,7 +38,8 @@
     "load_more": "Load more",
     "loading": "Loading memories...",
     "via": "via",
-    "copied": "Copied to clipboard"
+    "copied": "Copied to clipboard",
+    "linked_session": "From a conversation"
   },
   "detail": {
     "type": {
@@ -55,13 +56,16 @@
     "mixed_badge": "Mixed",
     "derived_tags": "Derived tags",
     "metadata": "Metadata",
-    "delete": "Delete this memory",
+    "delete": "Delete",
+    "delete_button_label": "Delete memory",
     "edit": "Edit",
     "close": "Close"
   },
   "session_preview": {
     "title": "Original Conversation",
     "loading": "Loading conversation...",
+    "jump_to_start": "Start",
+    "jump_to_latest": "Latest",
     "show_metadata": "Expand",
     "hide_metadata": "Collapse",
     "metadata_summary_empty": "Tap to view metadata",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -38,7 +38,8 @@
     "load_more": "加载更多",
     "loading": "正在加载记忆…",
     "via": "来自",
-    "copied": "已复制到剪贴板"
+    "copied": "已复制到剪贴板",
+    "linked_session": "有对话来源"
   },
   "detail": {
     "type": {
@@ -55,13 +56,16 @@
     "mixed_badge": "混合",
     "derived_tags": "派生标签",
     "metadata": "元数据",
-    "delete": "删除这条记忆",
+    "delete": "删除",
+    "delete_button_label": "删除记忆",
     "edit": "编辑",
     "close": "关闭"
   },
   "session_preview": {
     "title": "对话原文",
     "loading": "正在加载对话…",
+    "jump_to_start": "开头",
+    "jump_to_latest": "最新",
     "show_metadata": "展开",
     "hide_metadata": "收起",
     "metadata_summary_empty": "点击查看元数据",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -68,12 +68,16 @@
     "jump_to_latest": "最新",
     "show_metadata": "展开",
     "hide_metadata": "收起",
+    "show_tool_result": "展开结果",
+    "hide_tool_result": "收起结果",
+    "tool_result_empty": "工具结果",
     "metadata_summary_empty": "点击查看元数据",
     "role": {
       "user": "用户",
       "assistant": "助手",
       "system": "系统",
-      "tool": "工具"
+      "tool": "工具",
+      "toolResult": "工具结果"
     }
   },
   "add": {

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
   retry: vi.fn(),
   useStats: vi.fn(),
   useSourceMemories: vi.fn(),
-  useSessionPreviewMessages: vi.fn(),
+  useSelectedSessionMessages: vi.fn(),
   useMemories: vi.fn(),
   useDeepAnalysisReports: vi.fn(),
 }));
@@ -46,6 +46,10 @@ if (typeof Element.prototype.requestFullscreen === "undefined") {
 if (typeof document.exitFullscreen === "undefined") {
   document.exitFullscreen = vi.fn().mockResolvedValue(undefined);
 }
+Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+  value: vi.fn(),
+  writable: true,
+});
 
 function getAnalysisCategoryButton(category: string): HTMLButtonElement {
   const button = document.querySelector<HTMLButtonElement>(
@@ -314,8 +318,8 @@ vi.mock("@/components/space/use-memory-farm-entry-state", () => ({
 }));
 
 vi.mock("@/api/queries", () => ({
-  getSessionPreviewLookupKey: (memory: Memory) =>
-    memory.memory_type === "insight" ? memory.session_id : "",
+  getLinkedSessionID: (memory: Pick<Memory, "session_id"> | null | undefined) =>
+    memory?.session_id.trim() ?? "",
   useStats: (spaceId: string, range?: string, enabled = true) => {
     mocks.useStats(spaceId, range, enabled);
     return {
@@ -344,47 +348,53 @@ vi.mock("@/api/queries", () => ({
       isFetching: false,
     };
   },
-  useSessionPreviewMessages: (_spaceId: string, memories: Memory[]) => {
-    mocks.useSessionPreviewMessages(memories);
+  useSelectedSessionMessages: (_spaceId: string, memory: Memory | null) => {
+    mocks.useSelectedSessionMessages(memory);
     return {
-      data: {
-        "sess-activity-1": [
-          {
-            id: "msg-1",
-            session_id: "sess-activity-1",
-            agent_id: "agent",
-            source: "agent",
-            seq: 1,
-            role: "user",
-            content: "We should keep the launch demo focused and avoid expanding scope.",
-            content_type: "text/plain",
-            tags: [],
-            state: "active",
-            created_at: "2026-03-03T00:00:00Z",
-            updated_at: "2026-03-03T00:00:00Z",
-          },
-          {
-            id: "msg-2",
-            session_id: "sess-activity-1",
-            agent_id: "agent",
-            source: "agent",
-            seq: 2,
-            role: "assistant",
-            content: [
-              "Agreed. I will keep the dashboard release notes compact and demo-oriented.",
-              "",
-              "```json",
-              '{"status":"ok"}',
-              "```",
-            ].join("\n"),
-            content_type: "text/plain",
-            tags: [],
-            state: "active",
-            created_at: "2026-03-03T00:01:00Z",
-            updated_at: "2026-03-03T00:01:00Z",
-          },
-        ],
-      },
+      data: memory?.session_id === "sess-activity-1"
+        ? [
+            {
+              id: "msg-1",
+              session_id: "sess-activity-1",
+              agent_id: "agent",
+              source: "agent",
+              seq: 1,
+              role: "user",
+              content: "We should keep the launch demo focused and avoid expanding scope.",
+              content_type: "text/plain",
+              tags: [],
+              state: "active",
+              created_at: "2026-03-03T00:00:00Z",
+              updated_at: "2026-03-03T00:00:00Z",
+            },
+            {
+              id: "msg-2",
+              session_id: "sess-activity-1",
+              agent_id: "agent",
+              source: "agent",
+              seq: 2,
+              role: "assistant",
+              content: [
+                "Conversation info (untrusted metadata):",
+                "",
+                "```json",
+                '{"message_id":"1491334536338997298","sender":"Bosn Ma","timestamp":"Wed 2026-04-08 07:11 UTC"}',
+                "```",
+                "",
+                "Agreed. I will keep the dashboard release notes compact and demo-oriented.",
+                "",
+                "```json",
+                '{"status":"ok"}',
+                "```",
+              ].join("\n"),
+              content_type: "text/plain",
+              tags: [],
+              state: "active",
+              created_at: "2026-03-03T00:01:00Z",
+              updated_at: "2026-03-03T00:01:00Z",
+            },
+          ]
+        : [],
       isLoading: false,
       isFetching: false,
     };
@@ -499,6 +509,7 @@ describe("SpacePage", () => {
     window.dispatchEvent(new Event("resize"));
     mocks.useStats.mockClear();
     mocks.useSourceMemories.mockClear();
+    mocks.useSelectedSessionMessages.mockClear();
     mocks.useMemories.mockClear();
     mocks.useDeepAnalysisReports.mockClear();
     await i18n.changeLanguage("en");
@@ -536,7 +547,7 @@ describe("SpacePage", () => {
     expect(screen.getByText("Deploy dashboard status update")).toBeInTheDocument();
     expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete this memory" }),
+      screen.queryByRole("button", { name: "Delete memory" }),
     ).not.toBeInTheDocument();
   });
 
@@ -606,13 +617,13 @@ describe("SpacePage", () => {
 
     expect(screen.getByTestId("detail-scroll-area")).toHaveClass("flex-1");
     expect(
-      screen.getByRole("button", { name: "Delete this memory" }),
+      screen.getByRole("button", { name: "Delete memory" }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
     expect(
-      screen.queryByRole("button", { name: "Delete this memory" }),
+      screen.queryByRole("button", { name: "Delete memory" }),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
   });
@@ -628,14 +639,14 @@ describe("SpacePage", () => {
     fireEvent.click(preferenceCard!);
 
     expect(
-      screen.getByRole("button", { name: "Delete this memory" }),
+      screen.getByRole("button", { name: "Delete memory" }),
     ).toBeInTheDocument();
 
     fireEvent.click(getAnalysisCategoryButton("activity"));
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: "Delete this memory" }),
+        screen.queryByRole("button", { name: "Delete memory" }),
       ).not.toBeInTheDocument();
     });
 
@@ -683,7 +694,7 @@ describe("SpacePage", () => {
       within(detailDialog).getByTestId("detail-scroll-area"),
     ).not.toHaveClass("max-h-[60vh]");
     expect(
-      screen.getByRole("button", { name: "Delete this memory" }),
+      screen.getByRole("button", { name: "Delete memory" }),
     ).toBeInTheDocument();
 
     fireEvent.click(within(detailDialog).getByRole("button", { name: "Close" }));
@@ -812,34 +823,57 @@ describe("SpacePage", () => {
     fireEvent.click(olderCard!);
 
     expect(
-      screen.getByRole("button", { name: "Delete this memory" }),
+      screen.getByRole("button", { name: "Delete memory" }),
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole("button", { name: /0 memories$/i })[0]!);
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: "Delete this memory" }),
+        screen.queryByRole("button", { name: "Delete memory" }),
       ).not.toBeInTheDocument();
     });
   });
 
-  it("renders session preview content for insight memories with matched session data", async () => {
+  it("loads selected-memory raw session content in detail without rendering list previews", async () => {
     renderSpacePage();
 
     expect(
-      screen.getByText("We should keep the launch demo focused and avoid expanding scope."),
-    ).toBeInTheDocument();
-
+      screen.queryByText("We should keep the launch demo focused and avoid expanding scope."),
+    ).not.toBeInTheDocument();
     const activityCard = screen
       .getByText("Deploy dashboard status update")
       .closest('[role="button"]');
+    const preferenceCard = screen
+      .getByText("Prefer Neovim for edits")
+      .closest('[role="button"]');
 
     expect(activityCard).not.toBeNull();
-    fireEvent.click(activityCard!);
+    expect(preferenceCard).not.toBeNull();
+    const activityCardElement = activityCard as HTMLElement;
+    const preferenceCardElement = preferenceCard as HTMLElement;
+    expect(
+      within(activityCardElement).getByText("From a conversation"),
+    ).toBeInTheDocument();
+    expect(
+      within(preferenceCardElement).queryByText("From a conversation"),
+    ).not.toBeInTheDocument();
+    fireEvent.click(activityCardElement);
+
+    expect(mocks.useSelectedSessionMessages).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: activityNewest.id,
+        session_id: "sess-activity-1",
+      }),
+    );
 
     expect(
       within(screen.getByTestId("detail-scroll-area")).getByText("Original Conversation"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).getByText(
+        "We should keep the launch demo focused and avoid expanding scope.",
+      ),
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId("detail-scroll-area")).getByText(
@@ -847,10 +881,47 @@ describe("SpacePage", () => {
       ),
     ).toBeInTheDocument();
     expect(
+      within(screen.getByTestId("detail-scroll-area")).getByText(
+        "Conversation info (untrusted metadata):",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).getByText(
+        '{"message_id":"1491334536338997298","sender":"Bosn Ma","timestamp":"Wed 2026-04-08 07:11 UTC"}',
+      ),
+    ).toBeInTheDocument();
+    expect(
       within(screen.getByTestId("detail-scroll-area")).getByText('{"status":"ok"}'),
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId("detail-scroll-area")).queryByText("```json"),
+    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(HTMLElement.prototype.scrollTo).toHaveBeenCalled();
+    });
+  });
+
+  it("keeps detail focused on the memory when the selected item has no linked session", async () => {
+    renderSpacePage();
+
+    const preferenceCard = screen
+      .getByText("Prefer Neovim for edits")
+      .closest('[role="button"]');
+
+    expect(preferenceCard).not.toBeNull();
+    fireEvent.click(preferenceCard!);
+
+    expect(mocks.useSelectedSessionMessages).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: preferenceMemory.id,
+        session_id: "",
+      }),
+    );
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).queryByText("Original Conversation"),
+    ).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).queryByTestId("detail-session-section"),
     ).not.toBeInTheDocument();
   });
 

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -393,6 +393,24 @@ vi.mock("@/api/queries", () => ({
               created_at: "2026-03-03T00:01:00Z",
               updated_at: "2026-03-03T00:01:00Z",
             },
+            {
+              id: "msg-3",
+              session_id: "sess-activity-1",
+              agent_id: "agent",
+              source: "agent",
+              seq: 3,
+              role: "toolResult",
+              content: [
+                "Fetched release checklist",
+                "",
+                "hidden diagnostic line",
+              ].join("\n"),
+              content_type: "text/plain",
+              tags: [],
+              state: "active",
+              created_at: "2026-03-03T00:02:00Z",
+              updated_at: "2026-03-03T00:02:00Z",
+            },
           ]
         : [],
       isLoading: false,
@@ -894,8 +912,38 @@ describe("SpacePage", () => {
       within(screen.getByTestId("detail-scroll-area")).getByText('{"status":"ok"}'),
     ).toBeInTheDocument();
     expect(
+      within(screen.getByTestId("detail-scroll-area")).getByText("Tool result"),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).getByRole("button", {
+        name: "Show result",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).queryByText(
+        "hidden diagnostic line",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
       within(screen.getByTestId("detail-scroll-area")).queryByText("```json"),
     ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      within(screen.getByTestId("detail-scroll-area")).getByTestId(
+        "tool-result-toggle-msg-3",
+      ),
+    );
+
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).getByRole("button", {
+        name: "Hide result",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("detail-scroll-area")).getByText(
+        "hidden diagnostic line",
+      ),
+    ).toBeInTheDocument();
     await waitFor(() => {
       expect(HTMLElement.prototype.scrollTo).toHaveBeenCalled();
     });

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -547,8 +547,8 @@ describe("SpacePage", () => {
     expect(screen.getByText("Deploy dashboard status update")).toBeInTheDocument();
     expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Delete memory" }),
-    ).not.toBeInTheDocument();
+      document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+    ).toBeNull();
   });
 
   it("does not prefetch deep-analysis reports before the analysis tab is opened", async () => {
@@ -617,14 +617,14 @@ describe("SpacePage", () => {
 
     expect(screen.getByTestId("detail-scroll-area")).toHaveClass("flex-1");
     expect(
-      screen.getByRole("button", { name: "Delete memory" }),
-    ).toBeInTheDocument();
+      document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+    ).not.toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
     expect(
-      screen.queryByRole("button", { name: "Delete memory" }),
-    ).not.toBeInTheDocument();
+      document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+    ).toBeNull();
     expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
   });
 
@@ -639,15 +639,15 @@ describe("SpacePage", () => {
     fireEvent.click(preferenceCard!);
 
     expect(
-      screen.getByRole("button", { name: "Delete memory" }),
-    ).toBeInTheDocument();
+      document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+    ).not.toBeNull();
 
     fireEvent.click(getAnalysisCategoryButton("activity"));
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: "Delete memory" }),
-      ).not.toBeInTheDocument();
+        document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+      ).toBeNull();
     });
 
     expect(screen.getByText("Weekly activity planning notes")).toBeInTheDocument();
@@ -694,8 +694,8 @@ describe("SpacePage", () => {
       within(detailDialog).getByTestId("detail-scroll-area"),
     ).not.toHaveClass("max-h-[60vh]");
     expect(
-      screen.getByRole("button", { name: "Delete memory" }),
-    ).toBeInTheDocument();
+      document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+    ).not.toBeNull();
 
     fireEvent.click(within(detailDialog).getByRole("button", { name: "Close" }));
 
@@ -823,15 +823,15 @@ describe("SpacePage", () => {
     fireEvent.click(olderCard!);
 
     expect(
-      screen.getByRole("button", { name: "Delete memory" }),
-    ).toBeInTheDocument();
+      document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+    ).not.toBeNull();
 
     fireEvent.click(screen.getAllByRole("button", { name: /0 memories$/i })[0]!);
 
     await waitFor(() => {
       expect(
-        screen.queryByRole("button", { name: "Delete memory" }),
-      ).not.toBeInTheDocument();
+        document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
+      ).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
- stop loading linked raw session previews while fetching memory cards, and load raw session messages only after opening a memory detail with a linked session
- show a light conversation-source hint on cards with linked sessions, and hide the raw-session section when no linked messages are available
- polish raw session reading in detail with latest-message focus, Start/Latest jumps, cleaned metadata rendering, and collapsed tool-result messages by default

## Testing
- `pnpm typecheck`
- `pnpm test -- src/components/space/memory-card.test.tsx src/components/space/mobile-detail-sheet.test.tsx src/pages/space.test.tsx`
