### PR TITLE
[codex] Move source-turn handling into server

### DIFF
--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -156,10 +156,11 @@ type Phase1Result struct {
 
 // ExtractedFact holds a single atomic fact and the tags the LLM assigned to it.
 type ExtractedFact struct {
-	Text     string            `json:"text"`
-	Tags     []string          `json:"tags,omitempty"`
-	FactType string            `json:"fact_type,omitempty"` // "fact" | "query_intent" | "raw_fallback"; omitted = "fact"
-	Temporal *TemporalMetadata `json:"-"`
+	Text       string            `json:"text"`
+	Tags       []string          `json:"tags,omitempty"`
+	FactType   string            `json:"fact_type,omitempty"` // "fact" | "query_intent" | "raw_fallback"; omitted = "fact"
+	SourceSeqs []int             `json:"source_seqs,omitempty"`
+	Temporal   *TemporalMetadata `json:"-"`
 }
 
 // dropQueryIntentFacts removes facts classified as query_intent by the extraction
@@ -279,13 +280,13 @@ func buildRawFallbackFacts(input preparedExtractionInput, reason string) []Extra
 		return nil
 	}
 	slog.Warn("using raw fallback fact", "reason", reason, "len", len(text))
-	return normalizeRawFallbackFacts(input, []ExtractedFact{buildRawFallbackFact(text)})
+	return annotateFactsWithSourceSeqs(input, normalizeRawFallbackFacts(input, []ExtractedFact{buildRawFallbackFact(text)}))
 }
 
 func finalizeExtractedFacts(input preparedExtractionInput, parsed []ExtractedFact, emptyReason string) []ExtractedFact {
 	facts := dropQueryIntentFacts(parsed)
 	if len(facts) > 0 {
-		return normalizeTemporalFacts(input, facts)
+		return annotateFactsWithSourceSeqs(input, normalizeTemporalFacts(input, facts))
 	}
 	reason := emptyReason
 	if len(parsed) > 0 {
@@ -372,7 +373,7 @@ func (s *IngestService) ExtractPhase1(ctx context.Context, messages []IngestMess
 		return nil, err
 	}
 	return &Phase1Result{
-		Facts:       facts,
+		Facts:       annotateFactsWithSourceSeqs(input, facts),
 		MessageTags: expandMessageTags(messageTags, input, len(messages)),
 	}, nil
 }
@@ -1200,6 +1201,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 			if normalizedText == "" {
 				continue
 			}
+			sourceSeqs := sourceSeqsForReconcileText(event.Text, facts)
 			newID, addErr := s.addInsight(
 				ctx,
 				agentName,
@@ -1207,7 +1209,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				sessionID,
 				normalizedText,
 				ensureRawFallbackTag(event.Tags, facts),
-				MergeTemporalMetadata(nil, temporal),
+				SetSourceSeqMetadata(MergeTemporalMetadata(nil, temporal), sourceSeqs),
 			)
 			if addErr != nil {
 				slog.Warn("failed to add insight", "err", addErr)
@@ -1237,7 +1239,8 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				effectiveTags = existingMemories[intID].Tags
 			}
 			effectiveTags = ensureRawFallbackTag(effectiveTags, facts)
-			metadata := MergeTemporalMetadata(existingMemories[intID].Metadata, temporal)
+			sourceSeqs := sourceSeqsForReconcileText(event.Text, facts)
+			metadata := SetSourceSeqMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs)
 			if existingMemories[intID].MemoryType == domain.TypePinned {
 				slog.Warn("skipping UPDATE for pinned memory — treating as ADD", "id", realID)
 				newID, addErr := s.addInsight(ctx, agentName, agentID, sessionID, normalizedText, effectiveTags, metadata)
@@ -1493,7 +1496,7 @@ func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, ses
 	var ids []string
 	var warnings int
 	for _, fact := range facts {
-		id, err := s.addInsight(ctx, agentName, agentID, sessionID, fact.Text, fact.Tags, MergeTemporalMetadata(nil, fact.Temporal))
+		id, err := s.addInsight(ctx, agentName, agentID, sessionID, fact.Text, fact.Tags, metadataForExtractedFact(fact))
 		if err != nil {
 			slog.Warn("failed to add fact", "err", err, "fact_len", len(fact.Text))
 			warnings++

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -156,11 +156,12 @@ type Phase1Result struct {
 
 // ExtractedFact holds a single atomic fact and the tags the LLM assigned to it.
 type ExtractedFact struct {
-	Text       string            `json:"text"`
-	Tags       []string          `json:"tags,omitempty"`
-	FactType   string            `json:"fact_type,omitempty"` // "fact" | "query_intent" | "raw_fallback"; omitted = "fact"
-	SourceSeqs []int             `json:"source_seqs,omitempty"`
-	Temporal   *TemporalMetadata `json:"-"`
+	Text        string               `json:"text"`
+	Tags        []string             `json:"tags,omitempty"`
+	FactType    string               `json:"fact_type,omitempty"` // "fact" | "query_intent" | "raw_fallback"; omitted = "fact"
+	SourceSeqs  []int                `json:"source_seqs,omitempty"`
+	SourceTurns []sourceTurnMetadata `json:"source_turns,omitempty"`
+	Temporal    *TemporalMetadata    `json:"-"`
 }
 
 // dropQueryIntentFacts removes facts classified as query_intent by the extraction
@@ -1240,7 +1241,8 @@ Analyze the new facts and determine whether each should be added, updated, or de
 			}
 			effectiveTags = ensureRawFallbackTag(effectiveTags, facts)
 			sourceSeqs := sourceSeqsForReconcileText(event.Text, facts)
-			metadata := SetSourceSeqMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs)
+			sourceTurns := sourceTurnsForReconcileText(event.Text, facts)
+			metadata := SetSourceProvenanceMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs, sourceTurns)
 			if existingMemories[intID].MemoryType == domain.TypePinned {
 				slog.Warn("skipping UPDATE for pinned memory — treating as ADD", "id", realID)
 				newID, addErr := s.addInsight(ctx, agentName, agentID, sessionID, normalizedText, effectiveTags, metadata)

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -1203,6 +1203,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				continue
 			}
 			sourceSeqs := sourceSeqsForReconcileText(event.Text, facts)
+			sourceTurns := sourceTurnsForReconcileText(event.Text, facts)
 			newID, addErr := s.addInsight(
 				ctx,
 				agentName,
@@ -1210,7 +1211,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				sessionID,
 				normalizedText,
 				ensureRawFallbackTag(event.Tags, facts),
-				SetSourceSeqMetadata(MergeTemporalMetadata(nil, temporal), sourceSeqs),
+				SetSourceProvenanceMetadata(MergeTemporalMetadata(nil, temporal), sourceSeqs, sourceTurns),
 			)
 			if addErr != nil {
 				slog.Warn("failed to add insight", "err", addErr)

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -433,6 +433,44 @@ func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
 	}
 }
 
