### PR TITLE
feat(plugins): improve mem9 opencode plugin setup workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,6 @@ node_modules/
 dist/
 *.tgz
 .netlify/
-.npm-cache-publish/
-opencode-plugin/.tmp/
 
 # Python cache
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist/
 *.tgz
 .netlify/
 .npm-cache-publish/
+opencode-plugin/.tmp/
 
 # Python cache
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,3 @@ benchmark/MR-NIAH/.cache/
 
 # Claude Code and experiment outputs
 .claude/
-
-# Package-local generated output without a dedicated local ignore file
-openclaw-plugin/dist-test/

--- a/openclaw-plugin/.gitignore
+++ b/openclaw-plugin/.gitignore
@@ -1,0 +1,2 @@
+.npm-cache-publish/
+dist-test/

--- a/opencode-plugin/AGENTS.md
+++ b/opencode-plugin/AGENTS.md
@@ -4,11 +4,12 @@ title: opencode-plugin — OpenCode plugin for mem9
 
 ## Overview
 
-TypeScript OpenCode plugin that injects memories via hooks and exposes five memory tools backed by mem9 API.
+TypeScript OpenCode plugin package with a server entry for mem9 hooks and tools plus a TUI entry for `/mem9-setup`.
 
 ## Commands
 
 ```bash
+cd opencode-plugin && pnpm test
 cd opencode-plugin && pnpm run typecheck
 ```
 
@@ -33,6 +34,11 @@ cd opencode-plugin && pnpm run typecheck
 - Runtime prefers `MEM9_API_KEY`; `MEM9_API_URL` defaults to `https://api.mem9.ai`; legacy `MEM9_TENANT_ID` still works for compatibility.
 - Debug logs live under the OpenCode state dir at `plugins/mem9/log/`.
 - Default API URL is `https://api.mem9.ai` when no `MEM9_API_URL` is set.
+- Package exports raw TypeScript: `"."` and `"./server"` load `src/index.ts`, and `"./tui"` loads `src/tui/index.ts`.
+- Keep one-off npm caches and similar throwaway files under `opencode-plugin/.tmp/`, not the repo root or worktree root.
+- Chain `DialogPrompt` follow-up steps through `scheduleDialogTransition()` so the next prompt does not consume the same Enter keypress.
+- Use `showToast()` for plugin TUI messages so success and validation toasts keep a visible default duration.
+- Manual API key entry in the TUI still uses a plain-text OpenCode prompt, so keep the one-time visibility warning in place.
 - Tool handlers return JSON strings with `{ ok, ... }` payloads.
 - Known 404s return `null`/`false`; unexpected errors are re-thrown.
 

--- a/opencode-plugin/README.md
+++ b/opencode-plugin/README.md
@@ -9,75 +9,28 @@ The package ships two plugin entrypoints:
 
 ## Quick Start
 
-### 1. Install the server plugin
+### 1. Install mem9 once at user scope
 
-Install the server plugin in one scope only.
-
-User scope:
-
-File: `~/.config/opencode/opencode.json`
-
-```json
-{
-  "plugin": ["@mem9/opencode"]
-}
+```bash
+opencode plugin --global @mem9/opencode
 ```
 
-Project scope:
+That adds `@mem9/opencode` to both:
 
-File: `<project>/.opencode/opencode.json`
+- `~/.config/opencode/opencode.json`
+- `~/.config/opencode/tui.json`
+- `%APPDATA%\\opencode\\opencode.json`
+- `%APPDATA%\\opencode\\tui.json`
 
-```json
-{
-  "plugin": ["@mem9/opencode"]
-}
-```
+mem9 works best with one global plugin install plus project-level `mem9.json` overrides.
+OpenCode merges plugin lists across scopes, so one install keeps recall, ingest, and tools predictable.
 
-Recommended pattern:
+### 2. Restart OpenCode and run `/mem9-setup`
 
-- install the server plugin once at user scope
-- keep project-specific behavior in `<project>/.opencode/mem9.json`
-
-`@mem9/opencode` resolves npm `latest`.
-If you publish a prerelease channel, install it with an explicit npm specifier instead:
-
-```json
-{
-  "plugin": ["@mem9/opencode@rc"]
-}
-```
-
-You can also pin an exact prerelease version:
-
-```json
-{
-  "plugin": ["@mem9/opencode@0.1.0-rc.0"]
-}
-```
-
-Avoid duplicate plugin loading, such as:
-
-- user scope plugin plus project scope plugin
-- npm plugin plus local file plugin
-
-### 2. Install the TUI plugin for `/mem9-setup`
-
-File: `~/.config/opencode/tui.json`
-
-```json
-{
-  "plugin": ["@mem9/opencode"]
-}
-```
-
-That enables the `/mem9-setup` command inside OpenCode.
-
-### 3. Restart OpenCode and run `/mem9-setup`
-
-`/mem9-setup` is the single entrypoint for both:
+`/mem9-setup` is the main entrypoint for:
 
 - shared mem9 credentials
-- OpenCode user/project mem9 settings
+- OpenCode mem9 settings
 
 When no usable profile exists, it shows two actions:
 
@@ -89,32 +42,45 @@ When usable profiles already exist, it shows four actions:
 - `Get a mem9 API key automatically`
 - `Add an existing mem9 API key`
 - `Use an existing mem9 profile in a scope`
-- `Configure user/project settings`
+- `Adjust scope settings`
 
-Profile creation ends after the profile is saved. Scope configuration is a separate action.
+The last two actions have separate jobs:
 
-## File Layout
+- `Use an existing mem9 profile in a scope` changes which profile a user or project scope uses
+- `Adjust scope settings` changes `debug`, `defaultTimeoutMs`, and `searchTimeoutMs` for a user or project scope
 
-OpenCode config directory:
+### 3. Add project overrides only when you need them
 
-- macOS/Linux: usually `~/.config/opencode`
-- Windows: usually `%APPDATA%\\opencode`
+Keep the plugin install global.
+Use `<project>/.opencode/mem9.json` when one repository needs a different profile, debug flag, or timeout values.
 
-OpenCode state directory:
+Example:
 
-- macOS/Linux: usually `~/.local/share/opencode`
-- Windows: usually `%LOCALAPPDATA%\\opencode`
+```json
+{
+  "schemaVersion": 1,
+  "profileId": "default",
+  "debug": false,
+  "defaultTimeoutMs": 8000,
+  "searchTimeoutMs": 15000
+}
+```
 
-mem9 uses these files:
+## Where mem9 stores data
 
-- server plugin list: `~/.config/opencode/opencode.json` or `<project>/.opencode/opencode.json`
-- TUI plugin list: `~/.config/opencode/tui.json`
-- shared credentials: `$MEM9_HOME/.credentials.json`
-- user mem9 config: `<OpenCode config dir>/mem9.json`
-- project mem9 config: `<project>/.opencode/mem9.json`
-- debug logs: `<OpenCode state dir>/plugins/mem9/log/YYYY-MM-DD.jsonl`
+- Shared credentials:
+  macOS/Linux: `$HOME/.mem9/.credentials.json`
+  Windows: `%USERPROFILE%\\.mem9\\.credentials.json`
+- Global mem9 config:
+  macOS/Linux: `~/.config/opencode/mem9.json`
+  Windows: `%APPDATA%\\opencode\\mem9.json`
+- Project mem9 override:
+  all platforms: `<project>/.opencode/mem9.json`
+- Debug logs:
+  macOS/Linux: `~/.local/share/opencode/plugins/mem9/log/YYYY-MM-DD.jsonl`
+  Windows: `%LOCALAPPDATA%\\opencode\\plugins\\mem9\\log\\YYYY-MM-DD.jsonl`
 
-`MEM9_HOME` defaults to `$HOME/.mem9`.
+`MEM9_HOME` defaults to `$HOME/.mem9` on macOS/Linux and `%USERPROFILE%\\.mem9` on Windows.
 
 ## Credentials File
 
@@ -179,27 +145,27 @@ Legacy compatibility remains:
 
 `MEM9_TENANT_ID` is treated as the API key source for older setups.
 
-## Local Development Install
+## Upgrading
 
-You can also point OpenCode at a local checkout.
+OpenCode caches npm plugins by package specifier.
+When config points at `@mem9/opencode`, OpenCode resolves it as `@mem9/opencode@latest`.
 
-Server plugin example:
+Reliable upgrade flow:
 
-```json
-{
-  "plugin": ["./.opencode/plugins/mem9/src/index.ts"]
-}
+1. Quit OpenCode.
+2. Delete the cached folder that matches the installed specifier.
+   Default install on macOS/Linux: `~/.cache/opencode/packages/@mem9/opencode@latest`
+   On Windows, open your OpenCode cache directory for the current user and delete the `@mem9/opencode@latest` folder.
+   If you pinned an exact version such as `@mem9/opencode@0.1.1`, delete that exact folder name instead.
+3. Run:
+
+```bash
+opencode plugin --force --global @mem9/opencode
 ```
 
