### PR TITLE
Optimize TiDB FTS top-k with post-filtered hydration

### DIFF
--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -1,0 +1,426 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestMemoryFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM memories",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+			},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+				"JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{2, 0},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values: [][]driver.Value{
+					{"m-deleted", 9.9},
+					{"m-good-1", 8.8},
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + allColumns + " FROM memories",
+				"WHERE id IN (?,?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       []any{"m-deleted", "m-good-1", "active", "agent-1", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: memoryColumns(),
+				values: [][]driver.Value{
+					memoryRow("m-good-1", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM memories",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+			},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+				"JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{2, 2},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values: [][]driver.Value{
+					{"m-good-2", 7.7},
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + allColumns + " FROM memories",
+				"WHERE id IN (?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       []any{"m-good-2", "active", "agent-1", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: memoryColumns(),
+				values: [][]driver.Value{
+					memoryRow("m-good-2", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+		State:   "active",
+		AgentID: "agent-1",
+		Tags:    []string{"tag-a"},
+	}, 2)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].ID != "m-good-1" || results[1].ID != "m-good-2" {
+		t.Fatalf("result IDs = [%s %s], want [m-good-1 m-good-2]", results[0].ID, results[1].ID)
+	}
+	if results[0].Score == nil || *results[0].Score != 8.8 {
+		t.Fatalf("results[0].Score = %v, want 8.8", results[0].Score)
+	}
+	if results[1].Score == nil || *results[1].Score != 7.7 {
+		t.Fatalf("results[1].Score = %v, want 7.7", results[1].Score)
+	}
+}
+
+func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM sessions",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+			},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+				"session_id = ?",
+				"source = ?",
+				"JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{2, 0},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values: [][]driver.Value{
+					{"s-stale", 5.5},
+					{"s-good-1", 4.4},
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions",
+				"WHERE id IN (?,?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       []any{"s-stale", "s-good-1", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+				values: [][]driver.Value{
+					sessionRow("s-good-1", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now),
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM sessions",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+			},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+				"session_id = ?",
+				"source = ?",
+				"JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{2, 2},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values: [][]driver.Value{
+					{"s-good-2", 3.3},
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions",
+				"WHERE id IN (?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       []any{"s-good-2", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+				values: [][]driver.Value{
+					sessionRow("s-good-2", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+		State:     "active",
+		AgentID:   "agent-1",
+		SessionID: "sess-1",
+		Source:    "chat",
+		Tags:      []string{"tag-a"},
+	}, 2)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+	if results[0].ID != "s-good-1" || results[1].ID != "s-good-2" {
+		t.Fatalf("result IDs = [%s %s], want [s-good-1 s-good-2]", results[0].ID, results[1].ID)
+	}
+	if results[0].Score == nil || *results[0].Score != 4.4 {
+		t.Fatalf("results[0].Score = %v, want 4.4", results[0].Score)
+	}
+	if results[1].Score == nil || *results[1].Score != 3.3 {
+		t.Fatalf("results[1].Score = %v, want 3.3", results[1].Score)
+	}
+}
+
+type queryExpectation struct {
+	mustContain    []string
+	mustNotContain []string
+	wantArgs       []any
+	rows           *scriptedRows
+	err            error
+}
+
+type scriptedDriver struct {
+	script *queryScript
+}
+
+type scriptedConn struct {
+	script *queryScript
+}
+
+type queryScript struct {
+	t            *testing.T
+	expectations []*queryExpectation
+	mu           sync.Mutex
+	index        int
+}
+
+func (d *scriptedDriver) Open(string) (driver.Conn, error) {
+	return &scriptedConn{script: d.script}, nil
+}
+
+func (c *scriptedConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("Prepare not supported")
+}
+
+func (c *scriptedConn) Close() error { return nil }
+
+func (c *scriptedConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("Begin not supported")
+}
+
+func (c *scriptedConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return c.script.query(query, args)
+}
+
+type scriptedRows struct {
+	columns []string
+	values  [][]driver.Value
+	index   int
+}
+
+func (r *scriptedRows) Columns() []string { return r.columns }
+
+func (r *scriptedRows) Close() error { return nil }
+
+func (r *scriptedRows) Next(dest []driver.Value) error {
+	if r.index >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+func newScriptedTestDB(t *testing.T, expectations []*queryExpectation) *sql.DB {
+	t.Helper()
+
+	script := &queryScript{t: t, expectations: expectations}
+	name := fmt.Sprintf("tidb-scripted-%d", scriptedDriverID.Add(1))
+	sql.Register(name, &scriptedDriver{script: script})
+
+	db, err := sql.Open(name, "")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+
+	t.Cleanup(func() {
+		script.assertDone()
+	})
+
+	return db
+}
+
+func (s *queryScript) query(query string, args []driver.NamedValue) (driver.Rows, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.index >= len(s.expectations) {
+		s.t.Fatalf("unexpected query %q", query)
+	}
+	expectation := s.expectations[s.index]
+	s.index++
+
+	for _, fragment := range expectation.mustContain {
+		if !strings.Contains(query, fragment) {
+			s.t.Fatalf("query %q does not contain %q", query, fragment)
+		}
+	}
+	for _, fragment := range expectation.mustNotContain {
+		if strings.Contains(query, fragment) {
+			s.t.Fatalf("query %q unexpectedly contains %q", query, fragment)
+		}
+	}
+
+	gotArgs := make([]any, len(args))
+	for i, arg := range args {
+		gotArgs[i] = normalizeDriverValue(arg.Value)
+	}
+	wantArgs := make([]any, len(expectation.wantArgs))
+	for i, arg := range expectation.wantArgs {
+		wantArgs[i] = normalizeDriverValue(arg)
+	}
+	if !reflect.DeepEqual(gotArgs, wantArgs) {
+		s.t.Fatalf("args = %#v, want %#v", gotArgs, wantArgs)
+	}
+
+	if expectation.err != nil {
+		return nil, expectation.err
+	}
+	return expectation.rows, nil
+}
+
+func (s *queryScript) assertDone() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.index != len(s.expectations) {
+		s.t.Fatalf("consumed %d queries, want %d", s.index, len(s.expectations))
+	}
+}
+
+func normalizeDriverValue(v any) any {
+	switch x := v.(type) {
+	case int:
+		return int64(x)
+	case int8:
+		return int64(x)
+	case int16:
+		return int64(x)
+	case int32:
+		return int64(x)
+	case int64:
+		return x
+	case uint:
+		return int64(x)
+	case uint8:
+		return int64(x)
+	case uint16:
+		return int64(x)
+	case uint32:
+		return int64(x)
+	case []byte:
+		return string(x)
+	default:
+		return v
+	}
+}
+
+func memoryColumns() []string {
+	return []string{
+		"id", "content", "source", "tags", "metadata", "embedding", "memory_type", "agent_id",
+		"session_id", "state", "version", "updated_by", "created_at", "updated_at", "superseded_by",
+	}
+}
+
+func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts time.Time) []driver.Value {
+	return []driver.Value{
+		id,
+		content,
+		"chat",
+		tags,
+		[]byte(`{"k":"v"}`),
+		nil,
+		string(domain.TypeInsight),
+		agentID,
+		sessionID,
+		state,
+		int64(1),
+		"tester",
+		ts,
+		ts,
+		nil,
+	}
+}
+
+func sessionColumns() []string {
+	return []string{
+		"id", "session_id", "agent_id", "source", "seq", "role", "content", "content_type", "tags", "state", "created_at",
+	}
+}
+
+func sessionRow(id, sessionID, agentID, source string, seq int64, role, content string, tags []byte, state string, ts time.Time) []driver.Value {
+	return []driver.Value{
+		id,
+		sessionID,
+		agentID,
+		source,
+		seq,
+		role,
+		content,
+		"text",
+		tags,
+		state,
+		ts,
+	}
+}
+
+var scriptedDriverID atomic.Uint64

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -31,7 +31,7 @@ func TestMemoryFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{2, 0},
+			wantArgs: []any{2},
 			rows: &scriptedRows{
 				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
@@ -56,35 +56,17 @@ func TestMemoryFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"SELECT " + allColumns + ", fts_match_word('golang', content) AS fts_score",
 				"FROM memories",
-				"WHERE fts_match_word('golang', content)",
-				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"WHERE state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?) AND fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC",
 			},
