### PR TITLE
plugin: skip cron message

### DIFF
--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -57,6 +57,8 @@ interface HookContext {
   sessionId?: string;
   /** Legacy alias for sessionId used by older OpenClaw versions. */
   sessionKey?: string;
+  /** What initiated this agent run: "user", "heartbeat", "cron", or "memory". */
+  trigger?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +293,13 @@ export function registerHooks(
       };
       const hookCtx = (context ?? {}) as HookContext;
       if (!evt?.success || !evt.messages || evt.messages.length === 0) return;
+
+      // Skip cron-triggered runs — they produce repetitive low-value messages
+      // (e.g. "[cron:UUID task-name] Reply to the user with exactly: Hi")
+      if (hookCtx.trigger === "cron") {
+        logger.info("[mem9] Skipping auto-ingest for cron-triggered run");
+        return;
+      }
 
       // Format raw messages into IngestMessage format
       const formatted: IngestMessage[] = [];

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -309,6 +309,11 @@ export function registerHooks(
         const role = typeof m.role === "string" ? m.role : "";
         if (!role) continue;
 
+        // Skip cron tool results — structured JSON job definitions with no memory value
+        if (role === "toolResult" && typeof m.toolName === "string" && m.toolName === "cron") {
+          continue;
+        }
+
         let content = "";
         if (typeof m.content === "string") {
           content = m.content;


### PR DESCRIPTION
Cron messages are similar to system logs, so we don't load them into memories.

OpenClaw interface: https://github.com/openclaw/openclaw/blob/1fede43b948df40ca8674511d4bd08d39f6c5837/src/plugins/types.ts#L2396-L2397