-TUI plugin example:
+4. Restart OpenCode.
 
-```json
-{
-  "plugin": ["./.opencode/plugins/mem9/src/tui/index.ts"]
-}
-```
-
-Keep the same one-scope rule for the server plugin even when using local paths.
+For prerelease testing, install an explicit npm specifier such as `@mem9/opencode@rc` or an exact version.
 
 ## What the Plugin Does
 
@@ -258,11 +224,3 @@ The plugin registers these tools:
 - If recall, auto-ingest, or debug logs appear to run twice, check for duplicate plugin registration across user scope, project scope, npm, or local file paths.
 - If the selected profile exists but has no `apiKey`, update that profile in `$MEM9_HOME/.credentials.json`.
 - If debug logging is enabled and no file appears, confirm OpenCode can write to its state directory.
-
-## Local Verification
-
-```bash
-pnpm test
-pnpm run typecheck
-pnpm run pack:check
-```

--- a/opencode-plugin/README.md
+++ b/opencode-plugin/README.md
@@ -2,7 +2,7 @@
 
 Persistent memory for [OpenCode](https://opencode.ai).
 
-The package ships two plugin entrypoints:
+This package has two entrypoints:
 
 - a server plugin for recall, auto-ingest, and memory tools
 - a TUI plugin for interactive setup inside OpenCode
@@ -15,14 +15,19 @@ The package ships two plugin entrypoints:
 opencode plugin --global @mem9/opencode
 ```
 
-That adds `@mem9/opencode` to both:
+That adds `@mem9/opencode` to these files:
+
+macOS/Linux:
 
 - `~/.config/opencode/opencode.json`
 - `~/.config/opencode/tui.json`
+
+Windows:
+
 - `%APPDATA%\\opencode\\opencode.json`
 - `%APPDATA%\\opencode\\tui.json`
 
-mem9 works best with one global plugin install plus project-level `mem9.json` overrides.
+mem9 works best with one global plugin install plus project `mem9.json` overrides.
 OpenCode merges plugin lists across scopes, so one install keeps recall, ingest, and tools predictable.
 
 ### 2. Restart OpenCode and run `/mem9-setup`
@@ -44,7 +49,7 @@ When usable profiles already exist, it shows four actions:
 - `Use an existing mem9 profile in a scope`
 - `Adjust scope settings`
 
-The last two actions have separate jobs:
+The last two actions do different things:
 
 - `Use an existing mem9 profile in a scope` changes which profile a user or project scope uses
 - `Adjust scope settings` changes `debug`, `defaultTimeoutMs`, and `searchTimeoutMs` for a user or project scope
@@ -52,7 +57,7 @@ The last two actions have separate jobs:
 ### 3. Add project overrides only when you need them
 
 Keep the plugin install global.
-Use `<project>/.opencode/mem9.json` when one repository needs a different profile, debug flag, or timeout values.
+Use `<project>/.opencode/mem9.json` when one repository needs a different profile, debug flag, or timeout.
 
 Example:
 
@@ -139,7 +144,7 @@ These environment variables still override disk config at runtime:
 - `MEM9_DEBUG`
 - `MEM9_HOME`
 
-Legacy compatibility remains:
+Legacy compatibility:
 
 - `MEM9_TENANT_ID`
 
@@ -150,12 +155,12 @@ Legacy compatibility remains:
 OpenCode caches npm plugins by package specifier.
 When config points at `@mem9/opencode`, OpenCode resolves it as `@mem9/opencode@latest`.
 
-Reliable upgrade flow:
+Upgrade flow:
 
 1. Quit OpenCode.
 2. Delete the cached folder that matches the installed specifier.
-   Default install on macOS/Linux: `~/.cache/opencode/packages/@mem9/opencode@latest`
-   On Windows, open your OpenCode cache directory for the current user and delete the `@mem9/opencode@latest` folder.
+   macOS/Linux default: `~/.cache/opencode/packages/@mem9/opencode@latest`
+   Windows default: `%LOCALAPPDATA%\\opencode\\packages\\@mem9\\opencode@latest`
    If you pinned an exact version such as `@mem9/opencode@0.1.1`, delete that exact folder name instead.
 3. Run:
 
@@ -177,7 +182,7 @@ The server plugin does three things:
 
 ### Hook Flow
 
-OpenCode integration currently uses four runtime hooks:
+OpenCode integration uses four runtime hooks:
 
 | Hook | What mem9 does |
 | --- | --- |
@@ -219,7 +224,7 @@ The plugin registers these tools:
 ## Troubleshooting
 
 - `Setup pending` means the plugin could not find a usable runtime identity. Run `/mem9-setup`, add `MEM9_API_KEY`, or point the active `mem9.json` scope at a profile with a non-empty `apiKey`.
-- If `/mem9-setup` is missing, confirm `@mem9/opencode` is listed in `~/.config/opencode/tui.json`.
+- If `/mem9-setup` is missing, confirm `@mem9/opencode` is listed in your global `tui.json`.
 - If recall or tools work in one project and not another, check whether the project has its own `.opencode/mem9.json` override.
 - If recall, auto-ingest, or debug logs appear to run twice, check for duplicate plugin registration across user scope, project scope, npm, or local file paths.
 - If the selected profile exists but has no `apiKey`, update that profile in `$MEM9_HOME/.credentials.json`.

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/opencode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -4,12 +4,9 @@
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",
-  "oc-plugin": [
-    "server",
-    "tui"
-  ],
   "exports": {
     ".": "./src/index.ts",
+    "./server": "./src/index.ts",
     "./tui": "./src/tui/index.ts"
   },
   "license": "Apache-2.0",

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/opencode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/opencode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",

--- a/opencode-plugin/scripts/publish.mjs
+++ b/opencode-plugin/scripts/publish.mjs
@@ -21,7 +21,7 @@
 //   - `--skip-branch-check` skips only the publish-branch sync gate.
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -30,6 +30,7 @@ const packageDir = path.resolve(scriptDir, "..");
 const packageJsonPath = path.join(packageDir, "package.json");
 const publishEnvPath = path.join(packageDir, ".publish.env");
 const publishNpmrcPath = path.join(packageDir, ".npmrc.publish.tmp");
+const publishCacheDir = path.join(packageDir, ".tmp", "npm-cache-publish");
 const pnpmBin = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const gitBin = process.platform === "win32" ? "git.exe" : "git";
 
@@ -360,9 +361,11 @@ function writePublishNpmrc(token) {
 }
 
 function runPnpm(args) {
+  mkdirSync(publishCacheDir, { recursive: true });
   const env = {
     ...process.env,
     npm_config_userconfig: publishNpmrcPath,
+    npm_config_cache: publishCacheDir,
   };
   const result = spawnSync(pnpmBin, args, {
     cwd: packageDir,

--- a/opencode-plugin/scripts/publish.mjs
+++ b/opencode-plugin/scripts/publish.mjs
@@ -1,6 +1,22 @@
+// Publish helper for @mem9/opencode.
+//
 // Run from the package directory:
+//   cd opencode-plugin
+//
+// Normal package-level entrypoint:
 //   pnpm run publish:release current
 //   pnpm run publish:release current --dry-run
+//   pnpm run publish:release patch
+//
+// Direct script entrypoint:
+//   node ./scripts/publish.mjs current
+//   node ./scripts/publish.mjs current --dry-run
+//
+// Argument notes:
+//   - `pnpm run publish:release ...` is the normal workflow.
+//   - `node ./scripts/publish.mjs ...` matches the `--help` output.
+//   - Both `pnpm run publish:release current` and
+//     `pnpm run publish:release -- current` are accepted.
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";

--- a/opencode-plugin/scripts/publish.mjs
+++ b/opencode-plugin/scripts/publish.mjs
@@ -26,15 +26,15 @@ function fail(message) {
 
 function printHelp() {
   console.log(`Usage:
-  pnpm run publish:release -- <current|major|minor|patch|premajor|preminor|prepatch|prerelease> [--channel <alpha|beta|rc>] [--dry-run]
+  pnpm run publish:release <current|major|minor|patch|premajor|preminor|prepatch|prerelease> [--channel <alpha|beta|rc>] [--dry-run]
 
 Examples:
-  pnpm run publish:release -- current
-  pnpm run publish:release -- patch
-  pnpm run publish:release -- patch --channel rc
-  pnpm run publish:release -- prepatch --channel beta
-  pnpm run publish:release -- prerelease --channel rc
-  pnpm run publish:release -- prepatch --channel rc --dry-run
+  pnpm run publish:release current
+  pnpm run publish:release patch
+  pnpm run publish:release patch --channel rc
+  pnpm run publish:release prepatch --channel beta
+  pnpm run publish:release prerelease --channel rc
+  pnpm run publish:release prepatch --channel rc --dry-run
 
 Behavior:
   - \`current\` publishes the exact version already in package.json and derives the npm tag from that version.
@@ -52,6 +52,10 @@ function parseArgs(argv) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+
     if (arg === "--help" || arg === "-h") {
       return { help: true };
     }

--- a/opencode-plugin/scripts/publish.mjs
+++ b/opencode-plugin/scripts/publish.mjs
@@ -1,3 +1,7 @@
+// Run from the package directory:
+//   pnpm run publish:release current
+//   pnpm run publish:release current --dry-run
+
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -26,15 +30,15 @@ function fail(message) {
 
 function printHelp() {
   console.log(`Usage:
-  pnpm run publish:release <current|major|minor|patch|premajor|preminor|prepatch|prerelease> [--channel <alpha|beta|rc>] [--dry-run]
+  node ./scripts/publish.mjs <current|major|minor|patch|premajor|preminor|prepatch|prerelease> [--channel <alpha|beta|rc>] [--dry-run]
 
 Examples:
-  pnpm run publish:release current
-  pnpm run publish:release patch
-  pnpm run publish:release patch --channel rc
-  pnpm run publish:release prepatch --channel beta
-  pnpm run publish:release prerelease --channel rc
-  pnpm run publish:release prepatch --channel rc --dry-run
+  node ./scripts/publish.mjs current
+  node ./scripts/publish.mjs patch
+  node ./scripts/publish.mjs patch --channel rc
+  node ./scripts/publish.mjs prepatch --channel beta
+  node ./scripts/publish.mjs prerelease --channel rc
+  node ./scripts/publish.mjs prepatch --channel rc --dry-run
 
 Behavior:
   - \`current\` publishes the exact version already in package.json and derives the npm tag from that version.

--- a/opencode-plugin/scripts/publish.mjs
+++ b/opencode-plugin/scripts/publish.mjs
@@ -7,6 +7,7 @@
 //   pnpm run publish:release current
 //   pnpm run publish:release current --dry-run
 //   pnpm run publish:release patch
+//   pnpm run publish:release patch --skip-branch-check
 //
 // Direct script entrypoint:
 //   node ./scripts/publish.mjs current
@@ -17,6 +18,7 @@
 //   - `node ./scripts/publish.mjs ...` matches the `--help` output.
 //   - Both `pnpm run publish:release current` and
 //     `pnpm run publish:release -- current` are accepted.
+//   - `--skip-branch-check` skips only the publish-branch sync gate.
 
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -46,11 +48,12 @@ function fail(message) {
 
 function printHelp() {
   console.log(`Usage:
-  node ./scripts/publish.mjs <current|major|minor|patch|premajor|preminor|prepatch|prerelease> [--channel <alpha|beta|rc>] [--dry-run]
+  node ./scripts/publish.mjs <current|major|minor|patch|premajor|preminor|prepatch|prerelease> [--channel <alpha|beta|rc>] [--dry-run] [--skip-branch-check]
 
 Examples:
   node ./scripts/publish.mjs current
   node ./scripts/publish.mjs patch
+  node ./scripts/publish.mjs patch --skip-branch-check
   node ./scripts/publish.mjs patch --channel rc
   node ./scripts/publish.mjs prepatch --channel beta
   node ./scripts/publish.mjs prerelease --channel rc
@@ -61,6 +64,7 @@ Behavior:
   - Stable releases publish to the npm \`latest\` tag.
   - Stable increments with \`--channel\` become prereleases for that channel.
   - \`prerelease\` continues the current prerelease stream for the selected channel.
+  - \`--skip-branch-check\` skips only the publish-branch sync gate; the working tree must still be clean.
   - The script reads NPM_ACCESSTOKEN from opencode-plugin/.publish.env only.
 `);
 }