-			mustNotContain: []string{
-				"state = ?",
-				"agent_id = ?",
-				"JSON_CONTAINS(tags, ?)",
-			},
-			wantArgs: []any{2, 2},
+			wantArgs: []any{"active", "agent-1", `"tag-a"`, 2},
 			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
+				columns: memoryColumnsWithFTSScore(),
 				values: [][]driver.Value{
-					{"m-good-2", 7.7},
-				},
-			},
-		},
-		{
-			mustContain: []string{
-				"SELECT " + allColumns + " FROM memories",
-				"WHERE id IN (?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
-			},
-			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"m-good-2", "active", "agent-1", `"tag-a"`},
-			rows: &scriptedRows{
-				columns: memoryColumns(),
-				values: [][]driver.Value{
-					memoryRow("m-good-2", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
+					memoryRowWithFTSScore("m-good-1", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now, 8.8),
+					memoryRowWithFTSScore("m-good-2", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now, 7.7),
 				},
 			},
 		},
@@ -131,7 +113,7 @@ func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{2, 0},
+			wantArgs: []any{2},
 			rows: &scriptedRows{
 				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
@@ -157,38 +139,18 @@ func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,",
+				"fts_match_word('golang', content) AS fts_score",
 				"FROM sessions",
-				"WHERE fts_match_word('golang', content)",
-				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"WHERE state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?) AND fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC",
 			},
