### PR TITLE
Reduce phase1 extraction tokens by removing message tags

### DIFF
--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -142,10 +142,6 @@ func (s *testSessionRepo) ListBySessionIDs(context.Context, []string, int) ([]*d
 	return nil, nil
 }
 
-func intPtr(v int) *int {
-	return &v
-}
-
 // newTestServer creates a Server with pre-populated svcCache for testing.
 func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default())
@@ -383,7 +379,7 @@ func TestCreateMemory_SyncMessages_StripsInjectedContext(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]string{
-					"content": `{"facts":["hello world"],"message_tags":[["greeting"],["reply"]]}`,
+					"content": `{"facts":["hello world"]}`,
 				}},
 			},
 		})
@@ -453,7 +449,7 @@ func TestCreateMemory_SyncMessages_ReconcileFailure_Returns500(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]string{
-					"content": `{"facts":["test fact"],"message_tags":[["tag1"],["tag2"]]}`,
+					"content": `{"facts":["test fact"]}`,
 				}},
 			},
 		})
@@ -535,13 +531,13 @@ func TestCreateMemory_SyncMessages_Timeout_FallsBackToSuccess(t *testing.T) {
 	}
 }
 
-func TestCreateMemory_SyncMessages_ExplicitSeqUsesSeqAwarePatchHash(t *testing.T) {
+func TestCreateMemory_SyncMessages_SkipsPatchTagsWhenPhase1HasNoMessageTags(t *testing.T) {
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]string{
-					"content": `{"facts":[{"text":"test fact"}],"message_tags":[["tag1"],[]]}`,
+					"content": `{"facts":[{"text":"test fact"}]}`,
 				}},
 			},
 		})
@@ -580,18 +576,8 @@ func TestCreateMemory_SyncMessages_ExplicitSeqUsesSeqAwarePatchHash(t *testing.T
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
-	if !sessRepo.patchTagsCalled {
-		t.Fatal("expected PatchTags to be called")
-	}
-	wantHash := service.SessionContentHash("test-session", "assistant", "Take care, bye!", intPtr(36))
-	if sessRepo.patchedHash != wantHash {
-		t.Fatalf("patched hash = %q, want %q", sessRepo.patchedHash, wantHash)
-	}
-	if sessRepo.patchedSessionID != "test-session" {
-		t.Fatalf("patched session_id = %q, want test-session", sessRepo.patchedSessionID)
-	}
-	if len(sessRepo.patchedTags) != 1 || sessRepo.patchedTags[0] != "tag1" {
-		t.Fatalf("patched tags = %v, want [tag1]", sessRepo.patchedTags)
+	if sessRepo.patchTagsCalled {
+		t.Fatalf("expected PatchTags to be skipped, got hash=%q tags=%v", sessRepo.patchedHash, sessRepo.patchedTags)
 	}
 }
 

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -355,7 +355,7 @@ func normalizeReconciledTemporalContent(content string) (string, *TemporalMetada
 	return NormalizeStandaloneTemporalContent(content, time.Now())
 }
 
-// ExtractPhase1 runs fact extraction and per-message tagging in a single LLM call.
+// ExtractPhase1 runs fact extraction for the handler-driven ingest pipeline.
 // Returns an empty Phase1Result (no error) when LLM is nil or messages are empty.
 func (s *IngestService) ExtractPhase1(ctx context.Context, messages []IngestMessage) (*Phase1Result, error) {
 	if s.llm == nil || len(messages) == 0 {
@@ -367,13 +367,13 @@ func (s *IngestService) ExtractPhase1(ctx context.Context, messages []IngestMess
 		return &Phase1Result{}, nil
 	}
 
-	facts, messageTags, err := s.extractFactsAndTags(ctx, input.formatted, len(input.messages))
+	facts, err := s.extractFacts(ctx, input.formatted)
 	if err != nil {
 		return nil, err
 	}
 	return &Phase1Result{
 		Facts:       facts,
-		MessageTags: expandMessageTags(messageTags, input, len(messages)),
+		MessageTags: normalizeMessageTags(nil, len(messages)),
 	}, nil
 }
 

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -335,7 +335,7 @@ func TestExtractPhase1FactTagsPopulated(t *testing.T) {
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		resp := `{"facts": [{"text": "Uses Go 1.22", "tags": ["tech"]}], "message_tags": [["tech"], ["answer"]]}`
+		resp := `{"facts": [{"text": "Uses Go 1.22", "tags": ["tech"]}]}`
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]string{"content": resp}},
@@ -363,8 +363,8 @@ func TestExtractPhase1FactTagsPopulated(t *testing.T) {
 	if len(result.MessageTags) != 2 {
 		t.Fatalf("expected 2 message tag entries, got %d", len(result.MessageTags))
 	}
-	if len(result.MessageTags[0]) != 1 || result.MessageTags[0][0] != "tech" {
-		t.Fatalf("expected message_tags[0] = [tech], got %v", result.MessageTags[0])
+	if len(result.MessageTags[0]) != 0 || len(result.MessageTags[1]) != 0 {
+		t.Fatalf("expected empty message_tags, got %v", result.MessageTags)
 	}
 }
 
@@ -413,7 +413,7 @@ func TestExtractPhase1SingleMessageUsesLLMExtraction(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
-				{"message": map[string]string{"content": `{"facts": [{"text": "Uses Go 1.22", "tags": ["tech"]}], "message_tags": [["tech"]]}`}},
+				{"message": map[string]string{"content": `{"facts": [{"text": "Uses Go 1.22", "tags": ["tech"]}]}`}},
 			},
 		})
 	}))