@@ -69,6 +73,7 @@ function parseArgs(argv) {
   let increment = "";
   let channel;
   let dryRun = false;
+  let skipBranchCheck = false;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -82,6 +87,11 @@ function parseArgs(argv) {
 
     if (arg === "--dry-run") {
       dryRun = true;
+      continue;
+    }
+
+    if (arg === "--skip-branch-check") {
+      skipBranchCheck = true;
       continue;
     }
 
@@ -128,6 +138,7 @@ function parseArgs(argv) {
     increment,
     channel,
     dryRun,
+    skipBranchCheck,
   };
 }
 
@@ -189,9 +200,14 @@ function assertGitPublishState({
   publishBranch,
   aheadCount,
   behindCount,
+  skipBranchCheck = false,
 }) {
   if (statusOutput.trim()) {
     fail("git working tree must be clean before publishing");
+  }
+
+  if (skipBranchCheck) {
+    return;
   }
 
   if (currentBranch !== publishBranch) {
@@ -395,7 +411,7 @@ function resolvePublishBranch(repoRoot) {
   }
 }
 
-function ensureGitPublishReady(repoRoot) {
+function ensureGitPublishReady(repoRoot, options = {}) {
   const statusOutput = readCommandOutput(
     gitBin,
     ["status", "--porcelain", "--untracked-files=all"],
@@ -416,6 +432,7 @@ function ensureGitPublishReady(repoRoot) {
     publishBranch,
     aheadCount: Number(aheadRaw),
     behindCount: Number(behindRaw),
+    skipBranchCheck: options.skipBranchCheck,
   });
 }
 
@@ -446,7 +463,9 @@ async function main() {
   const currentVersion = String(pkg.version ?? "");
   const plan = resolveReleasePlan(currentVersion, args.increment, args.channel);
   const repoRoot = resolveRepoRoot();
-  ensureGitPublishReady(repoRoot);
+  ensureGitPublishReady(repoRoot, {
+    skipBranchCheck: args.skipBranchCheck,
+  });
   const token = readPublishToken();
   const originalPackageJson = readFileSync(packageJsonPath, "utf8");
 

--- a/opencode-plugin/scripts/publish.test.mjs
+++ b/opencode-plugin/scripts/publish.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import test from "node:test";
 
 import {
@@ -220,4 +221,15 @@ test("buildPublishArgs forwards dry-run without extra flags", () => {
     "--no-git-checks",
     "--dry-run",
   ]);
+});
+
+test("help output documents direct script usage", () => {
+  const result = spawnSync(process.execPath, ["./scripts/publish.mjs", "--help"], {
+    cwd: new URL("..", import.meta.url),
+    encoding: "utf8",
+  });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /node \.\/scripts\/publish\.mjs current/);
+  assert.doesNotMatch(result.stdout, /pnpm run publish:release -- current/);
 });

--- a/opencode-plugin/scripts/publish.test.mjs
+++ b/opencode-plugin/scripts/publish.test.mjs
@@ -17,6 +17,7 @@ test("parseArgs accepts current release mode", () => {
     increment: "current",
     channel: undefined,
     dryRun: true,
+    skipBranchCheck: false,
   });
 });
 
