### PR TITLE
fix(mem9-server): avoid cross-tenant tenant pool connect lock contention

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only appli
 | `MNEMO_TIDBCLOUD_API_SECRET` | No | — | TiDB Cloud Pool API secret for digest auth. Same conditions as `MNEMO_TIDBCLOUD_API_KEY` |
 | `MNEMO_TENANT_POOL_MAX_IDLE` | No | `5` | Max idle tenant database connections kept in the in-process tenant pool |
 | `MNEMO_TENANT_POOL_MAX_OPEN` | No | `10` | Max open connections per tenant database handle |
+| `MNEMO_TENANT_POOL_CONNECT_TIMEOUT` | No | `3s` | Timeout for tenant pool cold-connect ping/open attempts |
 | `MNEMO_TENANT_POOL_IDLE_TIMEOUT` | No | `10m` | Idle timeout for tenant database handles |
 | `MNEMO_TENANT_POOL_TOTAL_LIMIT` | No | `200` | Total tenant database handles allowed across the process |
 | `MNEMO_CLUSTER_BLACKLIST` | No | — | Comma-separated TiDB cluster IDs whose spend-limit errors should be translated to HTTP 429 instead of 503 |

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -97,11 +97,12 @@ func main() {
 	tenantRepo := repository.NewTenantRepo(cfg.DBBackend, db)
 	uploadTaskRepo := repository.NewUploadTaskRepo(cfg.DBBackend, db)
 	tenantPool := tenant.NewPool(tenant.PoolConfig{
-		MaxIdle:     cfg.TenantPoolMaxIdle,
-		MaxOpen:     cfg.TenantPoolMaxOpen,
-		IdleTimeout: cfg.TenantPoolIdleTimeout,
-		TotalLimit:  cfg.TenantPoolTotalLimit,
-		Backend:     cfg.DBBackend,
+		MaxIdle:        cfg.TenantPoolMaxIdle,
+		MaxOpen:        cfg.TenantPoolMaxOpen,
+		ConnectTimeout: cfg.TenantPoolConnectTimeout,
+		IdleTimeout:    cfg.TenantPoolIdleTimeout,
+		TotalLimit:     cfg.TenantPoolTotalLimit,
+		Backend:        cfg.DBBackend,
 	})
 	defer tenantPool.Close()
 

--- a/server/go.mod
+++ b/server/go.mod
@@ -5,6 +5,8 @@ go 1.24
 toolchain go1.24.6
 
 require (
+	github.com/aws/aws-sdk-go-v2/config v1.32.12
+	github.com/aws/aws-sdk-go-v2/service/kms v1.50.3
 	github.com/go-chi/chi/v5 v5.2.1
 	github.com/go-sql-driver/mysql v1.9.0
 	github.com/google/uuid v1.6.0
@@ -12,13 +14,13 @@ require (
 	github.com/pgvector/pgvector-go v0.2.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	golang.org/x/sync v0.16.0
 	golang.org/x/time v0.9.0
 )
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.41.4 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.32.12 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
@@ -26,7 +28,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect
-	github.com/aws/aws-sdk-go-v2/service/kms v1.50.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
@@ -43,7 +44,6 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -36,12 +36,13 @@ type Config struct {
 	LLMTemperature float64
 	IngestMode     string
 
-	TiDBZeroEnabled       bool
-	TiDBZeroAPIURL        string
-	TenantPoolMaxIdle     int
-	TenantPoolMaxOpen     int
-	TenantPoolIdleTimeout time.Duration
-	TenantPoolTotalLimit  int
+	TiDBZeroEnabled          bool
+	TiDBZeroAPIURL           string
+	TenantPoolMaxIdle        int
+	TenantPoolMaxOpen        int
+	TenantPoolConnectTimeout time.Duration
+	TenantPoolIdleTimeout    time.Duration
+	TenantPoolTotalLimit     int
 
 	// TiDB Cloud Pool configuration
 	TiDBCloudAPIURL string
@@ -98,37 +99,38 @@ func Load() (*Config, error) {
 	}
 
 	cfg := &Config{
-		Port:                  envOr("MNEMO_PORT", "8080"),
-		DSN:                   dsn,
-		DBBackend:             envOr("MNEMO_DB_BACKEND", "tidb"),
-		RateLimit:             envFloat("MNEMO_RATE_LIMIT", 100),
-		RateBurst:             envInt("MNEMO_RATE_BURST", 200),
-		EmbedAutoModel:        os.Getenv("MNEMO_EMBED_AUTO_MODEL"),
-		EmbedAutoDims:         envInt("MNEMO_EMBED_AUTO_DIMS", 1024),
-		EmbedAPIKey:           os.Getenv("MNEMO_EMBED_API_KEY"),
-		EmbedBaseURL:          os.Getenv("MNEMO_EMBED_BASE_URL"),
-		EmbedModel:            os.Getenv("MNEMO_EMBED_MODEL"),
-		EmbedDims:             envInt("MNEMO_EMBED_DIMS", 1536),
-		LLMAPIKey:             os.Getenv("MNEMO_LLM_API_KEY"),
-		LLMBaseURL:            os.Getenv("MNEMO_LLM_BASE_URL"),
-		LLMModel:              envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
-		LLMTemperature:        envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
-		IngestMode:            envOr("MNEMO_INGEST_MODE", "smart"),
-		TiDBZeroEnabled:       envBool("MNEMO_TIDB_ZERO_ENABLED", true),
-		TiDBZeroAPIURL:        envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
-		TiDBCloudAPIURL:       envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),
-		TiDBCloudPoolID:       envOr("MNEMO_TIDBCLOUD_POOL_ID", "2"),
-		TenantPoolMaxIdle:     envInt("MNEMO_TENANT_POOL_MAX_IDLE", 5),
-		TenantPoolMaxOpen:     envInt("MNEMO_TENANT_POOL_MAX_OPEN", 10),
-		TenantPoolIdleTimeout: envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
-		TenantPoolTotalLimit:  envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
-		UploadDir:             envOr("MNEMO_UPLOAD_DIR", "./uploads"),
-		FTSEnabled:            envBool("MNEMO_FTS_ENABLED", false),
-		WorkerConcurrency:     envInt("MNEMO_WORKER_CONCURRENCY", 5),
-		EncryptType:           envOr("MNEMO_ENCRYPT_TYPE", "plain"),
-		EncryptKey:            os.Getenv("MNEMO_ENCRYPT_KEY"),
-		DebugLLM:              envBool("MNEMO_DEBUG_LLM", false),
-		ClusterBlacklist:      parseClusterBlacklist(os.Getenv("MNEMO_CLUSTER_BLACKLIST")),
+		Port:                     envOr("MNEMO_PORT", "8080"),
+		DSN:                      dsn,
+		DBBackend:                envOr("MNEMO_DB_BACKEND", "tidb"),
+		RateLimit:                envFloat("MNEMO_RATE_LIMIT", 100),
+		RateBurst:                envInt("MNEMO_RATE_BURST", 200),
+		EmbedAutoModel:           os.Getenv("MNEMO_EMBED_AUTO_MODEL"),
+		EmbedAutoDims:            envInt("MNEMO_EMBED_AUTO_DIMS", 1024),
+		EmbedAPIKey:              os.Getenv("MNEMO_EMBED_API_KEY"),
+		EmbedBaseURL:             os.Getenv("MNEMO_EMBED_BASE_URL"),
+		EmbedModel:               os.Getenv("MNEMO_EMBED_MODEL"),
+		EmbedDims:                envInt("MNEMO_EMBED_DIMS", 1536),
+		LLMAPIKey:                os.Getenv("MNEMO_LLM_API_KEY"),
+		LLMBaseURL:               os.Getenv("MNEMO_LLM_BASE_URL"),
+		LLMModel:                 envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
+		LLMTemperature:           envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
+		IngestMode:               envOr("MNEMO_INGEST_MODE", "smart"),
+		TiDBZeroEnabled:          envBool("MNEMO_TIDB_ZERO_ENABLED", true),
+		TiDBZeroAPIURL:           envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
+		TiDBCloudAPIURL:          envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),
+		TiDBCloudPoolID:          envOr("MNEMO_TIDBCLOUD_POOL_ID", "2"),
+		TenantPoolMaxIdle:        envInt("MNEMO_TENANT_POOL_MAX_IDLE", 5),
+		TenantPoolMaxOpen:        envInt("MNEMO_TENANT_POOL_MAX_OPEN", 10),
+		TenantPoolConnectTimeout: envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
+		TenantPoolIdleTimeout:    envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
+		TenantPoolTotalLimit:     envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
+		UploadDir:                envOr("MNEMO_UPLOAD_DIR", "./uploads"),
+		FTSEnabled:               envBool("MNEMO_FTS_ENABLED", false),
+		WorkerConcurrency:        envInt("MNEMO_WORKER_CONCURRENCY", 5),
+		EncryptType:              envOr("MNEMO_ENCRYPT_TYPE", "plain"),
+		EncryptKey:               os.Getenv("MNEMO_ENCRYPT_KEY"),
+		DebugLLM:                 envBool("MNEMO_DEBUG_LLM", false),
+		ClusterBlacklist:         parseClusterBlacklist(os.Getenv("MNEMO_CLUSTER_BLACKLIST")),
 	}
 	// Validate ingest mode.
 	switch cfg.IngestMode {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -274,12 +274,18 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 					path = pattern
 				}
 			}
