### PR TITLE
fix(claude-plugin): use smart ingest in stop hook

### DIFF
--- a/claude-plugin/hooks/stop.sh
+++ b/claude-plugin/hooks/stop.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# stop.sh — Summarize the last assistant turn and save to mnemo.
+# stop.sh — Auto-capture session via smart ingest pipeline.
 # Hook: Stop (async, timeout: 120s)
-# Async means this runs in the background — it won't block Claude from responding.
+#
+# Collects recent conversation turns (size-aware) and sends them to the server's
+# LLM extraction + reconciliation pipeline, which decides what's worth keeping.
+# This replaces the old approach of blindly saving the last assistant message.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
@@ -14,67 +17,96 @@ if ! mnemo_check_env 2>/dev/null; then
 fi
 
 # Prevent recursion: if we're already in a stop hook, don't re-trigger.
-# Also extract last assistant message from the hook input.
-eval "$(echo "$HOOK_INPUT" | python3 -c "
-import json, sys, shlex
+# Also extract conversation messages for smart ingest.
+payload=$(echo "$HOOK_INPUT" | python3 -c "
+import json, sys, re, os
+
 data = json.load(sys.stdin)
 
 # Check recursion guard
 active = str(data.get('stopHookActive', data.get('stop_hook_active', False))).lower()
-print(f'stop_hook_active={shlex.quote(active)}')
+if active == 'true':
+    sys.exit(1)
 
-# Extract last assistant message from transcript (array of turns)
 transcript = data.get('transcript', [])
-msg = ''
+if not transcript:
+    sys.exit(1)
+
+# Strip previously injected memory context to prevent re-ingestion
+def strip_injected(content):
+    while True:
+        start = content.find('<relevant-memories>')
+        if start == -1:
+            break
+        end = content.find('</relevant-memories>')
+        if end == -1:
+            content = content[:start]
+            break
+        content = content[:start] + content[end + len('</relevant-memories>'):]
+    # Also strip [mem9] blocks from session-start hook
+    content = re.sub(r'\[mem9\].*?(?=\n\n|\Z)', '', content, flags=re.DOTALL)
+    return content.strip()
+
+# Size-aware message selection: walk backwards, collect up to 200KB / 20 messages
+MAX_BYTES = 200_000
+MAX_MESSAGES = 20
+MIN_TOTAL_LEN = 100  # skip trivially short sessions
+
+selected = []
+total_bytes = 0
+
 for turn in reversed(transcript):
-    if turn.get('role') == 'assistant':
-        msg = turn.get('content', '')
+    if len(selected) >= MAX_MESSAGES:
         break
-# Fallback: try legacy field name
-if not msg:
-    msg = data.get('last_assistant_message', '')
-if len(msg) > 8000:
-    msg = msg[:8000] + '...'
-print(f'last_message={shlex.quote(msg)}')
-" 2>/dev/null)" || { stop_hook_active="false"; last_message=""; }
+    role = turn.get('role', '')
+    if role not in ('user', 'assistant'):
+        continue
 
-if [[ "$stop_hook_active" == "true" ]]; then
-  exit 0
-fi
+    content = turn.get('content', '')
+    if isinstance(content, list):
+        # Handle content blocks array
+        parts = []
+        for block in content:
+            if isinstance(block, dict) and block.get('type') == 'text':
+                parts.append(block.get('text', ''))
+        content = ' '.join(parts)
 
-if [[ -z "$last_message" || ${#last_message} -lt 50 ]]; then
-  # Too short to be worth saving.
-  exit 0
-fi
+    if not isinstance(content, str) or not content.strip():
+        continue
 
-# Truncate the last message as the memory content.
-# NOTE: LLM summarization (claude -p --model haiku) was removed because it
-# causes hangs on Bedrock setups and risks recursive hook invocation.
-summary=$(echo "$last_message" | python3 -c "
-import sys
-msg = sys.stdin.read().strip()
-if len(msg) > 1000:
-    msg = msg[:1000] + '...'
-print(msg)
-" 2>/dev/null || echo "")
+    cleaned = strip_injected(content)
+    if not cleaned:
+        continue
 
-if [[ -z "$summary" || ${#summary} -lt 10 ]]; then
-  exit 0
-fi
+    msg_bytes = len(cleaned.encode('utf-8'))
+    if total_bytes + msg_bytes > MAX_BYTES and len(selected) > 0:
+        break
 
-# Determine tags from the working directory.
-project_name=$(basename "${CLAUDE_PROJECT_DIR:-$(pwd)}" 2>/dev/null || echo "unknown")
+    selected.insert(0, {'role': role, 'content': cleaned})
+    total_bytes += msg_bytes
 
-# Save to mnemo.
-body=$(MEM9_SUMMARY="$summary" MEM9_PROJECT="$project_name" python3 -c "
-import json, os
+# Check minimum content threshold
+total_content = sum(len(m['content']) for m in selected)
+if total_content < MIN_TOTAL_LEN:
+    sys.exit(1)
+
+# Build payload for smart ingest
+project = os.path.basename(os.environ.get('CLAUDE_PROJECT_DIR', os.getcwd()))
 payload = {
-    'content': os.environ['MEM9_SUMMARY'],
-    'tags': ['auto-captured', os.environ['MEM9_PROJECT']]
+    'messages': selected,
+    'session_id': 'cc_' + str(hash(json.dumps([m['content'][:50] for m in selected[:3]])) % (10**12)),
+    'agent_id': 'claude-code',
+    'source': 'claude-code',
+    'mode': 'smart',
+    'tags': ['auto-captured', project],
 }
-print(json.dumps(payload))
-" 2>/dev/null || echo "")
 
-if [[ -n "$body" ]]; then
-  mnemo_post_memory "$body" >/dev/null 2>&1 || true
+print(json.dumps(payload))
+" 2>/dev/null) || exit 0
+
+if [[ -z "$payload" ]]; then
+  exit 0
 fi
+
+# POST to memories endpoint — server handles LLM extraction + reconciliation
+mnemo_server_post "/memories" "$payload" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

- Rewrites `stop.sh` to collect recent conversation turns (size-aware, up to 200KB / 20 messages) instead of just the last assistant message
- Strips previously injected `<relevant-memories>` and `[mem9]` context to prevent re-ingestion
- POSTs via `messages` + `mode: "smart"` format, triggering server-side LLM fact extraction + reconciliation
- Skips trivially short sessions (< 100 chars total)

This aligns the Claude Code plugin with the OpenClaw plugin's `agent_end` hook approach, which already works correctly.

## Problem

The old `stop.sh` saved every session's last assistant message (truncated to 1000 chars) via the simple `content` mode — bypassing the server's smart ingest pipeline entirely. This filled memory stores with low-value ephemeral fragments like "User is waiting for X" or "The team is in a good place."

## Test plan

- [ ] Verify `bash -n stop.sh` passes (syntax check)
- [ ] Test with a real Claude Code session ending — confirm the payload uses `messages` format with `mode: "smart"`
- [ ] Verify short sessions (< 100 chars) are skipped
- [ ] Verify injected `<relevant-memories>` blocks are stripped from messages before ingestion
- [ ] Confirm server-side reconciliation produces higher-quality memories (ADD/UPDATE/DELETE/NOOP decisions)

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)