### PR TITLE
feat(server): refactor metering webhook writer and emit recall/ingest events

### DIFF
--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -175,7 +175,8 @@ func main() {
 	rateMW := rl.Middleware()
 
 	// Handler.
-	srv := handler.NewServer(tenantSvc, uploadTaskRepo, cfg.UploadDir, embedder, llmClient, cfg.EmbedAutoModel, cfg.FTSEnabled, service.IngestMode(cfg.IngestMode), cfg.DBBackend, logger)
+	srv := handler.NewServer(tenantSvc, uploadTaskRepo, cfg.UploadDir, embedder, llmClient, cfg.EmbedAutoModel, cfg.FTSEnabled, service.IngestMode(cfg.IngestMode), cfg.DBBackend, logger).
+		WithMetering(meteringWriter)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW)
 
 	httpSrv := &http.Server{

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/embed"
 	"github.com/qiffang/mnemos/server/internal/llm"
+	"github.com/qiffang/mnemos/server/internal/metering"
 	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/repository"
@@ -37,6 +38,7 @@ type Server struct {
 	ingestMode    service.IngestMode
 	dbBackend     string
 	logger        *slog.Logger
+	metering      metering.Writer
 	startedAt     time.Time
 	svcCache      sync.Map
 	gaugeDebounce sync.Map // cluster_id -> time.Time of last Gauge refresh
@@ -68,6 +70,11 @@ func NewServer(
 		logger:      logger,
 		startedAt:   time.Now().UTC(),
 	}
+}
+
+func (s *Server) WithMetering(writer metering.Writer) *Server {
+	s.metering = writer
+	return s
 }
 
 // resolvedSvc holds the correct service instances for a request.

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -93,7 +93,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if result != nil {
 				written = int64(result.MemoriesChanged)
 			}
-			go s.refreshWriteMetrics(auth, svc, written)
+			go s.afterSuccessfulIngest(auth, svc, written)
 			respond(w, http.StatusOK, map[string]string{"status": "ok"})
 		} else {
 			go func() {
@@ -106,7 +106,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				if result != nil {
 					written = int64(result.MemoriesChanged)
 				}
-				s.refreshWriteMetrics(auth, svc, written)
+				s.afterSuccessfulIngest(auth, svc, written)
 			}()
 			respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 		}
@@ -324,6 +324,9 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		for i := range memories {
 			memories[i].Content = service.TemporalRecallProjection(memories[i].Content, memories[i].Metadata)
 		}