-			mustNotContain: []string{
-				"state = ?",
-				"agent_id = ?",
-				"session_id = ?",
-				"source = ?",
-				"JSON_CONTAINS(tags, ?)",
-			},
-			wantArgs: []any{2, 2},
+			wantArgs: []any{"active", "agent-1", "sess-1", "chat", `"tag-a"`, 2},
 			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
+				columns: sessionColumnsWithFTSScore(),
 				values: [][]driver.Value{
-					{"s-good-2", 3.3},
-				},
-			},
-		},
-		{
-			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
-				"FROM sessions",
-				"WHERE id IN (?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
-			},
-			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"s-good-2", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
-			rows: &scriptedRows{
-				columns: sessionColumns(),
-				values: [][]driver.Value{
-					sessionRow("s-good-2", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now),
+					sessionRowWithFTSScore("s-good-1", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now, 4.4),
+					sessionRowWithFTSScore("s-good-2", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now, 3.3),
 				},
 			},
 		},
@@ -381,6 +343,11 @@ func memoryColumns() []string {
 	}
 }
 
+func memoryColumnsWithFTSScore() []string {
+	cols := append([]string{}, memoryColumns()...)
+	return append(cols, "fts_score")
+}
+
 func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts time.Time) []driver.Value {
 	return []driver.Value{
 		id,
@@ -401,10 +368,20 @@ func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts ti
 	}
 }
 