@@ -26,6 +27,7 @@ test("parseArgs accepts the pnpm argument separator", () => {
     increment: "current",
     channel: undefined,
     dryRun: true,
+    skipBranchCheck: false,
   });
 });
 
@@ -35,6 +37,7 @@ test("parseArgs accepts stable releases", () => {
     increment: "patch",
     channel: undefined,
     dryRun: false,
+    skipBranchCheck: false,
   });
 });
 
@@ -44,6 +47,17 @@ test("parseArgs accepts prerelease options", () => {
     increment: "prepatch",
     channel: "rc",
     dryRun: true,
+    skipBranchCheck: false,
+  });
+});
+
+test("parseArgs accepts skip-branch-check", () => {
+  assert.deepEqual(parseArgs(["patch", "--skip-branch-check"]), {
+    help: false,
+    increment: "patch",
+    channel: undefined,
+    dryRun: false,
+    skipBranchCheck: true,
   });
 });
 
@@ -154,6 +168,19 @@ test("assertGitPublishState accepts a clean synced publish branch", () => {
       publishBranch: "main",
       aheadCount: 0,
       behindCount: 0,
+    }),
+  );
+});
+
+test("assertGitPublishState allows clean feature branches when skip-branch-check is enabled", () => {
+  assert.doesNotThrow(() =>
+    assertGitPublishState({
+      statusOutput: "",
+      currentBranch: "fix/opencode-plugin-release-readiness",
+      publishBranch: "main",
+      aheadCount: 4,
+      behindCount: 0,
+      skipBranchCheck: true,
     }),
   );
 });

--- a/opencode-plugin/scripts/publish.test.mjs
+++ b/opencode-plugin/scripts/publish.test.mjs
@@ -19,6 +19,15 @@ test("parseArgs accepts current release mode", () => {
   });
 });
 
