### PR TITLE
fix(claude-plugin): drop agent_id filter from recall query

### DIFF
--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -51,7 +51,7 @@ SessionStart(startup)
   -> create auth.json if missing
 
 UserPromptSubmit
-  -> GET /v1alpha2/mem9s/memories?q=...&agent_id=claude-code-main
+  -> GET /v1alpha2/mem9s/memories?q=...
   -> inject <relevant-memories>...</relevant-memories>
 
 Stop
@@ -70,11 +70,13 @@ SessionEnd
 Automatic recall uses:
 
 ```text
-GET /v1alpha2/mem9s/memories?q=<prompt>&agent_id=claude-code-main&limit=10
+GET /v1alpha2/mem9s/memories?q=<prompt>&limit=10
 Headers:
   X-API-Key: <api_key>
   X-Mnemo-Agent-Id: claude-code
 ```
+
+Recall intentionally omits `agent_id` so every agent bucket in the account (e.g. other plugins) contributes to the result set. Ingest still scopes writes by `agent_id` (see below).
 
 Automatic transcript ingest uses:
 

--- a/claude-plugin/hooks/user-prompt-submit.sh
+++ b/claude-plugin/hooks/user-prompt-submit.sh
@@ -36,7 +36,7 @@ mem9_debug "UserPromptSubmit" "recall_request" \
   "auth_source" "${MEM9_AUTH_SOURCE:-unknown}"
 
 encoded_prompt="$(printf '%s' "${prompt}" | node -e 'const fs=require("node:fs"); const raw=fs.readFileSync(0, "utf8").trim(); process.stdout.write(encodeURIComponent(raw));')"
-if ! response="$(mem9_api_get "/memories?q=${encoded_prompt}&agent_id=${MEM9_AGENT_ID}&limit=10" 2>/dev/null)"; then
+if ! response="$(mem9_api_get "/memories?q=${encoded_prompt}&limit=10" 2>/dev/null)"; then
   mem9_debug "UserPromptSubmit" "recall_request_failed" \
     "prompt_length" "${#prompt}"
   exit 0

--- a/claude-plugin/skills/recall/SKILL.md
+++ b/claude-plugin/skills/recall/SKILL.md
@@ -15,7 +15,7 @@ Use this skill when the current request could benefit from historical context st
 
 1. Check `${CLAUDE_PLUGIN_DATA}/auth.json`. If it is missing, tell the user to run `/mem9:setup` first.
 2. Use `${CLAUDE_PLUGIN_DATA}/auth.json` only as request credentials. Do not print the file contents or the API key.
-3. Search Mem9 with the current question and `agent_id=claude-code-main`.
+3. Search Mem9 with the current question across all agents in the account (no `agent_id` filter).
 
 ```bash
 set -euo pipefail
@@ -35,7 +35,7 @@ curl -sf --max-time 8 \
   -H "Content-Type: application/json" \
   -H "X-API-Key: ${api_key}" \
   -H "X-Mnemo-Agent-Id: claude-code" \
-  "${base_url%/}/v1alpha2/mem9s/memories?q=${encoded_query}&agent_id=claude-code-main&limit=10"
+  "${base_url%/}/v1alpha2/mem9s/memories?q=${encoded_query}&limit=10"
 ```
 
 Return only the memories that help with the current question. Never reveal secret values.


### PR DESCRIPTION
## Summary
- The `UserPromptSubmit` hook in `claude-plugin` appended `&agent_id=${MEM9_AGENT_ID}` (default `claude-code-main`) to the recall GET URL. The server filters strictly on `agent_id`, so Claude Code could never see memories written by other agents (e.g. the `hermes` plugin), defeating the core cross-agent memory-sharing scenario.
- Drop the `agent_id` query param from the recall GET so every agent bucket in the account contributes to recall.
- **Ingest POST bodies keep `agent_id`** — write-path scoping (dedup / reconcile) is unchanged.

## Repro
Given an account with one memory under `agent_id=hermes` whose text matches `<keyword>`:

| Query | Result |
|---|---|
| `?q=<keyword>&agent_id=hermes` | total=1 ✅ |
| `?q=<keyword>&agent_id=claude-code-main` | total=0 ❌ |
| `?q=<keyword>&agent_id=random-fake-xyz` | total=0 ❌ |
| `?q=<keyword>` (no `agent_id`) | total=1 ✅ |

Confirms the server filters by `agent_id` at the HTTP layer; omitting it gives a cross-agent search.

## Test plan
- [x] `bash -n claude-plugin/hooks/user-prompt-submit.sh` — syntax OK
- [x] Hook recalls a memory written under a different `agent_id` — verified locally: `memories_count=10`, `context_injected` (length 1296) in debug log
- [x] Ingest POST body still carries `agent_id=${MEM9_AGENT_ID}` — confirmed at `claude-plugin/hooks/common.sh:261`