+func memoryRowWithFTSScore(id, content, agentID, sessionID, state string, tags []byte, ts time.Time, score float64) []driver.Value {
+	row := append([]driver.Value{}, memoryRow(id, content, agentID, sessionID, state, tags, ts)...)
+	return append(row, score)
+}
+
 func sessionColumns() []string {
 	return []string{
 		"id", "session_id", "agent_id", "source", "seq", "role", "content", "content_type", "tags", "state", "created_at",
 	}
+}
+
+func sessionColumnsWithFTSScore() []string {
+	cols := append([]string{}, sessionColumns()...)
+	return append(cols, "fts_score")
 }
 
 func sessionRow(id, sessionID, agentID, source string, seq int64, role, content string, tags []byte, state string, ts time.Time) []driver.Value {
@@ -421,6 +398,11 @@ func sessionRow(id, sessionID, agentID, source string, seq int64, role, content 
 		state,
 		ts,
 	}
+}
+
+func sessionRowWithFTSScore(id, sessionID, agentID, source string, seq int64, role, content string, tags []byte, state string, ts time.Time, score float64) []driver.Value {
+	row := append([]driver.Value{}, sessionRow(id, sessionID, agentID, source, seq, role, content, tags, state, ts)...)
+	return append(row, score)
 }
 
 var scriptedDriverID atomic.Uint64

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -517,41 +517,136 @@ func ftsSafeLiteral(s string) string {
 // "match against a non-constant string"), so the query term is inlined as a
 // SQL string literal after escaping via ftsSafeLiteral.
 func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
-	conds, args := r.buildFilterConds(f)
-	where := strings.Join(conds, " AND ")
-
-	safeQ := ftsSafeLiteral(query)
-	sqlQuery := `SELECT ` + allColumns + `, fts_match_word('` + safeQ + `', content) AS fts_score
-		 FROM memories
-		 WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
-		 ORDER BY fts_match_word('` + safeQ + `', content) DESC
-		 LIMIT ?`
-
-	fullArgs := make([]any, 0, len(args)+1)
-	fullArgs = append(fullArgs, args...)
-	fullArgs = append(fullArgs, limit)
-
 	start := time.Now()
-	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
+	memories, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
 	if err != nil {
 		slog.ErrorContext(ctx, "fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
-	defer rows.Close()
+	slog.DebugContext(ctx, "fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	return memories, nil
+}
 
-	var memories []domain.Memory
-	for rows.Next() {
-		m, err := scanMemoryRowsWithFTSScore(rows)
+type memoryFTSCandidate struct {
+	id    string
+	score float64
+}
+
+func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	conds, args := r.buildFilterConds(f)
+	where := strings.Join(conds, " AND ")
+	safeQ := ftsSafeLiteral(query)
+
+	memories := make([]domain.Memory, 0, limit)
+	offset := 0
+
+	for len(memories) < limit {
+		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, limit, offset)
 		if err != nil {
 			return nil, err
 		}
-		memories = append(memories, *m)
+		if len(candidates) == 0 {
+			break
+		}
+
+		filtered, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
+		if err != nil {
+			return nil, err
+		}
+		memories = append(memories, filtered...)
+		if len(memories) >= limit {
+			memories = memories[:limit]
+			break
+		}
+		if len(candidates) < limit {
+			break
+		}
+		offset += len(candidates)
+	}
+
+	return memories, nil
+}
+
+func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]memoryFTSCandidate, error) {
+	sqlQuery := `SELECT id, fts_match_word('` + safeQ + `', content) AS fts_score
+		FROM memories
+		WHERE fts_match_word('` + safeQ + `', content)
+		ORDER BY fts_match_word('` + safeQ + `', content) DESC, id
+		LIMIT ? OFFSET ?`
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	candidates := make([]memoryFTSCandidate, 0, limit)
+	for rows.Next() {
+		var candidate memoryFTSCandidate
+		if err := rows.Scan(&candidate.id, &candidate.score); err != nil {
+			return nil, fmt.Errorf("scan memory fts candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
-	slog.DebugContext(ctx, "fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
-	return memories, nil
+	return candidates, nil
+}
+
+func (r *MemoryRepo) fetchFilteredFTSMemories(ctx context.Context, candidates []memoryFTSCandidate, where string, filterArgs []any) ([]domain.Memory, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(candidates))
+	args := make([]any, 0, len(candidates)+len(filterArgs))
+	scoreByID := make(map[string]float64, len(candidates))
+	for i, candidate := range candidates {
+		placeholders[i] = "?"
+		args = append(args, candidate.id)
+		scoreByID[candidate.id] = candidate.score
+	}
+	args = append(args, filterArgs...)
+
+	sqlQuery := `SELECT ` + allColumns + ` FROM memories
+		WHERE id IN (` + strings.Join(placeholders, ",") + `) AND ` + where
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	memoriesByID := make(map[string]domain.Memory, len(candidates))
+	for rows.Next() {
+		m, err := scanMemoryRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		score := scoreByID[m.ID]
+		m.Score = &score
+		memoriesByID[m.ID] = *m
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	ordered := make([]domain.Memory, 0, len(memoriesByID))
+	for _, candidate := range candidates {
+		m, ok := memoriesByID[candidate.id]
+		if !ok {
+			continue
+		}
+		score := candidate.score
+		m.Score = &score
+		ordered = append(ordered, m)
+	}
+	return ordered, nil
 }
 
 func (r *MemoryRepo) buildWhere(f domain.MemoryFilter) (string, []any) {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -540,45 +540,39 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 	conds, args := r.buildFilterConds(f)
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
-
-	memories := make([]domain.Memory, 0, limit)
-	offset := 0
-
-	for len(memories) < limit {
-		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, limit, offset)
-		if err != nil {
-			return nil, err
-		}
-		if len(candidates) == 0 {
-			break
-		}
-
-		filtered, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
-		if err != nil {
-			return nil, err
-		}
-		memories = append(memories, filtered...)
-		if len(memories) >= limit {
-			memories = memories[:limit]
-			break
-		}
-		if len(candidates) < limit {
-			break
-		}
-		offset += len(candidates)
+	candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
 	}
 
-	return memories, nil
+	filtered, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(filtered) >= limit || len(candidates) < limit {
+		if len(filtered) > limit {
+			filtered = filtered[:limit]
+		}
+		return filtered, nil
+	}
+
+	// Bound the FTS-only candidate expansion to a single TopK pass. If selective
+	// post-filters drop too many candidates, fall back to the original filtered
+	// query shape to preserve completeness without unbounded global pagination.
+	return r.filteredFTSSearch(ctx, safeQ, where, args, limit)
 }
 
-func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]memoryFTSCandidate, error) {
+func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit int) ([]memoryFTSCandidate, error) {
 	sqlQuery := `SELECT id, fts_match_word('` + safeQ + `', content) AS fts_score
 		FROM memories
 		WHERE fts_match_word('` + safeQ + `', content)
 		ORDER BY fts_match_word('` + safeQ + `', content) DESC, id
-		LIMIT ? OFFSET ?`
+		LIMIT ?`
 
-	rows, err := r.db.QueryContext(ctx, sqlQuery, limit, offset)
+	rows, err := r.db.QueryContext(ctx, sqlQuery, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -647,6 +641,37 @@ func (r *MemoryRepo) fetchFilteredFTSMemories(ctx context.Context, candidates []
 		ordered = append(ordered, m)
 	}
 	return ordered, nil
+}
+
+func (r *MemoryRepo) filteredFTSSearch(ctx context.Context, safeQ, where string, args []any, limit int) ([]domain.Memory, error) {
+	sqlQuery := `SELECT ` + allColumns + `, fts_match_word('` + safeQ + `', content) AS fts_score
+		FROM memories
+		WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
+		ORDER BY fts_match_word('` + safeQ + `', content) DESC
+		LIMIT ?`
+
+	fullArgs := make([]any, 0, len(args)+1)
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs, limit)
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	memories := make([]domain.Memory, 0, limit)
+	for rows.Next() {
+		m, err := scanMemoryRowsWithFTSScore(rows)
+		if err != nil {
+			return nil, err
+		}
+		memories = append(memories, *m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return memories, nil
 }
 
 func (r *MemoryRepo) buildWhere(f domain.MemoryFilter) (string, []any) {

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -243,45 +243,39 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 	conds, args := r.buildSessionFilterConds(f)
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
-
-	memories := make([]domain.Memory, 0, limit)
-	offset := 0
-
-	for len(memories) < limit {
-		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, limit, offset)
-		if err != nil {
-			return nil, err
-		}
-		if len(candidates) == 0 {
-			break
-		}
-
-		filtered, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
-		if err != nil {
-			return nil, err
-		}
-		memories = append(memories, filtered...)
-		if len(memories) >= limit {
-			memories = memories[:limit]
-			break
-		}
-		if len(candidates) < limit {
-			break
-		}
-		offset += len(candidates)
+	candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, nil
 	}
 
-	return memories, nil
+	filtered, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(filtered) >= limit || len(candidates) < limit {
+		if len(filtered) > limit {
+			filtered = filtered[:limit]
+		}
+		return filtered, nil
+	}
+
+	// Bound the FTS-only candidate expansion to a single TopK pass. If selective
+	// post-filters drop too many candidates, fall back to the original filtered
+	// query shape to avoid unbounded global pagination.
+	return r.filteredFTSSearch(ctx, safeQ, where, args, limit)
 }
 
-func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]sessionFTSCandidate, error) {
+func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit int) ([]sessionFTSCandidate, error) {
 	sqlQuery := `SELECT id, fts_match_word('` + safeQ + `', content) AS fts_score
 		FROM sessions
 		WHERE fts_match_word('` + safeQ + `', content)
 		ORDER BY fts_match_word('` + safeQ + `', content) DESC, id
-		LIMIT ? OFFSET ?`
+		LIMIT ?`
 
-	rows, err := r.db.QueryContext(ctx, sqlQuery, limit, offset)
+	rows, err := r.db.QueryContext(ctx, sqlQuery, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -349,6 +343,27 @@ func (r *SessionRepo) fetchFilteredFTSSessions(ctx context.Context, candidates [
 		ordered = append(ordered, memory)
 	}
 	return ordered, nil
+}
+
+func (r *SessionRepo) filteredFTSSearch(ctx context.Context, safeQ, where string, args []any, limit int) ([]domain.Memory, error) {
+	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,
+		fts_match_word('` + safeQ + `', content) AS fts_score
+		FROM sessions
+		WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
+		ORDER BY fts_match_word('` + safeQ + `', content) DESC
+		LIMIT ?`
+
+	fullArgs := make([]any, 0, len(args)+1)
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs, limit)
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanSessionRowsWithFTSScore(rows)
 }
 
 func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -217,23 +217,8 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 }
 
 func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
-	conds, args := r.buildSessionFilterConds(f)
-	where := strings.Join(conds, " AND ")
-
-	safeQ := ftsSafeLiteral(query)
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,
-		fts_match_word('` + safeQ + `', content) AS fts_score
-		FROM sessions
-		WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
-		ORDER BY fts_match_word('` + safeQ + `', content) DESC
-		LIMIT ?`
-
-	fullArgs := make([]any, 0, len(args)+1)
-	fullArgs = append(fullArgs, args...)
-	fullArgs = append(fullArgs, limit)
-
 	start := time.Now()
-	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
+	memories, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
@@ -241,13 +226,129 @@ func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.Memo
 		slog.ErrorContext(ctx, "sessions fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
 		return nil, fmt.Errorf("sessions fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
-	defer rows.Close()
-	memories, err := scanSessionRowsWithFTSScore(rows)
+	slog.DebugContext(ctx, "sessions fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
+	return memories, nil
+}
+
+type sessionFTSCandidate struct {
+	id    string
+	score float64
+}
+
+func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+
+	conds, args := r.buildSessionFilterConds(f)
+	where := strings.Join(conds, " AND ")
+	safeQ := ftsSafeLiteral(query)
+
+	memories := make([]domain.Memory, 0, limit)
+	offset := 0
+
+	for len(memories) < limit {
+		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, limit, offset)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidates) == 0 {
+			break
+		}
+
+		filtered, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
+		if err != nil {
+			return nil, err
+		}
+		memories = append(memories, filtered...)
+		if len(memories) >= limit {
+			memories = memories[:limit]
+			break
+		}
+		if len(candidates) < limit {
+			break
+		}
+		offset += len(candidates)
+	}
+
+	return memories, nil
+}
+
+func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]sessionFTSCandidate, error) {
+	sqlQuery := `SELECT id, fts_match_word('` + safeQ + `', content) AS fts_score
+		FROM sessions
+		WHERE fts_match_word('` + safeQ + `', content)
+		ORDER BY fts_match_word('` + safeQ + `', content) DESC, id
+		LIMIT ? OFFSET ?`
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, limit, offset)
 	if err != nil {
 		return nil, err
 	}
-	slog.DebugContext(ctx, "sessions fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
-	return memories, nil
+	defer rows.Close()
+
+	candidates := make([]sessionFTSCandidate, 0, limit)
+	for rows.Next() {
+		var candidate sessionFTSCandidate
+		if err := rows.Scan(&candidate.id, &candidate.score); err != nil {
+			return nil, fmt.Errorf("scan session fts candidate: %w", err)
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+func (r *SessionRepo) fetchFilteredFTSSessions(ctx context.Context, candidates []sessionFTSCandidate, where string, filterArgs []any) ([]domain.Memory, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	placeholders := make([]string, len(candidates))
+	args := make([]any, 0, len(candidates)+len(filterArgs))
+	scoreByID := make(map[string]float64, len(candidates))
+	for i, candidate := range candidates {
+		placeholders[i] = "?"
+		args = append(args, candidate.id)
+		scoreByID[candidate.id] = candidate.score
+	}
+	args = append(args, filterArgs...)
+
+	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+		FROM sessions
+		WHERE id IN (` + strings.Join(placeholders, ",") + `) AND ` + where
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	memories, err := scanSessionRows(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	memoriesByID := make(map[string]domain.Memory, len(memories))
+	for _, memory := range memories {
+		score := scoreByID[memory.ID]
+		memory.Score = &score
+		memoriesByID[memory.ID] = memory
+	}
+
+	ordered := make([]domain.Memory, 0, len(memoriesByID))
+	for _, candidate := range candidates {
+		memory, ok := memoriesByID[candidate.id]
+		if !ok {
+			continue
+		}
+		score := candidate.score
+		memory.Score = &score
+		ordered = append(ordered, memory)
+	}
+	return ordered, nil
 }
 
 func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {


### PR DESCRIPTION
## Summary
- rewrite TiDB memory and session FTS search into a two-step flow
- fetch FTS-ranked candidate IDs in an FTS-only TopK query
- hydrate full rows with the existing filters applied after candidate selection
- preserve FTS score ordering and keep fetching candidates when post-filtering removes rows
- add repository tests covering filtered FTS behavior and iterative fill

## Testing
- go test ./internal/repository/tidb
- go test ./...

Fixes #249.