+test("parseArgs accepts the pnpm argument separator", () => {
+  assert.deepEqual(parseArgs(["--", "current", "--dry-run"]), {
+    help: false,
+    increment: "current",
+    channel: undefined,
+    dryRun: true,
+  });
+});
+
 test("parseArgs accepts stable releases", () => {
   assert.deepEqual(parseArgs(["patch"]), {
     help: false,

--- a/opencode-plugin/src/index.ts
+++ b/opencode-plugin/src/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./server/index.js";
+export { default } from "./server/index.ts";

--- a/opencode-plugin/src/server/backend.ts
+++ b/opencode-plugin/src/server/backend.ts
@@ -5,7 +5,7 @@ import type {
   SearchResult,
   StoreResult,
   UpdateMemoryInput,
-} from "../shared/types.js";
+} from "../shared/types.ts";
 
 export interface IngestMessage {
   role: string;

--- a/opencode-plugin/src/server/config.ts
+++ b/opencode-plugin/src/server/config.ts
@@ -1,18 +1,18 @@
 import { readFile } from "node:fs/promises";
 import type { PluginInput } from "@opencode-ai/plugin";
-import { parseCredentialsFile } from "../shared/credentials-store.js";
-import { DEFAULT_SCOPE_CONFIG } from "../shared/defaults.js";
+import { parseCredentialsFile } from "../shared/credentials-store.ts";
+import { DEFAULT_SCOPE_CONFIG } from "../shared/defaults.ts";
 import {
   resolveOpenCodeBasePaths,
   resolveMem9Home,
   resolveMem9Paths,
   type Mem9ResolvedPaths,
-} from "../shared/platform-paths.js";
+} from "../shared/platform-paths.ts";
 import {
   DEFAULT_API_URL,
   type Mem9ConfigFile,
   type Mem9CredentialsFile,
-} from "../shared/types.js";
+} from "../shared/types.ts";
 
 const EMPTY_CREDENTIALS: Mem9CredentialsFile = {
   schemaVersion: 1,

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -1,11 +1,11 @@
 import type { Hooks } from "@opencode-ai/plugin";
-import type { IngestMessage, MemoryBackend } from "./backend.js";
-import type { DebugLogger } from "./debug.js";
-import { selectMessagesForIngest } from "./ingest/select.js";
-import { submitMessagesForIngest } from "./ingest/submit.js";
-import { formatRecallBlock } from "./recall/format.js";
-import { buildRecallQuery } from "./recall/query.js";
-import type { SessionTranscriptLoader } from "./session-transcript.js";
+import type { IngestMessage, MemoryBackend } from "./backend.ts";
+import type { DebugLogger } from "./debug.ts";
+import { selectMessagesForIngest } from "./ingest/select.ts";
+import { submitMessagesForIngest } from "./ingest/submit.ts";
+import { formatRecallBlock } from "./recall/format.ts";
+import { buildRecallQuery } from "./recall/query.ts";
+import type { SessionTranscriptLoader } from "./session-transcript.ts";
 
 const MAX_RECALL_RESULTS = 10;
 const MIN_RECALL_QUERY_LEN = 5;

--- a/opencode-plugin/src/server/index.ts
+++ b/opencode-plugin/src/server/index.ts
@@ -1,16 +1,16 @@
 import type { Hooks, Plugin } from "@opencode-ai/plugin";
-import type { MemoryBackend } from "./backend.js";
+import type { MemoryBackend } from "./backend.ts";
 import {
   resolveEffectiveConfig,
   resolvePluginIdentity,
-} from "./config.js";
-import { createDebugLogger } from "./debug.js";
-import { ServerBackend } from "./server-backend.js";
-import { buildPendingSetupHooks } from "./setup-flow.js";
-import { buildTools } from "./tools.js";
-import { buildHooks } from "./hooks.js";
-import { createSessionTranscriptLoader } from "./session-transcript.js";
-import { PLUGIN_ID } from "../shared/plugin-meta.js";
+} from "./config.ts";
+import { createDebugLogger } from "./debug.ts";
+import { ServerBackend } from "./server-backend.ts";
+import { buildPendingSetupHooks } from "./setup-flow.ts";
+import { buildTools } from "./tools.ts";
+import { buildHooks } from "./hooks.ts";
+import { createSessionTranscriptLoader } from "./session-transcript.ts";
+import { PLUGIN_ID } from "../shared/plugin-meta.ts";
 
 function buildPluginHooksAndTools(
   backend: MemoryBackend,

--- a/opencode-plugin/src/server/ingest/select.ts
+++ b/opencode-plugin/src/server/ingest/select.ts
@@ -1,4 +1,4 @@
-import type { IngestMessage } from "../backend.js";
+import type { IngestMessage } from "../backend.ts";
 
 const RELEVANT_MEMORIES_BLOCK_RE = /<relevant-memories>[\s\S]*?(<\/relevant-memories>|$)/g;
 const MAX_INGEST_MESSAGES = 12;

--- a/opencode-plugin/src/server/ingest/submit.ts
+++ b/opencode-plugin/src/server/ingest/submit.ts
@@ -1,6 +1,6 @@
-import type { IngestInput, IngestResult, MemoryBackend } from "../backend.js";
-import type { DebugLogger } from "../debug.js";
-import { selectMessagesForIngest } from "./select.js";
+import type { IngestInput, IngestResult, MemoryBackend } from "../backend.ts";
+import type { DebugLogger } from "../debug.ts";
+import { selectMessagesForIngest } from "./select.ts";
 
 export interface SubmitIngestOptions {
   backend: MemoryBackend;

--- a/opencode-plugin/src/server/recall/format.ts
+++ b/opencode-plugin/src/server/recall/format.ts
@@ -1,4 +1,4 @@
-import type { Memory } from "../../shared/types.js";
+import type { Memory } from "../../shared/types.ts";
 
 const MAX_CONTENT_LEN = 500;
 const MAX_TAGS = 3;

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -2,7 +2,7 @@ import type {
   IngestInput,
   IngestResult,
   MemoryBackend,
-} from "./backend.js";
+} from "./backend.ts";
 import type {
   Memory,
   StoreResult,
@@ -10,8 +10,8 @@ import type {
   CreateMemoryInput,
   UpdateMemoryInput,
   SearchInput,
-} from "../shared/types.js";
-import { DEFAULT_SCOPE_CONFIG } from "../shared/defaults.js";
+} from "../shared/types.ts";
+import { DEFAULT_SCOPE_CONFIG } from "../shared/defaults.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/opencode-plugin/src/server/session-transcript.ts
+++ b/opencode-plugin/src/server/session-transcript.ts
@@ -1,5 +1,5 @@
 import type { PluginInput } from "@opencode-ai/plugin";
-import type { IngestMessage } from "./backend.js";
+import type { IngestMessage } from "./backend.ts";
 
 const SESSION_TRANSCRIPT_FETCH_LIMIT = 24;
 

--- a/opencode-plugin/src/server/setup-flow.ts
+++ b/opencode-plugin/src/server/setup-flow.ts
@@ -1,5 +1,5 @@
 import type { Hooks, PluginInput } from "@opencode-ai/plugin";
-import type { EffectiveConfig } from "./config.js";
+import type { EffectiveConfig } from "./config.ts";
 
 export function buildPendingSetupHooks(
   _input: PluginInput,

--- a/opencode-plugin/src/server/tools.ts
+++ b/opencode-plugin/src/server/tools.ts
@@ -1,10 +1,10 @@
 import { tool } from "@opencode-ai/plugin";
-import type { MemoryBackend } from "./backend.js";
+import type { MemoryBackend } from "./backend.ts";
 import type {
   CreateMemoryInput,
   UpdateMemoryInput,
   SearchInput,
-} from "../shared/types.js";
+} from "../shared/types.ts";
 
 /**
  * Build the 5 memory tools for OpenCode.

--- a/opencode-plugin/src/shared/credentials-store.ts
+++ b/opencode-plugin/src/shared/credentials-store.ts
@@ -1,4 +1,4 @@
-import type { Mem9CredentialsFile, Mem9Profile } from "./types.js";
+import type { Mem9CredentialsFile, Mem9Profile } from "./types.ts";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/opencode-plugin/src/shared/defaults.ts
+++ b/opencode-plugin/src/shared/defaults.ts
@@ -1,4 +1,4 @@
-import type { Mem9ConfigFile } from "./types.js";
+import type { Mem9ConfigFile } from "./types.ts";
 
 export const DEFAULT_SCOPE_CONFIG: Required<
   Pick<

--- a/opencode-plugin/src/shared/setup-files.ts
+++ b/opencode-plugin/src/shared/setup-files.ts
@@ -1,14 +1,14 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { Mem9ResolvedPaths } from "./platform-paths.js";
-import { parseCredentialsFile, stringifyCredentialsFile } from "./credentials-store.js";
-import { DEFAULT_SCOPE_CONFIG } from "./defaults.js";
+import type { Mem9ResolvedPaths } from "./platform-paths.ts";
+import { parseCredentialsFile, stringifyCredentialsFile } from "./credentials-store.ts";
+import { DEFAULT_SCOPE_CONFIG } from "./defaults.ts";
 import {
   DEFAULT_API_URL,
   type Mem9ConfigFile,
   type Mem9CredentialsFile,
   type Mem9Profile,
-} from "./types.js";
+} from "./types.ts";
 
 export type SetupScope = "user" | "project";
 

--- a/opencode-plugin/src/shared/setup-files.ts
+++ b/opencode-plugin/src/shared/setup-files.ts
@@ -17,6 +17,7 @@ export interface SetupProfileSummary {
   label: string;
   baseUrl: string;
   hasApiKey: boolean;
+  apiKeyPreview: string;
 }
 
 export interface ScopeConfigState {
@@ -112,6 +113,23 @@ function hasApiKey(profile: unknown): boolean {
   return Boolean(normalizeOptionalString(profile.apiKey));
 }
 
+function summarizeApiKeyPreview(apiKey: string): string {
+  const normalized = apiKey.trim();
+  if (normalized.length === 0) {
+    return "";
+  }
+
+  if (normalized.length <= 4) {
+    return `${normalized.slice(0, 1)}...`;
+  }
+
+  if (normalized.length <= 8) {
+    return `${normalized.slice(0, 2)}...${normalized.slice(-2)}`;
+  }
+
+  return `${normalized.slice(0, 4)}...${normalized.slice(-4)}`;
+}
+
 function normalizeProfileRecord(
   profileId: string,
   profile: Mem9Profile | undefined,
@@ -188,6 +206,7 @@ function buildProfiles(
         label: normalized.label,
         baseUrl: normalized.baseUrl,
         hasApiKey: normalized.apiKey.trim().length > 0,
+        apiKeyPreview: summarizeApiKeyPreview(normalized.apiKey),
       };
     })
     .sort(sortProfileSummaries);

--- a/opencode-plugin/src/tui/index.ts
+++ b/opencode-plugin/src/tui/index.ts
@@ -8,8 +8,8 @@ import {
   resolveMem9Home,
   resolveMem9Paths,
   type Mem9ResolvedPaths,
-} from "../shared/platform-paths.js";
-import { PLUGIN_ID } from "../shared/plugin-meta.js";
+} from "../shared/platform-paths.ts";
+import { PLUGIN_ID } from "../shared/plugin-meta.ts";
 import {
   loadSetupState,
   provisionApiKey,
@@ -19,7 +19,7 @@ import {
   type SetupProfileSummary,
   type SetupScope,
   type SetupState,
-} from "../shared/setup-files.js";
+} from "../shared/setup-files.ts";
 
 type SetupAction =
   | "auto-api-key"

--- a/opencode-plugin/src/tui/index.ts
+++ b/opencode-plugin/src/tui/index.ts
@@ -61,6 +61,12 @@ interface SetupProfileOptionState {
   currentProfileId?: string;
 }
 
+function scheduleDialogTransition(next: () => void): void {
+  // Delay prompt-to-prompt transitions so the next dialog does not reuse
+  // the same Enter keypress that confirmed the current prompt.
+  setTimeout(next, 0);
+}
+
 function getProjectDir(api: TuiPluginApi): string {
   const worktree = api.state.path.worktree.trim();
   if (worktree.length > 0) {
@@ -354,7 +360,9 @@ function showProfileIdDialog(
         if (draft.label.trim().length === 0) {
           draft.label = next === "default" ? "Personal" : next;
         }
-        showProfileLabelDialog(api, paths, state, action, draft);
+        scheduleDialogTransition(() => {
+          showProfileLabelDialog(api, paths, state, action, draft);
+        });
       },
       onCancel: () => {
         showActionDialog(api, paths, state);
@@ -386,10 +394,14 @@ function showProfileLabelDialog(
         }
 
         draft.label = next;
-        showProfileBaseUrlDialog(api, paths, state, action, draft);
+        scheduleDialogTransition(() => {
+          showProfileBaseUrlDialog(api, paths, state, action, draft);
+        });
       },
       onCancel: () => {
-        showProfileIdDialog(api, paths, state, action, draft);
+        scheduleDialogTransition(() => {
+          showProfileIdDialog(api, paths, state, action, draft);
+        });
       },
     }),
   );
@@ -423,10 +435,14 @@ function showProfileBaseUrlDialog(
           return;
         }
 
-        showProfileApiKeyDialog(api, paths, state, draft);
+        scheduleDialogTransition(() => {
+          showProfileApiKeyDialog(api, paths, state, draft);
+        });
       },
       onCancel: () => {
-        showProfileLabelDialog(api, paths, state, action, draft);
+        scheduleDialogTransition(() => {
+          showProfileLabelDialog(api, paths, state, action, draft);
+        });
       },
     }),
   );
@@ -462,7 +478,9 @@ function showProfileApiKeyDialog(
         void submitManualProfile(api, paths, draft);
       },
       onCancel: () => {
-        showProfileBaseUrlDialog(api, paths, state, "manual-api-key", draft);
+        scheduleDialogTransition(() => {
+          showProfileBaseUrlDialog(api, paths, state, "manual-api-key", draft);
+        });
       },
     }),
   );
@@ -578,7 +596,9 @@ function showDefaultTimeoutDialog(
         }
 
         draft.defaultTimeoutMs = parsed;
-        showSearchTimeoutDialog(api, paths, state, draft);
+        scheduleDialogTransition(() => {
+          showSearchTimeoutDialog(api, paths, state, draft);
+        });
       },
       onCancel: () => {
         showScopeDebugDialog(api, paths, state, draft);
@@ -612,7 +632,9 @@ function showSearchTimeoutDialog(
         void submitScopeConfigDraft(api, paths, draft);
       },
       onCancel: () => {
-        showDefaultTimeoutDialog(api, paths, state, draft);
+        scheduleDialogTransition(() => {
+          showDefaultTimeoutDialog(api, paths, state, draft);
+        });
       },
     }),
   );

--- a/opencode-plugin/src/tui/index.ts
+++ b/opencode-plugin/src/tui/index.ts
@@ -61,6 +61,8 @@ interface SetupProfileOptionState {
   currentProfileId?: string;
 }
 
+let hasShownVisibleApiKeyWarning = false;
+
 function scheduleDialogTransition(next: () => void): void {
   // Delay prompt-to-prompt transitions so the next dialog does not reuse
   // the same Enter keypress that confirmed the current prompt.
@@ -454,11 +456,14 @@ function showProfileApiKeyDialog(
   state: SetupState,
   draft: ProfileDraft,
 ): void {
-  api.ui.toast({
-    variant: "warning",
-    message: "The current OpenCode prompt is plain text. Your API key stays visible while typing.",
-    duration: 4000,
-  });
+  if (!hasShownVisibleApiKeyWarning) {
+    hasShownVisibleApiKeyWarning = true;
+    api.ui.toast({
+      variant: "warning",
+      message: "API key input is visible while typing.",
+      duration: 4000,
+    });
+  }
 
   api.ui.dialog.replace(() =>
     api.ui.DialogPrompt({

--- a/opencode-plugin/src/tui/index.ts
+++ b/opencode-plugin/src/tui/index.ts
@@ -3,6 +3,7 @@ import type {
   TuiCommand,
   TuiPlugin,
   TuiPluginApi,
+  TuiToast,
 } from "@opencode-ai/plugin/tui";
 import {
   resolveMem9Home,
@@ -62,11 +63,19 @@ interface SetupProfileOptionState {
 }
 
 let hasShownVisibleApiKeyWarning = false;
+const DEFAULT_TOAST_DURATION_MS = 5000;
 
 function scheduleDialogTransition(next: () => void): void {
   // Delay prompt-to-prompt transitions so the next dialog does not reuse
   // the same Enter keypress that confirmed the current prompt.
   setTimeout(next, 0);
+}
+
+function showToast(api: TuiPluginApi, toast: TuiToast): void {
+  api.ui.toast({
+    duration: toast.duration ?? DEFAULT_TOAST_DURATION_MS,
+    ...toast,
+  });
 }
 
 function getProjectDir(api: TuiPluginApi): string {
@@ -121,7 +130,7 @@ function showError(
   retryCommand = false,
 ): void {
   const suffix = retryCommand ? " Run /mem9-setup again when you are ready to retry." : "";
-  api.ui.toast({
+  showToast(api, {
     variant: "error",
     title: "mem9 setup failed",
     message: `${error instanceof Error ? error.message : String(error)}${suffix}`,
@@ -129,7 +138,7 @@ function showError(
 }
 
 function showProfileSavedSuccess(api: TuiPluginApi, profileId: string): void {
-  api.ui.toast({
+  showToast(api, {
     variant: "success",
     title: "mem9 configured",
     message: `Saved profile ${profileId} and set it as the default user profile. Restart OpenCode to reload mem9.`,
@@ -142,7 +151,7 @@ function showScopeSavedSuccess(
   profileId: string,
 ): void {
   const scopeLabel = scope === "user" ? "user settings" : "project settings";
-  api.ui.toast({
+  showToast(api, {
     variant: "success",
     title: "mem9 configured",
     message: `Saved ${scopeLabel} with profile ${profileId}. Restart OpenCode to reload mem9.`,
@@ -343,7 +352,7 @@ function showProfileIdDialog(
       onConfirm: (value) => {
         const next = value.trim();
         if (next.length === 0) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "Profile ID is required.",
           });
@@ -351,7 +360,7 @@ function showProfileIdDialog(
         }
 
         if (isReusableProfileID(state, next)) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "That profile already has credentials. Pick a new profile ID or use the existing profile in scope settings.",
           });
@@ -388,7 +397,7 @@ function showProfileLabelDialog(
       onConfirm: (value) => {
         const next = value.trim();
         if (next.length === 0) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "Profile label is required.",
           });
@@ -424,7 +433,7 @@ function showProfileBaseUrlDialog(
       onConfirm: (value) => {
         const next = value.trim();
         if (next.length === 0) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "mem9 API URL is required.",
           });
@@ -458,7 +467,7 @@ function showProfileApiKeyDialog(
 ): void {
   if (!hasShownVisibleApiKeyWarning) {
     hasShownVisibleApiKeyWarning = true;
-    api.ui.toast({
+    showToast(api, {
       variant: "warning",
       message: "API key input is visible while typing.",
       duration: 4000,
@@ -472,7 +481,7 @@ function showProfileApiKeyDialog(
       onConfirm: (value) => {
         const next = value.trim();
         if (next.length === 0) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "mem9 API key is required.",
           });
@@ -593,7 +602,7 @@ function showDefaultTimeoutDialog(
       onConfirm: (value) => {
         const parsed = parsePositiveInteger(value, "defaultTimeoutMs");
         if (parsed === null) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "Default timeout must be a positive integer.",
           });
@@ -626,7 +635,7 @@ function showSearchTimeoutDialog(
       onConfirm: (value) => {
         const parsed = parsePositiveInteger(value, "searchTimeoutMs");
         if (parsed === null) {
-          api.ui.toast({
+          showToast(api, {
             variant: "warning",
             message: "Search timeout must be a positive integer.",
           });

--- a/opencode-plugin/src/tui/index.ts
+++ b/opencode-plugin/src/tui/index.ts
@@ -27,7 +27,7 @@ type SetupAction =
   | "use-profile-in-scope"
   | "configure-scope";
 
-type ScopeFlowMode = "profile-only" | "full-config";
+type ScopeFlowMode = "profile-only" | "settings-only";
 
 interface ProfileDraft {
   profileId: string;
@@ -48,6 +48,17 @@ export interface SetupActionOption {
   title: string;
   value: SetupAction;
   description: string;
+}
+
+export interface SetupProfileOption {
+  title: string;
+  value: string;
+  description: string;
+  disabled: boolean;
+}
+
+interface SetupProfileOptionState {
+  currentProfileId?: string;
 }
 
 function getProjectDir(api: TuiPluginApi): string {
@@ -155,17 +166,41 @@ export function buildSetupActionOptions(
       {
         title: "Use an existing mem9 profile in a scope",
         value: "use-profile-in-scope",
-        description: "Choose a saved profile and apply it to user or project settings.",
+        description: "Choose which saved profile user or project settings should use.",
       },
       {
-        title: "Configure user/project settings",
+        title: "Adjust scope settings",
         value: "configure-scope",
-        description: "Change scope profile, debug logging, and request timeouts.",
+        description: "Change debug logging, request timeouts, and other mem9 settings for a user or project scope.",
       },
     );
   }
 
   return options;
+}
+
+function formatProfileTitle(profile: SetupProfileSummary): string {
+  return profile.label === profile.profileId
+    ? profile.label
+    : `${profile.label} (${profile.profileId})`;
+}
+
+export function buildScopeProfileOptions(
+  state: Pick<SetupState, "profiles">,
+  optionState: SetupProfileOptionState = {},
+): SetupProfileOption[] {
+  return state.profiles.map((profile) => ({
+    title: formatProfileTitle(profile),
+    value: profile.profileId,
+    description: [
+      profile.apiKeyPreview || "API key missing",
+      profile.baseUrl,
+      profile.profileId === optionState.currentProfileId ? "Current in this scope" : undefined,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join(" | "),
+    disabled: !profile.hasApiKey,
+  }));
 }
 
 function parsePositiveInteger(value: string, field: string): number | null {
@@ -279,7 +314,7 @@ function showActionDialog(
           return;
         }
 
-        showScopeDialog(api, paths, state, "full-config");
+        showScopeDialog(api, paths, state, "settings-only");
       },
     }),
   );
@@ -459,7 +494,12 @@ function showScopeDialog(
       ],
       onSelect: (option) => {
         const draft = createScopeDraft(state, option.value);
-        showScopeProfileDialog(api, paths, state, mode, draft);
+        if (mode === "profile-only") {
+          showScopeProfileDialog(api, paths, state, draft);
+          return;
+        }
+
+        showScopeDebugDialog(api, paths, state, draft);
       },
     }),
   );
@@ -469,27 +509,18 @@ function showScopeProfileDialog(
   api: TuiPluginApi,
   paths: Mem9ResolvedPaths,
   state: SetupState,
-  mode: ScopeFlowMode,
   draft: ScopeDraft,
 ): void {
   api.ui.dialog.replace(() =>
     api.ui.DialogSelect<string>({
       title: "Which mem9 profile should this scope use?",
       current: draft.profileId,
-      options: state.profiles.map((profile) => ({
-        title: `${profile.label} (${profile.profileId})`,
-        value: profile.profileId,
-        description: `${profile.baseUrl} • ${profile.hasApiKey ? "API key configured" : "API key missing"}`,
-        disabled: !profile.hasApiKey,
-      })),
+      options: buildScopeProfileOptions(state, {
+        currentProfileId: draft.profileId,
+      }),
       onSelect: (option) => {
         draft.profileId = option.value;
-        if (mode === "profile-only") {
-          void submitScopeConfigDraft(api, paths, draft);
-          return;
-        }
-
-        showScopeDebugDialog(api, paths, state, draft);
+        void submitScopeConfigDraft(api, paths, draft);
       },
     }),
   );
@@ -550,7 +581,7 @@ function showDefaultTimeoutDialog(
         showSearchTimeoutDialog(api, paths, state, draft);
       },
       onCancel: () => {
-        showScopeProfileDialog(api, paths, state, "full-config", draft);
+        showScopeDebugDialog(api, paths, state, draft);
       },
     }),
   );

--- a/opencode-plugin/tests/setup-files.test.ts
+++ b/opencode-plugin/tests/setup-files.test.ts
@@ -109,12 +109,14 @@ test("loadSetupState returns profile summaries and scope defaults for user and p
           label: "Personal",
           baseUrl: "https://api.mem9.ai",
           hasApiKey: true,
+          apiKeyPreview: "mk_d...ault",
         },
         {
           profileId: "acme",
           label: "Acme",
           baseUrl: "https://acme.mem9.ai",
           hasApiKey: false,
+          apiKeyPreview: "",
         },
       ],
       usableProfiles: [
@@ -123,6 +125,7 @@ test("loadSetupState returns profile summaries and scope defaults for user and p
           label: "Personal",
           baseUrl: "https://api.mem9.ai",
           hasApiKey: true,
+          apiKeyPreview: "mk_d...ault",
         },
       ],
       scopeStates: {

--- a/opencode-plugin/tests/source-imports.test.ts
+++ b/opencode-plugin/tests/source-imports.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const projectDir = path.resolve(testDir, "..");
+const sourceDir = path.join(projectDir, "src");
+
+function collectSourceFiles(dir: string): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath));
+      continue;
+    }
+
+    if (entry.isFile() && fullPath.endsWith(".ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+test("source files use .ts local imports for raw TypeScript package publishing", () => {
+  assert.equal(statSync(sourceDir).isDirectory(), true);
+
+  const offenders = collectSourceFiles(sourceDir)
+    .flatMap((filePath) => {
+      const source = readFileSync(filePath, "utf8");
+      const matches = source.matchAll(
+        /(?:from\s+|export\s+\{\s*default\s*\}\s+from\s+)["'](\.[^"']+\.js)["']/g,
+      );
+
+      return Array.from(matches, (match) => ({
+        filePath: path.relative(projectDir, filePath),
+        specifier: match[1],
+      }));
+    });
+
+  assert.deepEqual(offenders, []);
+});

--- a/opencode-plugin/tests/tui-setup.test.ts
+++ b/opencode-plugin/tests/tui-setup.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { buildSetupActionOptions } from "../src/tui/index.js";
+import {
+  buildScopeProfileOptions,
+  buildSetupActionOptions,
+} from "../src/tui/index.js";
 
 test("buildSetupActionOptions shows only API key actions when no usable profile exists", () => {
   const options = buildSetupActionOptions({
@@ -8,8 +11,19 @@ test("buildSetupActionOptions shows only API key actions when no usable profile 
   });
 
   assert.deepEqual(
-    options.map((option) => option.value),
-    ["auto-api-key", "manual-api-key"],
+    options,
+    [
+      {
+        title: "Get a mem9 API key automatically",
+        value: "auto-api-key",
+        description: "Request a new mem9 API key and save it as a profile.",
+      },
+      {
+        title: "Add an existing mem9 API key",
+        value: "manual-api-key",
+        description: "Paste a mem9 API key and save it as a profile.",
+      },
+    ],
   );
 });
 
@@ -21,17 +35,72 @@ test("buildSetupActionOptions shows scope actions after usable profiles exist", 
         label: "Personal",
         baseUrl: "https://api.mem9.ai",
         hasApiKey: true,
+        apiKeyPreview: "mk_d...ault",
       },
     ],
   });
 
   assert.deepEqual(
-    options.map((option) => option.value),
+    options,
     [
-      "auto-api-key",
-      "manual-api-key",
-      "use-profile-in-scope",
-      "configure-scope",
+      {
+        title: "Get a mem9 API key automatically",
+        value: "auto-api-key",
+        description: "Request a new mem9 API key and save it as a profile.",
+      },
+      {
+        title: "Add an existing mem9 API key",
+        value: "manual-api-key",
+        description: "Paste a mem9 API key and save it as a profile.",
+      },
+      {
+        title: "Use an existing mem9 profile in a scope",
+        value: "use-profile-in-scope",
+        description: "Choose which saved profile user or project settings should use.",
+      },
+      {
+        title: "Adjust scope settings",
+        value: "configure-scope",
+        description: "Change debug logging, request timeouts, and other mem9 settings for a user or project scope.",
+      },
     ],
   );
+});
+
+test("buildScopeProfileOptions shows masked API key previews and disables incomplete profiles", () => {
+  const options = buildScopeProfileOptions({
+    profiles: [
+      {
+        profileId: "default",
+        label: "Personal",
+        baseUrl: "https://api.mem9.ai",
+        hasApiKey: true,
+        apiKeyPreview: "mk_d...ault",
+      },
+      {
+        profileId: "acme",
+        label: "Acme Production",
+        baseUrl: "https://acme.mem9.ai",
+        hasApiKey: false,
+        apiKeyPreview: "",
+      },
+    ],
+  }, {
+    currentProfileId: "default",
+  });
+
+  assert.deepEqual(options, [
+    {
+      title: "Personal (default)",
+      value: "default",
+      description: "mk_d...ault | https://api.mem9.ai | Current in this scope",
+      disabled: false,
+    },
+    {
+      title: "Acme Production (acme)",
+      value: "acme",
+      description: "API key missing | https://acme.mem9.ai",
+      disabled: true,
+    },
+  ]);
 });

--- a/opencode-plugin/tsconfig.json
+++ b/opencode-plugin/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,

--- a/opencode-plugin/tsconfig.test.json
+++ b/opencode-plugin/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "allowImportingTsExtensions": false,
+    "allowImportingTsExtensions": true,
     "outDir": "./dist-test"
   },
   "exclude": ["node_modules", "dist", "dist-test"]


### PR DESCRIPTION
## Summary
- improve the OpenCode setup flow with clearer scope actions, masked profile previews, and current-profile hints
- simplify the package exports and rewrite the README around global install, project overrides, and cache-aware upgrades
- fix the OpenCode publish workflow so patch releases can run cleanly from a feature branch and ship the raw TS TUI entrypoint correctly

## Verification
- pnpm --dir opencode-plugin test
- pnpm --dir opencode-plugin run typecheck
- pnpm --dir opencode-plugin pack --dry-run
