### PR TITLE
chore(claude-plugin): bump plugin manifest to v0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "mem9",
       "source": "./claude-plugin",
       "description": "Persistent cloud memory for Claude Code with automatic recall, transcript ingest, and on-demand setup, recall, and store skills.",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "homepage": "https://mem9.ai",
       "repository": "https://github.com/mem9-ai/mem9",
       "license": "Apache-2.0"

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Persistent cloud memory for Claude Code. Requires Node.js 18+, auto-initializes auth on startup, recalls memories on each user turn, and uploads structured conversation turns to mem9.",
   "author": {
     "name": "mem9-ai"


### PR DESCRIPTION
## Summary
- bump `claude-plugin/.claude-plugin/plugin.json` from `0.3.0` to `0.3.1`
- bump the root Claude marketplace manifest at `.claude-plugin/marketplace.json` to `0.3.1`
- publish a patch version after the cross-agent recall fix merged in #266

## Why
Claude Code uses the plugin manifest and marketplace metadata versions to surface updates. Keeping both manifests aligned at `0.3.1` gives installed users a clean upgrade path to the cross-agent recall fix from #266.

## Test plan
- [x] inspected the manifest diffs
- [x] confirmed the change is limited to the Claude plugin version metadata files