### PR TITLE
feat: add batch delete API for memories (v1alpha2)

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -191,6 +191,7 @@ func (s *Server) Router(
 		r.Get("/memories/{id}", s.getMemory)
 		r.Put("/memories/{id}", s.updateMemory)
 		r.Delete("/memories/{id}", s.deleteMemory)
+		r.Post("/memories/batch-delete", s.batchDeleteMemories)
 
 		r.Post("/imports", s.createTask)
 		r.Get("/imports", s.listTasks)

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -472,6 +472,31 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+type batchDeleteRequest struct {
+	IDs []string `json:"ids"`
+}
+
+func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
+	var req batchDeleteRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+
+	auth := authInfo(r)
+	svc := s.resolveServices(auth)
+	deleted, err := svc.memory.BulkDelete(r.Context(), req.IDs, auth.AgentName)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+
+	go s.refreshWriteMetrics(auth, svc, 0)
+	respond(w, http.StatusOK, map[string]any{
+		"deleted": deleted,
+	})
+}
+
 type bulkCreateRequest struct {
 	Memories []service.BulkMemoryInput `json:"memories"`
 }

--- a/server/internal/handler/memory_batch_delete_test.go
+++ b/server/internal/handler/memory_batch_delete_test.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"testing"
+)
+
+func TestBatchDeleteMemories_Success_ReturnsDeletedCount(t *testing.T) {
+	memRepo := &testMemoryRepo{bulkSoftDeleteResult: 2}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+
+	body := map[string]any{"ids": []string{"a", "a", "", "b", "c", "b"}}
+	req := makeRequest(t, http.MethodPost, "/memories/batch-delete", body)
+	rr := httptest.NewRecorder()
+
+	srv.batchDeleteMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Deleted int64 `json:"deleted"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", resp.Deleted)
+	}
+
+	if len(memRepo.bulkSoftDeleteCalls) != 1 {
+		t.Fatalf("expected repo BulkSoftDelete called once, got %d", len(memRepo.bulkSoftDeleteCalls))
+	}
+	got := append([]string(nil), memRepo.bulkSoftDeleteCalls[0]...)
+	sort.Strings(got)
+	want := []string{"a", "b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("repo ids len = %d, want %d (ids=%v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("repo ids = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBatchDeleteMemories_EmptyIDs_Returns400(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+
+	body := map[string]any{"ids": []string{}}
+	req := makeRequest(t, http.MethodPost, "/memories/batch-delete", body)
+	rr := httptest.NewRecorder()
+
+	srv.batchDeleteMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(memRepo.bulkSoftDeleteCalls) != 0 {
+		t.Fatalf("repo must not be called, calls=%d", len(memRepo.bulkSoftDeleteCalls))
+	}
+}
+
+func TestBatchDeleteMemories_AllEmptyStrings_Returns400(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+
+	body := map[string]any{"ids": []string{"", "", ""}}
+	req := makeRequest(t, http.MethodPost, "/memories/batch-delete", body)
+	rr := httptest.NewRecorder()
+
+	srv.batchDeleteMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if len(memRepo.bulkSoftDeleteCalls) != 0 {
+		t.Fatalf("repo must not be called, calls=%d", len(memRepo.bulkSoftDeleteCalls))
+	}
+}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -44,7 +44,10 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 }
 func (m *testMemoryRepo) UpdateOptimistic(context.Context, *domain.Memory, int) error { return nil }
 func (m *testMemoryRepo) SoftDelete(context.Context, string, string) error            { return nil }
-func (m *testMemoryRepo) ArchiveMemory(context.Context, string, string) error         { return nil }
+func (m *testMemoryRepo) BulkSoftDelete(context.Context, []string, string) (int64, error) {
+	return 0, nil
+}
+func (m *testMemoryRepo) ArchiveMemory(context.Context, string, string) error { return nil }
 func (m *testMemoryRepo) ArchiveAndCreate(_ context.Context, _, _ string, mem *domain.Memory) error {
 	m.createCalls = append(m.createCalls, mem)
 	return nil

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -26,6 +26,8 @@ type testMemoryRepo struct {
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordFilter    domain.MemoryFilter
+	bulkSoftDeleteCalls  [][]string
+	bulkSoftDeleteResult int64
 }
 
 func (m *testMemoryRepo) Create(_ context.Context, mem *domain.Memory) error {
@@ -44,8 +46,9 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 }
 func (m *testMemoryRepo) UpdateOptimistic(context.Context, *domain.Memory, int) error { return nil }
 func (m *testMemoryRepo) SoftDelete(context.Context, string, string) error            { return nil }
-func (m *testMemoryRepo) BulkSoftDelete(context.Context, []string, string) (int64, error) {
-	return 0, nil
+func (m *testMemoryRepo) BulkSoftDelete(_ context.Context, ids []string, _ string) (int64, error) {
+	m.bulkSoftDeleteCalls = append(m.bulkSoftDeleteCalls, append([]string(nil), ids...))
+	return m.bulkSoftDeleteResult, nil
 }
 func (m *testMemoryRepo) ArchiveMemory(context.Context, string, string) error { return nil }
 func (m *testMemoryRepo) ArchiveAndCreate(_ context.Context, _, _ string, mem *domain.Memory) error {

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -115,6 +115,30 @@ func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) error
 	return tx.Commit()
 }
 
+func (r *MemoryRepo) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := `UPDATE memories SET state = 'deleted', updated_at = NOW()
+		 WHERE id IN (` + strings.Join(placeholders, ",") + `) AND state != 'deleted'`
+
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("bulk soft delete: %w", err)
+	}
+
+	n, _ := result.RowsAffected()
+	return n, nil
+}
+
 func (r *MemoryRepo) ArchiveMemory(ctx context.Context, id, supersededBy string) error {
 	result, err := r.db.ExecContext(ctx,
 		`UPDATE memories SET state = 'archived', superseded_by = $1, updated_at = NOW()

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -13,6 +13,7 @@ type MemoryRepo interface {
 	GetByID(ctx context.Context, id string) (*domain.Memory, error)
 	UpdateOptimistic(ctx context.Context, m *domain.Memory, expectedVersion int) error
 	SoftDelete(ctx context.Context, id, agentName string) error
+	BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error)
 	ArchiveMemory(ctx context.Context, id, supersededBy string) error
 	ArchiveAndCreate(ctx context.Context, archiveID, supersededBy string, newMem *domain.Memory) error
 	SetState(ctx context.Context, id string, state domain.MemoryState) error

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -139,6 +139,30 @@ func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) error
 	return tx.Commit()
 }
 