+	}
+	if filter.Query != "" {
+		s.recordRecallMetering(auth)
 	}
 
 	respond(w, http.StatusOK, listResponse{

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -102,6 +102,10 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					slog.Error("async ingest failed", "session", ingestReq.SessionID, "err", err)
 					return
 				}
+				if result != nil && result.Status == "failed" {
+					slog.Error("async ingest reconcile failed", "session", ingestReq.SessionID)
+					return
+				}
 				var written int64
 				if result != nil {
 					written = int64(result.MemoriesChanged)

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -93,7 +93,8 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if result != nil {
 				written = int64(result.MemoriesChanged)
 			}
-			go s.afterSuccessfulIngest(auth, svc, written)
+			s.recordIngestMetering(auth, svc)
+			go s.refreshWriteMetrics(auth, svc, written)
 			respond(w, http.StatusOK, map[string]string{"status": "ok"})
 		} else {
 			go func() {

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -11,11 +11,13 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/llm"
+	"github.com/qiffang/mnemos/server/internal/metering"
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
@@ -28,6 +30,9 @@ type testMemoryRepo struct {
 	lastKeywordFilter    domain.MemoryFilter
 	bulkSoftDeleteCalls  [][]string
 	bulkSoftDeleteResult int64
+	countStatsTotal      int64
+	countStatsLast7d     int64
+	countStatsErr        error
 }
 
 func (m *testMemoryRepo) Create(_ context.Context, mem *domain.Memory) error {
@@ -89,7 +94,9 @@ func (m *testMemoryRepo) NearDupSearch(context.Context, string) (string, float64
 	return "", 0, nil
 }
 
-func (m *testMemoryRepo) CountStats(context.Context) (int64, int64, error) { return 0, 0, nil }
+func (m *testMemoryRepo) CountStats(context.Context) (int64, int64, error) {
+	return m.countStatsTotal, m.countStatsLast7d, m.countStatsErr
+}
 
 // testSessionRepo is a minimal SessionRepo mock for handler tests.
 type testSessionRepo struct {
@@ -146,6 +153,54 @@ func intPtr(v int) *int {
 	return &v
 }
 
+type captureMeteringWriter struct {
+	mu     sync.Mutex
+	events []metering.Event
+}
+
+func (w *captureMeteringWriter) Record(evt metering.Event) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	evt.Data = cloneMap(evt.Data)
+	w.events = append(w.events, evt)
+}
+
+func (w *captureMeteringWriter) Close(context.Context) error { return nil }
+
+func (w *captureMeteringWriter) snapshot() []metering.Event {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]metering.Event, len(w.events))
+	copy(out, w.events)
+	return out
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func waitForMeteringEvents(t *testing.T, writer *captureMeteringWriter, want int, timeout time.Duration) []metering.Event {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		events := writer.snapshot()
+		if len(events) == want {
+			return events
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	events := writer.snapshot()
+	t.Fatalf("timed out waiting for %d metering events, got %d", want, len(events))
+	return nil
+}
+
 // newTestServer creates a Server with pre-populated svcCache for testing.
 func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default())
@@ -158,6 +213,7 @@ func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	// Key format matches resolveServices: fmt.Sprintf("db-%p", auth.TenantDB)
 	// When TenantDB is nil, %p formats as "0x0".
 	srv.svcCache.Store(tenantSvcKey("db-0x0"), svc)
+	srv.svcCache.Store(tenantSvcKey("tenant-a-0x0"), svc)
 	return srv
 }
 
@@ -174,6 +230,18 @@ func makeRequest(t *testing.T, method, path string, body any) *http.Request {
 	req.Header.Set("Content-Type", "application/json")
 	// Inject auth context using middleware's context key.
 	auth := &domain.AuthInfo{AgentName: "test-agent"}
+	ctx := middleware.WithAuthContext(req.Context(), auth)
+	return req.WithContext(ctx)
+}
+
+func makeTenantRequest(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+	req := makeRequest(t, method, path, body)
+	auth := &domain.AuthInfo{
+		AgentName: "test-agent",
+		TenantID:  "tenant-a",
+		ClusterID: "10006636",
+	}
 	ctx := middleware.WithAuthContext(req.Context(), auth)
 	return req.WithContext(ctx)
 }
@@ -263,6 +331,43 @@ func TestCreateMemory_SyncMessages_Returns200(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestCreateMemory_SyncMessages_RecordsIngestMetering(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsTotal: 126}
+	meteringWriter := &captureMeteringWriter{}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithMetering(meteringWriter)
+
+	body := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+			{"role": "assistant", "content": "hi there"},
+		},
+		"session_id": "test-session",
+		"sync":       true,
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	events := waitForMeteringEvents(t, meteringWriter, 1, time.Second)
+	if events[0].Category != meteringCategoryAPI {
+		t.Fatalf("event category = %q, want %q", events[0].Category, meteringCategoryAPI)
+	}
+	if events[0].TenantID != "tenant-a" || events[0].ClusterID != "10006636" {
+		t.Fatalf("unexpected event identity: %+v", events[0])
+	}
+	if got := events[0].Data["event_type"]; got != "ingest" {
+		t.Fatalf("event_type = %v, want ingest", got)
+	}
+	if got := events[0].Data["active_memory_count"]; got != int64(126) {
+		t.Fatalf("active_memory_count = %v, want 126", got)
 	}
 }
 
@@ -641,6 +746,49 @@ func TestListMemories_DefaultRecall_PrefersSessionForExactQuery(t *testing.T) {
 	}
 	if resp.Memories[0].Confidence == nil || *resp.Memories[0].Confidence < defaultMixedMinConfidence {
 		t.Fatalf("expected confidence >= %d, got %+v", defaultMixedMinConfidence, resp.Memories[0].Confidence)
+	}
+}
+
+func TestListMemories_DefaultRecall_RecordsMetering(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			switch filter.MemoryType {
+			case string(domain.TypePinned):
+				return nil, nil
+			case string(domain.TypeInsight):
+				return []domain.Memory{
+					{ID: "m1", Content: `"Under Armour"`, MemoryType: domain.TypeInsight, UpdatedAt: now, State: domain.StateActive},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+	}
+	meteringWriter := &captureMeteringWriter{}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithMetering(meteringWriter)
+
+	req := makeTenantRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	events := waitForMeteringEvents(t, meteringWriter, 1, time.Second)
+	if events[0].Category != meteringCategoryAPI {
+		t.Fatalf("event category = %q, want %q", events[0].Category, meteringCategoryAPI)
+	}
+	if events[0].TenantID != "tenant-a" || events[0].ClusterID != "10006636" {
+		t.Fatalf("unexpected event identity: %+v", events[0])
+	}
+	if got := events[0].Data["event_type"]; got != "recall" {
+		t.Fatalf("event_type = %v, want recall", got)
+	}
+	if got := events[0].Data["recall_call_count"]; got != 1 {
+		t.Fatalf("recall_call_count = %v, want 1", got)
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -201,6 +201,15 @@ func waitForMeteringEvents(t *testing.T, writer *captureMeteringWriter, want int
 	return nil
 }
 
+func ensureNoMeteringEvents(t *testing.T, writer *captureMeteringWriter, timeout time.Duration) {
+	t.Helper()
+	time.Sleep(timeout)
+	events := writer.snapshot()
+	if len(events) != 0 {
+		t.Fatalf("expected no metering events, got %+v", events)
+	}
+}
+
 // newTestServer creates a Server with pre-populated svcCache for testing.
 func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default())
@@ -427,6 +436,53 @@ func TestCreateMemory_AsyncMessages_Returns202(t *testing.T) {
 	if resp["status"] != "accepted" {
 		t.Errorf("expected status=accepted, got %q", resp["status"])
 	}
+}
+
+func TestCreateMemory_AsyncMessages_ReconcileFailed_DoesNotRecordIngestMetering(t *testing.T) {
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{
+					"content": `{"facts":["test fact"],"message_tags":[["tag1"],["tag2"]]}`,
+				}},
+			},
+		})
+	}))
+	defer llmServer.Close()
+
+	llmClient := llm.New(llm.Config{
+		APIKey:  "test-key",
+		BaseURL: llmServer.URL,
+		Model:   "test-model",
+	})
+
+	memRepo := &failSearchMemoryRepo{}
+	meteringWriter := &captureMeteringWriter{}
+	srv := NewServer(nil, nil, "", nil, llmClient, "", false, service.ModeSmart, "", slog.Default()).WithMetering(meteringWriter)
+	svc := resolvedSvc{
+		memory:  service.NewMemoryService(&memRepo.testMemoryRepo, nil, nil, "", service.ModeSmart),
+		ingest:  service.NewIngestService(memRepo, llmClient, nil, "", service.ModeSmart),
+		session: service.NewSessionService(&testSessionRepo{}, nil, ""),
+	}
+	srv.svcCache.Store(tenantSvcKey("tenant-a-0x0"), svc)
+
+	body := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+			{"role": "assistant", "content": "hi there"},
+		},
+		"session_id": "test-session",
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+	ensureNoMeteringEvents(t, meteringWriter, 100*time.Millisecond)
 }
 
 // failSearchMemoryRepo embeds testMemoryRepo but makes KeywordSearch fail,

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -175,6 +175,18 @@ func (w *captureMeteringWriter) snapshot() []metering.Event {
 	return out
 }
 