+func TestReconcilePhase2AddPersistsSourceTurnMetadata(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{}
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "sess-1", []ExtractedFact{
+		{
+			Text:       "Jon lost his job, which motivated him to start a dance studio",
+			Tags:       []string{"work"},
+			SourceSeqs: []int{4, 2, 4},
+			SourceTurns: []sourceTurnMetadata{
+				{Seq: 4, Content: "[date:1 January 2023] [speaker:Jon] I lost my job and decided to start a dance studio."},
+				{Seq: 2, Content: "[date:1 January 2023] [speaker:Gina] You should open your own studio."},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReconcilePhase2() error = %v", err)
+	}
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("expected 1 created memory, got %d", len(memRepo.createCalls))
+	}
+	var metadata struct {
+		SourceSeqs  []int                `json:"source_seqs"`
+		SourceTurns []sourceTurnMetadata `json:"source_turns"`
+	}
+	if err := json.Unmarshal(memRepo.createCalls[0].Metadata, &metadata); err != nil {
+		t.Fatalf("metadata unmarshal error = %v", err)
+	}
+	if !reflect.DeepEqual(metadata.SourceSeqs, []int{2, 4}) {
+		t.Fatalf("source_seqs = %v, want [2 4]", metadata.SourceSeqs)
+	}
+	if len(metadata.SourceTurns) != 2 || metadata.SourceTurns[0].Seq != 2 || metadata.SourceTurns[1].Seq != 4 {
+		t.Fatalf("source_turns = %+v, want seqs [2 4]", metadata.SourceTurns)
+	}
+}
+
 func TestSetSourceSeqMetadataClearsStaleSourceSeqs(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -368,6 +368,80 @@ func TestExtractPhase1FactTagsPopulated(t *testing.T) {
 	}
 }
 
+func TestExtractPhase1AnnotatesSourceSeqs(t *testing.T) {
+	t.Parallel()
+
+	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		resp := `{"facts": [{"text": "Jon lost his job, which motivated him to start his own dance studio", "tags": ["work", "dance"]}], "message_tags": [["career"], ["answer"]]}`
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": resp}},
+			},
+		})
+	}))
+	defer mockLLM.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	result, err := svc.ExtractPhase1(context.Background(), []IngestMessage{
+		{Role: "user", Content: "[date:1 January 2023] [speaker:Jon] I lost my job and decided to start my own dance studio.", Seq: intPtr(41)},
+		{Role: "assistant", Content: "That is a big step.", Seq: intPtr(42)},
+	})
+	if err != nil {
+		t.Fatalf("ExtractPhase1() error = %v", err)
+	}
+	if len(result.Facts) != 1 {
+		t.Fatalf("expected 1 fact, got %d", len(result.Facts))
+	}
+	if !reflect.DeepEqual(result.Facts[0].SourceSeqs, []int{41}) {
+		t.Fatalf("expected source seq [41], got %v", result.Facts[0].SourceSeqs)
+	}
+}
+
+func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{}
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "sess-1", []ExtractedFact{
+		{Text: "Jon lost his job, which motivated him to start a dance studio", Tags: []string{"work"}, SourceSeqs: []int{4, 2, 4}},
+	})
+	if err != nil {
+		t.Fatalf("ReconcilePhase2() error = %v", err)
+	}
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("expected 1 created memory, got %d", len(memRepo.createCalls))
+	}
+	var metadata struct {
+		SourceSeqs []int `json:"source_seqs"`
+	}
+	if err := json.Unmarshal(memRepo.createCalls[0].Metadata, &metadata); err != nil {
+		t.Fatalf("metadata unmarshal error = %v", err)
+	}
+	if !reflect.DeepEqual(metadata.SourceSeqs, []int{2, 4}) {
+		t.Fatalf("source_seqs = %v, want [2 4]", metadata.SourceSeqs)
+	}
+}
+
+func TestSetSourceSeqMetadataClearsStaleSourceSeqs(t *testing.T) {
+	t.Parallel()
+
+	metadata := SetSourceSeqMetadata(json.RawMessage(`{"source_seqs":[1,2],"temporal":{"display":"2023"}}`), nil)
+	var decoded map[string]any
+	if err := json.Unmarshal(metadata, &decoded); err != nil {
+		t.Fatalf("metadata unmarshal error = %v", err)
+	}
+	if _, ok := decoded["source_seqs"]; ok {
+		t.Fatalf("source_seqs should be removed from metadata: %s", metadata)
+	}
+	if _, ok := decoded["temporal"]; !ok {
+		t.Fatalf("temporal metadata should be preserved: %s", metadata)
+	}
+}
+
 func TestExtractFactsSingleMessageUsesLLMExtraction(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -398,6 +398,9 @@ func TestExtractPhase1AnnotatesSourceSeqs(t *testing.T) {
 	if !reflect.DeepEqual(result.Facts[0].SourceSeqs, []int{41}) {
 		t.Fatalf("expected source seq [41], got %v", result.Facts[0].SourceSeqs)
 	}
+	if len(result.Facts[0].SourceTurns) != 1 || result.Facts[0].SourceTurns[0].Seq != 41 {
+		t.Fatalf("expected source turn seq [41], got %+v", result.Facts[0].SourceTurns)
+	}
 }
 
 func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
@@ -416,13 +419,17 @@ func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
 		t.Fatalf("expected 1 created memory, got %d", len(memRepo.createCalls))
 	}
 	var metadata struct {
-		SourceSeqs []int `json:"source_seqs"`
+		SourceSeqs  []int                `json:"source_seqs"`
+		SourceTurns []sourceTurnMetadata `json:"source_turns"`
 	}
 	if err := json.Unmarshal(memRepo.createCalls[0].Metadata, &metadata); err != nil {
 		t.Fatalf("metadata unmarshal error = %v", err)
 	}
 	if !reflect.DeepEqual(metadata.SourceSeqs, []int{2, 4}) {
 		t.Fatalf("source_seqs = %v, want [2 4]", metadata.SourceSeqs)
+	}
+	if len(metadata.SourceTurns) != 0 {
+		t.Fatalf("source_turns should be empty when facts did not provide turn payloads, got %+v", metadata.SourceTurns)
 	}
 }
 

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -152,7 +152,7 @@ func (s *MemoryService) Search(ctx context.Context, filter domain.MemoryFilter) 
 		if err != nil {
 			return nil, 0, err
 		}