+func (r *MemoryRepo) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `UPDATE memories SET state = 'deleted', updated_at = NOW()
+		 WHERE id IN (` + strings.Join(placeholders, ",") + `) AND state != 'deleted'`
+
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("bulk soft delete: %w", err)
+	}
+
+	n, _ := result.RowsAffected()
+	return n, nil
+}
+
 func (r *MemoryRepo) ArchiveMemory(ctx context.Context, id, supersededBy string) error {
 	result, err := r.db.ExecContext(ctx,
 		`UPDATE memories SET state = 'archived', superseded_by = ?, updated_at = NOW()

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1005,6 +1005,10 @@ func (m *memoryRepoMock) SoftDelete(ctx context.Context, id, agentName string) e
 	return nil
 }
 
+func (m *memoryRepoMock) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	return 0, nil
+}
+
 func (m *memoryRepoMock) ArchiveMemory(ctx context.Context, id, supersededBy string) error {
 	return nil
 }

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -41,6 +41,10 @@ type memoryRepoMock struct {
 	autoVectorSearchHook func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	ftsSearchHook        func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
+	bulkSoftDeleteCalls  [][]string
+	bulkSoftDeleteAgent  string
+	bulkSoftDeleteResult int64
+	bulkSoftDeleteErr    error
 }
 
 type setStateCall struct {
@@ -1006,7 +1010,14 @@ func (m *memoryRepoMock) SoftDelete(ctx context.Context, id, agentName string) e
 }
 
 func (m *memoryRepoMock) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
-	return 0, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bulkSoftDeleteCalls = append(m.bulkSoftDeleteCalls, append([]string(nil), ids...))
+	m.bulkSoftDeleteAgent = agentName
+	if m.bulkSoftDeleteErr != nil {
+		return 0, m.bulkSoftDeleteErr
+	}
+	return m.bulkSoftDeleteResult, nil
 }
 
 func (m *memoryRepoMock) ArchiveMemory(ctx context.Context, id, supersededBy string) error {

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	maxContentLen   = 50000
-	maxTags         = 20
-	maxBulkSize     = 100
-	defaultMinScore = 0.3
+	maxContentLen     = 50000
+	maxTags           = 20
+	maxBulkSize       = 100
+	maxBulkDeleteSize = 1000
+	defaultMinScore   = 0.3
 
 	// secondHopWeight is the RRF weight applied to second-hop vector search results.
 	// Lower than 1.0 to prevent indirect matches from outranking direct hits.
@@ -768,6 +769,34 @@ func (s *MemoryService) Update(ctx context.Context, agentName, id, content strin
 
 func (s *MemoryService) Delete(ctx context.Context, id, agentName string) error {
 	return s.memories.SoftDelete(ctx, id, agentName)
+}
+
+// BulkDelete soft-deletes multiple memories by ID. Returns the number of
+// memories actually deleted (already-deleted rows are excluded from the count).
+func (s *MemoryService) BulkDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
+	}
+	if len(ids) > maxBulkDeleteSize {
+		return 0, &domain.ValidationError{Field: "ids", Message: "too many (max 1000)"}
+	}
+
+	seen := make(map[string]struct{}, len(ids))
+	unique := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+	}
+	if len(unique) == 0 {
+		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
+	}
+
+	return s.memories.BulkSoftDelete(ctx, unique, agentName)
 }
 
 func (s *MemoryService) Bootstrap(ctx context.Context, limit int) ([]domain.Memory, error) {

--- a/server/internal/service/memory_bulk_delete_test.go
+++ b/server/internal/service/memory_bulk_delete_test.go
@@ -1,0 +1,116 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestBulkDelete_EmptyIDs_ReturnsValidationError(t *testing.T) {
+	repo := &memoryRepoMock{}
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	n, err := svc.BulkDelete(context.Background(), nil, "agent-a")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if n != 0 {
+		t.Fatalf("deleted = %d, want 0", n)
+	}
+	var ve *domain.ValidationError
+	if !errors.As(err, &ve) || ve.Field != "ids" {
+		t.Fatalf("expected ValidationError on ids, got %T: %v", err, err)
+	}
+	if len(repo.bulkSoftDeleteCalls) != 0 {
+		t.Fatalf("repo must not be called on validation failure, calls=%d", len(repo.bulkSoftDeleteCalls))
+	}
+}
+
+func TestBulkDelete_AllEmptyStrings_ReturnsValidationError(t *testing.T) {
+	repo := &memoryRepoMock{}
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	n, err := svc.BulkDelete(context.Background(), []string{"", "", ""}, "agent-a")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if n != 0 {
+		t.Fatalf("deleted = %d, want 0", n)
+	}
+	var ve *domain.ValidationError
+	if !errors.As(err, &ve) || ve.Field != "ids" {
+		t.Fatalf("expected ValidationError on ids, got %T: %v", err, err)
+	}
+	if len(repo.bulkSoftDeleteCalls) != 0 {
+		t.Fatalf("repo must not be called when all ids are empty, calls=%d", len(repo.bulkSoftDeleteCalls))
+	}
+}
+
+func TestBulkDelete_TooManyIDs_ReturnsValidationError(t *testing.T) {
+	repo := &memoryRepoMock{}
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	ids := make([]string, maxBulkDeleteSize+1)
+	for i := range ids {
+		ids[i] = "id-" + strconv.Itoa(i)
+	}
+
+	n, err := svc.BulkDelete(context.Background(), ids, "agent-a")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if n != 0 {
+		t.Fatalf("deleted = %d, want 0", n)
+	}
+	var ve *domain.ValidationError
+	if !errors.As(err, &ve) || ve.Field != "ids" {
+		t.Fatalf("expected ValidationError on ids, got %T: %v", err, err)
+	}
+	if len(repo.bulkSoftDeleteCalls) != 0 {
+		t.Fatalf("repo must not be called when over the cap, calls=%d", len(repo.bulkSoftDeleteCalls))
+	}
+}
+
+func TestBulkDelete_DeduplicatesAndSkipsEmpty(t *testing.T) {
+	repo := &memoryRepoMock{bulkSoftDeleteResult: 3}
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	n, err := svc.BulkDelete(context.Background(), []string{"a", "a", "", "b", "c", "b"}, "agent-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("deleted = %d, want 3", n)
+	}
+	if len(repo.bulkSoftDeleteCalls) != 1 {
+		t.Fatalf("expected repo called once, got %d", len(repo.bulkSoftDeleteCalls))
+	}
+
+	got := append([]string(nil), repo.bulkSoftDeleteCalls[0]...)
+	sort.Strings(got)
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("repo ids = %v, want %v", got, want)
+	}
+	if repo.bulkSoftDeleteAgent != "agent-a" {
+		t.Fatalf("agent = %q, want agent-a", repo.bulkSoftDeleteAgent)
+	}
+}
+
+func TestBulkDelete_DeletedCountFromRepoIsReturned(t *testing.T) {
+	repo := &memoryRepoMock{bulkSoftDeleteResult: 2}
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	n, err := svc.BulkDelete(context.Background(), []string{"a", "b", "c"}, "agent-a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("deleted = %d, want 2 (count must come from repo, not input size)", n)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `POST /v1alpha2/mem9s/memories/batch-delete` endpoint for deleting up to 1000 memories by ID in a single request
- Uses `POST` instead of `DELETE` because many HTTP clients strip request bodies on DELETE
- Returns `{"deleted": N}` with the count of memories actually transitioned to deleted state (already-deleted rows excluded)

## Changes

- **Handler**: `batchDeleteMemories` in `handler/memory.go` — decodes `{"ids": [...]}`, delegates to service
- **Service**: `BulkDelete` in `service/memory.go` — validates max 1000, deduplicates, delegates to repo
- **Repository**: `BulkSoftDelete` in both `tidb/memory.go` and `postgres/memory.go` — single `UPDATE ... WHERE id IN (...) AND state != 'deleted'`
- **Interface**: `BulkSoftDelete` added to `MemoryRepo` in `repository.go`
- **Route**: registered on v1alpha2 only (`apiKeyMW`)