### PR TITLE
Parallelize recall pool searches

### DIFF
--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1142,6 +1142,92 @@ func TestListMemories_DefaultRecall_EnumerationFiltersLowConfidenceNoise(t *test
 	}
 }
 
+func TestDefaultConfidenceRecallSearch_FansOutPoolSearchesConcurrently(t *testing.T) {
+	release := make(chan struct{})
+	allStarted := make(chan struct{})
+	var (
+		mu          sync.Mutex
+		started     int
+		inFlight    int
+		maxInFlight int
+	)
+
+	enter := func(ctx context.Context) error {
+		mu.Lock()
+		started++
+		inFlight++
+		if inFlight > maxInFlight {
+			maxInFlight = inFlight
+		}
+		if started == 3 {
+			close(allStarted)
+		}
+		mu.Unlock()
+
+		defer func() {
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+		}()
+
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			if err := enter(ctx); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+	}
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			if err := enter(ctx); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+	}
+	srv := newTestServer(memRepo, sessRepo)
+	auth := &domain.AuthInfo{ClusterID: "cluster-a"}
+	svc := srv.resolveServices(auth)
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		select {
+		case <-allStarted:
+			close(release)
+		case <-ctx.Done():
+		}
+	}()
+
+	if _, _, err := srv.defaultConfidenceRecallSearch(ctx, auth, svc, domain.MemoryFilter{
+		Query: "tell me about john",
+		Limit: 10,
+	}); err != nil {
+		t.Fatalf("expected concurrent recall fan-out to complete, got %v", err)
+	}
+
+	mu.Lock()
+	gotStarted := started
+	gotMaxInFlight := maxInFlight
+	mu.Unlock()
+
+	if gotStarted != 3 {
+		t.Fatalf("expected 3 pool searches to start, got %d", gotStarted)
+	}
+	if gotMaxInFlight != 3 {
+		t.Fatalf("expected all 3 pool searches to overlap, max_in_flight=%d", gotMaxInFlight)
+	}
+}
+
 func TestListMemories_DefaultRecall_PrefersSessionForChineseExactQuery(t *testing.T) {
 	now := time.Now()
 	memRepo := &testMemoryRepo{

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -24,6 +24,7 @@ import (
 
 // testMemoryRepo is a minimal MemoryRepo mock for handler tests.
 type testMemoryRepo struct {
+	mu                   sync.Mutex
 	createCalls          []*domain.Memory
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
@@ -36,11 +37,15 @@ type testMemoryRepo struct {
 }
 
 func (m *testMemoryRepo) Create(_ context.Context, mem *domain.Memory) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.createCalls = append(m.createCalls, mem)
 	return nil
 }
 
 func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for _, mem := range m.createCalls {
 		if mem.ID == id {
 			cp := *mem
@@ -52,11 +57,15 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 func (m *testMemoryRepo) UpdateOptimistic(context.Context, *domain.Memory, int) error { return nil }
 func (m *testMemoryRepo) SoftDelete(context.Context, string, string) error            { return nil }
 func (m *testMemoryRepo) BulkSoftDelete(_ context.Context, ids []string, _ string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.bulkSoftDeleteCalls = append(m.bulkSoftDeleteCalls, append([]string(nil), ids...))
 	return m.bulkSoftDeleteResult, nil
 }
 func (m *testMemoryRepo) ArchiveMemory(context.Context, string, string) error { return nil }
 func (m *testMemoryRepo) ArchiveAndCreate(_ context.Context, _, _ string, mem *domain.Memory) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.createCalls = append(m.createCalls, mem)
 	return nil
 }
@@ -75,11 +84,15 @@ func (m *testMemoryRepo) AutoVectorSearch(context.Context, string, domain.Memory
 }
 
 func (m *testMemoryRepo) KeywordSearch(ctx context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	m.mu.Lock()
 	m.lastKeywordFilter = filter
-	if m.keywordSearchHook != nil {
-		return m.keywordSearchHook(ctx, query, filter, limit)
+	hook := m.keywordSearchHook
+	results := append([]domain.Memory(nil), m.keywordSearchResults...)
+	m.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, query, filter, limit)
 	}
-	return append([]domain.Memory(nil), m.keywordSearchResults...), nil
+	return results, nil
 }
 
 func (m *testMemoryRepo) FTSSearch(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
@@ -100,6 +113,7 @@ func (m *testMemoryRepo) CountStats(context.Context) (int64, int64, error) {
 
 // testSessionRepo is a minimal SessionRepo mock for handler tests.
 type testSessionRepo struct {
+	mu                   sync.Mutex
 	bulkCreateCalled     bool
 	patchTagsCalled      bool
 	patchedHash          string
@@ -112,12 +126,16 @@ type testSessionRepo struct {
 }
 
 func (s *testSessionRepo) BulkCreate(_ context.Context, sessions []*domain.Session) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.bulkCreateCalled = true
 	s.sessions = sessions
 	return nil
 }
 
 func (s *testSessionRepo) PatchTags(_ context.Context, sessionID, hash string, tags []string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.patchTagsCalled = true
 	s.patchedSessionID = sessionID
 	s.patchedHash = hash
@@ -138,11 +156,15 @@ func (s *testSessionRepo) FTSSearch(context.Context, string, domain.MemoryFilter
 }
 
 func (s *testSessionRepo) KeywordSearch(ctx context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	s.mu.Lock()
 	s.lastKeywordFilter = filter
-	if s.keywordSearchHook != nil {
-		return s.keywordSearchHook(ctx, query, filter, limit)
+	hook := s.keywordSearchHook
+	results := append([]domain.Memory(nil), s.keywordSearchResults...)
+	s.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, query, filter, limit)
 	}
-	return append([]domain.Memory(nil), s.keywordSearchResults...), nil
+	return results, nil
 }
 func (s *testSessionRepo) FTSAvailable() bool { return false }
 func (s *testSessionRepo) ListBySessionIDs(context.Context, []string, int) ([]*domain.Session, error) {

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -9,6 +9,8 @@ import (
 	"time"
 	"unicode"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
@@ -127,22 +129,47 @@ func (s *Server) defaultConfidenceRecallSearch(
 	sessionFilter := filter
 	sessionFilter.Limit = recallCandidateLimit(profile.shape, service.RecallSourceSession)
 
-	pinnedStart := time.Now()
-	pinnedCandidates, err := svc.memory.SearchCandidates(ctx, pinnedFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
-	pinnedDuration := time.Since(pinnedStart)
-	if err != nil {
-		return nil, 0, err
-	}
-	insightStart := time.Now()
-	insightCandidates, err := svc.memory.SearchCandidates(ctx, insightFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
-	insightDuration := time.Since(insightStart)
-	if err != nil {
-		return nil, 0, err
-	}
-	sessionStart := time.Now()
-	sessionCandidates, err := svc.session.SearchCandidates(ctx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
-	sessionDuration := time.Since(sessionStart)
-	if err != nil {
+	var (
+		pinnedCandidates  []service.RecallCandidate
+		insightCandidates []service.RecallCandidate
+		sessionCandidates []service.RecallCandidate
+		pinnedDuration    time.Duration
+		insightDuration   time.Duration
+		sessionDuration   time.Duration
+	)
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		branchStart := time.Now()
+		candidates, err := svc.memory.SearchCandidates(groupCtx, pinnedFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
+		pinnedDuration = time.Since(branchStart)
+		if err != nil {
+			return err
+		}
+		pinnedCandidates = candidates
+		return nil
+	})
+	group.Go(func() error {
+		branchStart := time.Now()
+		candidates, err := svc.memory.SearchCandidates(groupCtx, insightFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
+		insightDuration = time.Since(branchStart)
+		if err != nil {
+			return err
+		}
+		insightCandidates = candidates
+		return nil
+	})
+	group.Go(func() error {
+		branchStart := time.Now()
+		candidates, err := svc.session.SearchCandidates(groupCtx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
+		sessionDuration = time.Since(branchStart)
+		if err != nil {
+			return err
+		}
+		sessionCandidates = candidates
+		return nil
+	})
+	if err := group.Wait(); err != nil {
 		return nil, 0, err
 	}
 


### PR DESCRIPTION
## Summary
- run the pinned, insight, and session candidate searches concurrently in `defaultConfidenceRecallSearch()`
- keep recall selection and scoring behavior unchanged after all three candidate sets return
- add a regression test that verifies the three pool searches overlap in flight
- make the handler test repos concurrency-safe so `go test -race` stays clean after the recall fan-out change

## Why
- the current recall path executes three independent search legs sequentially, which adds their latencies directly to end-to-end recall time

## Testing
- `go test -race -count=1 ./internal/handler`
- `make test-cover`

## Notes
- the per-branch recall timing fields (`pinned_ms`, `insight_ms`, `session_ms`) now represent parallel branch durations, so they should not be expected to sum to `total_ms`