### PR TITLE
fix(site): add UTM params to landing outbound links

### DIFF
--- a/site/src/components/BridgeBanner.astro
+++ b/site/src/components/BridgeBanner.astro
@@ -10,7 +10,7 @@ const bridgeBody =
   security.bridgeBody
   ?? 'Memory is often the first state problem in an agent system. When your workflow expands into files, artifacts, and retrieval, drive9 becomes the next layer.';
 const bridgeCtaLabel = security.bridgeCtaLabel ?? 'Explore drive9 →';
-const drive9Href = 'https://drive9.ai';
+const drive9Href = 'https://drive9.ai?utm_source=mem9&utm_medium=referral&utm_campaign=site-cta';
 ---
 
 <section class="bridge-banner-section" aria-label="drive9 bridge">

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -13,8 +13,8 @@ const poweredByLabel = hero.poweredByLabel ?? 'Powered by TiDB Cloud';
 const substrateCtaLabel =
   hero.substrateCtaLabel
   ?? 'Need the backend substrate behind memory? Explore via TiDB Cloud Zero →';
-const tidbCloudHref = 'https://www.pingcap.com';
-const tidbZeroHref = 'https://zero.tidbcloud.com';
+const tidbCloudHref = 'https://www.pingcap.com?utm_source=mem9&utm_medium=referral&utm_campaign=site-cta';
+const tidbZeroHref = 'https://zero.tidbcloud.com?utm_source=mem9&utm_medium=referral&utm_campaign=site-cta';
 
 function splitOnboardingCommand(command: string): {
   prefix: string;


### PR DESCRIPTION
## What
Add consistent UTM parameters to the outbound landing page links introduced by PR #245.

## Why
The merged landing update added external CTAs to TiDB Cloud, TiDB Cloud Zero, and drive9 without referral tracking.

## Changes
- add `utm_source=mem9`
- add `utm_medium=referral`
- add `utm_campaign=agent-state-stack`
- update the hero Powered by TiDB Cloud link
- update the hero TiDB Cloud Zero link
- update the drive9 bridge banner link

## Verification
- ran `cd site && npm run build`
- confirmed all three outbound links now include the same UTM query string