### PR TITLE
docs: update locomo baseline cost

### DIFF
--- a/benchmark/BASELINE.md
+++ b/benchmark/BASELINE.md
@@ -1,13 +1,13 @@
 ── Results ──────────────────────────────────
-Overall F1 (micro): 58.84%  (n=1986)
-Overall F1 (macro): 49.47%
-Overall LLM (micro): 71.95%  (n=1540)
-Overall LLM (macro): 63.56%
-Overall Evidence Recall: 53.76%
+Overall F1 (micro): 58.28%  (n=1986)
+Overall F1 (macro): 49.12%
+Overall LLM (micro): 71.82%  (n=1540)
+Overall LLM (macro): 62.39%
+Overall Evidence Recall: 53.66%
 
-  Cat 1 (multi-hop   ):  F1=22.60%  LLM=53.90%  ER=25.1%  (n=282  llm_n=282)
-  Cat 2 (single-hop  ):  F1=58.18%  LLM=76.01%  ER=67.8%  (n=321  llm_n=321)
-  Cat 3 (temporal    ):  F1=13.79%  LLM=44.79%  ER=18.6%  (n=96  llm_n=96)
-  Cat 4 (open-domain ):  F1=56.57%  LLM=79.55%  ER=60.1%  (n=841  llm_n=841)
-  Cat 5 (adversarial ):  F1=96.19%  LLM=N/A  ER=57.1%  (n=446)
+  Cat 1 (multi-hop   ):  F1=22.46%  LLM=54.26%  ER=24.6%  (n=282  llm_n=282)
+  Cat 2 (single-hop  ):  F1=56.44%  LLM=72.90%  ER=68.2%  (n=321  llm_n=321)
+  Cat 3 (temporal    ):  F1=14.65%  LLM=41.67%  ER=18.6%  (n=96  llm_n=96)
+  Cat 4 (open-domain ):  F1=55.87%  LLM=80.74%  ER=59.7%  (n=841  llm_n=841)
+  Cat 5 (adversarial ):  F1=96.19%  LLM=N/A  ER=57.5%  (n=446)
 ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Update `benchmark/BASELINE.md` with the current best LoCoMo result from `okJiang/locomo-logs/reconcile-action-only-rich-prompt-full/`.
- Keep the original LoCoMo result-block format because this file is rendered directly by the frontend.
- Use the PR #241 run as the source result.

## Baseline
- Overall LLM (micro): 71.82%
- Overall LLM tokens: 1,885,667 (-18.1%)
- Reconciliation tokens: 873,892
- Recall embedding requests: 5,958

## Verification
- `git diff --check`
- Verified the baseline values against `llm-cost-summary.json` and `benchmark-results.json` from the archived run.
