### PR TITLE
feat: skip strong near-dup facts before reconcile

### DIFF
--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -85,7 +85,7 @@ func (m *testMemoryRepo) ListBootstrap(context.Context, int) ([]domain.Memory, e
 	return nil, nil
 }
 
-func (m *testMemoryRepo) NearDupSearch(context.Context, string) (string, float64, error) {
+func (m *testMemoryRepo) NearDupSearch(context.Context, string, string) (string, float64, error) {
 	return "", 0, nil
 }
 

--- a/server/internal/repository/db9/memory.go
+++ b/server/internal/repository/db9/memory.go
@@ -414,7 +414,7 @@ func isDuplicateKey(err error) bool {
 	return strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key")
 }
 
-func (r *DB9MemoryRepo) NearDupSearch(ctx context.Context, queryText string) (string, float64, error) {
+func (r *DB9MemoryRepo) NearDupSearch(ctx context.Context, agentID, queryText string) (string, float64, error) {
 	if r.autoModel == "" {
 		return "", 0, nil
 	}
@@ -426,13 +426,14 @@ func (r *DB9MemoryRepo) NearDupSearch(ctx context.Context, queryText string) (st
 			FROM memories
 			WHERE state = 'active'
 			  AND memory_type IN ('insight', 'pinned')
+			  AND agent_id = $2
 			  AND embedding IS NOT NULL
 		)
 		SELECT id, dist
 		FROM scored
 		ORDER BY dist
 		LIMIT 1`,
-		queryText,
+		queryText, agentID,
 	).Scan(&id, &dist)
 	if err == sql.ErrNoRows {
 		return "", 0, nil

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -701,7 +701,7 @@ func isDuplicateKey(err error) bool {
 	return strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key")
 }
 
-func (r *MemoryRepo) NearDupSearch(_ context.Context, _ string) (string, float64, error) {
+func (r *MemoryRepo) NearDupSearch(_ context.Context, _ string, _ string) (string, float64, error) {
 	return "", 0, nil
 }
 

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -42,7 +42,7 @@ type MemoryRepo interface {
 	// configured, or backend does not support auto-embedding).
 	// Postgres returns ("", 0, nil) — auto-embedding is not supported.
 	// DB9 implements real search when autoModel is configured; returns ("", 0, nil) otherwise.
-	NearDupSearch(ctx context.Context, queryText string) (id string, score float64, err error)
+	NearDupSearch(ctx context.Context, agentID, queryText string) (id string, score float64, err error)
 	// CountStats returns the total active memory count and the count created in the last 7 days.
 	CountStats(ctx context.Context) (total int64, last7d int64, err error)
 }

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -833,7 +833,7 @@ func vecToString(embedding []float32) any {
 	return sb.String()
 }
 
-func (r *MemoryRepo) NearDupSearch(ctx context.Context, queryText string) (string, float64, error) {
+func (r *MemoryRepo) NearDupSearch(ctx context.Context, agentID, queryText string) (string, float64, error) {
 	if r.autoModel == "" {
 		return "", 0, nil
 	}
@@ -844,10 +844,11 @@ func (r *MemoryRepo) NearDupSearch(ctx context.Context, queryText string) (strin
 		 FROM memories
 		 WHERE state = 'active'
 		   AND memory_type IN ('insight', 'pinned')
+		   AND agent_id = ?
 		   AND embedding IS NOT NULL
 		 ORDER BY VEC_EMBED_COSINE_DISTANCE(embedding, ?)
 		 LIMIT 1`,
-		queryText, queryText,
+		queryText, agentID, queryText,
 	).Scan(&id, &dist)
 	if err == sql.ErrNoRows {
 		return "", 0, nil

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -34,6 +34,7 @@ const (
 	factTypeQueryIntent            = "query_intent"
 	factTypeRawFallback            = "raw_fallback"
 	rawFallbackTag                 = "raw-fallback"
+	nearDupNoopThreshold           = 0.99
 )
 
 var formattedConversationMessageRE = regexp.MustCompile(`(?:^|\n\n)([A-Za-z][A-Za-z0-9_-]*): `)
@@ -348,6 +349,13 @@ func ensureRawFallbackTag(tags []string, facts []ExtractedFact) []string {
 
 func projectReconcileFactText(fact ExtractedFact) string {
 	return ProjectTemporalFactText(fact.Text, fact.Temporal)
+}
+
+func shouldSkipNearDupFact(fact ExtractedFact, score float64) bool {
+	if strings.EqualFold(fact.FactType, factTypeRawFallback) {
+		return false
+	}
+	return score >= nearDupNoopThreshold
 }
 
 func normalizeReconciledTemporalContent(content string) (string, *TemporalMetadata) {
@@ -990,14 +998,33 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessi
 		)
 	}()
 
-	// Shadow mode: record cosine similarity of the nearest existing memory to each
-	// extracted fact. Facts always pass through unchanged — suppression is deferred
-	// until the score distribution is analyzed from prod metrics.
-	// Once a threshold is validated, add: if score >= threshold { drop or annotate }
+	// Near-dup suppression: if a normal fact is extremely close to an existing
+	// memory, skip reconcile entirely for that fact. raw_fallback facts are
+	// excluded from this optimization because they are already lossy.
+	filteredFacts := make([]ExtractedFact, 0, len(facts))
+	suppressedFacts := 0
 	for i := range facts {
 		if id, score, err := s.memories.NearDupSearch(ctx, projectReconcileFactText(facts[i])); err == nil && id != "" {
 			metrics.NearDupCosineScore.Observe(score)
+			if shouldSkipNearDupFact(facts[i], score) {
+				suppressedFacts++
+				continue
+			}
 		}
+		filteredFacts = append(filteredFacts, facts[i])
+	}
+	if suppressedFacts > 0 {
+		slog.Info("suppressed near-duplicate facts before reconciliation",
+			"agent_id", agentID,
+			"session_id", sessionID,
+			"suppressed", suppressedFacts,
+			"threshold", nearDupNoopThreshold,
+		)
+	}
+	facts = filteredFacts
+	if len(facts) == 0 {
+		status = "near_dup_noop"
+		return nil, 0, nil
 	}
 
 	texts := make([]string, len(facts))

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -1004,7 +1004,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessi
 	filteredFacts := make([]ExtractedFact, 0, len(facts))
 	suppressedFacts := 0
 	for i := range facts {
-		if id, score, err := s.memories.NearDupSearch(ctx, projectReconcileFactText(facts[i])); err == nil && id != "" {
+		if id, score, err := s.memories.NearDupSearch(ctx, agentID, projectReconcileFactText(facts[i])); err == nil && id != "" {
 			metrics.NearDupCosineScore.Observe(score)
 			if shouldSkipNearDupFact(facts[i], score) {
 				suppressedFacts++

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -41,6 +41,10 @@ type memoryRepoMock struct {
 	autoVectorSearchHook func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	ftsSearchHook        func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
+	nearDupSearchHook    func(context.Context, string) (string, float64, error)
+	nearDupID            string
+	nearDupScore         float64
+	nearDupErr           error
 	bulkSoftDeleteCalls  [][]string
 	bulkSoftDeleteAgent  string
 	bulkSoftDeleteResult int64
@@ -1131,8 +1135,17 @@ func (m *memoryRepoMock) ListBootstrap(ctx context.Context, limit int) ([]domain
 	return nil, nil
 }
 
-func (m *memoryRepoMock) NearDupSearch(_ context.Context, _ string) (string, float64, error) {
-	return "", 0, nil
+func (m *memoryRepoMock) NearDupSearch(ctx context.Context, query string) (string, float64, error) {
+	m.mu.Lock()
+	hook := m.nearDupSearchHook
+	id := m.nearDupID
+	score := m.nearDupScore
+	err := m.nearDupErr
+	m.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, query)
+	}
+	return id, score, err
 }
 
 func TestDropQueryIntentFacts(t *testing.T) {
@@ -1893,6 +1906,92 @@ func TestReconcileFallbackWritesNothing(t *testing.T) {
 	}
 	if res.Status != "partial" {
 		t.Fatalf("expected status 'partial' for reconciliation LLM failure, got %q", res.Status)
+	}
+}
+
+func TestReconcileSkipsStrongNearDupFacts(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{
+		nearDupID:    "mem-existing",
+		nearDupScore: 0.995,
+	}
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	resultIDs, warnings, err := svc.reconcile(context.Background(), "agent-1", "agent-1", "session-1", []ExtractedFact{
+		{Text: "Uses Go for backend", Tags: []string{"tech"}},
+	})
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("expected 0 warnings, got %d", warnings)
+	}
+	if len(resultIDs) != 0 {
+		t.Fatalf("expected 0 result IDs, got %v", resultIDs)
+	}
+	if got := len(memRepo.createCalls); got != 0 {
+		t.Fatalf("expected 0 writes when fact is suppressed as near-dup, got %d", got)
+	}
+}
+
+func TestReconcileDoesNotSkipRawFallbackFacts(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{
+		nearDupID:    "mem-existing",
+		nearDupScore: 0.999,
+	}
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	resultIDs, warnings, err := svc.reconcile(context.Background(), "agent-1", "agent-1", "session-1", []ExtractedFact{
+		{Text: "User asked about nginx config", Tags: []string{rawFallbackTag}, FactType: factTypeRawFallback},
+	})
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("expected 0 warnings, got %d", warnings)
+	}
+	if len(resultIDs) != 1 {
+		t.Fatalf("expected 1 created insight for raw fallback fact, got %v", resultIDs)
+	}
+	if got := len(memRepo.createCalls); got != 1 {
+		t.Fatalf("expected 1 write for raw fallback fact, got %d", got)
+	}
+}
+
+func TestReconcileSuppressesOnlyNearDupSubset(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{
+		nearDupSearchHook: func(_ context.Context, query string) (string, float64, error) {
+			if strings.Contains(query, "Uses Go for backend") {
+				return "mem-existing", 0.995, nil
+			}
+			return "", 0, nil
+		},
+	}
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	resultIDs, warnings, err := svc.reconcile(context.Background(), "agent-1", "agent-1", "session-1", []ExtractedFact{
+		{Text: "Uses Go for backend", Tags: []string{"tech"}},
+		{Text: "Uses PostgreSQL for storage", Tags: []string{"tech"}},
+	})
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("expected 0 warnings, got %d", warnings)
+	}
+	if len(resultIDs) != 1 {
+		t.Fatalf("expected 1 created insight for non-duplicate fact, got %v", resultIDs)
+	}
+	if got := len(memRepo.createCalls); got != 1 {
+		t.Fatalf("expected 1 write after suppressing near-dup subset, got %d", got)
+	}
+	if got := memRepo.createCalls[0].Content; got != "Uses PostgreSQL for storage" {
+		t.Fatalf("expected surviving fact to be written, got %q", got)
 	}
 }
 

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -41,7 +41,7 @@ type memoryRepoMock struct {
 	autoVectorSearchHook func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	ftsSearchHook        func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
-	nearDupSearchHook    func(context.Context, string) (string, float64, error)
+	nearDupSearchHook    func(context.Context, string, string) (string, float64, error)
 	nearDupID            string
 	nearDupScore         float64
 	nearDupErr           error
@@ -1135,7 +1135,7 @@ func (m *memoryRepoMock) ListBootstrap(ctx context.Context, limit int) ([]domain
 	return nil, nil
 }
 
-func (m *memoryRepoMock) NearDupSearch(ctx context.Context, query string) (string, float64, error) {
+func (m *memoryRepoMock) NearDupSearch(ctx context.Context, agentID, query string) (string, float64, error) {
 	m.mu.Lock()
 	hook := m.nearDupSearchHook
 	id := m.nearDupID
@@ -1143,7 +1143,7 @@ func (m *memoryRepoMock) NearDupSearch(ctx context.Context, query string) (strin
 	err := m.nearDupErr
 	m.mu.Unlock()
 	if hook != nil {
-		return hook(ctx, query)
+		return hook(ctx, agentID, query)
 	}
 	return id, score, err
 }
@@ -1965,7 +1965,7 @@ func TestReconcileSuppressesOnlyNearDupSubset(t *testing.T) {
 	t.Parallel()
 
 	memRepo := &memoryRepoMock{
-		nearDupSearchHook: func(_ context.Context, query string) (string, float64, error) {
+		nearDupSearchHook: func(_ context.Context, _ string, query string) (string, float64, error) {
 			if strings.Contains(query, "Uses Go for backend") {
 				return "mem-existing", 0.995, nil
 			}
@@ -1992,6 +1992,39 @@ func TestReconcileSuppressesOnlyNearDupSubset(t *testing.T) {
 	}
 	if got := memRepo.createCalls[0].Content; got != "Uses PostgreSQL for storage" {
 		t.Fatalf("expected surviving fact to be written, got %q", got)
+	}
+}
+
+func TestReconcileDoesNotSuppressAcrossAgents(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{
+		nearDupSearchHook: func(_ context.Context, agentID, query string) (string, float64, error) {
+			if agentID != "agent-1" {
+				t.Fatalf("expected agent-1 filter, got %q", agentID)
+			}
+			if strings.Contains(query, "Uses Go for backend") {
+				return "", 0, nil
+			}
+			return "", 0, nil
+		},
+	}
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	resultIDs, warnings, err := svc.reconcile(context.Background(), "agent-1", "agent-1", "session-1", []ExtractedFact{
+		{Text: "Uses Go for backend", Tags: []string{"tech"}},
+	})
+	if err != nil {
+		t.Fatalf("reconcile() error = %v", err)
+	}
+	if warnings != 0 {
+		t.Fatalf("expected 0 warnings, got %d", warnings)
+	}
+	if len(resultIDs) != 1 {
+		t.Fatalf("expected fact to be written for this agent, got %v", resultIDs)
+	}
+	if got := len(memRepo.createCalls); got != 1 {
+		t.Fatalf("expected 1 write when near-dup belongs to another agent, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- suppress very strong near-duplicate facts before reconciliation
- keep raw_fallback facts on the existing reconciliation path
- add focused tests for full suppression, subset suppression, and raw_fallback safety

## Notes
- threshold starts at `0.99` for a conservative first pass
- benchmark validation is still blocked by tenant provision rate limiting, so this PR is for code review first

## Testing
- go test ./internal/service
