### PR TITLE
fix(openclaw-plugin): preserve recall order and configure search timeouts

### DIFF
--- a/openclaw-plugin/AGENTS.md
+++ b/openclaw-plugin/AGENTS.md
@@ -28,7 +28,7 @@ cd openclaw-plugin && npm run typecheck
 - ESM only; local imports always end with `.js`.
 - `MemoryBackend` is the seam between hooks/tools and the HTTP implementation.
 - `ServerBackend` is the only backend currently used; keep request logic centralized there.
-- `AbortSignal.timeout(8_000)` is the standard fetch timeout.
+- Timeouts are configurable: `searchTimeoutMs` defaults to 15000ms, and `defaultTimeoutMs` defaults to 8000ms for other requests.
 - Plugin uses `kind: "memory"`; OpenClaw owns lifecycle timing, this package only supplies tools/hooks.
 
 ## Error handling

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -31,7 +31,8 @@ Add mnemo to your project's `openclaw.json`:
         "enabled": true,
         "config": {
           "apiUrl": "http://localhost:8080",
-          "apiKey": "uuid"
+          "apiKey": "uuid",
+          "searchTimeoutMs": 15000
         }
       }
     }
@@ -173,9 +174,38 @@ Defined in `openclaw.plugin.json`:
 |---|---|---|
 | `apiUrl` | string | mnemo-server URL |
 | `apiKey` | string | Preferred key. Uses `/v1alpha2/mem9s/...` with `X-API-Key` header |
+| `defaultTimeoutMs` | number | Default timeout for non-search mem9 API requests in milliseconds. Default: `8000` |
+| `searchTimeoutMs` | number | Timeout for `memory_search` and automatic recall search in milliseconds. Default: `15000` |
 | `tenantID` | string | Legacy alias for `apiKey`. The plugin still uses `/v1alpha2/mem9s/...` with `X-API-Key`. |
 
 > **Note**: `apiKey` takes precedence when both fields are set. If only `tenantID` is present, the plugin treats it as a legacy alias for `apiKey`, still uses v1alpha2, and logs a deprecation warning once at startup.
