### PR TITLE
plugin: skip heartbeat message

### DIFF
--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -294,10 +294,9 @@ export function registerHooks(
       const hookCtx = (context ?? {}) as HookContext;
       if (!evt?.success || !evt.messages || evt.messages.length === 0) return;
 
-      // Skip cron-triggered runs — they produce repetitive low-value messages
-      // (e.g. "[cron:UUID task-name] Reply to the user with exactly: Hi")
-      if (hookCtx.trigger === "cron") {
-        logger.info("[mem9] Skipping auto-ingest for cron-triggered run");
+      // Skip cron/heartbeat-triggered runs — they produce low-value messages
+      if (hookCtx.trigger === "cron" || hookCtx.trigger === "heartbeat") {
+        logger.info(`[mem9] Skipping auto-ingest for ${hookCtx.trigger}-triggered run`);
         return;
       }
 

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -103,7 +103,8 @@ func (r *SessionRepo) PatchTags(ctx context.Context, sessionID, contentHash stri
 }
 
 func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, []any) {
-	conds := []string{}
+	// sessions which are not used for recall purposes (e.g. tool results).
+	conds := []string{`role NOT IN ("toolResult")`}
 	args := []any{}
 
 	if f.State == "all" {


### PR DESCRIPTION
The following heartbeat messages are also low value and need to be ignored.
- "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK ..."
- "The system performed a self-check at ..."

OpenClaw interface: https://github.com/openclaw/openclaw/blob/1fede43b948df40ca8674511d4bd08d39f6c5837/src/plugins/types.ts#L2396-L2397