-		return populateRelativeAge(mems), total, nil
+			return finalizeSearchResults(mems, filter.Query), total, nil
 	}
 	searchFilter := filter
 	searchFilter.SessionID = ""
@@ -246,7 +246,7 @@ func (s *MemoryService) ftsOnlySearch(ctx context.Context, filter domain.MemoryF
 	slog.Info("fts search completed", "query_len", len(filter.Query), "results", len(ftsResults))
 
 	page, total := s.paginate(ftsResults, offset, limit)
-	return populateRelativeAge(page), total, nil
+	return finalizeSearchResults(page, filter.Query), total, nil
 }
 
 func observeRecallEmbeddingRequest(embedder *embed.Embedder, err error) {
@@ -294,7 +294,7 @@ func (s *MemoryService) keywordOnlySearch(ctx context.Context, filter domain.Mem
 	slog.Info("keyword search completed (FTS unavailable)", "query_len", len(filter.Query), "results", len(kwResults))
 
 	page, total := s.paginate(kwResults, offset, limit)
-	return populateRelativeAge(page), total, nil
+	return finalizeSearchResults(page, filter.Query), total, nil
 }
 
 func (s *MemoryService) ftsOnlyCandidates(ctx context.Context, filter domain.MemoryFilter, sourcePool RecallSourcePool, opts RecallCandidateOptions) ([]RecallCandidate, error) {
@@ -378,7 +378,7 @@ func (s *MemoryService) hybridSearch(ctx context.Context, filter domain.MemoryFi
 	merged := sortByScore(mems, scores)
 
 	page, total := s.paginate(merged, offset, limit)
-	return populateRelativeAge(setScores(page, scores)), total, nil
+	return finalizeSearchResults(setScores(page, scores), filter.Query), total, nil
 }
 
 func (s *MemoryService) hybridCandidates(ctx context.Context, filter domain.MemoryFilter, sourcePool RecallSourcePool, opts RecallCandidateOptions) ([]RecallCandidate, error) {
@@ -487,7 +487,7 @@ func (s *MemoryService) autoHybridSearch(ctx context.Context, filter domain.Memo
 	merged := sortByScore(mems, scores)
 
 	page, total := s.paginate(merged, offset, limit)
-	return populateRelativeAge(setScores(page, scores)), total, nil
+	return finalizeSearchResults(setScores(page, scores), filter.Query), total, nil
 }
 
 func (s *MemoryService) autoHybridCandidates(

--- a/server/internal/service/search_source_turns.go
+++ b/server/internal/service/search_source_turns.go
@@ -1,0 +1,292 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+const (
+	defaultSearchSourceTurnMinScore     = 2
+	defaultSearchSourceTurnPerMemoryCap = 2
+	defaultSearchSourceTurnTotalCap     = 12
+)
+
+var targetSpeakerQuestionRe = regexp.MustCompile(`(?i)\bhow\s+(?:does|did)\s+([a-z][a-z'-]*)\s+(?:describe|feel|respond|react|view|think|say)\b`)
+
+type searchSourceTurnCandidate struct {
+	memoryIndex int
+	score       int
+	sourceOrder int
+	turn        sourceTurnMetadata
+}
+
+func finalizeSearchResults(memories []domain.Memory, query string) []domain.Memory {
+	return populateRelativeAge(decorateSearchResultsWithSourceTurns(memories, query))
+}
+
+func decorateSearchResultsWithSourceTurns(memories []domain.Memory, query string) []domain.Memory {
+	if len(memories) == 0 || strings.TrimSpace(query) == "" {
+		return memories
+	}
+
+	selectedByMemory := selectSearchSourceTurns(memories, query)
+	out := make([]domain.Memory, len(memories))
+	copy(out, memories)
+	for i := range out {
+		if !shouldDecorateSearchMemory(out[i]) {
+			continue
+		}
+		selected := selectedByMemory[i]
+		out[i].Metadata = SetSourceProvenanceMetadata(out[i].Metadata, sourceTurnSeqs(selected), selected)
+		if len(selected) == 0 {
+			continue
+		}
+		out[i].Content = formatSearchMemoryWithSourceTurns(out[i].Content, selected)
+	}
+	return out
+}
+
+func selectSearchSourceTurns(memories []domain.Memory, query string) map[int][]sourceTurnMetadata {
+	minScore := readPositiveEnvInt("MEM9_SOURCE_TURN_MIN_SCORE", defaultSearchSourceTurnMinScore)
+	perMemoryCap := readPositiveEnvInt("MEM9_SOURCE_TURN_PER_MEMORY_LIMIT", defaultSearchSourceTurnPerMemoryCap)
+	totalCap := readPositiveEnvInt("MEM9_SOURCE_TURN_TOTAL_LIMIT", defaultSearchSourceTurnTotalCap)
+
+	candidates := make([]searchSourceTurnCandidate, 0)
+	for memoryIndex, memory := range memories {
+		if !shouldDecorateSearchMemory(memory) {
+			continue
+		}
+		turns := parseSourceTurnsFromMetadata(memory.Metadata)
+		for sourceOrder, turn := range turns {
+			score := scoreSearchSourceTurn(query, memory.Content, turn.Content)
+			if score < minScore {
+				continue
+			}
+			candidates = append(candidates, searchSourceTurnCandidate{
+				memoryIndex: memoryIndex,
+				score:       score,
+				sourceOrder: sourceOrder,
+				turn:        turn,
+			})
+		}
+	}
+	if len(candidates) == 0 {
+		return map[int][]sourceTurnMetadata{}
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		if candidates[i].memoryIndex != candidates[j].memoryIndex {
+			return candidates[i].memoryIndex < candidates[j].memoryIndex
+		}
+		return candidates[i].sourceOrder < candidates[j].sourceOrder
+	})
+
+	perMemoryCounts := make(map[int]int, len(memories))
+	selectedByMemory := make(map[int][]sourceTurnMetadata, len(memories))
+	selectedOrders := make(map[int][]int, len(memories))
+	selectedTotal := 0
+	for _, candidate := range candidates {
+		if selectedTotal >= totalCap {
+			break
+		}
+		if perMemoryCounts[candidate.memoryIndex] >= perMemoryCap {
+			continue
+		}
+		perMemoryCounts[candidate.memoryIndex]++
+		selectedTotal++
+		selectedByMemory[candidate.memoryIndex] = append(selectedByMemory[candidate.memoryIndex], candidate.turn)
+		selectedOrders[candidate.memoryIndex] = append(selectedOrders[candidate.memoryIndex], candidate.sourceOrder)
+	}
+
+	for memoryIndex, turns := range selectedByMemory {
+		orders := selectedOrders[memoryIndex]
+		sort.SliceStable(turns, func(i, j int) bool {
+			return orders[i] < orders[j]
+		})
+		selectedByMemory[memoryIndex] = turns
+	}
+	return selectedByMemory
+}
+
+func shouldDecorateSearchMemory(memory domain.Memory) bool {
+	if memory.MemoryType != domain.TypeInsight {
+		return false
+	}
+	if strings.Contains(memory.Content, "\n[source-turns]\n") {
+		return false
+	}
+	if hasSearchDirectSeq(memory.Metadata) {
+		return false
+	}
+	return len(parseSourceTurnsFromMetadata(memory.Metadata)) > 0
+}
+
+func hasSearchDirectSeq(metadata json.RawMessage) bool {
+	if len(metadata) == 0 {
+		return false
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &payload); err != nil {
+		return false
+	}
+	_, ok := parseJSONInt(payload["seq"])
+	return ok
+}
+
+func parseSourceTurnsFromMetadata(metadata json.RawMessage) []sourceTurnMetadata {
+	if len(metadata) == 0 {
+		return nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &payload); err != nil {
+		return nil
+	}
+	rawTurns, ok := payload[sourceTurnsMetadataKey]
+	if !ok || len(rawTurns) == 0 {
+		return nil
+	}
+	var turns []sourceTurnMetadata
+	if err := json.Unmarshal(rawTurns, &turns); err != nil {
+		return nil
+	}
+	return normalizeSourceTurns(nil, turns)
+}
+
+func parseJSONInt(raw json.RawMessage) (int, bool) {
+	var num int
+	if err := json.Unmarshal(raw, &num); err == nil {
+		return num, true
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return 0, false
+	}
+	return parsePositiveInt(s)
+}
+
+func sourceTurnSeqs(turns []sourceTurnMetadata) []int {
+	seqs := make([]int, 0, len(turns))
+	for _, turn := range turns {
+		seqs = append(seqs, turn.Seq)
+	}
+	return normalizeSourceSeqs(seqs)
+}
+
+func formatSearchMemoryWithSourceTurns(content string, turns []sourceTurnMetadata) string {
+	if len(turns) == 0 {
+		return content
+	}
+	parts := make([]string, 0, len(turns))
+	for _, turn := range turns {
+		parts = append(parts, turn.Content)
+	}
+	return content + "\n[source-turns]\n" + strings.Join(parts, "\n")
+}
+
+func scoreSearchSourceTurn(question, memoryContent, sourceContent string) int {
+	questionTokens := tokenizeForSourceTurnScoring(question)
+	sourceTokens := tokenSet(tokenizeForSourceTurnScoring(sourceContent))
+	memoryTokens := tokenSet(tokenizeForSourceTurnScoring(memoryContent))
+	speakerTokens := tokenizeForSourceTurnScoring(extractSearchSpeakerLabel(sourceContent))
+	targetSpeakerTokens := tokenSet(extractSearchTargetSpeakerTokens(question))
+	questionSet := tokenSet(questionTokens)
+
+	score := 0
+	for _, token := range questionTokens {
+		if _, ok := sourceTokens[token]; ok {
+			if len(token) >= 5 {
+				score += 3
+			} else {
+				score += 2
+			}
+		}
+	}
+	for _, token := range speakerTokens {
+		if _, ok := targetSpeakerTokens[token]; ok {
+			score += 8
+		} else if len(targetSpeakerTokens) == 0 {
+			if _, ok := questionSet[token]; ok {
+				score += 3
+			}
+		}
+	}
+
+	memoryOverlap := 0
+	for token := range memoryTokens {
+		if _, ok := questionSet[token]; ok {
+			continue
+		}
+		if _, ok := sourceTokens[token]; ok {
+			memoryOverlap++
+		}
+	}
+	score += minInt(memoryOverlap, 6)
+	return score
+}
+
+func extractSearchSpeakerLabel(content string) string {
+	match := regexp.MustCompile(`(?i)\[speaker:([^\]]+)\]`).FindStringSubmatch(content)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
+}
+
+func extractSearchTargetSpeakerTokens(question string) []string {
+	match := targetSpeakerQuestionRe.FindStringSubmatch(question)
+	if len(match) < 2 {
+		return nil
+	}
+	return tokenizeForSourceTurnScoring(match[1])
+}
+
+func tokenizeForSourceTurnScoring(text string) []string {
+	matches := sourceProvenanceTokenRe.FindAllString(strings.ToLower(text), -1)
+	out := make([]string, 0, len(matches))
+	for _, token := range matches {
+		token = strings.Trim(token, "'")
+		if len([]rune(token)) < 2 {
+			continue
+		}
+		if _, stop := sourceProvenanceStopwords[token]; stop {
+			continue
+		}
+		out = append(out, token)
+	}
+	return out
+}
+
+func tokenSet(tokens []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		set[token] = struct{}{}
+	}
+	return set
+}
+
+func readPositiveEnvInt(name string, fallback int) int {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback
+	}
+	parsed, ok := parsePositiveInt(value)
+	if !ok || parsed <= 0 {
+		return fallback
+	}
+	return parsed
+}
+
+func minInt(left, right int) int {
+	if left < right {
+		return left
+	}
+	return right
+}

--- a/server/internal/service/search_source_turns_test.go
+++ b/server/internal/service/search_source_turns_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func withSearchEnv(t *testing.T, values map[string]string, fn func()) {
+	t.Helper()
+	previous := make(map[string]string, len(values))
+	missing := make(map[string]bool, len(values))
+	for key, value := range values {
+		if current, ok := os.LookupEnv(key); ok {
+			previous[key] = current
+		} else {
+			missing[key] = true
+		}
+		if err := os.Setenv(key, value); err != nil {
+			t.Fatalf("Setenv(%q) error = %v", key, err)
+		}
+	}
+	defer func() {
+		for key := range values {
+			if missing[key] {
+				_ = os.Unsetenv(key)
+				continue
+			}
+			_ = os.Setenv(key, previous[key])
+		}
+	}()
+	fn()
+}
+
+func TestDecorateSearchResultsWithSourceTurnsSelectsSpeakerAwareTurn(t *testing.T) {
+	t.Parallel()
+
+	withSearchEnv(t, map[string]string{
+		"MEM9_SOURCE_TURN_PER_MEMORY_LIMIT": "1",
+		"MEM9_SOURCE_TURN_TOTAL_LIMIT":      "1",
+	}, func() {
+		memories := decorateSearchResultsWithSourceTurns([]domain.Memory{
+			{
+				ID:         "m1",
+				Content:    "Jon opened a dance studio after losing his job.",
+				MemoryType: domain.TypeInsight,
+				Metadata: SetSourceProvenanceMetadata(nil, []int{1, 2}, []sourceTurnMetadata{
+					{Seq: 1, Content: "[date:19 June 2023] [speaker:Jon] Thanks, Gina. Still working on opening a dance studio."},
+					{Seq: 2, Content: "[date:19 June 2023] [speaker:Gina] Congrats, Jon! The studio looks amazing."},
+				}),
+			},
+		}, "How does Gina describe the studio that Jon has opened?")
+
+		if len(memories) != 1 {
+			t.Fatalf("expected 1 memory, got %d", len(memories))
+		}
+		if strings.Contains(memories[0].Content, "[speaker:Jon]") {
+			t.Fatalf("expected Jon source turn pruned, got content %q", memories[0].Content)
+		}
+		if !strings.Contains(memories[0].Content, "[speaker:Gina]") {
+			t.Fatalf("expected Gina source turn included, got content %q", memories[0].Content)
+		}
+
+		var metadata struct {
+			SourceSeqs []int `json:"source_seqs"`
+		}
+		if err := json.Unmarshal(memories[0].Metadata, &metadata); err != nil {
+			t.Fatalf("metadata unmarshal error = %v", err)
+		}
+		if len(metadata.SourceSeqs) != 1 || metadata.SourceSeqs[0] != 2 {
+			t.Fatalf("source_seqs = %v, want [2]", metadata.SourceSeqs)
+		}
+	})
+}
+
+func TestDecorateSearchResultsWithSourceTurnsClearsUnselectedProvenance(t *testing.T) {
+	t.Parallel()
+
+	withSearchEnv(t, map[string]string{
+		"MEM9_SOURCE_TURN_MIN_SCORE": "7",
+	}, func() {
+		memories := decorateSearchResultsWithSourceTurns([]domain.Memory{
+			{
+				ID:         "m1",
+				Content:    "Jon opened a dance studio after losing his job.",
+				MemoryType: domain.TypeInsight,
+				Metadata: SetSourceProvenanceMetadata(nil, []int{1}, []sourceTurnMetadata{
+					{Seq: 1, Content: "[date:19 June 2023] [speaker:Jon] Thanks, Gina. Still working on opening a dance studio."},
+				}),
+			},
+		}, "Where did Maria buy the cake?")
+
+		if len(memories) != 1 {
+			t.Fatalf("expected 1 memory, got %d", len(memories))
+		}
+		if strings.Contains(memories[0].Content, "[source-turns]") {
+			t.Fatalf("expected no source-turn append, got content %q", memories[0].Content)
+		}
+
+		if len(memories[0].Metadata) == 0 {
+			return
+		}
+
+		var decoded map[string]any
+		if err := json.Unmarshal(memories[0].Metadata, &decoded); err != nil {
+			t.Fatalf("metadata unmarshal error = %v", err)
+		}
+		if _, ok := decoded["source_seqs"]; ok {
+			t.Fatalf("source_seqs should be cleared from decorated response metadata: %s", memories[0].Metadata)
+		}
+		if _, ok := decoded["source_turns"]; ok {
+			t.Fatalf("source_turns should be cleared from decorated response metadata: %s", memories[0].Metadata)
+		}
+	})
+}

--- a/server/internal/service/source_provenance.go
+++ b/server/internal/service/source_provenance.go
@@ -1,0 +1,353 @@
+package service
+
+import (
+	"encoding/json"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+const (
+	sourceSeqsMetadataKey = "source_seqs"
+	maxSourceSeqsPerFact  = 6
+)
+
+var sourceProvenanceTokenRe = regexp.MustCompile(`[A-Za-z]+(?:'[A-Za-z]+)?|\d+|[\p{Han}]{2,}`)
+
+var sourceProvenanceStopwords = map[string]struct{}{
+	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "by": {},
+	"did": {}, "do": {}, "does": {}, "for": {}, "from": {}, "had": {}, "has": {}, "have": {},
+	"he": {}, "her": {}, "his": {}, "how": {}, "i": {}, "in": {}, "is": {}, "it": {},
+	"me": {}, "my": {}, "of": {}, "on": {}, "or": {}, "our": {}, "she": {}, "so": {},
+	"that": {}, "the": {}, "their": {}, "them": {}, "they": {}, "this": {}, "to": {},
+	"was": {}, "we": {}, "were": {}, "what": {}, "when": {}, "where": {}, "which": {},
+	"who": {}, "why": {}, "with": {}, "you": {}, "your": {},
+	"date": {}, "speaker": {}, "user": {}, "assistant": {},
+}
+
+func annotateFactsWithSourceSeqs(input preparedExtractionInput, facts []ExtractedFact) []ExtractedFact {
+	if len(facts) == 0 {
+		return facts
+	}
+	out := make([]ExtractedFact, len(facts))
+	copy(out, facts)
+	for i := range out {
+		if len(out[i].SourceSeqs) > 0 {
+			out[i].SourceSeqs = normalizeSourceSeqs(out[i].SourceSeqs)
+			continue
+		}
+		if strings.EqualFold(out[i].FactType, factTypeRawFallback) {
+			out[i].SourceSeqs = messageSourceSeqs(input.messages)
+			continue
+		}
+		out[i].SourceSeqs = inferSourceSeqs(out[i].Text, input.messages)
+	}
+	return out
+}
+
+func metadataForExtractedFact(fact ExtractedFact) json.RawMessage {
+	return SetSourceSeqMetadata(MergeTemporalMetadata(nil, fact.Temporal), fact.SourceSeqs)
+}
+
+func MergeSourceSeqMetadata(existing json.RawMessage, seqs []int) json.RawMessage {
+	return sourceSeqMetadata(existing, seqs, true)
+}
+
+func SetSourceSeqMetadata(existing json.RawMessage, seqs []int) json.RawMessage {
+	return setSourceSeqMetadata(existing, seqs)
+}
+
+func sourceSeqMetadata(existing json.RawMessage, seqs []int, mergeExisting bool) json.RawMessage {
+	seqs = normalizeSourceSeqs(seqs)
+	if len(seqs) == 0 {
+		return existing
+	}
+
+	var payload map[string]json.RawMessage
+	if len(existing) > 0 {
+		_ = json.Unmarshal(existing, &payload)
+	}
+	if payload == nil {
+		payload = map[string]json.RawMessage{}
+	}
+
+	if mergeExisting {
+		existingRaw := payload[sourceSeqsMetadataKey]
+		seqs = normalizeSourceSeqs(append(parseSourceSeqsRaw(existingRaw), seqs...))
+	}
+	rawSeqs, err := json.Marshal(seqs)
+	if err != nil {
+		return existing
+	}
+	payload[sourceSeqsMetadataKey] = rawSeqs
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return existing
+	}
+	return raw
+}
+
+func setSourceSeqMetadata(existing json.RawMessage, seqs []int) json.RawMessage {
+	var payload map[string]json.RawMessage
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &payload); err != nil {
+			payload = nil
+		}
+	}
+	if payload == nil {
+		payload = map[string]json.RawMessage{}
+	}
+
+	seqs = normalizeSourceSeqs(seqs)
+	if len(seqs) == 0 {
+		delete(payload, sourceSeqsMetadataKey)
+		if len(payload) == 0 {
+			return nil
+		}
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return existing
+		}
+		return raw
+	}
+
+	rawSeqs, err := json.Marshal(seqs)
+	if err != nil {
+		return existing
+	}
+	payload[sourceSeqsMetadataKey] = rawSeqs
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return existing
+	}
+	return raw
+}
+
+func sourceSeqsForReconcileText(text string, facts []ExtractedFact) []int {
+	if len(facts) == 0 {
+		return nil
+	}
+	if len(facts) == 1 {
+		return normalizeSourceSeqs(facts[0].SourceSeqs)
+	}
+
+	query := sourceTokenSet(text)
+	if len(query) == 0 {
+		return nil
+	}
+
+	type candidate struct {
+		index int
+		hits  int
+	}
+	candidates := make([]candidate, 0, len(facts))
+	maxHits := 0
+	for i, fact := range facts {
+		hits := countTokenOverlap(query, sourceTokenSet(projectReconcileFactText(fact)))
+		if hits == 0 {
+			continue
+		}
+		if hits > maxHits {
+			maxHits = hits
+		}
+		candidates = append(candidates, candidate{index: i, hits: hits})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].hits != candidates[j].hits {
+			return candidates[i].hits > candidates[j].hits
+		}
+		return candidates[i].index < candidates[j].index
+	})
+
+	minHits := sourceMinHits(len(query))
+	var seqs []int
+	for _, candidate := range candidates {
+		if candidate.hits < minHits && candidate.hits < maxHits {
+			continue
+		}
+		if float64(candidate.hits) < math.Ceil(float64(maxHits)*0.6) {
+			continue
+		}
+		seqs = append(seqs, facts[candidate.index].SourceSeqs...)
+	}
+	return normalizeSourceSeqs(seqs)
+}
+
+func inferSourceSeqs(text string, messages []IngestMessage) []int {
+	query := sourceTokenSet(text)
+	if len(query) == 0 {
+		return nil
+	}
+
+	type candidate struct {
+		seq  int
+		hits int
+	}
+	var candidates []candidate
+	maxHits := 0
+	for _, msg := range messages {
+		if msg.Seq == nil || !strings.EqualFold(msg.Role, "user") {
+			continue
+		}
+		hits := countTokenOverlap(query, sourceTokenSet(msg.Content))
+		if hits == 0 {
+			continue
+		}
+		if hits > maxHits {
+			maxHits = hits
+		}
+		candidates = append(candidates, candidate{seq: *msg.Seq, hits: hits})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].hits != candidates[j].hits {
+			return candidates[i].hits > candidates[j].hits
+		}
+		return candidates[i].seq < candidates[j].seq
+	})
+
+	minHits := sourceMinHits(len(query))
+	threshold := int(math.Ceil(float64(maxHits) * 0.6))
+	if threshold < minHits {
+		threshold = minHits
+	}
+
+	seqs := make([]int, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.hits < threshold {
+			continue
+		}
+		seqs = append(seqs, candidate.seq)
+		if len(seqs) >= maxSourceSeqsPerFact {
+			break
+		}
+	}
+	return normalizeSourceSeqs(seqs)
+}
+
+func sourceMinHits(tokenCount int) int {
+	switch {
+	case tokenCount <= 2:
+		return 1
+	case tokenCount <= 7:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func sourceTokenSet(text string) map[string]struct{} {
+	matches := sourceProvenanceTokenRe.FindAllString(strings.ToLower(text), -1)
+	tokens := make(map[string]struct{}, len(matches))
+	for _, token := range matches {
+		token = strings.Trim(token, "'")
+		if len([]rune(token)) < 2 {
+			continue
+		}
+		if _, stop := sourceProvenanceStopwords[token]; stop {
+			continue
+		}
+		tokens[token] = struct{}{}
+	}
+	return tokens
+}
+
+func countTokenOverlap(left, right map[string]struct{}) int {
+	if len(left) > len(right) {
+		left, right = right, left
+	}
+	hits := 0
+	for token := range left {
+		if _, ok := right[token]; ok {
+			hits++
+		}
+	}
+	return hits
+}
+
+func messageSourceSeqs(messages []IngestMessage) []int {
+	seqs := make([]int, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Seq == nil || !strings.EqualFold(msg.Role, "user") {
+			continue
+		}
+		seqs = append(seqs, *msg.Seq)
+		if len(seqs) >= maxSourceSeqsPerFact {
+			break
+		}
+	}
+	return normalizeSourceSeqs(seqs)
+}
+
+func parseSourceSeqsRaw(raw json.RawMessage) []int {
+	var nums []int
+	if err := json.Unmarshal(raw, &nums); err == nil {
+		return nums
+	}
+	var mixed []any
+	if err := json.Unmarshal(raw, &mixed); err != nil {
+		return nil
+	}
+	out := make([]int, 0, len(mixed))
+	for _, item := range mixed {
+		switch value := item.(type) {
+		case float64:
+			if value == math.Trunc(value) {
+				out = append(out, int(value))
+			}
+		case string:
+			if parsed, ok := parsePositiveInt(value); ok {
+				out = append(out, parsed)
+			}
+		}
+	}
+	return out
+}
+
+func parsePositiveInt(value string) (int, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+	total := 0
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		total = total*10 + int(r-'0')
+	}
+	return total, true
+}
+
+func normalizeSourceSeqs(seqs []int) []int {
+	if len(seqs) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{}, len(seqs))
+	out := make([]int, 0, len(seqs))
+	for _, seq := range seqs {
+		if seq < 0 {
+			continue
+		}
+		if _, ok := seen[seq]; ok {
+			continue
+		}
+		seen[seq] = struct{}{}
+		out = append(out, seq)
+	}
+	sort.Ints(out)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/server/internal/service/source_provenance.go
+++ b/server/internal/service/source_provenance.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	sourceSeqsMetadataKey = "source_seqs"
-	maxSourceSeqsPerFact  = 6
+	sourceSeqsMetadataKey  = "source_seqs"
+	sourceTurnsMetadataKey = "source_turns"
+	maxSourceSeqsPerFact   = 6
 )
 
 var sourceProvenanceTokenRe = regexp.MustCompile(`[A-Za-z]+(?:'[A-Za-z]+)?|\d+|[\p{Han}]{2,}`)