@@ -437,8 +437,8 @@ func TestExtractPhase1SingleMessageUsesLLMExtraction(t *testing.T) {
 	if result.Facts[0].FactType != "" || result.Facts[0].Text != "Uses Go 1.22" {
 		t.Fatalf("expected normal extracted fact, got %+v", result.Facts[0])
 	}
-	if len(result.MessageTags) != 1 || len(result.MessageTags[0]) != 1 || result.MessageTags[0][0] != "tech" {
-		t.Fatalf("expected message_tags[0] = [tech], got %v", result.MessageTags)
+	if len(result.MessageTags) != 1 || len(result.MessageTags[0]) != 0 {
+		t.Fatalf("expected empty message_tags, got %v", result.MessageTags)
 	}
 }
 
@@ -506,7 +506,7 @@ func TestExtractPhase1SingleMessageEmptyResultFallsBackToRawFact(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
-				{"message": map[string]string{"content": `{"facts": [], "message_tags": [["tech"]]}`}},
+				{"message": map[string]string{"content": `{"facts": []}`}},
 			},
 		})
 	}))
@@ -527,8 +527,8 @@ func TestExtractPhase1SingleMessageEmptyResultFallsBackToRawFact(t *testing.T) {
 	if len(result.Facts) != 1 || result.Facts[0].FactType != factTypeRawFallback || result.Facts[0].Text != "I use Go 1.22" {
 		t.Fatalf("expected raw fallback fact after empty extraction, got %v", result.Facts)
 	}
-	if len(result.MessageTags) != 1 || len(result.MessageTags[0]) != 1 || result.MessageTags[0][0] != "tech" {
-		t.Fatalf("expected message_tags[0] = [tech], got %v", result.MessageTags)
+	if len(result.MessageTags) != 1 || len(result.MessageTags[0]) != 0 {
+		t.Fatalf("expected empty message_tags, got %v", result.MessageTags)
 	}
 }
 
@@ -2561,7 +2561,7 @@ func TestExtractPhase1LegacyStringArrayFallback(t *testing.T) {
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		resp := `{"facts": ["Uses Go 1.22"], "message_tags": [["tech"], ["answer"]]}`
+		resp := `{"facts": ["Uses Go 1.22"]}`
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]string{"content": resp}},
@@ -2589,8 +2589,8 @@ func TestExtractPhase1LegacyStringArrayFallback(t *testing.T) {
 	if result.Facts[0].Tags != nil {
 		t.Fatalf("expected nil tags from legacy format, got %v", result.Facts[0].Tags)
 	}
-	if len(result.MessageTags) != 2 || result.MessageTags[0][0] != "tech" {
-		t.Fatalf("expected message_tags intact, got %v", result.MessageTags)
+	if len(result.MessageTags) != 2 || len(result.MessageTags[0]) != 0 || len(result.MessageTags[1]) != 0 {
+		t.Fatalf("expected empty message_tags, got %v", result.MessageTags)
 	}
 }
 
@@ -2631,7 +2631,7 @@ func TestExtractPhase1FencedLegacyStringArrayFallback(t *testing.T) {
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fenced := "```json\n{\"facts\": [\"Uses Go 1.22\"], \"message_tags\": [[\"tech\"], [\"answer\"]]}\n```"
+		fenced := "```json\n{\"facts\": [\"Uses Go 1.22\"]}\n```"
 		json.NewEncoder(w).Encode(map[string]any{
 			"choices": []map[string]any{
 				{"message": map[string]string{"content": fenced}},
@@ -2659,8 +2659,8 @@ func TestExtractPhase1FencedLegacyStringArrayFallback(t *testing.T) {
 	if result.Facts[0].Tags != nil {
 		t.Fatalf("expected nil tags from legacy format, got %v", result.Facts[0].Tags)
 	}
-	if len(result.MessageTags) != 2 || result.MessageTags[0][0] != "tech" {
-		t.Fatalf("expected message_tags intact, got %v", result.MessageTags)
+	if len(result.MessageTags) != 2 || len(result.MessageTags[0]) != 0 || len(result.MessageTags[1]) != 0 {
+		t.Fatalf("expected empty message_tags, got %v", result.MessageTags)
 	}
 }
 


### PR DESCRIPTION
## Summary
- stop generating `message_tags` during phase1 extraction
- keep fact extraction and fact tags unchanged
- return empty per-message tag entries so the response shape remains stable

## Benchmark
Compared against current main baseline `9d87a00` (`main-baseline-full-20260421T150040`):

| Metric | Main baseline | Median of 3 runs | Change |
| --- | ---: | ---: | ---: |
| Overall LLM (micro) | 70.91% | 72.14% | +1.23pt |
| Overall LLM tokens | 1,892,683 | 1,692,579 | -200,104 / -10.57% |
| Extraction tokens | 1,012,060 | 834,951 | -177,109 |
| Reconciliation tokens | 880,623 | 856,977 | -23,646 |
| Recall embedding requests | 5,958 | 6,002 | +44 |

Three full benchmark runs:

| Run | Overall LLM (micro) | Overall LLM tokens | Extraction tokens | Reconciliation tokens | Recall embedding requests |
| --- | ---: | ---: | ---: | ---: | ---: |
| `doris-remove-message-tags-full-20260421T175352` | 72.21% | 1,692,579 | 835,602 | 856,977 | 5,958 |
| `doris-remove-message-tags-full-r2-clean-20260421T230613` | 72.14% | 1,656,525 | 818,647 | 837,878 | 6,011 |
| `doris-remove-message-tags-full-r3-clean-20260422T005823` | 71.49% | 1,696,230 | 834,951 | 861,279 | 6,002 |

Median selection: each metric uses its independent median across the three valid runs.

Logs commits:
- okJiang/locomo-logs@3f011f3 (`doris-remove-message-tags-full-20260421T175352`)
- okJiang/locomo-logs@6792afe (`doris-remove-message-tags-full-r2-clean-20260421T230613`, `doris-remove-message-tags-full-r3-clean-20260422T005823`)

## Tests
- `go test ./internal/service ./internal/handler`
- `go test ./...`