+
+## Timeout Behavior
+
+The plugin uses two timeout buckets:
+
+- `searchTimeoutMs` applies to `memory_search` and the automatic recall search in `before_prompt_build`
+- `defaultTimeoutMs` applies to all other mem9 HTTP requests, including register, store, get, update, delete, and ingest
+
+Example:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "openclaw": {
+        "enabled": true,
+        "config": {
+          "apiUrl": "http://your-server:8080",
+          "apiKey": "uuid",
+          "defaultTimeoutMs": 8000,
+          "searchTimeoutMs": 15000
+        }
+      }
+    }
+  }
+}
+```
 
 ## File Structure
 
@@ -197,4 +227,5 @@ openclaw-plugin/
 |---|---|---|
 | `No mode configured` | Missing config | Add `apiUrl` and `apiKey` (or legacy `tenantID`) to plugin config |
 | `Server mode requires...` | Missing key | Add `apiKey` (or legacy `tenantID`) to config |
+| Search requests time out | Hybrid/vector search exceeds plugin timeout | Increase `searchTimeoutMs` in plugin config |
 | Plugin not loading | Not in memory slot | Set `"slots": {"memory": "openclaw"}` in openclaw.json |

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -3,7 +3,7 @@
  *
  * Provides automatic memory recall and capture via OpenClaw's hook system:
  * - before_prompt_build: inject relevant memories into every LLM call
- *   (grouped by type: pinned → insights)
+ *   (preserving the server/backend recall order)
  * - after_compaction: (no-op placeholder for future use)
  * - before_reset: save session context before /reset wipes it
  * - agent_end: auto-capture via smart pipeline with size-aware message selection
@@ -107,26 +107,10 @@ function escapeForPrompt(text: string): string {
 }
 
 /**
- * Format memories for injection, grouped by type for maximum comprehension:
- * 1. Pinned memories first (user-explicit preferences)
- * 2. Insights (extracted facts)
+ * Format memories for injection while preserving the backend recall order.
  */
 function formatMemoriesBlock(memories: Memory[]): string {
   if (memories.length === 0) return "";
-
-  // Group by memory_type, falling back to "pinned" for legacy memories
-  const pinned: Memory[] = [];
-  const insights: Memory[] = [];
-  const other: Memory[] = [];
-
-  for (const m of memories) {
-    const mtype = m.memory_type ?? "pinned";
-    switch (mtype) {
-      case "pinned": pinned.push(m); break;
-      case "insight": insights.push(m); break;
-      default: other.push(m); break;
-    }
-  }
 
   const lines: string[] = [];
   let idx = 1;
@@ -142,18 +126,8 @@ function formatMemoriesBlock(memories: Memory[]): string {
     return `${idx++}.${sep}${escapeForPrompt(content)}`;
   };
 
-  if (pinned.length > 0) {
-    lines.push("[Preferences]");
-    for (const m of pinned) lines.push(formatMem(m));
-  }
-  if (insights.length > 0) {
-    if (lines.length > 0) lines.push("");
-    lines.push("[Knowledge]");
-    for (const m of insights) lines.push(formatMem(m));
-  }
-  if (other.length > 0) {
-    if (lines.length > 0) lines.push("");
-    for (const m of other) lines.push(formatMem(m));
+  for (const memory of memories) {
+    lines.push(formatMem(memory));
   }
 
   return [

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -1,5 +1,10 @@
 import type { MemoryBackend } from "./backend.js";
-import { ServerBackend } from "./server-backend.js";
+import {
+  DEFAULT_SEARCH_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+  ServerBackend,
+  type BackendTimeouts,
+} from "./server-backend.js";
 import { registerHooks } from "./hooks.js";
 import type {
   PluginConfig,
@@ -12,6 +17,49 @@ import type {
 } from "./types.js";
 
 const DEFAULT_API_URL = "https://api.mem9.ai";
+const TIMEOUT_FIELDS = ["defaultTimeoutMs", "searchTimeoutMs"] as const;
+
+function normalizeTimeoutMs(
+  value: unknown,
+  field: (typeof TIMEOUT_FIELDS)[number],
+  fallback: number,
+  logger: OpenClawPluginApi["logger"],
+): number {
+  if (value == null) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    logger.info(`[mem9] invalid ${field}; using ${fallback}ms`);
+    return fallback;
+  }
+  return Math.floor(value);
+}
+
+function resolveTimeouts(
+  cfg: PluginConfig,
+  logger: OpenClawPluginApi["logger"],
+): Required<BackendTimeouts> {
+  const timeouts = {
+    defaultTimeoutMs: normalizeTimeoutMs(
+      cfg.defaultTimeoutMs,
+      "defaultTimeoutMs",
+      DEFAULT_TIMEOUT_MS,
+      logger,
+    ),
+    searchTimeoutMs: normalizeTimeoutMs(
+      cfg.searchTimeoutMs,
+      "searchTimeoutMs",
+      DEFAULT_SEARCH_TIMEOUT_MS,
+      logger,
+    ),
+  };
+
+  if (TIMEOUT_FIELDS.some((field) => cfg[field] != null)) {
+    logger.info(
+      `[mem9] timeout config: defaultTimeoutMs=${timeouts.defaultTimeoutMs}, searchTimeoutMs=${timeouts.searchTimeoutMs}`,
+    );
+  }
+
+  return timeouts;
+}
 
 function jsonResult(data: unknown) {
   // Older OpenClaw versions may assume tool results have a normalized
@@ -254,6 +302,7 @@ const mnemoPlugin = {
   register(api: OpenClawPluginApi) {
     const cfg = (api.pluginConfig ?? {}) as PluginConfig;
     const effectiveApiUrl = cfg.apiUrl ?? DEFAULT_API_URL;
+    const timeoutConfig = resolveTimeouts(cfg, api.logger);
     if (!cfg.apiUrl) {
       api.logger.info(`[mem9] apiUrl not configured, using default ${DEFAULT_API_URL}`);
     }
@@ -265,7 +314,7 @@ const mnemoPlugin = {
       api.logger.info("[mem9] tenantID is deprecated; treating it as apiKey for v1alpha2");
     }
     const registerTenant = async (agentName: string): Promise<string> => {
-      const backend = new ServerBackend(effectiveApiUrl, "", agentName);
+      const backend = new ServerBackend(effectiveApiUrl, "", agentName, timeoutConfig);
       const result = await backend.register();
       api.logger.info(
         `[mem9] *** Auto-provisioned apiKey=${result.id} *** Save this to your config as apiKey`
@@ -291,6 +340,7 @@ const mnemoPlugin = {
         effectiveApiUrl,
         () => resolveAPIKey(agentId),
         agentId,
+        timeoutConfig,
       );
       return buildTools(backend);
     };
@@ -302,6 +352,7 @@ const mnemoPlugin = {
       effectiveApiUrl,
       () => resolveAPIKey(hookAgentId),
       hookAgentId,
+      timeoutConfig,
     );
 
     // Register memory capability so OpenClaw 2026.4.2+ binds this plugin to
@@ -346,6 +397,7 @@ class LazyServerBackend implements MemoryBackend {
     private apiUrl: string,
     private apiKeyProvider: () => Promise<string>,
     private agentId: string,
+    private timeouts: BackendTimeouts,
   ) {}
 
   private async resolve(): Promise<ServerBackend> {
@@ -354,7 +406,7 @@ class LazyServerBackend implements MemoryBackend {
 
     this.resolving = this.apiKeyProvider().then((apiKey) =>
       Promise.resolve().then(() => {
-        this.resolved = new ServerBackend(this.apiUrl, apiKey, this.agentId);
+        this.resolved = new ServerBackend(this.apiUrl, apiKey, this.agentId, this.timeouts);
         return this.resolved;
       })
     ).catch((err) => {

--- a/openclaw-plugin/openclaw.plugin.json
+++ b/openclaw-plugin/openclaw.plugin.json
@@ -14,6 +14,16 @@
         "type": "string",
         "description": "mem9 API key (secret — do not share)"
       },
+      "defaultTimeoutMs": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Default timeout in milliseconds for non-search mem9 API requests (default 8000)"
+      },
+      "searchTimeoutMs": {
+        "type": "number",
+        "minimum": 1,
+        "description": "Timeout in milliseconds for memory search and automatic recall search (default 15000)"
+      },
       "tenantID": {
         "type": "string",
         "description": "Deprecated: use apiKey"
@@ -29,6 +39,14 @@
       "label": "API Key",
       "placeholder": "key...",
       "sensitive": true
+    },
+    "defaultTimeoutMs": {
+      "label": "Default Timeout (ms)",
+      "placeholder": "8000"
+    },
+    "searchTimeoutMs": {
+      "label": "Search Timeout (ms)",
+      "placeholder": "15000"
     },
     "tenantID": {
       "label": "Tenant ID (legacy)",

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -14,25 +14,43 @@ type ProvisionMem9sResponse = {
   id: string;
 };
 
+export const DEFAULT_TIMEOUT_MS = 8_000;
+export const DEFAULT_SEARCH_TIMEOUT_MS = 15_000;
+
+export interface BackendTimeouts {
+  defaultTimeoutMs?: number;
+  searchTimeoutMs?: number;
+}
+
+interface RequestOptions {
+  timeoutMs?: number;
+}
+
 export class ServerBackend implements MemoryBackend {
   private baseUrl: string;
   private apiKey: string;
   private agentName: string;
+  private timeouts: Required<BackendTimeouts>;
 
   constructor(
     apiUrl: string,
     apiKey: string,
     agentName: string,
+    timeouts: BackendTimeouts = {},
   ) {
     this.baseUrl = apiUrl.replace(/\/+$/, "");
     this.apiKey = apiKey;
     this.agentName = agentName;
+    this.timeouts = {
+      defaultTimeoutMs: timeouts.defaultTimeoutMs ?? DEFAULT_TIMEOUT_MS,
+      searchTimeoutMs: timeouts.searchTimeoutMs ?? DEFAULT_SEARCH_TIMEOUT_MS,
+    };
   }
 
   async register(): Promise<ProvisionMem9sResponse> {
     const resp = await fetch(this.baseUrl + "/v1alpha1/mem9s", {
       method: "POST",
-      signal: AbortSignal.timeout(8_000),
+      signal: AbortSignal.timeout(this.timeouts.defaultTimeoutMs),
     });
 
     if (!resp.ok) {
@@ -75,7 +93,12 @@ export class ServerBackend implements MemoryBackend {
       total: number;
       limit: number;
       offset: number;
-    }>("GET", `${this.memoryPath("/memories")}${qs ? "?" + qs : ""}`);
+    }>(
+      "GET",
+      `${this.memoryPath("/memories")}${qs ? "?" + qs : ""}`,
+      undefined,
+      { timeoutMs: this.timeouts.searchTimeoutMs },
+    );
     return {
       data: raw.memories ?? [],
       total: raw.total,
@@ -116,7 +139,8 @@ export class ServerBackend implements MemoryBackend {
   private async requestRaw(
     method: string,
     path: string,
-    body?: unknown
+    body?: unknown,
+    options?: RequestOptions,
   ): Promise<Response> {
     const url = this.baseUrl + path;
     const headers: Record<string, string> = {
@@ -128,16 +152,17 @@ export class ServerBackend implements MemoryBackend {
       method,
       headers,
       body: body != null ? JSON.stringify(body) : undefined,
-      signal: AbortSignal.timeout(8_000),
+      signal: AbortSignal.timeout(options?.timeoutMs ?? this.timeouts.defaultTimeoutMs),
     });
   }
 
   private async request<T>(
     method: string,
     path: string,
-    body?: unknown
+    body?: unknown,
+    options?: RequestOptions,
   ): Promise<T> {
-    const resp = await this.requestRaw(method, path, body);
+    const resp = await this.requestRaw(method, path, body, options);
 
     if (resp.status === 204) {
       return undefined as T;

--- a/openclaw-plugin/types.ts
+++ b/openclaw-plugin/types.ts
@@ -3,6 +3,8 @@ export interface PluginConfig {
   apiUrl?: string;
   apiKey?: string;
   tenantID?: string;
+  defaultTimeoutMs?: number;
+  searchTimeoutMs?: number;
 
   tenantName?: string;
 


### PR DESCRIPTION
## Summary
- preserve the backend/server recall order when building `<relevant-memories>`
- add configurable `searchTimeoutMs` for memory search and automatic recall search
- add configurable `defaultTimeoutMs` for other mem9 plugin requests and document the new config fields

## Testing
- `pnpm run typecheck`