### PR TITLE
Add offline e2e script checks

### DIFF
--- a/.github/workflows/e2e-script-checks.yml
+++ b/.github/workflows/e2e-script-checks.yml
@@ -1,0 +1,36 @@
+name: E2E script checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/e2e-script-checks.yml"
+      - "Makefile"
+      - "e2e/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/e2e-script-checks.yml"
+      - "Makefile"
+      - "e2e/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-check:
+    name: Offline e2e script checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check scripts
+        run: make e2e-check

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 IMG ?= $(REGISTRY)/mnemo-server:$(COMMIT)
 
-.PHONY: build vet clean run test test-cover test-integration docker
+.PHONY: build vet clean run test test-cover test-integration e2e-check docker
 
 build:
 	mkdir -p $(MAKEFILE_DIR)/server/bin
@@ -25,6 +25,10 @@ test-cover:
 
 test-integration:
 	cd server && go test -tags=integration -race -count=1 -v ./internal/repository/tidb/
+
+e2e-check:
+	bash e2e/check-scripts.sh
+
 clean:
 	rm -f server/bin/mnemo-server
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,9 +2,23 @@
 title: E2E Tests
 ---
 
-End-to-end tests for the CRDT branch with user/space model. All scripts run
-against a live mnemo-server instance using the `user_space_test_01` database
-with auto-embedding enabled.
+End-to-end and smoke scripts for live mnemo-server validation. The API smoke
+scripts exercise tenant provisioning, ingestion, recall/search, sessions, UTM
+attribution, and existing-tenant compatibility. The CRDT scripts exercise the
+user/space model.
+
+Most scripts in this directory hit a running mnemo-server. Use the offline
+guardrail below for PR-safe checks that do not require dev/staging, secrets, or
+network access.
+
+## Offline guardrail
+
+```bash
+make e2e-check
+```
+
+This checks shell syntax, shell strict mode, Python syntax, and v1alpha2 wrapper
+targets. It does not call any Mem9 API and is safe to run in PR CI.
 
 ## Prerequisites
 

--- a/e2e/check-scripts.sh
+++ b/e2e/check-scripts.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Offline guardrails for live e2e scripts. This must not call mnemo-server.
+set -euo pipefail
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+say() {
+  printf '==> %s\n' "$*"
+}
+
+check_shell_scripts() {
+  local script
+  local scripts=(e2e/*.sh)
+
+  if [ "${#scripts[@]}" -eq 0 ]; then
+    printf 'No shell scripts found under e2e/.\n' >&2
+    return 1
+  fi
+
+  say "Checking shell syntax"
+  for script in "${scripts[@]}"; do
+    printf '  bash -n %s\n' "$script"
+    bash -n "$script"
+  done
+
+  say "Checking shell strict mode"
+  for script in "${scripts[@]}"; do
+    if ! grep -q '^set -euo pipefail$' "$script"; then
+      printf '%s must include: set -euo pipefail\n' "$script" >&2
+      return 1
+    fi
+  done
+}
+
+check_python_scripts() {
+  local scripts=(e2e/*.py)
+
+  if [ "${#scripts[@]}" -eq 0 ]; then
+    printf 'No Python scripts found under e2e/.\n' >&2
+    return 1
+  fi
+
+  say "Checking Python syntax"
+  python3 - "${scripts[@]}" <<'PY'
+import pathlib
+import sys
+
+for filename in sys.argv[1:]:
+    path = pathlib.Path(filename)
+    compile(path.read_text(encoding="utf-8"), filename, "exec")
+    print(f"  compile {filename}")
+PY
+}
+
+check_wrappers() {
+  say "Checking API version wrappers"
+
+  if ! grep -Fq 'MNEMO_API_VERSION=v1alpha2 bash "$SCRIPT_DIR/api-smoke-test.sh" "$@"' \
+    e2e/api-smoke-test-v1alpha2.sh; then
+    printf 'e2e/api-smoke-test-v1alpha2.sh must wrap api-smoke-test.sh with MNEMO_API_VERSION=v1alpha2.\n' >&2
+    return 1
+  fi
+
+  if ! grep -Fq 'MNEMO_API_VERSION=v1alpha2 bash "$SCRIPT_DIR/api-smoke-test-round2.sh" "$@"' \
+    e2e/api-smoke-test-round2-v1alpha2.sh; then
+    printf 'e2e/api-smoke-test-round2-v1alpha2.sh must wrap api-smoke-test-round2.sh with MNEMO_API_VERSION=v1alpha2.\n' >&2
+    return 1
+  fi
+}
+
+check_shell_scripts
+check_python_scripts
+check_wrappers
+
+say "All e2e script checks passed"


### PR DESCRIPTION
## Summary
- Add `make e2e-check` for offline validation of `e2e` scripts.
- Add a PR/push/manual GitHub Actions workflow that runs the guardrail without requiring dev/staging, secrets, or network access.
- Document the offline guardrail in `e2e/README.md`.

## Details
The new guardrail checks shell syntax, `set -euo pipefail`, Python syntax via `compile(...)`, and the v1alpha2 wrapper script targets. It intentionally does not call any Mem9 API or live backend.

## Validation
- `make e2e-check`
- `make test-cover`
