### PR TITLE
feat: include tool results in session ingest and recall

### DIFF
--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -295,11 +295,6 @@ export function registerHooks(
         const role = typeof m.role === "string" ? m.role : "";
         if (!role) continue;
 
-        // Skip cron tool results — structured JSON job definitions with no memory value
-        if (role === "toolResult" && typeof m.toolName === "string" && m.toolName === "cron") {
-          continue;
-        }
-
         let content = "";
         if (typeof m.content === "string") {
           content = m.content;

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -103,8 +103,7 @@ func (r *SessionRepo) PatchTags(ctx context.Context, sessionID, contentHash stri
 }
 
 func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, []any) {
-	// sessions which are not used for recall purposes (e.g. tool results).
-	conds := []string{`role NOT IN ("toolResult")`}
+	conds := []string{}
 	args := []any{}
 
 	if f.State == "all" {

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -484,11 +484,7 @@ func parseOpenClawLine(line []byte) *IngestMessage {
 	if entry.Type != "message" || entry.Message.Role == "" {
 		return nil
 	}
-	// Only keep user and assistant messages for ingest.
 	role := entry.Message.Role
-	if role != "user" && role != "assistant" {
-		return nil
-	}
 
 	content := flattenContentBlocks(entry.Message.Content)
 	if content == "" {

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -148,7 +148,7 @@ func TestParseSessionFile(t *testing.T) {
 {"type":"message","id":"msg1","parentId":"m1","timestamp":"2026-03-04T19:24:44.263Z","message":{"role":"user","content":[{"type":"text","text":"hello world"}]}}
 {"type":"message","id":"msg2","parentId":"msg1","timestamp":"2026-03-04T19:24:45.000Z","message":{"role":"assistant","content":[{"type":"text","text":"hi there"}]}}
 {"type":"message","id":"msg3","parentId":"msg2","timestamp":"2026-03-04T19:24:46.000Z","message":{"role":"toolResult","content":[{"type":"text","text":"tool output"}]}}`,
-			wantMsgs: 2, // only user + assistant, not toolResult
+			wantMsgs: 3, // user + assistant + toolResult are all ingested
 		},
 		{
 			name:     "OpenClaw JSONL with multi-block content",


### PR DESCRIPTION
## What

Remove the exclusions that filtered out `toolResult` messages from memory
ingest and recall queries.

- `openclaw-plugin/hooks.ts`: stop skipping cron tool results during hook
  processing
- `server/internal/service/upload.go`: allow all message roles (not just
  `user` and `assistant`) to pass through `parseOpenClawLine`
- `server/internal/repository/tidb/sessions.go`: drop the
  `role NOT IN ("toolResult")` filter from session recall queries so tool
  results are visible during search
- `server/internal/service/upload_test.go`: update expected message count
  from 2 to 3 to reflect the new behavior

## Why

Tool results (e.g. cron job output, function call responses) carry
context that is useful for recall. Excluding them silently dropped
potentially relevant session content from memory.