@@ -26,6 +27,11 @@ var sourceProvenanceStopwords = map[string]struct{}{
 	"date": {}, "speaker": {}, "user": {}, "assistant": {},
 }
 
+type sourceTurnMetadata struct {
+	Seq     int    `json:"seq"`
+	Content string `json:"content"`
+}
+
 func annotateFactsWithSourceSeqs(input preparedExtractionInput, facts []ExtractedFact) []ExtractedFact {
 	if len(facts) == 0 {
 		return facts
@@ -35,19 +41,66 @@ func annotateFactsWithSourceSeqs(input preparedExtractionInput, facts []Extracte
 	for i := range out {
 		if len(out[i].SourceSeqs) > 0 {
 			out[i].SourceSeqs = normalizeSourceSeqs(out[i].SourceSeqs)
-			continue
-		}
-		if strings.EqualFold(out[i].FactType, factTypeRawFallback) {
+		} else if strings.EqualFold(out[i].FactType, factTypeRawFallback) {
 			out[i].SourceSeqs = messageSourceSeqs(input.messages)
-			continue
+		} else {
+			out[i].SourceSeqs = inferSourceSeqs(out[i].Text, input.messages)
 		}
-		out[i].SourceSeqs = inferSourceSeqs(out[i].Text, input.messages)
+		out[i].SourceTurns = sourceTurnsFromMessages(input.messages, out[i].SourceSeqs)
 	}
 	return out
 }
 
 func metadataForExtractedFact(fact ExtractedFact) json.RawMessage {
-	return SetSourceSeqMetadata(MergeTemporalMetadata(nil, fact.Temporal), fact.SourceSeqs)
+	return SetSourceProvenanceMetadata(MergeTemporalMetadata(nil, fact.Temporal), fact.SourceSeqs, fact.SourceTurns)
+}
+
+func SetSourceProvenanceMetadata(existing json.RawMessage, seqs []int, turns []sourceTurnMetadata) json.RawMessage {
+	var payload map[string]json.RawMessage
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &payload); err != nil {
+			payload = nil
+		}
+	}
+	if payload == nil {
+		payload = map[string]json.RawMessage{}
+	}
+
+	seqs = normalizeSourceSeqs(seqs)
+	turns = normalizeSourceTurns(seqs, turns)
+	if len(seqs) == 0 {
+		delete(payload, sourceSeqsMetadataKey)
+		delete(payload, sourceTurnsMetadataKey)
+		if len(payload) == 0 {
+			return nil
+		}
+		raw, err := json.Marshal(payload)
+		if err != nil {
+			return existing
+		}
+		return raw
+	}
+
+	rawSeqs, err := json.Marshal(seqs)
+	if err != nil {
+		return existing
+	}
+	payload[sourceSeqsMetadataKey] = rawSeqs
+	if len(turns) == 0 {
+		delete(payload, sourceTurnsMetadataKey)
+	} else {
+		rawTurns, err := json.Marshal(turns)
+		if err != nil {
+			return existing
+		}
+		payload[sourceTurnsMetadataKey] = rawTurns
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return existing
+	}
+	return raw
 }
 
 func MergeSourceSeqMetadata(existing json.RawMessage, seqs []int) json.RawMessage {
@@ -180,6 +233,60 @@ func sourceSeqsForReconcileText(text string, facts []ExtractedFact) []int {
 	return normalizeSourceSeqs(seqs)
 }
 
+func sourceTurnsForReconcileText(text string, facts []ExtractedFact) []sourceTurnMetadata {
+	if len(facts) == 0 {
+		return nil
+	}
+	if len(facts) == 1 {
+		return normalizeSourceTurns(facts[0].SourceSeqs, facts[0].SourceTurns)
+	}
+
+	query := sourceTokenSet(text)
+	if len(query) == 0 {
+		return nil
+	}
+
+	type candidate struct {
+		index int
+		hits  int
+	}
+	candidates := make([]candidate, 0, len(facts))
+	maxHits := 0
+	for i, fact := range facts {
+		hits := countTokenOverlap(query, sourceTokenSet(projectReconcileFactText(fact)))
+		if hits == 0 {
+			continue
+		}
+		if hits > maxHits {
+			maxHits = hits
+		}
+		candidates = append(candidates, candidate{index: i, hits: hits})
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].hits != candidates[j].hits {
+			return candidates[i].hits > candidates[j].hits
+		}
+		return candidates[i].index < candidates[j].index
+	})
+
+	minHits := sourceMinHits(len(query))
+	var turns []sourceTurnMetadata
+	for _, candidate := range candidates {
+		if candidate.hits < minHits && candidate.hits < maxHits {
+			continue
+		}
+		if float64(candidate.hits) < math.Ceil(float64(maxHits)*0.6) {
+			continue
+		}
+		turns = append(turns, facts[candidate.index].SourceTurns...)
+	}
+	return normalizeSourceTurns(nil, turns)
+}
+
 func inferSourceSeqs(text string, messages []IngestMessage) []int {
 	query := sourceTokenSet(text)
 	if len(query) == 0 {
@@ -289,6 +396,37 @@ func messageSourceSeqs(messages []IngestMessage) []int {
 	return normalizeSourceSeqs(seqs)
 }
 
+func sourceTurnsFromMessages(messages []IngestMessage, seqs []int) []sourceTurnMetadata {
+	seqs = normalizeSourceSeqs(seqs)
+	if len(seqs) == 0 {
+		return nil
+	}
+	contentsBySeq := make(map[int]string, len(messages))
+	for _, msg := range messages {
+		if msg.Seq == nil || !strings.EqualFold(msg.Role, "user") {
+			continue
+		}
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			continue
+		}
+		if _, exists := contentsBySeq[*msg.Seq]; exists {
+			continue
+		}
+		contentsBySeq[*msg.Seq] = content
+	}
+
+	turns := make([]sourceTurnMetadata, 0, len(seqs))
+	for _, seq := range seqs {
+		content, ok := contentsBySeq[seq]
+		if !ok {
+			continue
+		}
+		turns = append(turns, sourceTurnMetadata{Seq: seq, Content: content})
+	}
+	return normalizeSourceTurns(seqs, turns)
+}
+
 func parseSourceSeqsRaw(raw json.RawMessage) []int {
 	var nums []int
 	if err := json.Unmarshal(raw, &nums); err == nil {
@@ -349,5 +487,48 @@ func normalizeSourceSeqs(seqs []int) []int {
 	if len(out) == 0 {
 		return nil
 	}
+	return out
+}
+
+func normalizeSourceTurns(seqs []int, turns []sourceTurnMetadata) []sourceTurnMetadata {
+	if len(turns) == 0 {
+		return nil
+	}
+	allowed := make(map[int]struct{}, len(seqs))
+	if len(seqs) > 0 {
+		for _, seq := range seqs {
+			allowed[seq] = struct{}{}
+		}
+	}
+	seen := make(map[int]struct{}, len(turns))
+	out := make([]sourceTurnMetadata, 0, len(turns))
+	for _, turn := range turns {
+		if turn.Seq < 0 {
+			continue
+		}
+		if len(allowed) > 0 {
+			if _, ok := allowed[turn.Seq]; !ok {
+				continue
+			}
+		}
+		turn.Content = strings.TrimSpace(turn.Content)
+		if turn.Content == "" {
+			continue
+		}
+		if _, ok := seen[turn.Seq]; ok {
+			continue
+		}
+		seen[turn.Seq] = struct{}{}
+		out = append(out, turn)
+		if len(out) >= maxSourceSeqsPerFact {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Seq < out[j].Seq
+	})
 	return out
 }


### PR DESCRIPTION
## Summary

Moves source-turn handling into the Mem9 server so every client benefits from the same recall strategy, while keeping source-turn provenance persistence correct during ingest/reconciliation.

Key changes:

- persist source-turn provenance for extracted insights during smart ingest
- fix reconciliation so both `ADD` and `UPDATE` paths persist `source_turns` together with `source_seqs`
- move source-turn selection, ordering, speaker-aware scoring, and cap budget into server-side search decoration
- keep benchmark-specific adaptation out of this repo; the paired benchmark PR now only consumes server-returned `source_seqs` / `source_turns`
- add focused service tests for provenance inference, persistence, and search-time source-turn selection

Paired benchmark PR: https://github.com/mem9-ai/mem9-benchmark/pull/11

## Validation

Unit checks:

- `go test ./internal/service`

Resplit smoke check:

- First `conv-30` smoke after the repo-scope split regressed because `ReconcilePhase2 -> ADD` still wrote only `source_seqs`
- Fix `918a147` (`fix: persist source-turn metadata on add`) restored the server contract so search responses consistently carry full `source_turns`
- Follow-up `conv-30` smoke (`20260423T171125`) recovered to LLM `65.43%`, ER `65.06%`, F1 `60.33%`, tokens `118,859`

Full LoCoMo benchmark settings:

- Server/chat model: `qwen3.6-flash`
- Judge model: `qwen3.6-plus`
- `sample-concurrency=10`
- `evaluation-concurrency=6`
- `MNEMO_TENANT_POOL_CONNECT_TIMEOUT=15s`

| Run | LLM micro | Evidence recall | F1 micro | Tokens | Embedding errors |
| --- | ---: | ---: | ---: | ---: | ---: |
| main baseline | 60.91% | 53.25% | 59.00% | 1,843,676 | - |
| r1 (`20260423T172528`) | 61.88% | 68.73% | 60.41% | 1,834,473 | 6 |
| r2 (`20260423T174643`) | 62.47% | 69.70% | 61.45% | 1,827,394 | 1 |
| r3 (`20260423T180819`) | 60.71% | 67.01% | 60.35% | 1,804,740 | 0 |
| median | 61.88% | 68.73% | 60.41% | 1,827,394 | - |

Gate result: median recall passes (`61.88% > 60.91%`) and median tokens pass (`1,827,394 < 1,843,676`). All three runs had `smart_ingest_retry_count=0`.

Logs are archived in `okJiang/locomo-logs` under:

- `20260423T172528`
- `20260423T174643`
- `20260423T180819`