+type blockingMeteringWriter struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (w *blockingMeteringWriter) Record(evt metering.Event) {
+	close(w.started)
+	<-w.release
+}
+
+func (w *blockingMeteringWriter) Close(context.Context) error { return nil }
+
 func cloneMap(in map[string]any) map[string]any {
 	if in == nil {
 		return nil
@@ -377,6 +389,56 @@ func TestCreateMemory_SyncMessages_RecordsIngestMetering(t *testing.T) {
 	}
 	if got := events[0].Data["active_memory_count"]; got != int64(126) {
 		t.Fatalf("active_memory_count = %v, want 126", got)
+	}
+}
+
+func TestCreateMemory_SyncMessages_WaitsForMeteringBeforeReturning(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsTotal: 126}
+	blockingWriter := &blockingMeteringWriter{
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithMetering(blockingWriter)
+
+	body := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "hello"},
+			{"role": "assistant", "content": "hi there"},
+		},
+		"session_id": "test-session",
+		"sync":       true,
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+
+	go func() {
+		srv.createMemory(rr, req)
+		close(done)
+	}()
+
+	select {
+	case <-blockingWriter.started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sync ingest metering to start")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("sync createMemory returned before metering Record completed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(blockingWriter.release)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for createMemory to return after metering completed")
+	}
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/server/internal/handler/metering.go
+++ b/server/internal/handler/metering.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metering"
+)
+
+const meteringCategoryAPI = "mem9-api"
+
+func (s *Server) afterSuccessfulIngest(auth *domain.AuthInfo, svc resolvedSvc, written int64) {
+	s.refreshWriteMetrics(auth, svc, written)
+	s.recordIngestMetering(auth, svc)
+}
+
+func (s *Server) recordRecallMetering(auth *domain.AuthInfo) {
+	if s == nil || s.metering == nil || auth == nil {
+		return
+	}
+	s.metering.Record(metering.Event{
+		Category:  meteringCategoryAPI,
+		TenantID:  auth.TenantID,
+		ClusterID: auth.ClusterID,
+		Data: map[string]any{
+			"event_type":        "recall",
+			"recall_call_count": 1,
+		},
+	})
+}
+
+func (s *Server) recordIngestMetering(auth *domain.AuthInfo, svc resolvedSvc) {
+	if s == nil || s.metering == nil || auth == nil {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	total, _, err := svc.memory.CountStats(ctx)
+	if err != nil {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("ingest metering skipped: count stats failed",
+			"tenant_id", auth.TenantID,
+			"cluster_id", auth.ClusterID,
+			"err", err,
+		)
+		return
+	}
+
+	s.metering.Record(metering.Event{
+		Category:  meteringCategoryAPI,
+		TenantID:  auth.TenantID,
+		ClusterID: auth.ClusterID,
+		Data: map[string]any{
+			"event_type":          "ingest",
+			"active_memory_count": total,
+		},
+	})
+}

--- a/server/internal/metering/config.go
+++ b/server/internal/metering/config.go
@@ -3,10 +3,10 @@
 //
 // It is a slimmed-down port of the PingCAP metering_sdk
 // (https://github.com/pingcap/metering_sdk), adapted for mem9: no shared-pool
-// concept, tenant/cluster as the two-level identity, a 10-second in-memory
-// batch with lossy-on-error flush, and slog-based logging. Supported
-// destinations are S3 object storage (`s3://`) and webhook POST endpoints
-// (`http://` / `https://`).
+// concept, tenant/cluster as the two-level identity, slog-based logging, S3
+// delivery with a 10-second in-memory batch, and webhook delivery with one
+// request per recorded event. Supported destinations are S3 object storage
+// (`s3://`) and webhook POST endpoints (`http://` / `https://`).
 //
 // NOTE: the writer is fully implemented, but this round only wires startup
 // lifecycle. Caller-side Record() hooks still land in a follow-up change.
@@ -25,7 +25,7 @@ type Config struct {
 	URL           string // metering destination: s3://bucket/prefix/ or http(s)://webhook
 	Bucket        string
 	Prefix        string        // optional, prepended to every object key
-	FlushInterval time.Duration // default 10s
+	FlushInterval time.Duration // default 10s; used by batched transports such as S3
 	ChannelSize   int           // default 1024
 }
 

--- a/server/internal/metering/webhook_writer.go
+++ b/server/internal/metering/webhook_writer.go
@@ -6,27 +6,215 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
 )
 
 type httpDoer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-type webhookTransport struct {
-	url    string
-	client httpDoer
+type webhookEvent struct {
+	ID        string          `json:"id"`
+	EventType string          `json:"event_type"`
+	CreatedAt string          `json:"created_at"`
+	Payload   map[string]any  `json:"payload"`
+	Metadata  webhookMetadata `json:"metadata"`
 }
 
-func newWebhookTransport(url string, client httpDoer) *webhookTransport {
-	return &webhookTransport{
-		url:    url,
-		client: client,
+type webhookMetadata struct {
+	TenantID  string `json:"tenant_id"`
+	ClusterID string `json:"cluster_id,omitempty"`
+}
+
+type webhookWriter struct {
+	cfg    Config
+	url    string
+	client httpDoer
+	logger *slog.Logger
+
+	ch   chan queuedEvent
+	done chan struct{}
+	wg   sync.WaitGroup
+
+	closeOnce sync.Once
+
+	lastFullWarn int64
+	now          func() time.Time
+	idFn         func() string
+
+	closeCtxMu sync.Mutex
+	closeCtx   context.Context
+
+	runtimeCtx    context.Context
+	runtimeCancel context.CancelFunc
+}
+
+func newWebhookWriter(cfg Config, url string, client httpDoer, logger *slog.Logger) *webhookWriter {
+	runtimeCtx, runtimeCancel := context.WithCancel(context.Background())
+	w := &webhookWriter{
+		cfg:           cfg,
+		url:           url,
+		client:        client,
+		logger:        logger,
+		ch:            make(chan queuedEvent, cfg.ChannelSize),
+		done:          make(chan struct{}),
+		now:           time.Now,
+		idFn:          newWebhookEventID,
+		runtimeCtx:    runtimeCtx,
+		runtimeCancel: runtimeCancel,
+	}
+	w.wg.Add(1)
+	go w.run()
+	return w
+}
+
+func newWebhookEventID() string {
+	return "evt_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
+func (w *webhookWriter) Record(evt Event) {
+	if evt.Category == "" || evt.TenantID == "" {
+		return
+	}
+	item := w.makeQueuedEvent(evt)
+	select {
+	case w.ch <- item:
+	default:
+		w.maybeWarnFull()
 	}
 }
 
-func (w *webhookTransport) Write(ctx context.Context, payload batchPayload) error {
-	body, err := json.Marshal(&payload)
+func (w *webhookWriter) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	w.closeOnce.Do(func() {
+		w.closeCtxMu.Lock()
+		w.closeCtx = ctx
+		w.closeCtxMu.Unlock()
+		if w.runtimeCancel != nil {
+			w.runtimeCancel()
+		}
+		if w.done != nil {
+			close(w.done)
+		}
+	})
+
+	waitCh := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *webhookWriter) run() {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case item := <-w.ch:
+			w.deliver(item)
+		case <-w.done:
+			w.drainAndDeliver(w.shutdownContext())
+			return
+		}
+	}
+}
+
+func (w *webhookWriter) deliver(item queuedEvent) {
+	if err := w.postEvent(w.runtimeCtx, item); err != nil {
+		if w.runtimeCtx.Err() != nil {
+			shutdownCtx := w.shutdownContext()
+			if shutdownCtx.Err() == nil {
+				if retryErr := w.postEvent(shutdownCtx, item); retryErr == nil {
+					return
+				} else {
+					err = retryErr
+				}
+			}
+		}
+		w.logDeliveryError(item, err)
+	}
+}
+
+func (w *webhookWriter) drainAndDeliver(ctx context.Context) {
+	for {
+		select {
+		case item := <-w.ch:
+			if err := w.postEvent(ctx, item); err != nil {
+				w.logDeliveryError(item, err)
+				if ctx.Err() != nil {
+					return
+				}
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (w *webhookWriter) shutdownContext() context.Context {
+	w.closeCtxMu.Lock()
+	defer w.closeCtxMu.Unlock()
+	if w.closeCtx == nil {
+		return context.Background()
+	}
+	return w.closeCtx
+}
+
+func (w *webhookWriter) makeQueuedEvent(evt Event) queuedEvent {
+	if evt.Data != nil {
+		copied := make(map[string]any, len(evt.Data))
+		for k, v := range evt.Data {
+			copied[k] = deepCopyAny(v)
+		}
+		evt.Data = copied
+	}
+
+	recordedAt := w.now().Unix()
+	key := batchKey{
+		TsMinute:  minuteAlign(recordedAt),
+		Category:  evt.Category,
+		TenantID:  evt.TenantID,
+		ClusterID: evt.ClusterID,
+	}
+	return queuedEvent{
+		event:      evt,
+		recordedAt: recordedAt,
+		tsMinute:   key.TsMinute,
+		key:        key,
+	}
+}
+
+func (w *webhookWriter) maybeWarnFull() {
+	now := w.now().Unix()
+	last := atomic.LoadInt64(&w.lastFullWarn)
+	if now-last < 10 {
+		return
+	}
+	if !atomic.CompareAndSwapInt64(&w.lastFullWarn, last, now) {
+		return
+	}
+	w.logger.Warn("metering: event channel full, dropping event", "capacity", cap(w.ch))
+}
+
+func (w *webhookWriter) postEvent(ctx context.Context, item queuedEvent) error {
+	body, err := json.Marshal(w.buildWebhookEvent(item))
 	if err != nil {
 		return err
 	}
@@ -48,4 +236,47 @@ func (w *webhookTransport) Write(ctx context.Context, payload batchPayload) erro
 		return fmt.Errorf("metering: webhook returned status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+func (w *webhookWriter) buildWebhookEvent(item queuedEvent) webhookEvent {
+	eventType, payload := splitWebhookEventData(item.event.Category, item.event.Data)
+	return webhookEvent{
+		ID:        w.idFn(),
+		EventType: eventType,
+		CreatedAt: time.Unix(item.recordedAt, 0).UTC().Format(time.RFC3339),
+		Payload:   payload,
+		Metadata: webhookMetadata{
+			TenantID:  item.event.TenantID,
+			ClusterID: item.event.ClusterID,
+		},
+	}
+}
+
+func splitWebhookEventData(fallbackType string, data map[string]any) (string, map[string]any) {
+	eventType := fallbackType
+	if raw, ok := data["event_type"]; ok {
+		if s, ok := raw.(string); ok && s != "" {
+			eventType = s
+		}
+	}
+
+	payload := make(map[string]any, len(data))
+	for k, v := range data {
+		if k == "event_type" {
+			continue
+		}
+		payload[k] = v
+	}
+	return eventType, payload
+}
+
+func (w *webhookWriter) logDeliveryError(item queuedEvent, err error) {
+	eventType, _ := splitWebhookEventData(item.event.Category, item.event.Data)
+	w.logger.Warn("metering: webhook delivery failed, dropping event",
+		"category", item.event.Category,
+		"event_type", eventType,
+		"tenant_id", item.event.TenantID,
+		"cluster_id", item.event.ClusterID,
+		"err", err,
+	)
 }

--- a/server/internal/metering/writer.go
+++ b/server/internal/metering/writer.go
@@ -11,13 +11,14 @@ import (
 )
 
 // Event is the unit passed to Writer.Record. It is non-blocking — the writer
-// enqueues it for later batching and flushing.
+// enqueues it for later asynchronous delivery.
 //
 // Category and TenantID MUST be non-empty; events with either missing are
 // silently dropped (no log, no error, no panic).
 //
 // ClusterID may be empty (rendered as "_" in the S3 key).
-// AgentID may be empty; when present it is merged into Data as "agent_id".
+// AgentID may be empty. S3 batches currently merge it into Data as "agent_id";
+// webhook delivery currently ignores it.
 // Data may be nil or empty; it is the caller-defined per-event payload.
 type Event struct {
 	Category  string
@@ -27,9 +28,9 @@ type Event struct {
 	Data      map[string]any
 }
 
-// Writer records metering events asynchronously and flushes them through the
+// Writer records metering events asynchronously and delivers them through the
 // configured destination transport. Record is non-blocking and safe for
-// concurrent use. Close flushes any pending batch and stops the background
+// concurrent use. Close flushes any pending work and stops the background
 // goroutine.
 type Writer interface {
 	// Record enqueues evt for later flush. Must not block. Must be safe for
@@ -45,7 +46,7 @@ type Writer interface {
 
 // New constructs a Writer. When cfg.Enabled is false or cfg.URL is empty,
 // returns a no-op Writer and logs at Info level. Otherwise it selects the
-// destination transport from the URL scheme, starts the background flusher
+// destination transport from the URL scheme, starts the background delivery
 // goroutine, and returns the configured Writer.
 //
 // The ctx argument is used only for initial AWS SDK config loading. The
@@ -67,7 +68,6 @@ func New(ctx context.Context, cfg Config, logger *slog.Logger) (Writer, error) {
 		return nil, fmt.Errorf("metering: parse destination URL: %w", err)
 	}
 
-	var transport batchTransport
 	switch u.Scheme {
 	case "s3":
 		if u.Host == "" {
@@ -79,14 +79,12 @@ func New(ctx context.Context, cfg Config, logger *slog.Logger) (Writer, error) {
 		if err != nil {
 			return nil, err
 		}
-		transport = newS3Transport(cfg.Bucket, cfg.Prefix, client)
+		return newS3Writer(cfg, client, logger), nil
 	case "http", "https":
-		transport = newWebhookTransport(cfg.URL, &http.Client{Timeout: 10 * time.Second})
+		return newWebhookWriter(cfg, cfg.URL, &http.Client{Timeout: 10 * time.Second}, logger), nil
 	default:
 		return nil, fmt.Errorf("metering: unsupported destination scheme %q", u.Scheme)
 	}
-
-	return newTransportWriter(cfg, transport, logger), nil
 }
 
 // noopWriter drops all events. Used when metering is disabled.

--- a/server/internal/metering/writer_test.go
+++ b/server/internal/metering/writer_test.go
@@ -68,7 +68,7 @@ func (f *fakeS3) snapshot() []fakePut {
 	return out
 }
 
-type payload struct {
+type s3Payload struct {
 	Timestamp int64            `json:"timestamp"`
 	Category  string           `json:"category"`
 	TenantID  string           `json:"tenant_id"`
@@ -77,13 +77,21 @@ type payload struct {
 	Data      []map[string]any `json:"data"`
 }
 
+type webhookPayload struct {
+	ID        string                 `json:"id"`
+	EventType string                 `json:"event_type"`
+	CreatedAt string                 `json:"created_at"`
+	Payload   map[string]any         `json:"payload"`
+	Metadata  map[string]interface{} `json:"metadata"`
+}
+
 func newTestLogger() (*slog.Logger, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	return logger, buf
 }
 
-func decodePayload(t *testing.T, body []byte) payload {
+func decodePayload(t *testing.T, body []byte) s3Payload {
 	t.Helper()
 	r, err := gzip.NewReader(bytes.NewReader(body))
 	if err != nil {
@@ -96,7 +104,7 @@ func decodePayload(t *testing.T, body []byte) payload {
 		t.Fatalf("io.ReadAll: %v", err)
 	}
 
-	var p payload
+	var p s3Payload
 	if err := json.Unmarshal(raw, &p); err != nil {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
@@ -222,16 +230,16 @@ func TestNew_EmptyURL_ReturnsNoop(t *testing.T) {
 func TestNew_HTTPURL_PostsWebhookJSON(t *testing.T) {
 	type requestRecord struct {
 		contentType string
-		payload     payload
+		payload     webhookPayload
 	}
-	reqCh := make(chan requestRecord, 1)
+	reqCh := make(chan requestRecord, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatalf("io.ReadAll: %v", err)
 		}
-		var p payload
+		var p webhookPayload
 		if err := json.Unmarshal(body, &p); err != nil {
 			t.Fatalf("json.Unmarshal: %v", err)
 		}
@@ -247,25 +255,63 @@ func TestNew_HTTPURL_PostsWebhookJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	ww, ok := w.(*webhookWriter)
+	if !ok {
+		t.Fatalf("New returned %T, want *webhookWriter", w)
+	}
+	fixed := time.Unix(1710000003, 0).UTC()
+	var idCounter int
+	ww.now = func() time.Time { return fixed }
+	ww.idFn = func() string {
+		idCounter++
+		return "evt-test-" + string(rune('0'+idCounter))
+	}
 
-	w.Record(Event{Category: "mem9-api", TenantID: "tenant-a", ClusterID: "10006636", AgentID: "agent-a", Data: map[string]any{"op": "store"}})
+	w.Record(Event{Category: "mem9-api", TenantID: "tenant-a", ClusterID: "10006636", Data: map[string]any{"event_type": "recall", "recall_call_count": 1}})
+	w.Record(Event{Category: "mem9-api", TenantID: "tenant-a", ClusterID: "10006636", Data: map[string]any{"event_type": "ingest", "active_memory_count": 126}})
 	if err := w.Close(context.Background()); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
-	select {
-	case got := <-reqCh:
+	gotRequests := make([]requestRecord, 0, 2)
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-reqCh:
+			gotRequests = append(gotRequests, got)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for webhook request")
+		}
+	}
+
+	for i, got := range gotRequests {
 		if got.contentType != "application/json" {
-			t.Fatalf("Content-Type = %q, want application/json", got.contentType)
+			t.Fatalf("request[%d] Content-Type = %q, want application/json", i, got.contentType)
 		}
-		if got.payload.Category != "mem9-api" || got.payload.TenantID != "tenant-a" || got.payload.ClusterID != "10006636" {
-			t.Fatalf("unexpected webhook payload: %+v", got.payload)
+		if got.payload.ID == "" {
+			t.Fatalf("request[%d] missing event id", i)
 		}
-		if len(got.payload.Data) != 1 {
-			t.Fatalf("payload data len = %d, want 1", len(got.payload.Data))
+		if got.payload.CreatedAt != "2024-03-09T16:00:03Z" {
+			t.Fatalf("request[%d] created_at = %q, want 2024-03-09T16:00:03Z", i, got.payload.CreatedAt)
 		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for webhook request")
+		if got.payload.Metadata["tenant_id"] != "tenant-a" || got.payload.Metadata["cluster_id"] != "10006636" {
+			t.Fatalf("request[%d] unexpected metadata: %+v", i, got.payload.Metadata)
+		}
+	}
+
+	if gotRequests[0].payload.EventType != "recall" {
+		t.Fatalf("first event_type = %q, want recall", gotRequests[0].payload.EventType)
+	}
+	if gotRequests[0].payload.Payload["recall_call_count"] != float64(1) {
+		t.Fatalf("first payload = %+v, want recall_call_count=1", gotRequests[0].payload.Payload)
+	}
+	if _, ok := gotRequests[0].payload.Payload["event_type"]; ok {
+		t.Fatalf("first payload unexpectedly retained event_type: %+v", gotRequests[0].payload.Payload)
+	}
+	if gotRequests[1].payload.EventType != "ingest" {
+		t.Fatalf("second event_type = %q, want ingest", gotRequests[1].payload.EventType)
+	}
+	if gotRequests[1].payload.Payload["active_memory_count"] != float64(126) {
+		t.Fatalf("second payload = %+v, want active_memory_count=126", gotRequests[1].payload.Payload)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR changes the server metering flow in two ways:

- refactors webhook metering delivery to use a webhook-specific payload instead of reusing the S3 batch payload
- wires the recall path and message-ingest path to emit metering events through the shared metering writer

## Changes

- keep the existing batched S3 metering writer behavior
- introduce a dedicated async webhook writer that sends one HTTP request per recorded event
- use a webhook event shape with `id`, `event_type`, `created_at`, `payload`, and `metadata`
- put `tenant_id` and `cluster_id` in webhook `metadata`
- emit one `recall` event after a successful query-backed `GET /memories`
- emit one `ingest` event after successful message-based ingest, including `active_memory_count`
- inject the metering writer into the HTTP handler layer from `main.go`

## Notes

- webhook and S3 are now free to use different wire payloads
- `agent_id` is intentionally not included in webhook metadata in this round
- this wiring is scoped to request-facing recall and message-ingest paths; it does not add metering to content-only create or upload-worker flows

## Testing

- `cd server && go test ./internal/handler ./internal/metering`
- `cd server && go test ./cmd/mnemo-server`