-			logger.Info("request",
+			level := slog.LevelInfo
+			if ww.Status() >= 500 {
+				level = slog.LevelError
+			}
+			logger.Log(
+				r.Context(),
+				level,
+				"handle request done",
 				"method", r.Method,
 				"path", path,
 				"status", ww.Status(),
 				"duration_ms", time.Since(start).Milliseconds(),
-				"request_id", chimw.GetReqID(r.Context()),
 			)
 		})
 	}

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -109,6 +109,7 @@ func (s *Server) defaultConfidenceRecallSearch(
 	svc resolvedSvc,
 	filter domain.MemoryFilter,
 ) ([]domain.Memory, int, error) {
+	start := time.Now()
 	profile := buildRecallQueryProfile(filter.Query)
 	budget := effectiveRecallBudget(profile.shape, filter.Limit)
 	if budget <= 0 {
@@ -126,15 +127,21 @@ func (s *Server) defaultConfidenceRecallSearch(
 	sessionFilter := filter
 	sessionFilter.Limit = recallCandidateLimit(profile.shape, service.RecallSourceSession)
 
+	pinnedStart := time.Now()
 	pinnedCandidates, err := svc.memory.SearchCandidates(ctx, pinnedFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
+	pinnedDuration := time.Since(pinnedStart)
 	if err != nil {
 		return nil, 0, err
 	}
+	insightStart := time.Now()
 	insightCandidates, err := svc.memory.SearchCandidates(ctx, insightFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
+	insightDuration := time.Since(insightStart)
 	if err != nil {
 		return nil, 0, err
 	}
+	sessionStart := time.Now()
 	sessionCandidates, err := svc.session.SearchCandidates(ctx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
+	sessionDuration := time.Since(sessionStart)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -143,11 +150,13 @@ func (s *Server) defaultConfidenceRecallSearch(
 	insightCandidates = applyRecallConfidence(profile, insightCandidates)
 	sessionCandidates = applyRecallConfidence(profile, sessionCandidates)
 
+	selectionStart := time.Now()
 	pinned, seen := selectPinnedRecallCandidates(profile.shape, budget, pinnedCandidates)
 	mixed, cutoffReason, stats := selectMixedRecallCandidates(profile, budget-len(pinned), append(insightCandidates, sessionCandidates...), seen)
+	selectionDuration := time.Since(selectionStart)
 
 	memories := append(pinned, mixed...)
-	slog.Info("confidence recall search",
+	slog.InfoContext(ctx, "confidence recall search",
 		"cluster_id", auth.ClusterID,
 		"query_len", len(filter.Query),
 		"shape", recallQueryShapeLabel(profile.shape),
@@ -165,6 +174,11 @@ func (s *Server) defaultConfidenceRecallSearch(
 		"backfill_selected", stats.backfillCount,
 		"returned", len(memories),
 		"cutoff_reason", cutoffReason,
+		"pinned_ms", pinnedDuration.Milliseconds(),
+		"insight_ms", insightDuration.Milliseconds(),
+		"session_ms", sessionDuration.Milliseconds(),
+		"selection_ms", selectionDuration.Milliseconds(),
+		"total_ms", time.Since(start).Milliseconds(),
 	)
 	return memories, len(memories), nil
 }
@@ -175,6 +189,7 @@ func (s *Server) singlePoolConfidenceRecallSearch(
 	svc resolvedSvc,
 	filter domain.MemoryFilter,
 ) ([]domain.Memory, int, error) {
+	start := time.Now()
 	if filter.Query == "" || filter.Limit <= 0 {
 		return []domain.Memory{}, 0, nil
 	}
@@ -190,6 +205,7 @@ func (s *Server) singlePoolConfidenceRecallSearch(
 	effectiveFilter := filter
 	effectiveFilter.Limit = effectiveRecallBudget(profile.shape, filter.Limit)
 
+	candidateStart := time.Now()
 	switch filter.MemoryType {
 	case string(domain.TypeSession):
 		candidates, err = svc.session.SearchCandidates(ctx, effectiveFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
@@ -205,6 +221,7 @@ func (s *Server) singlePoolConfidenceRecallSearch(
 	if err != nil {
 		return nil, 0, err
 	}
+	candidateDuration := time.Since(candidateStart)
 
 	candidates = applyRecallConfidence(profile, candidates)
 	var (
@@ -212,18 +229,20 @@ func (s *Server) singlePoolConfidenceRecallSearch(
 		cutoffReason string
 		stats        recallSelectionStats
 	)
+	selectionStart := time.Now()
 	if profile.shape == recallQueryShapeEnumeration {
 		memories, cutoffReason, stats = selectEnumerationRecallCandidates(profile, effectiveFilter.Limit, candidates, nil)
 	} else {
 		memories, cutoffReason = selectTopRecallCandidates(profile.shape, effectiveFilter.Limit, minConfidence, applyGapCutoff, candidates, nil)
 		stats.mode = "top"
 	}
+	selectionDuration := time.Since(selectionStart)
 
 	pinnedSelected := 0
 	if filter.MemoryType == string(domain.TypePinned) {
 		pinnedSelected = len(memories)
 	}
-	slog.Info("single-pool confidence recall",
+	slog.InfoContext(ctx, "single-pool confidence recall",
 		"cluster_id", auth.ClusterID,
 		"query_len", len(filter.Query),
 		"shape", recallQueryShapeLabel(profile.shape),
@@ -240,6 +259,9 @@ func (s *Server) singlePoolConfidenceRecallSearch(
 		"backfill_selected", stats.backfillCount,
 		"returned", len(memories),
 		"cutoff_reason", cutoffReason,
+		"candidate_ms", candidateDuration.Milliseconds(),
+		"selection_ms", selectionDuration.Milliseconds(),
+		"total_ms", time.Since(start).Milliseconds(),
 	)
 	return memories, len(memories), nil
 }

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -51,13 +51,16 @@ func ResolveTenant(
 ) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authStart := time.Now()
 			tenantID := chi.URLParam(r, "tenantID")
 			if tenantID == "" {
 				writeError(w, http.StatusBadRequest, "missing tenant ID in path")
 				return
 			}
 
+			lookupStart := time.Now()
 			t, err := tenantRepo.GetByID(r.Context(), tenantID)
+			lookupDuration := time.Since(lookupStart)
 			if err != nil {
 				writeError(w, http.StatusNotFound, "tenant not found")
 				return
@@ -70,7 +73,9 @@ func ResolveTenant(
 			}
 
 			// Decrypt password before using
+			decryptStart := time.Now()
 			decryptedPassword, err := enc.Decrypt(r.Context(), t.DBPassword)
+			decryptDuration := time.Since(decryptStart)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to decrypt tenant credentials")
 				return
@@ -79,8 +84,9 @@ func ResolveTenant(
 
 			poolStart := time.Now()
 			db, err := pool.Get(r.Context(), t.ID, t.DSNForBackend(pool.Backend()))
+			poolDuration := time.Since(poolStart)
 			if err != nil {
-				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", time.Since(poolStart).Milliseconds(), "classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err), "err", err)
+				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", poolDuration.Milliseconds(), "classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err), "err", err)
 				if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
 					writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
 					return
@@ -88,6 +94,14 @@ func ResolveTenant(
 				writeError(w, http.StatusServiceUnavailable, "cannot connect to tenant database")
 				return
 			}
+			slog.InfoContext(r.Context(), "tenant auth resolved",
+				"auth_mode", "path_tenant",
+				"cluster_id", t.ClusterID,
+				"tenant_lookup_ms", lookupDuration.Milliseconds(),
+				"decrypt_ms", decryptDuration.Milliseconds(),
+				"pool_get_ms", poolDuration.Milliseconds(),
+				"total_ms", time.Since(authStart).Milliseconds(),
+			)
 
 			info := &domain.AuthInfo{
 				TenantID:  t.ID,
@@ -115,13 +129,16 @@ func ResolveApiKey(
 ) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authStart := time.Now()
 			apiKey := r.Header.Get(APIKeyHeader)
 			if apiKey == "" {
 				writeError(w, http.StatusBadRequest, "missing API key")
 				return
 			}
 
+			lookupStart := time.Now()
 			t, err := tenantRepo.GetByID(r.Context(), apiKey)
+			lookupDuration := time.Since(lookupStart)
 			if err != nil {
 				writeError(w, http.StatusBadRequest, "invalid API key")
 				return
@@ -132,7 +149,9 @@ func ResolveApiKey(
 			}
 
 			// Decrypt password before using
+			decryptStart := time.Now()
 			decryptedPassword, err := enc.Decrypt(r.Context(), t.DBPassword)
+			decryptDuration := time.Since(decryptStart)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "failed to decrypt tenant credentials")
 				return
@@ -141,8 +160,9 @@ func ResolveApiKey(
 
 			poolStart := time.Now()
 			db, err := pool.Get(r.Context(), t.ID, t.DSNForBackend(pool.Backend()))
+			poolDuration := time.Since(poolStart)
 			if err != nil {
-				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", time.Since(poolStart).Milliseconds(), "classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err), "err", err)
+				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", poolDuration.Milliseconds(), "classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err), "err", err)
 				if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
 					writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
 					return
@@ -150,6 +170,14 @@ func ResolveApiKey(
 				writeError(w, http.StatusServiceUnavailable, "cannot connect to tenant database")
 				return
 			}
+			slog.InfoContext(r.Context(), "tenant auth resolved",
+				"auth_mode", "api_key",
+				"cluster_id", t.ClusterID,
+				"tenant_lookup_ms", lookupDuration.Milliseconds(),
+				"decrypt_ms", decryptDuration.Milliseconds(),
+				"pool_get_ms", poolDuration.Milliseconds(),
+				"total_ms", time.Since(authStart).Milliseconds(),
+			)
 
 			info := &domain.AuthInfo{
 				TenantID:  t.ID,

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/qiffang/mnemos/server/internal/domain"
-	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 type MemoryRepo struct {
@@ -381,7 +380,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
-		slog.Error("vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
+		slog.ErrorContext(ctx, "vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("vector search: %w", err)
 	}
 	defer rows.Close()
@@ -397,7 +396,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	slog.Debug("vector search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	slog.DebugContext(ctx, "vector search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
 	return memories, nil
 }
 
@@ -421,7 +420,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
-		slog.Error("auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
+		slog.ErrorContext(ctx, "auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -437,7 +436,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	slog.Debug("auto vector search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	slog.DebugContext(ctx, "auto vector search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
 	return memories, nil
 }
 
@@ -456,7 +455,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		slog.Error("keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
+		slog.ErrorContext(ctx, "keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 	defer rows.Close()
@@ -472,7 +471,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	slog.Debug("keyword search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	slog.DebugContext(ctx, "keyword search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
 	return memories, nil
 }
 
@@ -511,7 +510,7 @@ func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Memor
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
-		slog.Error("fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "request_id", reqid.FromContext(ctx), "err", err)
+		slog.ErrorContext(ctx, "fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -527,7 +526,7 @@ func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Memor
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	slog.Debug("fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	slog.DebugContext(ctx, "fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
 	return memories, nil
 }
 

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -159,15 +159,22 @@ func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f doma
 	fullArgs = append(fullArgs, args...)
 	fullArgs = append(fullArgs, query, limit)
 
+	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
+		slog.ErrorContext(ctx, "sessions auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("sessions auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
-	return scanSessionRowsWithDistance(rows)
+	memories, err := scanSessionRowsWithDistance(rows)
+	if err != nil {
+		return nil, err
+	}
+	slog.DebugContext(ctx, "sessions auto vector search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	return memories, nil
 }
 
 func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
@@ -192,15 +199,22 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 	fullArgs = append(fullArgs, args...)
 	fullArgs = append(fullArgs, vecStr, limit)
 
+	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
+		slog.ErrorContext(ctx, "sessions vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("sessions vector search: %w", err)
 	}
 	defer rows.Close()
-	return scanSessionRowsWithDistance(rows)
+	memories, err := scanSessionRowsWithDistance(rows)
+	if err != nil {
+		return nil, err
+	}
+	slog.DebugContext(ctx, "sessions vector search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	return memories, nil
 }
 
 func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
@@ -219,15 +233,22 @@ func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.Memo
 	fullArgs = append(fullArgs, args...)
 	fullArgs = append(fullArgs, limit)
 
+	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
+		slog.ErrorContext(ctx, "sessions fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("sessions fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
-	return scanSessionRowsWithFTSScore(rows)
+	memories, err := scanSessionRowsWithFTSScore(rows)
+	if err != nil {
+		return nil, err
+	}
+	slog.DebugContext(ctx, "sessions fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	return memories, nil
 }
 
 func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
@@ -245,15 +266,22 @@ func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.
 		LIMIT ?`
 	args = append(args, limit)
 
+	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
+		slog.ErrorContext(ctx, "sessions keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("sessions keyword search: %w", err)
 	}
 	defer rows.Close()
-	return scanSessionRows(rows)
+	memories, err := scanSessionRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	slog.DebugContext(ctx, "sessions keyword search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	return memories, nil
 }
 
 func scanSessionRows(rows *sql.Rows) ([]domain.Memory, error) {

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -466,16 +466,20 @@ func (s *MemoryService) autoHybridCandidates(
 	sourcePool RecallSourcePool,
 	opts RecallCandidateOptions,
 ) ([]RecallCandidate, error) {
+	start := time.Now()
 	limit := normalizeRecallLimit(filter.Limit, 10)
 	fetchLimit := limit * normalizeRecallFetchMultiplier(opts.FetchMultiplier, 3)
 
+	vectorStart := time.Now()
 	vecResults, err := s.memories.AutoVectorSearch(ctx, filter.Query, filter, fetchLimit)
+	vectorDuration := time.Since(vectorStart)
 	if err != nil {
 		return nil, fmt.Errorf("auto vector search: %w", err)
 	}
 	vecResults = applyMinScore(vecResults, filter.MinScore)
 
 	var kwResults []domain.Memory
+	keywordStart := time.Now()
 	if s.memories.FTSAvailable() {
 		kwResults, err = s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
 		if err != nil {
@@ -487,8 +491,10 @@ func (s *MemoryService) autoHybridCandidates(
 			return nil, fmt.Errorf("keyword search: %w", err)
 		}
 	}
+	keywordDuration := time.Since(keywordStart)
 
 	var secondHopResults []domain.Memory
+	secondHopStart := time.Now()
 	if opts.EnableSecondHop {
 		maxVecScore := 0.0
 		for _, m := range vecResults {
@@ -506,6 +512,20 @@ func (s *MemoryService) autoHybridCandidates(
 			secondHopResults = s.secondHopAutoSearch(ctx, mems, scores, filter, limit, topN)
 		}
 	}
+	secondHopDuration := time.Since(secondHopStart)
+
+	slog.InfoContext(ctx, "memory recall candidate search",
+		"query_len", len(filter.Query),
+		"source_pool", string(sourcePool),
+		"memory_type", filter.MemoryType,
+		"fetch_limit", fetchLimit,
+		"vector_ms", vectorDuration.Milliseconds(),
+		"keyword_ms", keywordDuration.Milliseconds(),
+		"second_hop_ms", secondHopDuration.Milliseconds(),
+		"second_hop_enabled", opts.EnableSecondHop,
+		"second_hop_count", len(secondHopResults),
+		"total_ms", time.Since(start).Milliseconds(),
+	)
 
 	return dedupRecallCandidatesByContent(mergeRecallCandidates(sourcePool, kwResults, vecResults, secondHopResults)), nil
 }

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/qiffang/mnemos/server/internal/domain"
@@ -153,16 +154,30 @@ func (s *SessionService) autoHybridCandidates(
 	_,
 	fetchLimit int,
 ) ([]RecallCandidate, error) {
+	start := time.Now()
+	vectorStart := time.Now()
 	vecResults, err := s.sessions.AutoVectorSearch(ctx, f.Query, f, fetchLimit)
+	vectorDuration := time.Since(vectorStart)
 	if err != nil {
 		return nil, fmt.Errorf("session auto vector search: %w", err)
 	}
 	vecResults = applyMinScore(vecResults, f.MinScore)
 
+	keywordStart := time.Now()
 	kwResults, err := s.ftsOrKeyword(ctx, f, fetchLimit)
+	keywordDuration := time.Since(keywordStart)
 	if err != nil {
 		return nil, err
 	}
+
+	slog.InfoContext(ctx, "session recall candidate search",
+		"query_len", len(f.Query),
+		"source_pool", string(sourcePool),
+		"fetch_limit", fetchLimit,
+		"vector_ms", vectorDuration.Milliseconds(),
+		"keyword_ms", keywordDuration.Milliseconds(),
+		"total_ms", time.Since(start).Milliseconds(),
+	)
 
 	return mergeRecallCandidates(sourcePool, kwResults, vecResults, nil), nil
 }

--- a/server/internal/tenant/pool.go
+++ b/server/internal/tenant/pool.go
@@ -4,20 +4,28 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
+var sqlOpen = sql.Open
+
 type TenantPool struct {
-	mu          sync.RWMutex
-	conns       map[string]*tenantConn
-	maxIdle     int
-	maxOpen     int
-	lifetime    time.Duration
-	idleTimeout time.Duration
-	totalLimit  int
-	backend     string // "tidb", "postgres", or "db9"
-	stopCh      chan struct{}
+	mu             sync.RWMutex
+	conns          map[string]*tenantConn
+	maxIdle        int
+	maxOpen        int
+	lifetime       time.Duration
+	idleTimeout    time.Duration
+	totalLimit     int
+	backend        string // "tidb", "postgres", or "db9"
+	stopCh         chan struct{}
+	connectGroup   singleflight.Group
+	opening        int
+	connectTimeout time.Duration
 }
 
 type tenantConn struct {
@@ -27,12 +35,13 @@ type tenantConn struct {
 }
 
 type PoolConfig struct {
-	MaxIdle     int
-	MaxOpen     int
-	Lifetime    time.Duration
-	IdleTimeout time.Duration
-	TotalLimit  int
-	Backend     string // "tidb" (default), "postgres", or "db9"
+	MaxIdle        int
+	MaxOpen        int
+	Lifetime       time.Duration
+	IdleTimeout    time.Duration
+	TotalLimit     int
+	Backend        string // "tidb" (default), "postgres", or "db9"
+	ConnectTimeout time.Duration
 }
 
 func NewPool(cfg PoolConfig) *TenantPool {
@@ -51,20 +60,24 @@ func NewPool(cfg PoolConfig) *TenantPool {
 	if cfg.TotalLimit == 0 {
 		cfg.TotalLimit = 200
 	}
+	if cfg.ConnectTimeout == 0 {
+		cfg.ConnectTimeout = 3 * time.Second
+	}
 	backend := cfg.Backend
 	if backend == "" {
 		backend = "tidb"
 	}
 
 	p := &TenantPool{
-		conns:       make(map[string]*tenantConn),
-		maxIdle:     cfg.MaxIdle,
-		maxOpen:     cfg.MaxOpen,
-		lifetime:    cfg.Lifetime,
-		idleTimeout: cfg.IdleTimeout,
-		totalLimit:  cfg.TotalLimit,
-		backend:     backend,
-		stopCh:      make(chan struct{}),
+		conns:          make(map[string]*tenantConn),
+		maxIdle:        cfg.MaxIdle,
+		maxOpen:        cfg.MaxOpen,
+		lifetime:       cfg.Lifetime,
+		idleTimeout:    cfg.IdleTimeout,
+		totalLimit:     cfg.TotalLimit,
+		backend:        backend,
+		stopCh:         make(chan struct{}),
+		connectTimeout: cfg.ConnectTimeout,
 	}
 
 	go p.evictLoop()
@@ -72,11 +85,16 @@ func NewPool(cfg PoolConfig) *TenantPool {
 }
 
 func (p *TenantPool) Get(ctx context.Context, tenantID string, dsn string) (*sql.DB, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	p.mu.RLock()
 	conn, ok := p.conns[tenantID]
 	p.mu.RUnlock()
 
 	if ok {
+		pingStart := time.Now()
 		if err := conn.db.PingContext(ctx); err == nil {
 			p.mu.Lock()
 			if cached, stillOk := p.conns[tenantID]; stillOk {
@@ -85,29 +103,68 @@ func (p *TenantPool) Get(ctx context.Context, tenantID string, dsn string) (*sql
 			}
 			p.mu.Unlock()
 			return conn.db, nil
+		} else {
+			slog.ErrorContext(ctx, "tenant pool cached ping failed",
+				"tenant_id", tenantID,
+				"duration_ms", time.Since(pingStart).Milliseconds(),
+				"err", err,
+			)
+			p.Remove(tenantID)
 		}
-
-		p.Remove(tenantID)
 	}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	// open tenantDB
+	resultCh := p.connectGroup.DoChan(tenantID, func() (any, error) {
+		openStart := time.Now()
+		db, err := p.openTenantDB(tenantID, dsn)
+		if err != nil {
+			slog.ErrorContext(ctx, "tenant pool open failed",
+				"tenant_id", tenantID,
+				"duration_ms", time.Since(openStart).Milliseconds(),
+				"err", err,
+			)
+		}
+		return db, err
+	})
 
+	select {
+	case res := <-resultCh:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		db, ok := res.Val.(*sql.DB)
+		if !ok {
+			return nil, fmt.Errorf("tenant pool: unexpected connection type %T", res.Val)
+		}
+		return db, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *TenantPool) openTenantDB(tenantID string, dsn string) (*sql.DB, error) {
+	p.mu.Lock()
 	if conn, ok := p.conns[tenantID]; ok {
 		conn.lastUsed = time.Now()
+		p.mu.Unlock()
 		return conn.db, nil
 	}
-
-	if len(p.conns) >= p.totalLimit {
+	if len(p.conns)+p.opening >= p.totalLimit {
+		p.mu.Unlock()
 		return nil, fmt.Errorf("tenant pool: total limit %d reached", p.totalLimit)
 	}
+	p.opening++
+	p.mu.Unlock()
 
 	driver := "mysql"
 	if p.backend == "postgres" || p.backend == "db9" {
 		driver = "pgx"
 	}
-	db, err := sql.Open(driver, dsn)
+	db, err := sqlOpen(driver, dsn)
 	if err != nil {
+		p.mu.Lock()
+		p.opening--
+		p.mu.Unlock()
 		return nil, err
 	}
 
@@ -115,21 +172,32 @@ func (p *TenantPool) Get(ctx context.Context, tenantID string, dsn string) (*sql
 	db.SetMaxOpenConns(p.maxOpen)
 	db.SetConnMaxLifetime(p.lifetime)
 
-	if err := db.PingContext(ctx); err != nil {
+	openCtx, cancel := context.WithTimeout(context.Background(), p.connectTimeout)
+	defer cancel()
+
+	if err := db.PingContext(openCtx); err != nil {
 		_ = db.Close()
+		p.mu.Lock()
+		p.opening--
+		p.mu.Unlock()
 		return nil, err
 	}
 
-	conn = &tenantConn{
-		db:       db,
-		lastUsed: time.Now(),
-		tenantID: tenantID,
-	}
+	now := time.Now()
+	p.mu.Lock()
+	p.opening--
 	if existing := p.conns[tenantID]; existing != nil {
+		existing.lastUsed = now
+		p.mu.Unlock()
 		_ = db.Close()
 		return existing.db, nil
 	}
-	p.conns[tenantID] = conn
+	p.conns[tenantID] = &tenantConn{
+		db:       db,
+		lastUsed: now,
+		tenantID: tenantID,
+	}
+	p.mu.Unlock()
 	return db, nil
 }
 

--- a/server/internal/tenant/pool.go
+++ b/server/internal/tenant/pool.go
@@ -109,7 +109,7 @@ func (p *TenantPool) Get(ctx context.Context, tenantID string, dsn string) (*sql
 				"duration_ms", time.Since(pingStart).Milliseconds(),
 				"err", err,
 			)
-			p.Remove(tenantID)
+			p.removeIfMatch(tenantID, conn)
 		}
 	}
 
@@ -186,6 +186,8 @@ func (p *TenantPool) openTenantDB(tenantID string, dsn string) (*sql.DB, error) 
 	now := time.Now()
 	p.mu.Lock()
 	p.opening--
+	// Close/Remove/eviction can mutate this slot while the shared open is in flight.
+	// Reuse any handle already published before we reacquire the lock.
 	if existing := p.conns[tenantID]; existing != nil {
 		existing.lastUsed = now
 		p.mu.Unlock()
@@ -225,6 +227,24 @@ func (p *TenantPool) Remove(tenantID string) {
 	if ok {
 		_ = conn.db.Close()
 	}
+}
+
+func (p *TenantPool) removeIfMatch(tenantID string, expected *tenantConn) bool {
+	if expected == nil {
+		return false
+	}
+
+	p.mu.Lock()
+	current, ok := p.conns[tenantID]
+	if !ok || current != expected {
+		p.mu.Unlock()
+		return false
+	}
+	delete(p.conns, tenantID)
+	p.mu.Unlock()
+
+	_ = expected.db.Close()
+	return true
 }
 
 func (p *TenantPool) Stats() map[string]time.Time {

--- a/server/internal/tenant/pool_test.go
+++ b/server/internal/tenant/pool_test.go
@@ -5,38 +5,101 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-type failingDriver struct{}
+type testDriver struct{}
 
-func (f failingDriver) Open(name string) (driver.Conn, error) {
-	return failingConn{}, nil
+func (testDriver) Open(name string) (driver.Conn, error) {
+	return nil, errors.New("open not supported")
 }
 
-type failingConn struct{}
+type testConnector struct {
+	pingStarted  chan struct{}
+	pingRelease  chan struct{}
+	pingErr      error
+	connectErr   error
+	connectCalls atomic.Int32
+}
 
-func (f failingConn) Prepare(query string) (driver.Stmt, error) {
+func (c *testConnector) Connect(context.Context) (driver.Conn, error) {
+	if c.connectErr != nil {
+		return nil, c.connectErr
+	}
+	c.connectCalls.Add(1)
+	return &testConn{connector: c}, nil
+}
+
+func (c *testConnector) Driver() driver.Driver {
+	return testDriver{}
+}
+
+type testConn struct{ connector *testConnector }
+
+func (c *testConn) Prepare(query string) (driver.Stmt, error) {
 	return nil, errors.New("prepare not supported")
 }
 
-func (f failingConn) Close() error {
-	return nil
-}
+func (c *testConn) Close() error { return nil }
 
-func (f failingConn) Begin() (driver.Tx, error) {
+func (c *testConn) Begin() (driver.Tx, error) {
 	return nil, errors.New("begin not supported")
 }
 
-func (f failingConn) Ping(ctx context.Context) error {
-	return errors.New("ping failed")
+func (c *testConn) Ping(ctx context.Context) error {
+	if c.connector.pingStarted != nil {
+		select {
+		case c.connector.pingStarted <- struct{}{}:
+		default:
+		}
+	}
+	if c.connector.pingRelease != nil {
+		select {
+		case <-c.connector.pingRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return c.connector.pingErr
 }
 
-func init() {
-	// Use a unique driver name for testing to avoid conflicts with real mysql driver
-	sql.Register("mysql_test", failingDriver{})
+type getResult struct {
+	db  *sql.DB
+	err error
+}
+
+func withSQLOpen(t *testing.T, opener func(driverName, dsn string) (*sql.DB, error)) {
+	t.Helper()
+
+	prev := sqlOpen
+	sqlOpen = opener
+	t.Cleanup(func() {
+		sqlOpen = prev
+	})
+}
+
+func cacheTenantConn(pool *TenantPool, tenantID string, db *sql.DB) {
+	pool.mu.Lock()
+	pool.conns[tenantID] = &tenantConn{
+		db:       db,
+		lastUsed: time.Now(),
+		tenantID: tenantID,
+	}
+	pool.mu.Unlock()
+}
+
+func startGet(pool *TenantPool, tenantID string, dsn string) (<-chan getResult, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	resultCh := make(chan getResult, 1)
+	go func() {
+		db, err := pool.Get(ctx, tenantID, dsn)
+		resultCh <- getResult{db: db, err: err}
+	}()
+	return resultCh, cancel
 }
 
 func TestNewPool_Defaults(t *testing.T) {
@@ -58,15 +121,19 @@ func TestNewPool_Defaults(t *testing.T) {
 	if pool.totalLimit != 200 {
 		t.Fatalf("totalLimit = %d, want %d", pool.totalLimit, 200)
 	}
+	if pool.connectTimeout != 3*time.Second {
+		t.Fatalf("connectTimeout = %v, want %v", pool.connectTimeout, 3*time.Second)
+	}
 }
 
 func TestNewPool_CustomConfig(t *testing.T) {
 	cfg := PoolConfig{
-		MaxIdle:     2,
-		MaxOpen:     4,
-		Lifetime:    15 * time.Minute,
-		IdleTimeout: 5 * time.Minute,
-		TotalLimit:  9,
+		MaxIdle:        2,
+		MaxOpen:        4,
+		Lifetime:       15 * time.Minute,
+		IdleTimeout:    5 * time.Minute,
+		TotalLimit:     9,
+		ConnectTimeout: 2 * time.Second,
 	}
 	pool := NewPool(cfg)
 	defer pool.Close()
@@ -86,16 +153,25 @@ func TestNewPool_CustomConfig(t *testing.T) {
 	if pool.totalLimit != cfg.TotalLimit {
 		t.Fatalf("totalLimit = %d, want %d", pool.totalLimit, cfg.TotalLimit)
 	}
+	if pool.connectTimeout != cfg.ConnectTimeout {
+		t.Fatalf("connectTimeout = %v, want %v", pool.connectTimeout, cfg.ConnectTimeout)
+	}
 }
 
-func TestPool_Get_InvalidDSN(t *testing.T) {
+func TestPool_Get_OpenError(t *testing.T) {
 	pool := NewPool(PoolConfig{})
 	defer pool.Close()
 
-	dsn := "mysql_test://user:pass@tcp(127.0.0.1:1)/db?parseTime=true"
-	_, err := pool.Get(context.Background(), "tenant-1", dsn)
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		return nil, errors.New("open failed")
+	})
+
+	_, err := pool.Get(context.Background(), "tenant-1", "tenant-1")
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "open failed") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -131,20 +207,188 @@ func TestPool_TotalLimit(t *testing.T) {
 	pool := NewPool(PoolConfig{TotalLimit: 1})
 	defer pool.Close()
 
-	db, err := sql.Open("mysql_test", "user:pass@tcp(127.0.0.1:1)/db?parseTime=true")
-	if err != nil {
-		t.Fatalf("sql.Open error: %v", err)
-	}
+	db := sql.OpenDB(&testConnector{})
+	cacheTenantConn(pool, "tenant-1", db)
 
-	pool.mu.Lock()
-	pool.conns["tenant-1"] = &tenantConn{db: db, lastUsed: time.Now(), tenantID: "tenant-1"}
-	pool.mu.Unlock()
-
-	_, err = pool.Get(context.Background(), "tenant-2", "mysql_test://user:pass@tcp(127.0.0.1:1)/db?parseTime=true")
+	_, err := pool.Get(context.Background(), "tenant-2", "tenant-2")
 	if err == nil {
 		t.Fatal("expected total limit error, got nil")
 	}
 	if !strings.Contains(err.Error(), "total limit 1 reached") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPool_Get_SameTenantOpenUsesSingleflight(t *testing.T) {
+	pool := NewPool(PoolConfig{ConnectTimeout: time.Second})
+	defer pool.Close()
+
+	slowConnector := &testConnector{
+		pingStarted: make(chan struct{}, 1),
+		pingRelease: make(chan struct{}),
+	}
+	var openCalls atomic.Int32
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		openCalls.Add(1)
+		if dsn != "tenant-1" {
+			return nil, fmt.Errorf("unexpected dsn %q", dsn)
+		}
+		return sql.OpenDB(slowConnector), nil
+	})
+
+	firstCh, cancelFirst := startGet(pool, "tenant-1", "tenant-1")
+	defer cancelFirst()
+
+	select {
+	case <-slowConnector.pingStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first ping to start")
+	}
+
+	secondCh, cancelSecond := startGet(pool, "tenant-1", "tenant-1")
+	defer cancelSecond()
+
+	close(slowConnector.pingRelease)
+
+	first := <-firstCh
+	second := <-secondCh
+	if first.err != nil {
+		t.Fatalf("first Get error: %v", first.err)
+	}
+	if second.err != nil {
+		t.Fatalf("second Get error: %v", second.err)
+	}
+	if first.db != second.db {
+		t.Fatal("expected both callers to receive the same cached *sql.DB")
+	}
+	if openCalls.Load() != 1 {
+		t.Fatalf("sqlOpen calls = %d, want 1", openCalls.Load())
+	}
+	if slowConnector.connectCalls.Load() != 1 {
+		t.Fatalf("connector connects = %d, want 1", slowConnector.connectCalls.Load())
+	}
+}
+
+func TestPool_Get_CachedPingFailureReopensConnection(t *testing.T) {
+	pool := NewPool(PoolConfig{ConnectTimeout: time.Second})
+	defer pool.Close()
+
+	staleDB := sql.OpenDB(&testConnector{pingErr: errors.New("ping failed")})
+	cacheTenantConn(pool, "tenant-1", staleDB)
+
+	freshConnector := &testConnector{}
+	var openCalls atomic.Int32
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		openCalls.Add(1)
+		if dsn != "tenant-1" {
+			return nil, fmt.Errorf("unexpected dsn %q", dsn)
+		}
+		return sql.OpenDB(freshConnector), nil
+	})
+
+	db, err := pool.Get(context.Background(), "tenant-1", "tenant-1")
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if db == staleDB {
+		t.Fatal("expected stale cached DB to be replaced after ping failure")
+	}
+	if openCalls.Load() != 1 {
+		t.Fatalf("sqlOpen calls = %d, want 1", openCalls.Load())
+	}
+	if freshConnector.connectCalls.Load() != 1 {
+		t.Fatalf("connector connects = %d, want 1", freshConnector.connectCalls.Load())
+	}
+}
+
+func TestPool_Get_SlowOpenDoesNotBlockOtherCachedTenant(t *testing.T) {
+	pool := NewPool(PoolConfig{ConnectTimeout: time.Second})
+	defer pool.Close()
+
+	slowConnector := &testConnector{
+		pingStarted: make(chan struct{}, 1),
+		pingRelease: make(chan struct{}),
+	}
+	fastConnector := &testConnector{}
+	cachedDB := sql.OpenDB(fastConnector)
+	cacheTenantConn(pool, "tenant-b", cachedDB)
+
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		if dsn != "tenant-a" {
+			return nil, fmt.Errorf("unexpected dsn %q", dsn)
+		}
+		return sql.OpenDB(slowConnector), nil
+	})
+
+	slowCh, cancelSlow := startGet(pool, "tenant-a", "tenant-a")
+	defer cancelSlow()
+
+	select {
+	case <-slowConnector.pingStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for slow ping to start")
+	}
+
+	fastCtx, cancelFast := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancelFast()
+
+	db, err := pool.Get(fastCtx, "tenant-b", "tenant-b")
+	if err != nil {
+		t.Fatalf("cached tenant Get error: %v", err)
+	}
+	if db != cachedDB {
+		t.Fatal("expected cached tenant DB to be returned")
+	}
+
+	close(slowConnector.pingRelease)
+	if slow := <-slowCh; slow.err != nil {
+		t.Fatalf("slow tenant Get error: %v", slow.err)
+	}
+}
+
+func TestPool_Get_InFlightOpenCountsTowardTotalLimit(t *testing.T) {
+	pool := NewPool(PoolConfig{TotalLimit: 1, ConnectTimeout: time.Second})
+	defer pool.Close()
+
+	slowConnector := &testConnector{
+		pingStarted: make(chan struct{}, 1),
+		pingRelease: make(chan struct{}),
+	}
+	var openCalls atomic.Int32
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		openCalls.Add(1)
+		switch dsn {
+		case "tenant-a":
+			return sql.OpenDB(slowConnector), nil
+		case "tenant-b":
+			return sql.OpenDB(&testConnector{}), nil
+		default:
+			return nil, fmt.Errorf("unexpected dsn %q", dsn)
+		}
+	})
+
+	slowCh, cancelSlow := startGet(pool, "tenant-a", "tenant-a")
+	defer cancelSlow()
+
+	select {
+	case <-slowConnector.pingStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for slow ping to start")
+	}
+
+	_, err := pool.Get(context.Background(), "tenant-b", "tenant-b")
+	if err == nil {
+		t.Fatal("expected total limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "total limit 1 reached") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if openCalls.Load() != 1 {
+		t.Fatalf("sqlOpen calls = %d, want 1", openCalls.Load())
+	}
+
+	close(slowConnector.pingRelease)
+	if slow := <-slowCh; slow.err != nil {
+		t.Fatalf("slow tenant Get error: %v", slow.err)
 	}
 }

--- a/server/internal/tenant/pool_test.go
+++ b/server/internal/tenant/pool_test.go
@@ -182,6 +182,43 @@ func TestPool_Remove_NonExistent(t *testing.T) {
 	pool.Remove("missing-tenant")
 }
 
+func TestPool_RemoveIfMatch_DoesNotRemoveReplacement(t *testing.T) {
+	pool := NewPool(PoolConfig{})
+	defer pool.Close()
+
+	staleDB := sql.OpenDB(&testConnector{})
+	freshDB := sql.OpenDB(&testConnector{})
+
+	staleConn := &tenantConn{db: staleDB, lastUsed: time.Now(), tenantID: "tenant-1"}
+	freshConn := &tenantConn{db: freshDB, lastUsed: time.Now(), tenantID: "tenant-1"}
+
+	pool.mu.Lock()
+	pool.conns["tenant-1"] = staleConn
+	pool.mu.Unlock()
+
+	if removed := pool.removeIfMatch("tenant-1", staleConn); !removed {
+		t.Fatal("expected initial stale connection to be removed")
+	}
+
+	pool.mu.Lock()
+	pool.conns["tenant-1"] = freshConn
+	pool.mu.Unlock()
+
+	if removed := pool.removeIfMatch("tenant-1", staleConn); removed {
+		t.Fatal("expected stale retry removal to leave replacement connection intact")
+	}
+
+	pool.mu.RLock()
+	got := pool.conns["tenant-1"]
+	pool.mu.RUnlock()
+	if got != freshConn {
+		t.Fatal("expected replacement connection to remain cached")
+	}
+	if err := freshDB.PingContext(context.Background()); err != nil {
+		t.Fatalf("replacement DB should still be open: %v", err)
+	}
+}
+
 func TestPool_Stats_Empty(t *testing.T) {
 	pool := NewPool(PoolConfig{})
 	defer pool.Close()


### PR DESCRIPTION
## Summary
- move tenant DB open/ping work out of the pool-wide mutex so a slow cold connect for one tenant does not block other tenants
- dedupe same-tenant cold connects with `singleflight`, count in-flight opens toward `TotalLimit`, and reopen stale cached handles after ping failure
- add tenant pool error logs for cached ping failure and cold open failure with `tenant_id`, `duration_ms`, and request-scoped logging context
- add deterministic tenant pool tests for same-tenant singleflight, cached ping failure reopen, cross-tenant non-blocking behavior, and in-flight total-limit accounting

## Testing
- `cd server && go test ./internal/tenant -run 'Test(NewPool|Pool_)'`
- `cd server && go test ./...`

Fixes #192
