### PR TITLE
fix: make client-side embedding vector dimensions configurable via MNEMO_EMBED_DIMS

### DIFF
--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -110,7 +110,7 @@ func main() {
 	var provisioner tenant.Provisioner
 	if cfg.TiDBZeroEnabled && cfg.DBBackend == "tidb" {
 		// Zero mode (explicit toggle takes precedence)
-		provisioner = tenant.NewZeroProvisioner(cfg.TiDBZeroAPIURL, cfg.DBBackend, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.FTSEnabled)
+		provisioner = tenant.NewZeroProvisioner(cfg.TiDBZeroAPIURL, cfg.DBBackend, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.EmbedDims, cfg.FTSEnabled)
 		logger.Info("using TiDB Zero provisioner")
 	} else if cfg.TiDBZeroEnabled {
 		logger.Warn("TiDB Zero provisioning is only supported with tidb backend; disabling auto-provisioning", "backend", cfg.DBBackend)
@@ -129,7 +129,7 @@ func main() {
 		logger.Info("no provisioner configured (pre-existing tenants mode)")
 	}
 
-	tenantSvc := service.NewTenantService(tenantRepo, provisioner, tenantPool, logger, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.FTSEnabled, encryptor)
+	tenantSvc := service.NewTenantService(tenantRepo, provisioner, tenantPool, logger, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.EmbedDims, cfg.FTSEnabled, encryptor)
 
 	// Middleware.
 	tenantMW := middleware.ResolveTenant(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist)

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -21,6 +21,7 @@ type TenantService struct {
 	logger      *slog.Logger
 	autoModel   string
 	autoDims    int
+	clientDims  int
 	ftsEnabled  bool
 	encryptor   encrypt.Encryptor
 }
@@ -32,6 +33,7 @@ func NewTenantService(
 	logger *slog.Logger,
 	autoModel string,
 	autoDims int,
+	clientDims int,
 	ftsEnabled bool,
 	encryptor encrypt.Encryptor,
 ) *TenantService {
@@ -42,6 +44,7 @@ func NewTenantService(
 		logger:      logger,
 		autoModel:   autoModel,
 		autoDims:    autoDims,
+		clientDims:  clientDims,
 		ftsEnabled:  ftsEnabled,
 		encryptor:   encryptor,
 	}
@@ -205,7 +208,7 @@ func (s *TenantService) GetInfo(ctx context.Context, tenantID string) (*domain.T
 }
 
 func (s *TenantService) EnsureSessionsTable(ctx context.Context, db *sql.DB) error {
-	if _, err := db.ExecContext(ctx, tenant.BuildSessionsSchema(s.autoModel, s.autoDims)); err != nil {
+	if _, err := db.ExecContext(ctx, tenant.BuildSessionsSchema(s.autoModel, s.autoDims, s.clientDims)); err != nil {
 		return fmt.Errorf("ensure sessions table: create: %w", err)
 	}
 	if s.autoModel != "" {

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -118,13 +118,13 @@ func TestProvision_WithEncryptor(t *testing.T) {
 	// Create mock provisioner that returns known password
 	mockProv := &mockProvisioner{
 		info: &tenant.ClusterInfo{
-			ID:       testTenantID,
+			ID:        testTenantID,
 			ClusterID: testTenantID,
-			Host:     "test-host",
-			Port:     4000,
-			Username: "root",
-			Password: testPassword,
-			DBName:   "test",
+			Host:      "test-host",
+			Port:      4000,
+			Username:  "root",
+			Password:  testPassword,
+			DBName:    "test",
 		},
 	}
 

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -22,7 +22,7 @@ func TestBuildMemorySchema(t *testing.T) {
 	}
 
 	t.Run("no auto-model uses plain VECTOR(1536)", func(t *testing.T) {
-		schema := tenant.BuildMemorySchema("", 0)
+		schema := tenant.BuildMemorySchema("", 0, 0)
 		for _, needle := range commonChecks {
 			if !strings.Contains(schema, needle) {
 				t.Fatalf("schema missing %q", needle)
@@ -36,8 +36,30 @@ func TestBuildMemorySchema(t *testing.T) {
 		}
 	})
 
+	t.Run("no auto-model with clientDims=4096 uses VECTOR(4096)", func(t *testing.T) {
+		schema := tenant.BuildMemorySchema("", 0, 4096)
+		for _, needle := range commonChecks {
+			if !strings.Contains(schema, needle) {
+				t.Fatalf("schema missing %q", needle)
+			}
+		}
+		if !strings.Contains(schema, "VECTOR(4096)") {
+			t.Fatal("schema missing VECTOR(4096) for clientDims=4096")
+		}
+		if strings.Contains(schema, "GENERATED ALWAYS AS") {
+			t.Fatal("schema must not contain GENERATED ALWAYS AS for no-auto-model mode")
+		}
+	})
+
+	t.Run("no auto-model with clientDims=1024 uses VECTOR(1024)", func(t *testing.T) {
+		schema := tenant.BuildMemorySchema("", 0, 1024)
+		if !strings.Contains(schema, "VECTOR(1024)") {
+			t.Fatal("schema missing VECTOR(1024) for clientDims=1024")
+		}
+	})
+
 	t.Run("auto-model emits EMBED_TEXT generated column with correct dims", func(t *testing.T) {
-		schema := tenant.BuildMemorySchema("tidbcloud_free/amazon/titan-embed-text-v2", 1024)
+		schema := tenant.BuildMemorySchema("tidbcloud_free/amazon/titan-embed-text-v2", 1024, 0)
 		for _, needle := range commonChecks {
 			if !strings.Contains(schema, needle) {
 				t.Fatalf("schema missing %q", needle)
@@ -65,7 +87,7 @@ func TestProvisionRejectsNonTiDBBackend(t *testing.T) {
 	defer pool.Close()
 
 	enc := encrypt.NewPlainEncryptor()
-	svc := NewTenantService(nil, nil, pool, nil, "", 0, false, enc)
+	svc := NewTenantService(nil, nil, pool, nil, "", 0, 0, false, enc)
 	_, err := svc.Provision(context.Background())
 	if err == nil {
 		t.Fatal("expected validation error for non-tidb backend")
@@ -115,7 +137,7 @@ func TestProvision_WithEncryptor(t *testing.T) {
 
 	// Create service with a real logger (discard output)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	svc := NewTenantService(mockRepo, mockProv, pool, logger, "", 0, false, enc)
+	svc := NewTenantService(mockRepo, mockProv, pool, logger, "", 0, 0, false, enc)
 
 	// Call Provision
 	_, err := svc.Provision(context.Background())
@@ -194,7 +216,7 @@ func TestBuildDB9MemorySchema(t *testing.T) {
 	}
 
 	t.Run("no auto-model uses plain VECTOR(1536)", func(t *testing.T) {
-		schema := tenant.BuildDB9MemorySchema("", 0)
+		schema := tenant.BuildDB9MemorySchema("", 0, 0)
 		for _, needle := range commonChecks {
 			if !strings.Contains(schema, needle) {
 				t.Fatalf("schema missing %q", needle)
@@ -208,8 +230,18 @@ func TestBuildDB9MemorySchema(t *testing.T) {
 		}
 	})
 
+	t.Run("no auto-model with clientDims=4096 uses VECTOR(4096)", func(t *testing.T) {
+		schema := tenant.BuildDB9MemorySchema("", 0, 4096)
+		if !strings.Contains(schema, "VECTOR(4096)") {
+			t.Fatal("schema missing VECTOR(4096) for clientDims=4096")
+		}
+		if strings.Contains(schema, "GENERATED ALWAYS AS") {
+			t.Fatal("schema must not contain GENERATED ALWAYS AS for no-auto-model mode")
+		}
+	})
+
 	t.Run("auto-model emits EMBED_TEXT generated column with correct dims", func(t *testing.T) {
-		schema := tenant.BuildDB9MemorySchema("amazon.titan-embed-text-v2:0", 1024)
+		schema := tenant.BuildDB9MemorySchema("amazon.titan-embed-text-v2:0", 1024, 0)
 		for _, needle := range commonChecks {
 			if !strings.Contains(schema, needle) {
 				t.Fatalf("schema missing %q", needle)
@@ -234,7 +266,7 @@ func TestBuildDB9MemorySchema(t *testing.T) {
 	})
 
 	t.Run("auto-model with 512 dims", func(t *testing.T) {
-		schema := tenant.BuildDB9MemorySchema("some-model", 512)
+		schema := tenant.BuildDB9MemorySchema("some-model", 512, 0)
 		if !strings.Contains(schema, "VECTOR(512)") {
 			t.Fatal("schema missing VECTOR(512)")
 		}
@@ -244,7 +276,7 @@ func TestBuildDB9MemorySchema(t *testing.T) {
 	})
 
 	t.Run("single-quote in model name is escaped", func(t *testing.T) {
-		schema := tenant.BuildDB9MemorySchema("model'inject", 1024)
+		schema := tenant.BuildDB9MemorySchema("model'inject", 1024, 0)
 		// Should be escaped to double single-quotes
 		if !strings.Contains(schema, "model''inject") {
 			t.Fatal("single quote in model name not escaped")
@@ -254,14 +286,14 @@ func TestBuildDB9MemorySchema(t *testing.T) {
 
 func TestBuildMemorySchema_DimensionsArg(t *testing.T) {
 	t.Run("auto-model includes dimensions in EMBED_TEXT", func(t *testing.T) {
-		schema := tenant.BuildMemorySchema("tidbcloud_free/amazon/titan-embed-text-v2", 1024)
+		schema := tenant.BuildMemorySchema("tidbcloud_free/amazon/titan-embed-text-v2", 1024, 0)
 		if !strings.Contains(schema, `'{"dimensions": 1024}'`) {
 			t.Fatal("schema missing dimensions arg in EMBED_TEXT call")
 		}
 	})
 
 	t.Run("single-quote in model name is escaped", func(t *testing.T) {
-		schema := tenant.BuildMemorySchema("model'inject", 1024)
+		schema := tenant.BuildMemorySchema("model'inject", 1024, 0)
 		if !strings.Contains(schema, "model''inject") {
 			t.Fatal("single quote in model name not escaped")
 		}

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -218,7 +218,7 @@ func TestZeroProvisioner_Provision_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	p := NewZeroProvisioner(server.URL, "tidb", "", 0, false)
+	p := NewZeroProvisioner(server.URL, "tidb", "", 0, 0, false)
 	ctx := context.Background()
 
 	info, err := p.Provision(ctx)
@@ -265,7 +265,7 @@ func TestZeroProvisioner_Provision_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	p := NewZeroProvisioner(server.URL, "tidb", "", 0, false)
+	p := NewZeroProvisioner(server.URL, "tidb", "", 0, 0, false)
 	ctx := context.Background()
 
 	_, err := p.Provision(ctx)
@@ -286,7 +286,7 @@ func TestZeroProvisioner_ProviderType(t *testing.T) {
 func TestZeroProvisioner_InitSchema_InvalidBackend(t *testing.T) {
 	// Current implementation only supports "tidb" backend
 	// For other backends, it will fail when trying to execute DDL
-	p := NewZeroProvisioner("http://localhost", "postgres", "", 0, false)
+	p := NewZeroProvisioner("http://localhost", "postgres", "", 0, 0, false)
 
 	// nil db should cause an error (not panic)
 	err := p.InitSchema(context.Background(), nil)
@@ -299,7 +299,7 @@ func TestZeroProvisioner_InitSchema_InvalidBackend(t *testing.T) {
 func TestZeroProvisioner_InitSchema_Success(t *testing.T) {
 	// This test would need a real or mocked database connection
 	// For now, just verify it doesn't panic with valid parameters
-	p := NewZeroProvisioner("http://localhost", "tidb", "", 0, false)
+	p := NewZeroProvisioner("http://localhost", "tidb", "", 0, 0, false)
 	_ = p // Avoid unused variable error
 }
 

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -89,7 +89,7 @@ CREATE TRIGGER trg_memories_updated BEFORE UPDATE ON memories FOR EACH ROW EXECU
 `
 
 // BuildMemorySchema builds the TiDB memory schema with optional auto-embedding.
-func BuildMemorySchema(autoModel string, autoDims int) string {
+func BuildMemorySchema(autoModel string, autoDims int, clientDims int) string {
 	var embeddingCol string
 	if autoModel != "" {
 		sanitizedModel := strings.ReplaceAll(autoModel, "'", "''")
@@ -98,13 +98,17 @@ func BuildMemorySchema(autoModel string, autoDims int) string {
 			autoDims, sanitizedModel, autoDims,
 		)
 	} else {
-		embeddingCol = `embedding VECTOR(1536) NULL,`
+		dims := clientDims
+		if dims <= 0 {
+			dims = 1536
+		}
+		embeddingCol = fmt.Sprintf(`embedding VECTOR(%d) NULL,`, dims)
 	}
 	return fmt.Sprintf(TenantMemorySchemaBase, embeddingCol)
 }
 
 // BuildDB9MemorySchema builds the db9 memory schema with optional auto-embedding.
-func BuildDB9MemorySchema(autoModel string, autoDims int) string {
+func BuildDB9MemorySchema(autoModel string, autoDims int, clientDims int) string {
 	var embeddingCol string
 	if autoModel != "" {
 		sanitizedModel := strings.ReplaceAll(autoModel, "'", "''")
@@ -113,7 +117,11 @@ func BuildDB9MemorySchema(autoModel string, autoDims int) string {
 			autoDims, sanitizedModel, autoDims,
 		)
 	} else {
-		embeddingCol = `embedding VECTOR(1536) NULL,`
+		dims := clientDims
+		if dims <= 0 {
+			dims = 1536
+		}
+		embeddingCol = fmt.Sprintf(`embedding VECTOR(%d) NULL,`, dims)
 	}
 	return fmt.Sprintf(TenantMemorySchemaDB9Base, embeddingCol)
 }
@@ -141,7 +149,7 @@ const TenantSessionsSchemaBase = `CREATE TABLE IF NOT EXISTS sessions (
 )`
 
 // BuildSessionsSchema builds the TiDB sessions schema with optional auto-embedding.
-func BuildSessionsSchema(autoModel string, autoDims int) string {
+func BuildSessionsSchema(autoModel string, autoDims int, clientDims int) string {
 	var embeddingCol string
 	if autoModel != "" {
 		sanitizedModel := strings.ReplaceAll(autoModel, "'", "''")
@@ -150,7 +158,11 @@ func BuildSessionsSchema(autoModel string, autoDims int) string {
 			autoDims, sanitizedModel, autoDims,
 		)
 	} else {
-		embeddingCol = `embedding VECTOR(1536) NULL,`
+		dims := clientDims
+		if dims <= 0 {
+			dims = 1536
+		}
+		embeddingCol = fmt.Sprintf(`embedding VECTOR(%d) NULL,`, dims)
 	}
 	return fmt.Sprintf(TenantSessionsSchemaBase, embeddingCol)
 }

--- a/server/internal/tenant/zero.go
+++ b/server/internal/tenant/zero.go
@@ -115,17 +115,19 @@ type ZeroProvisioner struct {
 	backend    string
 	autoModel  string
 	autoDims   int
+	clientDims int
 	ftsEnabled bool
 }
 
 // NewZeroProvisioner creates a provisioner for TiDB Zero API.
 // backend is "tidb", "postgres", or "db9".
-func NewZeroProvisioner(baseURL, backend, autoModel string, autoDims int, ftsEnabled bool) *ZeroProvisioner {
+func NewZeroProvisioner(baseURL, backend, autoModel string, autoDims int, clientDims int, ftsEnabled bool) *ZeroProvisioner {
 	return &ZeroProvisioner{
 		client:     NewZeroClient(baseURL),
 		backend:    backend,
 		autoModel:  autoModel,
 		autoDims:   autoDims,
+		clientDims: clientDims,
 		ftsEnabled: ftsEnabled,
 	}
 }
@@ -180,7 +182,7 @@ func (p *ZeroProvisioner) InitSchema(ctx context.Context, db *sql.DB) error {
 			if _, err := db.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
 				return fmt.Errorf("init schema: vector extension: %w", err)
 			}
-			if _, err := db.ExecContext(ctx, BuildDB9MemorySchema(p.autoModel, p.autoDims)); err != nil {
+			if _, err := db.ExecContext(ctx, BuildDB9MemorySchema(p.autoModel, p.autoDims, p.clientDims)); err != nil {
 				return fmt.Errorf("init schema: create table: %w", err)
 			}
 			// Add HNSW index
@@ -190,7 +192,7 @@ func (p *ZeroProvisioner) InitSchema(ctx context.Context, db *sql.DB) error {
 			}
 			return nil
 	*/
-	if _, err := db.ExecContext(ctx, BuildMemorySchema(p.autoModel, p.autoDims)); err != nil {
+	if _, err := db.ExecContext(ctx, BuildMemorySchema(p.autoModel, p.autoDims, p.clientDims)); err != nil {
 		return fmt.Errorf("init schema: create table: %w", err)
 	}
 	if p.autoModel != "" {
@@ -217,7 +219,7 @@ func (p *ZeroProvisioner) InitSchema(ctx context.Context, db *sql.DB) error {
 			}
 		}
 	}
-	if _, err := db.ExecContext(ctx, BuildSessionsSchema(p.autoModel, p.autoDims)); err != nil {
+	if _, err := db.ExecContext(ctx, BuildSessionsSchema(p.autoModel, p.autoDims, p.clientDims)); err != nil {
 		return fmt.Errorf("init schema: sessions table: %w", err)
 	}
 	if p.autoModel != "" {


### PR DESCRIPTION
## Problem

When using client-side embedding (non-TiDB-Cloud auto-embedding), the `VECTOR()` column size in the schema is hardcoded to `1536` in `server/internal/tenant/schema.go`:

```go
// before
embeddingCol = `embedding VECTOR(1536) NULL,`
```

This causes insertion failures when using embedding models with different output dimensions:

```
Error 1105 (HY000): vector has 4096 dimensions, does not fit VECTOR(1536)
```

`MNEMO_EMBED_DIMS` already exists as a config field to control the dimensions requested from the embedding API — but this value was not propagated to the schema DDL.

Closes #221

## Changes

- `internal/tenant/schema.go`: add `clientDims` parameter to `BuildMemorySchema`, `BuildDB9MemorySchema`, and `BuildSessionsSchema`; use it in the client-side branch with a fallback to `1536` for backward compatibility
- `internal/tenant/zero.go`: thread `clientDims` through `ZeroProvisioner`
- `internal/service/tenant.go`: thread `clientDims` through `TenantService`
- `cmd/mnemo-server/main.go`: pass `cfg.EmbedDims` to `NewZeroProvisioner` and `NewTenantService`

`MNEMO_EMBED_DIMS` is now the single source of truth for both the dimensions requested from the embedding API and the `VECTOR()` column size in the schema.

## Testing

- Updated existing unit tests to use the new function signatures
- Added new test cases for `clientDims=4096` (Qwen3-Embedding-8B) and `clientDims=1024` (BGE-M3)
- End-to-end verified: schema created with `VECTOR(4096)`, 4096-dim vectors from Qwen3-Embedding-8B inserted and queried successfully against a local TiDB instance

## Backward Compatibility

`clientDims=0` falls back to `VECTOR(1536)`, preserving existing behavior for deployments that do not set `MNEMO_EMBED_DIMS`.