### PR TITLE
feat(dashboard, server): align connect flow with MEM9_API_KEY and pinned manual memory create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ vendor/
 # Server outputs
 server/bin
 server/coverage/
+server/.tmp
 
 # Benchmark results
 benchmark/results/*

--- a/dashboard/app/.env.production
+++ b/dashboard/app/.env.production
@@ -1,2 +1,3 @@
 # Production — real API via Netlify proxy rewrite
 VITE_USE_MOCK=false
+VITE_ENABLE_MANUAL_ADD=true

--- a/dashboard/app/.env.production
+++ b/dashboard/app/.env.production
@@ -1,3 +1,3 @@
 # Production — real API via Netlify proxy rewrite
 VITE_USE_MOCK=false
-VITE_ENABLE_MANUAL_ADD=true
+VITE_ENABLE_MANUAL_ADD=false

--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -89,6 +89,30 @@ describe("httpProvider", () => {
     );
   });
 
+  it("rejects legacy accepted responses for manual creates and skips cache writes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "accepted",
+        }),
+        {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await expect(
+      httpProvider.createMemory("space-1", {
+        content: "Remember my coffee order",
+        memory_type: "pinned",
+      }),
+    ).rejects.toThrow(
+      "Manual add requires pinned-memory create support on the server.",
+    );
+    expect(upsertCachedMemories).not.toHaveBeenCalled();
+  });
+
   it("uses the same fixed path for multipart imports and keeps auth in headers", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(

--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { upsertCachedMemories } from "./local-cache";
 import { httpProvider } from "./provider-http";
+
+vi.mock("./local-cache", () => ({
+  removeCachedMemory: vi.fn().mockResolvedValue(undefined),
+  upsertCachedMemories: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("httpProvider", () => {
   afterEach(() => {
@@ -35,6 +41,52 @@ describe("httpProvider", () => {
     expect(headers.get("X-API-Key")).toBe("space-1");
     expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
     expect(headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("posts manual creates to /memories with explicit pinned memory_type", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          id: "mem-1",
+          content: "Remember my coffee order",
+          memory_type: "pinned",
+          tags: ["preference", "coffee"],
+          created_at: "2026-03-16T00:00:00Z",
+          updated_at: "2026-03-16T00:00:00Z",
+        }),
+        {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const result = await httpProvider.createMemory("space-1", {
+      content: "Remember my coffee order",
+      memory_type: "pinned",
+      tags: ["preference", "coffee"],
+    });
+
+    expect(result.memory_type).toBe("pinned");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    const headers = init?.headers as Headers;
+    expect(url).toBe("/your-memory/api/memories");
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBe(
+      JSON.stringify({
+        content: "Remember my coffee order",
+        memory_type: "pinned",
+        tags: ["preference", "coffee"],
+      }),
+    );
+    expect(headers.get("X-API-Key")).toBe("space-1");
+    expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
+    expect(upsertCachedMemories).toHaveBeenCalledWith(
+      "space-1",
+      [expect.objectContaining({ id: "mem-1", memory_type: "pinned" })],
+    );
   });
 
   it("uses the same fixed path for multipart imports and keeps auth in headers", async () => {

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -33,7 +33,7 @@ function normalizeTags(tags: unknown): string[] {
 }
 
 function buildHeaders(
-  spaceId: string,
+  apiKey: string,
   initHeaders?: HeadersInit,
   includeContentType = true,
 ): Headers {
@@ -41,7 +41,7 @@ function buildHeaders(
   if (includeContentType) {
     headers.set("Content-Type", "application/json");
   }
-  headers.set("X-API-Key", spaceId.trim());
+  headers.set("X-API-Key", apiKey.trim());
   headers.set("X-Mnemo-Agent-Id", AGENT_ID);
   return headers;
 }
@@ -108,14 +108,14 @@ function normalizeSessionMessageListResponse(
 }
 
 async function request<T>(
-  spaceId: string,
+  apiKey: string,
   path: string,
   init?: RequestInit,
 ): Promise<T> {
   const url = `${API_BASE}${path}`;
   const res = await fetch(url, {
     ...init,
-    headers: buildHeaders(spaceId, init?.headers),
+    headers: buildHeaders(apiKey, init?.headers),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }));
@@ -126,14 +126,14 @@ async function request<T>(
 }
 
 async function requestRaw(
-  spaceId: string,
+  apiKey: string,
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
   const url = `${API_BASE}${path}`;
   const res = await fetch(url, {
     ...init,
-    headers: buildHeaders(spaceId, init?.headers, false),
+    headers: buildHeaders(apiKey, init?.headers, false),
   });
   if (!res.ok) {
     const body = await res.json().catch(() => ({ error: res.statusText }));
@@ -143,8 +143,8 @@ async function requestRaw(
 }
 
 export const httpProvider: DashboardProvider = {
-  async verifySpace(spaceId: string): Promise<SpaceInfo> {
-    const id = spaceId.trim();
+  async verifySpace(apiKey: string): Promise<SpaceInfo> {
+    const id = apiKey.trim();
     const res = await request<MemoryListResponse>(id, "/memories?limit=1");
     return {
       tenant_id: id,
@@ -157,7 +157,7 @@ export const httpProvider: DashboardProvider = {
   },
 
   async listMemories(
-    spaceId: string,
+    apiKey: string,
     params: MemoryListParams = {},
   ): Promise<MemoryListResponse> {
     const qs = new URLSearchParams();
@@ -169,16 +169,16 @@ export const httpProvider: DashboardProvider = {
     qs.set("limit", String(params.limit ?? 50));
     qs.set("offset", String(params.offset ?? 0));
     const response = await request<MemoryListResponse>(
-      spaceId,
+      apiKey,
       `/memories?${qs}`,
     );
     const normalized = normalizeMemoryListResponse(response);
-    void upsertCachedMemories(spaceId, normalized.memories);
+    void upsertCachedMemories(apiKey, normalized.memories);
     return normalized;
   },
 
   async listSessionMessages(
-    spaceId: string,
+    apiKey: string,
     params: SessionMessageListParams,
   ): Promise<SessionMessageListResponse> {
     const sessionIDs = Array.from(
@@ -203,7 +203,7 @@ export const httpProvider: DashboardProvider = {
 
     const url = `${API_BASE}/session-messages?${qs}`;
     const res = await fetch(url, {
-      headers: buildHeaders(spaceId),
+      headers: buildHeaders(apiKey),
     });
 
     if (res.status === 404 || res.status === 405 || res.status === 501) {
@@ -219,7 +219,7 @@ export const httpProvider: DashboardProvider = {
   },
 
   async getStats(
-    spaceId: string,
+    apiKey: string,
     params?: TimeRangeParams,
   ): Promise<MemoryStats> {
     const qs = new URLSearchParams({ limit: "1" });
@@ -232,9 +232,9 @@ export const httpProvider: DashboardProvider = {
     qsInsight.set("memory_type", "insight");
 
     const [all, pinned, insight] = await Promise.all([
-      request<MemoryListResponse>(spaceId, `/memories?${qs}`),
-      request<MemoryListResponse>(spaceId, `/memories?${qsPinned}`),
-      request<MemoryListResponse>(spaceId, `/memories?${qsInsight}`),
+      request<MemoryListResponse>(apiKey, `/memories?${qs}`),
+      request<MemoryListResponse>(apiKey, `/memories?${qsPinned}`),
+      request<MemoryListResponse>(apiKey, `/memories?${qsInsight}`),
     ]);
     return {
       total: all.total,
@@ -243,22 +243,22 @@ export const httpProvider: DashboardProvider = {
     };
   },
 
-  async getMemory(spaceId: string, memoryId: string): Promise<Memory> {
+  async getMemory(apiKey: string, memoryId: string): Promise<Memory> {
     const response = await request<Memory>(
-      spaceId,
+      apiKey,
       `/memories/${memoryId}`,
     );
     const normalized = normalizeMemory(response);
-    void upsertCachedMemories(spaceId, [normalized]);
+    void upsertCachedMemories(apiKey, [normalized]);
     return normalized;
   },
 
   async createMemory(
-    spaceId: string,
+    apiKey: string,
     input: MemoryCreateInput,
   ): Promise<Memory> {
     const response = await request<Memory>(
-      spaceId,
+      apiKey,
       "/memories",
       {
         method: "POST",
@@ -266,12 +266,12 @@ export const httpProvider: DashboardProvider = {
       },
     );
     const normalized = normalizeMemory(response);
-    await upsertCachedMemories(spaceId, [normalized]);
+    await upsertCachedMemories(apiKey, [normalized]);
     return normalized;
   },
 
   async updateMemory(
-    spaceId: string,
+    apiKey: string,
     memoryId: string,
     input: MemoryUpdateInput,
     version?: number,
@@ -279,7 +279,7 @@ export const httpProvider: DashboardProvider = {
     const headers: Record<string, string> = {};
     if (version !== undefined) headers["If-Match"] = String(version);
     const response = await request<Memory>(
-      spaceId,
+      apiKey,
       `/memories/${memoryId}`,
       {
         method: "PUT",
@@ -288,25 +288,25 @@ export const httpProvider: DashboardProvider = {
       },
     );
     const normalized = normalizeMemory(response);
-    await upsertCachedMemories(spaceId, [normalized]);
+    await upsertCachedMemories(apiKey, [normalized]);
     return normalized;
   },
 
-  async deleteMemory(spaceId: string, memoryId: string): Promise<void> {
-    await request<void>(spaceId, `/memories/${memoryId}`, {
+  async deleteMemory(apiKey: string, memoryId: string): Promise<void> {
+    await request<void>(apiKey, `/memories/${memoryId}`, {
       method: "DELETE",
     });
-    await removeCachedMemory(spaceId, memoryId);
+    await removeCachedMemory(apiKey, memoryId);
   },
 
-  async exportMemories(spaceId: string): Promise<MemoryExportFile> {
+  async exportMemories(apiKey: string): Promise<MemoryExportFile> {
     const PAGE = 200;
     const allMemories: Memory[] = [];
     let offset = 0;
     let total = Infinity;
 
     while (offset < total) {
-      const page = await this.listMemories(spaceId, {
+      const page = await this.listMemories(apiKey, {
         limit: PAGE,
         offset,
       });
@@ -318,7 +318,7 @@ export const httpProvider: DashboardProvider = {
     return {
       schema_version: "mem9.memory_export.v1",
       exported_at: new Date().toISOString(),
-      source_space_id: spaceId,
+      source_space_id: apiKey,
       agent_id: AGENT_ID,
       memories: allMemories.map((m) => ({
         content: m.content,
@@ -332,13 +332,13 @@ export const httpProvider: DashboardProvider = {
     };
   },
 
-  async importMemories(spaceId: string, file: File): Promise<ImportTask> {
+  async importMemories(apiKey: string, file: File): Promise<ImportTask> {
     const formData = new FormData();
     formData.append("file", file);
     formData.append("agent_id", AGENT_ID);
     formData.append("file_type", "memory");
 
-    const res = await requestRaw(spaceId, "/imports", {
+    const res = await requestRaw(apiKey, "/imports", {
       method: "POST",
       body: formData,
     });
@@ -346,14 +346,14 @@ export const httpProvider: DashboardProvider = {
   },
 
   async getImportTask(
-    spaceId: string,
+    apiKey: string,
     taskId: string,
   ): Promise<ImportTask> {
-    return request<ImportTask>(spaceId, `/imports/${taskId}`);
+    return request<ImportTask>(apiKey, `/imports/${taskId}`);
   },
 
-  async listImportTasks(spaceId: string): Promise<ImportTaskList> {
-    const tasks = await request<ImportTask[]>(spaceId, "/imports");
+  async listImportTasks(apiKey: string): Promise<ImportTaskList> {
+    const tasks = await request<ImportTask[]>(apiKey, "/imports");
     if (!tasks || tasks.length === 0) {
       return { tasks: [], status: "empty" };
     }
@@ -372,7 +372,7 @@ export const httpProvider: DashboardProvider = {
   },
 
   async getTopicSummary(
-    _spaceId: string,
+    _apiKey: string,
     _params?: TimeRangeParams,
   ): Promise<TopicSummary> {
     // Backend /summary not yet available; return empty.

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -65,6 +65,14 @@ function normalizeMemory(memory: Partial<Memory>): Memory {
   };
 }
 
+function hasValidMemoryShape(memory: Partial<Memory>): boolean {
+  return (
+    typeof memory.id === "string" &&
+    memory.id.trim().length > 0 &&
+    typeof memory.content === "string"
+  );
+}
+
 function normalizeMemoryListResponse(
   response: Partial<MemoryListResponse>,
 ): MemoryListResponse {
@@ -265,6 +273,9 @@ export const httpProvider: DashboardProvider = {
         body: JSON.stringify(input),
       },
     );
+    if (!hasValidMemoryShape(response)) {
+      throw new Error("Manual add requires pinned-memory create support on the server.");
+    }
     const normalized = normalizeMemory(response);
     await upsertCachedMemories(apiKey, [normalized]);
     return normalized;

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -3,7 +3,6 @@ import type {
   Memory,
   MemoryListParams,
   MemoryListResponse,
-  MemoryBatchCreateResponse,
   MemoryCreateInput,
   MemoryUpdateInput,
   MemoryStats,
@@ -258,17 +257,15 @@ export const httpProvider: DashboardProvider = {
     spaceId: string,
     input: MemoryCreateInput,
   ): Promise<Memory> {
-    const res = await request<MemoryBatchCreateResponse>(
+    const response = await request<Memory>(
       spaceId,
-      "/memories/batch",
+      "/memories",
       {
         method: "POST",
-        body: JSON.stringify({ memories: [input] }),
+        body: JSON.stringify(input),
       },
     );
-    const created = res.memories[0];
-    if (!created) throw new Error("No memory returned from batch create");
-    const normalized = normalizeMemory(created);
+    const normalized = normalizeMemory(response);
     await upsertCachedMemories(spaceId, [normalized]);
     return normalized;
   },

--- a/dashboard/app/src/api/provider-mock.test.ts
+++ b/dashboard/app/src/api/provider-mock.test.ts
@@ -5,7 +5,7 @@ import { mockProvider } from "./provider-mock";
 describe("mockProvider", () => {
   it("uses MEM9_API_KEY wording for connect validation errors", async () => {
     await expect(mockProvider.verifySpace("short")).rejects.toThrow(
-      "Cannot access this memory. Check your MEM9_API_KEY and try again.",
+      "Cannot access this memory space. Check your MEM9_API_KEY and try again.",
     );
   });
 });

--- a/dashboard/app/src/api/provider-mock.test.ts
+++ b/dashboard/app/src/api/provider-mock.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { mockProvider } from "./provider-mock";
+
+describe("mockProvider", () => {
+  it("uses MEM9_API_KEY wording for connect validation errors", async () => {
+    await expect(mockProvider.verifySpace("short")).rejects.toThrow(
+      "Cannot access this memory. Check your MEM9_API_KEY and try again.",
+    );
+  });
+});

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -216,9 +216,9 @@ function mockTopicSummary(params?: TimeRangeParams): TopicSummary {
 }
 
 export const mockProvider: DashboardProvider = {
-  async verifySpace(spaceId: string): Promise<SpaceInfo> {
+  async verifySpace(apiKey: string): Promise<SpaceInfo> {
     await delay(400);
-    const id = spaceId.trim();
+    const id = apiKey.trim();
     if (!id || id.length < 8) {
       throw new Error("Cannot access this space. Please check your ID.");
     }
@@ -226,7 +226,7 @@ export const mockProvider: DashboardProvider = {
   },
 
   async listMemories(
-    _spaceId: string,
+    _apiKey: string,
     params: MemoryListParams = {},
   ): Promise<MemoryListResponse> {
     await delay(300);
@@ -234,7 +234,7 @@ export const mockProvider: DashboardProvider = {
   },
 
   async listSessionMessages(
-    _spaceId: string,
+    _apiKey: string,
     params: SessionMessageListParams,
   ): Promise<SessionMessageListResponse> {
     await delay(180);
@@ -242,14 +242,14 @@ export const mockProvider: DashboardProvider = {
   },
 
   async getStats(
-    _spaceId: string,
+    _apiKey: string,
     params?: TimeRangeParams,
   ): Promise<MemoryStats> {
     await delay(200);
     return mockStats(params);
   },
 
-  async getMemory(_spaceId: string, memoryId: string): Promise<Memory> {
+  async getMemory(_apiKey: string, memoryId: string): Promise<Memory> {
     await delay(150);
     const mem = mockStore.find((m) => m.id === memoryId);
     if (!mem) throw new Error("Memory not found");
@@ -257,7 +257,7 @@ export const mockProvider: DashboardProvider = {
   },
 
   async createMemory(
-    _spaceId: string,
+    apiKey: string,
     input: MemoryCreateInput,
   ): Promise<Memory> {
     await delay(500);
@@ -277,12 +277,12 @@ export const mockProvider: DashboardProvider = {
       updated_at: new Date().toISOString(),
     };
     mockStore.unshift(mem);
-    await upsertCachedMemories(_spaceId, [mem]);
+    await upsertCachedMemories(apiKey, [mem]);
     return mem;
   },
 
   async updateMemory(
-    _spaceId: string,
+    apiKey: string,
     memoryId: string,
     input: MemoryUpdateInput,
     _version?: number,
@@ -303,22 +303,22 @@ export const mockProvider: DashboardProvider = {
     };
     const idx = mockStore.indexOf(existing);
     mockStore[idx] = updated;
-    await upsertCachedMemories(_spaceId, [updated]);
+    await upsertCachedMemories(apiKey, [updated]);
     return { ...updated };
   },
 
-  async deleteMemory(_spaceId: string, memoryId: string): Promise<void> {
+  async deleteMemory(apiKey: string, memoryId: string): Promise<void> {
     await delay(300);
     mockStore = mockStore.filter((m) => m.id !== memoryId);
-    await removeCachedMemory(_spaceId, memoryId);
+    await removeCachedMemory(apiKey, memoryId);
   },
 
-  async exportMemories(_spaceId: string): Promise<MemoryExportFile> {
+  async exportMemories(apiKey: string): Promise<MemoryExportFile> {
     await delay(500);
     return {
       schema_version: "mem9.memory_export.v1",
       exported_at: new Date().toISOString(),
-      source_space_id: _spaceId,
+      source_space_id: apiKey,
       agent_id: AGENT_ID,
       memories: mockStore.map((m) => ({
         content: m.content,
@@ -333,13 +333,13 @@ export const mockProvider: DashboardProvider = {
   },
 
   async importMemories(
-    _spaceId: string,
+    apiKey: string,
     file: File,
   ): Promise<ImportTask> {
     await delay(800);
     const task: ImportTask = {
       id: `task-${Date.now()}`,
-      tenant_id: _spaceId,
+      tenant_id: apiKey,
       agent_id: AGENT_ID,
       file_name: file.name,
       file_type: "memory",
@@ -364,7 +364,7 @@ export const mockProvider: DashboardProvider = {
   },
 
   async getImportTask(
-    _spaceId: string,
+    apiKey: string,
     taskId: string,
   ): Promise<ImportTask> {
     await delay(300);
@@ -372,7 +372,7 @@ export const mockProvider: DashboardProvider = {
     if (task) return { ...task };
     return {
       id: taskId,
-      tenant_id: _spaceId,
+      tenant_id: apiKey,
       agent_id: AGENT_ID,
       file_name: "import.json",
       file_type: "memory",
@@ -385,7 +385,7 @@ export const mockProvider: DashboardProvider = {
     };
   },
 
-  async listImportTasks(_spaceId: string): Promise<ImportTaskList> {
+  async listImportTasks(_apiKey: string): Promise<ImportTaskList> {
     await delay(400);
     if (mockImportTaskStore.length === 0) {
       return { tasks: [], status: "empty" };
@@ -408,7 +408,7 @@ export const mockProvider: DashboardProvider = {
   },
 
   async getTopicSummary(
-    _spaceId: string,
+    _apiKey: string,
     params?: TimeRangeParams,
   ): Promise<TopicSummary> {
     await delay(250);

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -264,7 +264,7 @@ export const mockProvider: DashboardProvider = {
     const mem: Memory = {
       id: `mem-${Date.now()}`,
       content: input.content,
-      memory_type: "pinned",
+      memory_type: input.memory_type,
       source: "dashboard",
       tags: input.tags ?? [],
       metadata: null,

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -221,7 +221,7 @@ export const mockProvider: DashboardProvider = {
     const id = apiKey.trim();
     if (!id || id.length < 8) {
       throw new Error(
-        "Cannot access this memory. Check your MEM9_API_KEY and try again.",
+        "Cannot access this memory space. Check your MEM9_API_KEY and try again.",
       );
     }
     return { ...mockSpaceInfo, tenant_id: id };

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -220,7 +220,9 @@ export const mockProvider: DashboardProvider = {
     await delay(400);
     const id = apiKey.trim();
     if (!id || id.length < 8) {
-      throw new Error("Cannot access this space. Please check your ID.");
+      throw new Error(
+        "Cannot access this memory. Check your MEM9_API_KEY and try again.",
+      );
     }
     return { ...mockSpaceInfo, tenant_id: id };
   },

--- a/dashboard/app/src/api/provider.ts
+++ b/dashboard/app/src/api/provider.ts
@@ -15,31 +15,31 @@ import type { TimeRangeParams } from "@/types/time-range";
 import type { ImportTask, ImportTaskList } from "@/types/import";
 
 export interface DashboardProvider {
-  verifySpace(spaceId: string): Promise<SpaceInfo>;
+  verifySpace(apiKey: string): Promise<SpaceInfo>;
   listMemories(
-    spaceId: string,
+    apiKey: string,
     params: MemoryListParams,
   ): Promise<MemoryListResponse>;
   listSessionMessages(
-    spaceId: string,
+    apiKey: string,
     params: SessionMessageListParams,
   ): Promise<SessionMessageListResponse>;
-  getStats(spaceId: string, params?: TimeRangeParams): Promise<MemoryStats>;
-  getMemory(spaceId: string, memoryId: string): Promise<Memory>;
-  createMemory(spaceId: string, input: MemoryCreateInput): Promise<Memory>;
+  getStats(apiKey: string, params?: TimeRangeParams): Promise<MemoryStats>;
+  getMemory(apiKey: string, memoryId: string): Promise<Memory>;
+  createMemory(apiKey: string, input: MemoryCreateInput): Promise<Memory>;
   updateMemory(
-    spaceId: string,
+    apiKey: string,
     memoryId: string,
     input: MemoryUpdateInput,
     version?: number,
   ): Promise<Memory>;
-  deleteMemory(spaceId: string, memoryId: string): Promise<void>;
-  exportMemories(spaceId: string): Promise<MemoryExportFile>;
-  importMemories(spaceId: string, file: File): Promise<ImportTask>;
-  getImportTask(spaceId: string, taskId: string): Promise<ImportTask>;
-  listImportTasks(spaceId: string): Promise<ImportTaskList>;
+  deleteMemory(apiKey: string, memoryId: string): Promise<void>;
+  exportMemories(apiKey: string): Promise<MemoryExportFile>;
+  importMemories(apiKey: string, file: File): Promise<ImportTask>;
+  getImportTask(apiKey: string, taskId: string): Promise<ImportTask>;
+  listImportTasks(apiKey: string): Promise<ImportTaskList>;
   getTopicSummary(
-    spaceId: string,
+    apiKey: string,
     params?: TimeRangeParams,
   ): Promise<TopicSummary>;
 }

--- a/dashboard/app/src/components/space/empty-state.tsx
+++ b/dashboard/app/src/components/space/empty-state.tsx
@@ -5,9 +5,11 @@ import { Button } from "@/components/ui/button";
 export function EmptyState({
   t,
   onAdd,
+  canAdd,
 }: {
   t: TFunction;
   onAdd: () => void;
+  canAdd: boolean;
 }) {
   return (
     <div className="flex flex-col items-center justify-center gap-5 py-16 text-center">
@@ -17,18 +19,20 @@ export function EmptyState({
       <div>
         <h3 className="text-base font-semibold">{t("empty.title")}</h3>
         <p className="mt-2 max-w-sm text-sm leading-relaxed text-muted-foreground">
-          {t("empty.description")}
+          {t(canAdd ? "empty.description" : "empty.description_readonly")}
         </p>
       </div>
-      <Button
-        onClick={onAdd}
-        data-mp-event="Dashboard/EmptyState/AddClicked"
-        data-mp-page-name="space"
-        className="gap-2 text-sm"
-      >
-        <Plus className="size-4" />
-        {t("empty.cta")}
-      </Button>
+      {canAdd && (
+        <Button
+          onClick={onAdd}
+          data-mp-event="Dashboard/EmptyState/AddClicked"
+          data-mp-page-name="space"
+          className="gap-2 text-sm"
+        >
+          <Plus className="size-4" />
+          {t("empty.cta")}
+        </Button>
+      )}
     </div>
   );
 }

--- a/dashboard/app/src/components/space/space-page-layout.tsx
+++ b/dashboard/app/src/components/space/space-page-layout.tsx
@@ -479,7 +479,11 @@ export const SpacePageLayout = ({
 
             <div id="memory-list" className="mt-4 scroll-mt-20">
               {isEmpty ? (
-                <EmptyState t={t} onAdd={() => setAddOpen(true)} />
+                <EmptyState
+                  t={t}
+                  onAdd={() => setAddOpen(true)}
+                  canAdd={features.enableManualAdd}
+                />
               ) : dataModel.displayedMemories.length === 0 && !dataModel.isMemoryLoading ? (
                 <div className="flex flex-col items-center justify-center gap-2 py-16">
                   <Search className="size-8 text-foreground/15" />

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -2,18 +2,17 @@
   "_locale": "en",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "Enter your memory space",
-    "placeholder": "Space ID",
-    "submit": "Enter space",
+    "subtitle": "Enter your MEM9_API_KEY",
+    "placeholder": "MEM9_API_KEY",
+    "submit": "Open memory",
     "remember_login": "Keep me signed in for 15 days",
-    "security": "Space ID is your private key. Do not share it with others.",
+    "security": "MEM9_API_KEY unlocks your memory. Keep it private.",
     "error": {
-      "invalid": "Cannot access this space. Please check your ID and try again."
+      "invalid": "Cannot access this memory. Check your MEM9_API_KEY and try again."
     },
-    "how_title": "What is mem9",
-    "how_1": "Your agent accumulates memories during conversations",
-    "how_2": "You can also ask your agent to remember specific things",
-    "how_3": "This dashboard shows what has been saved"
+    "how_title": "Get your MEM9_API_KEY",
+    "how_1": "In OpenClaw, copy MEM9_API_KEY from your mem9 or environment settings.",
+    "how_2": "Other agent tools usually expose the same MEM9_API_KEY in their mem9 config."
   },
   "space": {
     "title": "Your Memory",

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -4,7 +4,7 @@
     "title": "Your Memory",
     "subtitle": "Use your <code>MEM9_API_KEY</code> to continue",
     "placeholder": "MEM9_API_KEY",
-    "submit": "Open memory space",
+    "submit": "Open your memory",
     "remember_login": "Keep me signed in for 15 days",
     "security": "<code>MEM9_API_KEY</code> is your private key. Do not share it.",
     "error": {

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -2,11 +2,11 @@
   "_locale": "en",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "Enter your MEM9_API_KEY to open your memory space",
+    "subtitle": "Use your MEM9_API_KEY to continue",
     "placeholder": "MEM9_API_KEY",
     "submit": "Open memory space",
     "remember_login": "Keep me signed in for 15 days",
-    "security": "MEM9_API_KEY is your private key. Do not share it with others.",
+    "security": "MEM9_API_KEY is your private key. Do not share it.",
     "error": {
       "invalid": "Cannot access this memory space. Check your MEM9_API_KEY and try again."
     },

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -2,17 +2,17 @@
   "_locale": "en",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "Enter your MEM9_API_KEY",
+    "subtitle": "Enter your MEM9_API_KEY to open your memory space",
     "placeholder": "MEM9_API_KEY",
-    "submit": "Open memory",
+    "submit": "Open memory space",
     "remember_login": "Keep me signed in for 15 days",
-    "security": "MEM9_API_KEY unlocks your memory. Keep it private.",
+    "security": "MEM9_API_KEY is your private key. Do not share it with others.",
     "error": {
-      "invalid": "Cannot access this memory. Check your MEM9_API_KEY and try again."
+      "invalid": "Cannot access this memory space. Check your MEM9_API_KEY and try again."
     },
-    "how_title": "Get your MEM9_API_KEY",
-    "how_1": "In OpenClaw, copy MEM9_API_KEY from your mem9 or environment settings.",
-    "how_2": "Other agent tools usually expose the same MEM9_API_KEY in their mem9 config."
+    "how_title": "How to get your MEM9_API_KEY",
+    "how_1": "Ask OpenClaw to show you the MEM9_API_KEY it is already using.",
+    "how_2": "For other agent tools, ask the agent to show you its MEM9_API_KEY or tell you where it is stored."
   },
   "space": {
     "title": "Your Memory",

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -2,17 +2,17 @@
   "_locale": "en",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "Use your MEM9_API_KEY to continue",
+    "subtitle": "Use your <code>MEM9_API_KEY</code> to continue",
     "placeholder": "MEM9_API_KEY",
     "submit": "Open memory space",
     "remember_login": "Keep me signed in for 15 days",
-    "security": "MEM9_API_KEY is your private key. Do not share it.",
+    "security": "<code>MEM9_API_KEY</code> is your private key. Do not share it.",
     "error": {
       "invalid": "Cannot access this memory space. Check your MEM9_API_KEY and try again."
     },
-    "how_title": "How to get your MEM9_API_KEY",
-    "how_1": "Ask OpenClaw to show you the MEM9_API_KEY it is already using.",
-    "how_2": "For other agent tools, ask the agent to show you its MEM9_API_KEY or tell you where it is stored."
+    "how_title": "How to get your <code>MEM9_API_KEY</code>",
+    "how_1": "Ask OpenClaw to show you the <code>MEM9_API_KEY</code> it is already using.",
+    "how_2": "For other agent tools, ask the agent to show you its <code>MEM9_API_KEY</code> or tell you where it is stored."
   },
   "space": {
     "title": "Your Memory",

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -109,6 +109,7 @@
   "empty": {
     "title": "This space has no memories yet",
     "description": "Memories are accumulated as you chat with your agent. You can also save the first one now.",
+    "description_readonly": "Memories are accumulated as you chat with your agent.",
     "cta": "Save your first memory"
   },
   "legend": {

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -2,11 +2,11 @@
   "_locale": "zh-CN",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "输入 MEM9_API_KEY 以打开你的记忆空间",
+    "subtitle": "使用 MEM9_API_KEY 继续",
     "placeholder": "MEM9_API_KEY",
     "submit": "打开记忆空间",
     "remember_login": "保留登录状态 15 天",
-    "security": "MEM9_API_KEY 是你的私密密钥。请勿分享给他人。",
+    "security": "MEM9_API_KEY 是你的私密密钥。请勿分享。",
     "error": {
       "invalid": "无法访问这个记忆空间，请检查 MEM9_API_KEY 后重试"
     },

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -109,6 +109,7 @@
   "empty": {
     "title": "这个 space 还没有记忆",
     "description": "记忆会在你和 agent 对话时自动积累，你也可以现在手动保存第一条",
+    "description_readonly": "记忆会在你和 agent 对话时自动积累。",
     "cta": "保存第一条记忆"
   },
   "legend": {

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -2,17 +2,17 @@
   "_locale": "zh-CN",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "使用 MEM9_API_KEY 继续",
+    "subtitle": "使用 <code>MEM9_API_KEY</code> 继续",
     "placeholder": "MEM9_API_KEY",
     "submit": "打开记忆空间",
     "remember_login": "保留登录状态 15 天",
-    "security": "MEM9_API_KEY 是你的私密密钥。请勿分享。",
+    "security": "<code>MEM9_API_KEY</code> 是你的私密密钥。请勿分享。",
     "error": {
       "invalid": "无法访问这个记忆空间，请检查 MEM9_API_KEY 后重试"
     },
-    "how_title": "如何获取 MEM9_API_KEY",
-    "how_1": "让 OpenClaw 直接把它当前正在使用的 MEM9_API_KEY 发给你。",
-    "how_2": "对于其他 agent 工具，让它直接把自己的 MEM9_API_KEY 发给你，或告诉你存放位置。"
+    "how_title": "如何获取 <code>MEM9_API_KEY</code>",
+    "how_1": "让 OpenClaw 直接把它当前正在使用的 <code>MEM9_API_KEY</code> 发给你。",
+    "how_2": "对于其他 agent 工具，让它直接把自己的 <code>MEM9_API_KEY</code> 发给你，或告诉你存放位置。"
   },
   "space": {
     "title": "Your Memory",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -2,17 +2,17 @@
   "_locale": "zh-CN",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "输入你的 MEM9_API_KEY",
+    "subtitle": "输入 MEM9_API_KEY 以打开你的记忆空间",
     "placeholder": "MEM9_API_KEY",
-    "submit": "打开记忆",
+    "submit": "打开记忆空间",
     "remember_login": "保留登录状态 15 天",
-    "security": "MEM9_API_KEY 可以访问你的记忆，请妥善保管",
+    "security": "MEM9_API_KEY 是你的私密密钥。请勿分享给他人。",
     "error": {
-      "invalid": "无法访问这份记忆，请检查 MEM9_API_KEY 后重试"
+      "invalid": "无法访问这个记忆空间，请检查 MEM9_API_KEY 后重试"
     },
-    "how_title": "去哪里拿 MEM9_API_KEY",
-    "how_1": "在 OpenClaw 里，从 mem9 或环境设置复制 MEM9_API_KEY。",
-    "how_2": "其他 agent 工具通常也会在 mem9 配置里暴露同一个 MEM9_API_KEY。"
+    "how_title": "如何获取 MEM9_API_KEY",
+    "how_1": "让 OpenClaw 直接把它当前正在使用的 MEM9_API_KEY 发给你。",
+    "how_2": "对于其他 agent 工具，让它直接把自己的 MEM9_API_KEY 发给你，或告诉你存放位置。"
   },
   "space": {
     "title": "Your Memory",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -2,18 +2,17 @@
   "_locale": "zh-CN",
   "connect": {
     "title": "Your Memory",
-    "subtitle": "进入你的记忆空间",
-    "placeholder": "Space ID",
-    "submit": "进入 Space",
+    "subtitle": "输入你的 MEM9_API_KEY",
+    "placeholder": "MEM9_API_KEY",
+    "submit": "打开记忆",
     "remember_login": "保留登录状态 15 天",
-    "security": "Space ID 是你的私密标识，请勿分享给他人",
+    "security": "MEM9_API_KEY 可以访问你的记忆，请妥善保管",
     "error": {
-      "invalid": "无法访问此 Space，请检查 ID 后重试"
+      "invalid": "无法访问这份记忆，请检查 MEM9_API_KEY 后重试"
     },
-    "how_title": "mem9 是什么",
-    "how_1": "你的 agent 在对话中自动积累记忆",
-    "how_2": "你也可以让 agent 明确记住特定内容",
-    "how_3": "这里展示的是已经存下来的记忆"
+    "how_title": "去哪里拿 MEM9_API_KEY",
+    "how_1": "在 OpenClaw 里，从 mem9 或环境设置复制 MEM9_API_KEY。",
+    "how_2": "其他 agent 工具通常也会在 mem9 配置里暴露同一个 MEM9_API_KEY。"
   },
   "space": {
     "title": "Your Memory",

--- a/dashboard/app/src/lib/session.test.ts
+++ b/dashboard/app/src/lib/session.test.ts
@@ -1,12 +1,20 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   clearSpace,
+  getActiveApiKey,
   getActiveSpaceId,
+  getApiKey,
   getSpaceId,
+  restoreRememberedApiKey,
   restoreRememberedSpace,
+  setApiKey,
   setSpaceId,
 } from "./session";
 
+const API_KEY_KEY = "mem9-api-key";
+const SPACE_ID_KEY = "mem9-space-id";
+const LAST_ACTIVE_KEY = "mem9-last-active";
+const REMEMBERED_API_KEY = "mem9-remembered-api-key";
 const REMEMBERED_SPACE_KEY = "mem9-remembered-space";
 
 afterEach(() => {
@@ -15,41 +23,129 @@ afterEach(() => {
 });
 
 describe("session helpers", () => {
-  it("stores the active space in sessionStorage without remembering login", () => {
-    setSpaceId("space-1");
+  it("stores the active api key in sessionStorage without remembering login", () => {
+    setApiKey("space-1");
 
+    expect(getApiKey()).toBe("space-1");
     expect(getSpaceId()).toBe("space-1");
+    expect(sessionStorage.getItem(API_KEY_KEY)).toBe("space-1");
+    expect(sessionStorage.getItem(SPACE_ID_KEY)).toBeNull();
+    expect(localStorage.getItem(REMEMBERED_API_KEY)).toBeNull();
     expect(localStorage.getItem(REMEMBERED_SPACE_KEY)).toBeNull();
   });
 
   it("restores a remembered login into the current session", () => {
-    setSpaceId("space-remembered", true);
+    setApiKey("space-remembered", true);
     sessionStorage.clear();
 
+    expect(restoreRememberedApiKey()).toBe("space-remembered");
+    expect(restoreRememberedSpace()).toBe("space-remembered");
+    expect(getApiKey()).toBe("space-remembered");
     expect(restoreRememberedSpace()).toBe("space-remembered");
     expect(getSpaceId()).toBe("space-remembered");
+    expect(getActiveApiKey()).toBe("space-remembered");
     expect(getActiveSpaceId()).toBe("space-remembered");
   });
 
   it("drops expired remembered sessions", () => {
     localStorage.setItem(
-      REMEMBERED_SPACE_KEY,
+      REMEMBERED_API_KEY,
       JSON.stringify({
-        spaceId: "space-expired",
+        apiKey: "space-expired",
         expiresAt: Date.now() - 1_000,
       }),
     );
 
-    expect(restoreRememberedSpace()).toBeNull();
-    expect(localStorage.getItem(REMEMBERED_SPACE_KEY)).toBeNull();
+    expect(restoreRememberedApiKey()).toBeNull();
+    expect(localStorage.getItem(REMEMBERED_API_KEY)).toBeNull();
   });
 
   it("clears both session and remembered login", () => {
-    setSpaceId("space-1", true);
+    setApiKey("space-1", true);
 
     clearSpace();
 
+    expect(getApiKey()).toBeNull();
     expect(getSpaceId()).toBeNull();
+    expect(localStorage.getItem(REMEMBERED_API_KEY)).toBeNull();
+    expect(localStorage.getItem(REMEMBERED_SPACE_KEY)).toBeNull();
+  });
+
+  it("migrates a legacy session key into the new api key slot", () => {
+    sessionStorage.setItem(LAST_ACTIVE_KEY, "123");
+    sessionStorage.setItem(SPACE_ID_KEY, "legacy-space");
+
+    expect(getApiKey()).toBe("legacy-space");
+    expect(sessionStorage.getItem(API_KEY_KEY)).toBe("legacy-space");
+    expect(sessionStorage.getItem(LAST_ACTIVE_KEY)).toBe("123");
+    expect(sessionStorage.getItem(SPACE_ID_KEY)).toBeNull();
+  });
+
+  it("migrates a legacy remembered key into the new api key slot", () => {
+    const expiresAt = Date.now() + 10_000;
+
+    localStorage.setItem(
+      REMEMBERED_SPACE_KEY,
+      JSON.stringify({
+        expiresAt,
+        spaceId: "legacy-remembered-space",
+      }),
+    );
+
+    expect(restoreRememberedApiKey()).toBe("legacy-remembered-space");
+    expect(getApiKey()).toBe("legacy-remembered-space");
+    expect(localStorage.getItem(REMEMBERED_API_KEY)).toBe(
+      JSON.stringify({
+        apiKey: "legacy-remembered-space",
+        expiresAt,
+      }),
+    );
+    expect(localStorage.getItem(REMEMBERED_SPACE_KEY)).toBeNull();
+  });
+
+  it("prefers the new api key when both new and legacy session keys exist", () => {
+    sessionStorage.setItem(API_KEY_KEY, "new-space");
+    sessionStorage.setItem(SPACE_ID_KEY, "legacy-space");
+
+    expect(getApiKey()).toBe("new-space");
+    expect(sessionStorage.getItem(SPACE_ID_KEY)).toBeNull();
+  });
+
+  it("prefers the new remembered api key when both remembered keys exist", () => {
+    localStorage.setItem(
+      REMEMBERED_API_KEY,
+      JSON.stringify({
+        apiKey: "new-space",
+        expiresAt: Date.now() + 10_000,
+      }),
+    );
+    localStorage.setItem(
+      REMEMBERED_SPACE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 10_000,
+        spaceId: "legacy-space",
+      }),
+    );
+
+    expect(restoreRememberedApiKey()).toBe("new-space");
+    expect(localStorage.getItem(REMEMBERED_SPACE_KEY)).toBeNull();
+  });
+
+  it("writes through to new keys and clears legacy copies", () => {
+    sessionStorage.setItem(SPACE_ID_KEY, "legacy-space");
+    localStorage.setItem(
+      REMEMBERED_SPACE_KEY,
+      JSON.stringify({
+        expiresAt: Date.now() + 10_000,
+        spaceId: "legacy-space",
+      }),
+    );
+
+    setSpaceId("fresh-space", true);
+
+    expect(sessionStorage.getItem(API_KEY_KEY)).toBe("fresh-space");
+    expect(sessionStorage.getItem(SPACE_ID_KEY)).toBeNull();
+    expect(localStorage.getItem(REMEMBERED_API_KEY)).toBeTruthy();
     expect(localStorage.getItem(REMEMBERED_SPACE_KEY)).toBeNull();
   });
 });

--- a/dashboard/app/src/lib/session.ts
+++ b/dashboard/app/src/lib/session.ts
@@ -1,72 +1,156 @@
+const API_KEY_KEY = "mem9-api-key";
 const SPACE_ID_KEY = "mem9-space-id";
 const LAST_ACTIVE_KEY = "mem9-last-active";
+const REMEMBERED_API_KEY = "mem9-remembered-api-key";
 const REMEMBERED_SPACE_KEY = "mem9-remembered-space";
 const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const REMEMBER_ME_TTL_MS = 15 * 24 * 60 * 60 * 1000;
 export const MEM9_CONNECT_READY_EVENT = "mem9-connect-ready";
 export const MEM9_SPACE_HANDOFF_EVENT = "mem9-space-handoff";
 
-interface RememberedSpace {
-  spaceId: string;
+interface RememberedApiKey {
+  apiKey: string;
   expiresAt: number;
 }
 
-function writeSessionState(storage: Storage, id: string): void {
-  storage.setItem(SPACE_ID_KEY, id);
+function writeSessionKey(storage: Storage, apiKey: string): void {
+  storage.setItem(API_KEY_KEY, apiKey);
+  removeLegacySessionState(storage);
+}
+
+function removeLegacySessionState(storage: Storage): void {
+  storage.removeItem(SPACE_ID_KEY);
+}
+
+function removeLegacyRememberedState(storage: Storage): void {
+  storage.removeItem(REMEMBERED_SPACE_KEY);
+}
+
+function writeSessionState(storage: Storage, apiKey: string): void {
+  writeSessionKey(storage, apiKey);
   storage.setItem(LAST_ACTIVE_KEY, String(Date.now()));
 }
 
-export function getSpaceId(): string | null {
-  return sessionStorage.getItem(SPACE_ID_KEY);
+function migrateLegacySessionState(storage: Storage): string | null {
+  const legacyApiKey = storage.getItem(SPACE_ID_KEY);
+  if (!legacyApiKey) {
+    return null;
+  }
+
+  writeSessionKey(storage, legacyApiKey);
+  return legacyApiKey;
 }
 
-function readRememberedSpace(): RememberedSpace | null {
+function readRawRememberedApiKey(
+  storage: Storage,
+  key: string,
+  valueKey: "apiKey" | "spaceId",
+): RememberedApiKey | null {
   try {
-    const raw = localStorage.getItem(REMEMBERED_SPACE_KEY);
+    const raw = storage.getItem(key);
     if (!raw) return null;
 
-    const parsed = JSON.parse(raw) as Partial<RememberedSpace>;
+    const parsed = JSON.parse(raw) as Partial<RememberedApiKey & { spaceId: string }>;
+    const storedValue = parsed[valueKey];
     if (
-      typeof parsed.spaceId !== "string" ||
+      typeof storedValue !== "string" ||
       typeof parsed.expiresAt !== "number"
     ) {
-      localStorage.removeItem(REMEMBERED_SPACE_KEY);
+      storage.removeItem(key);
       return null;
     }
 
     if (parsed.expiresAt <= Date.now()) {
-      localStorage.removeItem(REMEMBERED_SPACE_KEY);
+      storage.removeItem(key);
       return null;
     }
 
     return {
-      spaceId: parsed.spaceId,
+      apiKey: storedValue,
       expiresAt: parsed.expiresAt,
     };
   } catch {
-    localStorage.removeItem(REMEMBERED_SPACE_KEY);
+    storage.removeItem(key);
     return null;
   }
 }
 
-export function setSpaceId(id: string, remember = false): void {
-  writeSessionState(sessionStorage, id);
+function writeRememberedApiKey(
+  storage: Storage,
+  apiKey: string,
+  expiresAt = Date.now() + REMEMBER_ME_TTL_MS,
+): void {
+  const remembered: RememberedApiKey = {
+    apiKey,
+    expiresAt,
+  };
+  storage.setItem(REMEMBERED_API_KEY, JSON.stringify(remembered));
+  removeLegacyRememberedState(storage);
+}
+
+function readRememberedApiKey(): RememberedApiKey | null {
+  const rememberedApiKey = readRawRememberedApiKey(
+    localStorage,
+    REMEMBERED_API_KEY,
+    "apiKey",
+  );
+  if (rememberedApiKey) {
+    removeLegacyRememberedState(localStorage);
+    return rememberedApiKey;
+  }
+
+  const legacyRememberedApiKey = readRawRememberedApiKey(
+    localStorage,
+    REMEMBERED_SPACE_KEY,
+    "spaceId",
+  );
+  if (!legacyRememberedApiKey) {
+    return null;
+  }
+
+  writeRememberedApiKey(
+    localStorage,
+    legacyRememberedApiKey.apiKey,
+    legacyRememberedApiKey.expiresAt,
+  );
+  return legacyRememberedApiKey;
+}
+
+export function getApiKey(): string | null {
+  const apiKey = sessionStorage.getItem(API_KEY_KEY);
+  if (apiKey) {
+    removeLegacySessionState(sessionStorage);
+    return apiKey;
+  }
+
+  return migrateLegacySessionState(sessionStorage);
+}
+
+export function setApiKey(apiKey: string, remember = false): void {
+  writeSessionState(sessionStorage, apiKey);
 
   if (remember) {
-    const remembered: RememberedSpace = {
-      spaceId: id,
-      expiresAt: Date.now() + REMEMBER_ME_TTL_MS,
-    };
-    localStorage.setItem(REMEMBERED_SPACE_KEY, JSON.stringify(remembered));
+    writeRememberedApiKey(localStorage, apiKey);
     return;
   }
 
-  localStorage.removeItem(REMEMBERED_SPACE_KEY);
+  localStorage.removeItem(REMEMBERED_API_KEY);
+  removeLegacyRememberedState(localStorage);
+}
+
+export function getSpaceId(): string | null {
+  return getApiKey();
+}
+
+export function setSpaceId(spaceId: string, remember = false): void {
+  setApiKey(spaceId, remember);
 }
 
 export function clearSpace(): void {
+  sessionStorage.removeItem(API_KEY_KEY);
   sessionStorage.removeItem(SPACE_ID_KEY);
   sessionStorage.removeItem(LAST_ACTIVE_KEY);
+  localStorage.removeItem(REMEMBERED_API_KEY);
   localStorage.removeItem(REMEMBERED_SPACE_KEY);
 }
 
@@ -80,24 +164,36 @@ export function isSessionExpired(): boolean {
   return Date.now() - Number(last) > IDLE_TIMEOUT_MS;
 }
 
-export function restoreRememberedSpace(): string | null {
-  const remembered = readRememberedSpace();
+export function restoreRememberedApiKey(): string | null {
+  const remembered = readRememberedApiKey();
   if (!remembered) return null;
 
-  writeSessionState(sessionStorage, remembered.spaceId);
-  return remembered.spaceId;
+  writeSessionState(sessionStorage, remembered.apiKey);
+  return remembered.apiKey;
+}
+
+export function getActiveApiKey(): string | null {
+  return getApiKey() ?? restoreRememberedApiKey();
+}
+
+export function restoreRememberedSpace(): string | null {
+  return restoreRememberedApiKey();
 }
 
 export function getActiveSpaceId(): string | null {
-  return getSpaceId() ?? restoreRememberedSpace();
+  return getActiveApiKey();
 }
 
-export function isRememberedSpace(spaceId: string): boolean {
-  if (!spaceId) {
+export function isRememberedApiKey(apiKey: string): boolean {
+  if (!apiKey) {
     return false;
   }
 
-  return readRememberedSpace()?.spaceId === spaceId;
+  return readRememberedApiKey()?.apiKey === apiKey;
+}
+
+export function isRememberedSpace(spaceId: string): boolean {
+  return isRememberedApiKey(spaceId);
 }
 
 export function maskSpaceId(id: string): string {

--- a/dashboard/app/src/pages/connect-loader.ts
+++ b/dashboard/app/src/pages/connect-loader.ts
@@ -5,7 +5,7 @@ import {
   consumeConnectBootstrap,
   initializeConnectBootstrapFromLocation,
 } from "@/lib/connect-bootstrap";
-import { setSpaceId } from "@/lib/session";
+import { setApiKey } from "@/lib/session";
 
 export interface ConnectRouteLoaderData {
   hasBootstrapParams: boolean;
@@ -41,7 +41,7 @@ export async function loadConnectRouteData(): Promise<ConnectRouteLoaderData> {
 
   try {
     await api.verifySpace(bootstrap.autoConnectKey);
-    setSpaceId(bootstrap.autoConnectKey, false);
+    setApiKey(bootstrap.autoConnectKey, false);
     throw redirect({ replace: true, to: "/space" });
   } catch (error) {
     if (isRedirect(error)) {

--- a/dashboard/app/src/pages/connect.test.tsx
+++ b/dashboard/app/src/pages/connect.test.tsx
@@ -7,7 +7,7 @@ import { ConnectPage } from "./connect";
 import { loadConnectRouteData, type ConnectRouteLoaderData } from "./connect-loader";
 
 const mocks = vi.hoisted(() => ({
-  getActiveSpaceId: vi.fn<() => string | null>(() => null),
+  getActiveApiKey: vi.fn<() => string | null>(() => null),
   initMixpanelOnLogin: vi.fn(),
   loaderData: {
     hasBootstrapParams: false,
@@ -15,7 +15,7 @@ const mocks = vi.hoisted(() => ({
     initialInput: "",
   } as ConnectRouteLoaderData,
   navigate: vi.fn(() => Promise.resolve()),
-  setSpaceId: vi.fn(),
+  setApiKey: vi.fn(),
   trackMixpanelEvent: vi.fn(),
   verifySpace: vi.fn(),
 }));
@@ -50,9 +50,9 @@ vi.mock("@/lib/mixpanel", () => ({
 vi.mock("@/lib/session", () => ({
   MEM9_CONNECT_READY_EVENT: "mem9-connect-ready",
   MEM9_SPACE_HANDOFF_EVENT: "mem9-space-handoff",
-  getActiveSpaceId: () => mocks.getActiveSpaceId(),
-  setSpaceId: (spaceId: string, remember?: boolean) =>
-    mocks.setSpaceId(spaceId, remember),
+  getActiveApiKey: () => mocks.getActiveApiKey(),
+  setApiKey: (apiKey: string, remember?: boolean) =>
+    mocks.setApiKey(apiKey, remember),
 }));
 
 function setLoaderData(next: ConnectRouteLoaderData): void {
@@ -65,11 +65,11 @@ function currentURL(): string {
 
 beforeEach(() => {
   resetConnectBootstrapForTests();
-  mocks.getActiveSpaceId.mockReset();
-  mocks.getActiveSpaceId.mockReturnValue(null);
+  mocks.getActiveApiKey.mockReset();
+  mocks.getActiveApiKey.mockReturnValue(null);
   mocks.initMixpanelOnLogin.mockReset();
   mocks.navigate.mockClear();
-  mocks.setSpaceId.mockReset();
+  mocks.setApiKey.mockReset();
   mocks.trackMixpanelEvent.mockReset();
   mocks.verifySpace.mockReset();
   setLoaderData({
@@ -104,7 +104,7 @@ describe("loadConnectRouteData", () => {
   });
 
   it("auto-logins key params, replaces the active space, and strips them from the URL", async () => {
-    mocks.getActiveSpaceId.mockReturnValue("space-old");
+    mocks.getActiveApiKey.mockReturnValue("space-old");
     mocks.verifySpace.mockResolvedValue({
       created_at: "",
       memory_count: 0,
@@ -129,7 +129,7 @@ describe("loadConnectRouteData", () => {
     }
 
     expect(mocks.verifySpace).toHaveBeenCalledWith("space-new");
-    expect(mocks.setSpaceId).toHaveBeenCalledWith("space-new", false);
+    expect(mocks.setApiKey).toHaveBeenCalledWith("space-new", false);
     expect(currentURL()).toBe("/your-memory?foo=1#details");
   });
 
@@ -144,14 +144,14 @@ describe("loadConnectRouteData", () => {
       initialError: i18n.t("connect.error.invalid"),
       initialInput: "bad-space",
     });
-    expect(mocks.setSpaceId).not.toHaveBeenCalled();
+    expect(mocks.setApiKey).not.toHaveBeenCalled();
     expect(currentURL()).toBe("/your-memory");
   });
 });
 
 describe("ConnectPage", () => {
   it("shows bootstrap-prefilled input and does not auto-redirect an existing session", async () => {
-    mocks.getActiveSpaceId.mockReturnValue("space-existing");
+    mocks.getActiveApiKey.mockReturnValue("space-existing");
     setLoaderData({
       hasBootstrapParams: true,
       initialError: "",
@@ -168,7 +168,7 @@ describe("ConnectPage", () => {
   });
 
   it("auto-redirects existing sessions when there are no bootstrap params", async () => {
-    mocks.getActiveSpaceId.mockReturnValue("space-existing");
+    mocks.getActiveApiKey.mockReturnValue("space-existing");
 
     render(<ConnectPage />);
 
@@ -191,5 +191,26 @@ describe("ConnectPage", () => {
 
     expect(screen.getByDisplayValue("bad-space")).toBeInTheDocument();
     expect(screen.getByText(i18n.t("connect.error.invalid"))).toBeInTheDocument();
+  });
+
+  it("renders MEM9_API_KEY wording and retrieval guidance", () => {
+    render(<ConnectPage />);
+
+    expect(screen.getByText("Enter your MEM9_API_KEY")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("MEM9_API_KEY")).toBeInTheDocument();
+    expect(
+      screen.getByText("MEM9_API_KEY unlocks your memory. Keep it private."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Get your MEM9_API_KEY")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "In OpenClaw, copy MEM9_API_KEY from your mem9 or environment settings.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Other agent tools usually expose the same MEM9_API_KEY in their mem9 config.",
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/dashboard/app/src/pages/connect.test.tsx
+++ b/dashboard/app/src/pages/connect.test.tsx
@@ -196,20 +196,24 @@ describe("ConnectPage", () => {
   it("renders MEM9_API_KEY wording and retrieval guidance", () => {
     render(<ConnectPage />);
 
-    expect(screen.getByText("Enter your MEM9_API_KEY")).toBeInTheDocument();
+    expect(
+      screen.getByText("Enter your MEM9_API_KEY to open your memory space"),
+    ).toBeInTheDocument();
     expect(screen.getByPlaceholderText("MEM9_API_KEY")).toBeInTheDocument();
     expect(
-      screen.getByText("MEM9_API_KEY unlocks your memory. Keep it private."),
+      screen.getByText(
+        "MEM9_API_KEY is your private key. Do not share it with others.",
+      ),
     ).toBeInTheDocument();
-    expect(screen.getByText("Get your MEM9_API_KEY")).toBeInTheDocument();
+    expect(screen.getByText("How to get your MEM9_API_KEY")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "In OpenClaw, copy MEM9_API_KEY from your mem9 or environment settings.",
+        "Ask OpenClaw to show you the MEM9_API_KEY it is already using.",
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Other agent tools usually expose the same MEM9_API_KEY in their mem9 config.",
+        "For other agent tools, ask the agent to show you its MEM9_API_KEY or tell you where it is stored.",
       ),
     ).toBeInTheDocument();
   });

--- a/dashboard/app/src/pages/connect.test.tsx
+++ b/dashboard/app/src/pages/connect.test.tsx
@@ -63,7 +63,16 @@ function currentURL(): string {
   return `${window.location.pathname}${window.location.search}${window.location.hash}`;
 }
 
-beforeEach(() => {
+function getByExactText(text: string): HTMLElement {
+  return screen.getByText((_, element) => element?.textContent === text);
+}
+
+function getInlineCodeTokens(): HTMLElement[] {
+  return screen.getAllByText("MEM9_API_KEY", { selector: "code" });
+}
+
+beforeEach(async () => {
+  await i18n.changeLanguage("en");
   resetConnectBootstrapForTests();
   mocks.getActiveApiKey.mockReset();
   mocks.getActiveApiKey.mockReturnValue(null);
@@ -196,22 +205,38 @@ describe("ConnectPage", () => {
   it("renders MEM9_API_KEY wording and retrieval guidance", () => {
     render(<ConnectPage />);
 
-    expect(
-      screen.getByText("Use your MEM9_API_KEY to continue"),
-    ).toBeInTheDocument();
+    expect(getByExactText("Use your MEM9_API_KEY to continue")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("MEM9_API_KEY")).toBeInTheDocument();
+    expect(getInlineCodeTokens()).toHaveLength(5);
     expect(
-      screen.getByText("MEM9_API_KEY is your private key. Do not share it."),
+      getByExactText("MEM9_API_KEY is your private key. Do not share it."),
     ).toBeInTheDocument();
-    expect(screen.getByText("How to get your MEM9_API_KEY")).toBeInTheDocument();
+    expect(getByExactText("How to get your MEM9_API_KEY")).toBeInTheDocument();
     expect(
-      screen.getByText(
+      getByExactText(
         "Ask OpenClaw to show you the MEM9_API_KEY it is already using.",
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
+      getByExactText(
         "For other agent tools, ask the agent to show you its MEM9_API_KEY or tell you where it is stored.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders zh-CN MEM9_API_KEY guidance with inline code tokens", async () => {
+    await i18n.changeLanguage("zh-CN");
+
+    render(<ConnectPage />);
+
+    expect(getByExactText("使用 MEM9_API_KEY 继续")).toBeInTheDocument();
+    expect(getInlineCodeTokens()).toHaveLength(5);
+    expect(
+      getByExactText("MEM9_API_KEY 是你的私密密钥。请勿分享。"),
+    ).toBeInTheDocument();
+    expect(
+      getByExactText(
+        "让 OpenClaw 直接把它当前正在使用的 MEM9_API_KEY 发给你。",
       ),
     ).toBeInTheDocument();
   });

--- a/dashboard/app/src/pages/connect.test.tsx
+++ b/dashboard/app/src/pages/connect.test.tsx
@@ -249,7 +249,9 @@ describe("ConnectPage", () => {
     fireEvent.change(screen.getByPlaceholderText("MEM9_API_KEY"), {
       target: { value: "bad-key" },
     });
-    fireEvent.click(screen.getByRole("button", { name: /open memory/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: i18n.t("connect.submit") }),
+    );
 
     await waitFor(() => {
       expect(

--- a/dashboard/app/src/pages/connect.test.tsx
+++ b/dashboard/app/src/pages/connect.test.tsx
@@ -197,13 +197,11 @@ describe("ConnectPage", () => {
     render(<ConnectPage />);
 
     expect(
-      screen.getByText("Enter your MEM9_API_KEY to open your memory space"),
+      screen.getByText("Use your MEM9_API_KEY to continue"),
     ).toBeInTheDocument();
     expect(screen.getByPlaceholderText("MEM9_API_KEY")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "MEM9_API_KEY is your private key. Do not share it with others.",
-      ),
+      screen.getByText("MEM9_API_KEY is your private key. Do not share it."),
     ).toBeInTheDocument();
     expect(screen.getByText("How to get your MEM9_API_KEY")).toBeInTheDocument();
     expect(

--- a/dashboard/app/src/pages/connect.test.tsx
+++ b/dashboard/app/src/pages/connect.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { isRedirect } from "@tanstack/react-router";
 import i18n from "@/i18n";
@@ -212,5 +212,23 @@ describe("ConnectPage", () => {
         "Other agent tools usually expose the same MEM9_API_KEY in their mem9 config.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("shows the generic invalid copy when manual connect fails", async () => {
+    mocks.verifySpace.mockRejectedValue(new Error("invalid API key"));
+
+    render(<ConnectPage />);
+
+    fireEvent.change(screen.getByPlaceholderText("MEM9_API_KEY"), {
+      target: { value: "bad-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /open memory/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(i18n.t("connect.error.invalid")),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("invalid API key")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/app/src/pages/connect.tsx
+++ b/dashboard/app/src/pages/connect.tsx
@@ -134,9 +134,8 @@ export function ConnectPage() {
         }
       } catch (err) {
         if (!cancelled) {
-          setError(
-            err instanceof Error ? err.message : t("connect.error.invalid"),
-          );
+          void err;
+          setError(t("connect.error.invalid"));
         }
       } finally {
         if (!cancelled) {

--- a/dashboard/app/src/pages/connect.tsx
+++ b/dashboard/app/src/pages/connect.tsx
@@ -9,10 +9,10 @@ import { api } from "@/api/client";
 import { initMixpanelOnLogin, trackMixpanelEvent } from "@/lib/mixpanel";
 import type { ConnectRouteLoaderData } from "@/pages/connect-loader";
 import {
-  getActiveSpaceId,
+  getActiveApiKey,
   MEM9_CONNECT_READY_EVENT,
   MEM9_SPACE_HANDOFF_EVENT,
-  setSpaceId,
+  setApiKey,
 } from "@/lib/session";
 
 const connectRoute = getRouteApi("/");
@@ -39,8 +39,8 @@ export function ConnectPage() {
   const [loading, setLoading] = useState(false);
   const [rememberLogin, setRememberLogin] = useState(false);
   const [pendingConnect, setPendingConnect] = useState<{
+    apiKey: string;
     remember: boolean;
-    spaceId: string;
   } | null>(null);
 
   useEffect(() => {
@@ -48,7 +48,7 @@ export function ConnectPage() {
       return;
     }
 
-    if (getActiveSpaceId()) {
+    if (getActiveApiKey()) {
       void navigate({ to: "/space", replace: true });
     }
   }, [loaderData.hasBootstrapParams, navigate]);
@@ -88,7 +88,7 @@ export function ConnectPage() {
       setInput(nextSpaceId);
       setRememberLogin(false);
       setPendingConnect((current) =>
-        current ?? { remember: false, spaceId: nextSpaceId },
+        current ?? { apiKey: nextSpaceId, remember: false },
       );
     }
 
@@ -112,7 +112,7 @@ export function ConnectPage() {
     let cancelled = false;
 
     async function connectToSpace() {
-      const normalizedInput = connectRequest.spaceId.trim();
+      const normalizedInput = connectRequest.apiKey.trim();
       if (!normalizedInput) {
         setPendingConnect(null);
         return;
@@ -127,7 +127,7 @@ export function ConnectPage() {
         trackMixpanelEvent("Dashboard/Connect/SubmitClicked", {
           pageName: "connect",
         });
-        setSpaceId(normalizedInput, connectRequest.remember);
+        setApiKey(normalizedInput, connectRequest.remember);
 
         if (!cancelled) {
           await navigate({ to: "/space", replace: true });
@@ -157,8 +157,8 @@ export function ConnectPage() {
     e.preventDefault();
     setError("");
     setPendingConnect({
+      apiKey: input,
       remember: rememberLogin,
-      spaceId: input,
     });
   }
 
@@ -270,7 +270,7 @@ export function ConnectPage() {
             {t("connect.how_title")}
           </h2>
           <div className="space-y-3">
-            {(["how_1", "how_2", "how_3"] as const).map((key, i) => (
+            {(["how_1", "how_2"] as const).map((key, i) => (
               <div key={key} className="flex items-start gap-3">
                 <span className="flex size-5 shrink-0 items-center justify-center rounded-md bg-secondary text-[11px] font-semibold text-muted-foreground">
                   {i + 1}

--- a/dashboard/app/src/pages/connect.tsx
+++ b/dashboard/app/src/pages/connect.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { getRouteApi, useNavigate } from "@tanstack/react-router";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Loader2, Globe, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -27,6 +27,14 @@ function getOpenerOrigin(): string | null {
   } catch {
     return null;
   }
+}
+
+function InlineToken({ children }: { children?: ReactNode }) {
+  return (
+    <code className="rounded bg-secondary px-1 py-0.5 font-mono text-[0.92em] text-foreground">
+      {children}
+    </code>
+  );
 }
 
 export function ConnectPage() {
@@ -198,7 +206,7 @@ export function ConnectPage() {
             {t("connect.title")}
           </h1>
           <p className="mt-2 text-[15px] text-muted-foreground">
-            {t("connect.subtitle")}
+            <Trans i18nKey="connect.subtitle" components={{ code: <InlineToken /> }} />
           </p>
         </div>
 
@@ -260,13 +268,13 @@ export function ConnectPage() {
           </form>
 
           <p className="mt-4 text-center text-xs text-soft-foreground">
-            {t("connect.security")}
+            <Trans i18nKey="connect.security" components={{ code: <InlineToken /> }} />
           </p>
         </div>
 
         <div className="mt-10 space-y-4">
           <h2 className="text-xs font-semibold uppercase tracking-[0.22em] text-ring">
-            {t("connect.how_title")}
+            <Trans i18nKey="connect.how_title" components={{ code: <InlineToken /> }} />
           </h2>
           <div className="space-y-3">
             {(["how_1", "how_2"] as const).map((key, i) => (
@@ -275,7 +283,7 @@ export function ConnectPage() {
                   {i + 1}
                 </span>
                 <p className="text-sm leading-relaxed text-muted-foreground">
-                  {t(`connect.${key}`)}
+                  <Trans i18nKey={`connect.${key}`} components={{ code: <InlineToken /> }} />
                 </p>
               </div>
             ))}

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "@tanstack/react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { router } from "@/router";
+import { features } from "@/config/features";
 import i18n from "@/i18n";
 import type { Memory } from "@/types/memory";
 import type { SpaceAnalysisState } from "@/types/analysis";
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   useSelectedSessionMessages: vi.fn(),
   useMemories: vi.fn(),
   useDeepAnalysisReports: vi.fn(),
+  createMemoryMutateAsync: vi.fn(),
 }));
 
 const FIXED_NOW = new Date("2026-03-21T12:00:00Z");
@@ -417,7 +419,10 @@ vi.mock("@/api/queries", () => ({
       isFetching: false,
     };
   },
-  useCreateMemory: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCreateMemory: () => ({
+    mutateAsync: mocks.createMemoryMutateAsync,
+    isPending: false,
+  }),
   useDeleteMemory: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useUpdateMemory: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useExportMemories: () => ({ mutateAsync: vi.fn(), isPending: false }),
@@ -530,6 +535,17 @@ describe("SpacePage", () => {
     mocks.useSelectedSessionMessages.mockClear();
     mocks.useMemories.mockClear();
     mocks.useDeepAnalysisReports.mockClear();
+    mocks.createMemoryMutateAsync.mockReset();
+    mocks.createMemoryMutateAsync.mockResolvedValue(
+      createMemory(
+        "mem-new-1",
+        "Remember my coffee order",
+        "2026-03-21T12:00:00Z",
+        "pinned",
+        ["preference", "coffee"],
+      ),
+    );
+    features.enableManualAdd = false;
     await i18n.changeLanguage("en");
     window.history.pushState({}, "", "/your-memory/space");
     await act(async () => {
@@ -600,6 +616,39 @@ describe("SpacePage", () => {
 
     await waitFor(() => {
       expect(mocks.useStats).toHaveBeenCalledWith("space-1", undefined, true);
+    });
+  });
+
+  it("creates pinned manual memory from the toolbar add dialog", async () => {
+    features.enableManualAdd = true;
+
+    renderSpacePage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add memory" }));
+
+    const dialog = screen.getByRole("dialog");
+    const textboxes = within(dialog).getAllByRole("textbox");
+    const contentInput = textboxes[0];
+    const tagsInput = textboxes[1];
+
+    if (!contentInput || !tagsInput) {
+      throw new Error("Expected content and tags inputs in the add dialog");
+    }
+
+    fireEvent.change(contentInput, {
+      target: { value: "Remember my coffee order" },
+    });
+    fireEvent.change(tagsInput, {
+      target: { value: "preference, coffee" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.createMemoryMutateAsync).toHaveBeenCalledWith({
+        content: "Remember my coffee order",
+        memory_type: "pinned",
+        tags: ["preference", "coffee"],
+      });
     });
   });
 

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -167,6 +167,16 @@ const archivedMemory = createMemory(
   "2026-03-21T00:00:00Z",
 );
 
+const defaultMemories = [
+  activityNewest,
+  preferenceMemory,
+  activityOlder,
+  archivedMemory,
+];
+
+let mockedPageMemories = [...defaultMemories];
+let mockedSourceMemories = [...defaultMemories];
+
 const analysisState: SpaceAnalysisState = {
   phase: "completed",
   snapshot: {
@@ -325,7 +335,13 @@ vi.mock("@/api/queries", () => ({
   useStats: (spaceId: string, range?: string, enabled = true) => {
     mocks.useStats(spaceId, range, enabled);
     return {
-      data: enabled ? { total: 4, pinned: 0, insight: 4 } : undefined,
+      data: enabled
+        ? {
+            total: mockedPageMemories.length,
+            pinned: mockedPageMemories.filter((memory) => memory.memory_type === "pinned").length,
+            insight: mockedPageMemories.filter((memory) => memory.memory_type === "insight").length,
+          }
+        : undefined,
       isLoading: false,
       isFetching: false,
     };
@@ -336,8 +352,8 @@ vi.mock("@/api/queries", () => ({
       data: {
         pages: [
           {
-            memories: [activityNewest, preferenceMemory, activityOlder, archivedMemory],
-            total: 4,
+            memories: mockedPageMemories,
+            total: mockedPageMemories.length,
             limit: 50,
             offset: 0,
           },
@@ -436,7 +452,7 @@ vi.mock("@/api/source-memories", () => ({
   useSourceMemories: (_spaceId: string) => {
     mocks.useSourceMemories(_spaceId);
     return {
-      data: [activityNewest, preferenceMemory, activityOlder, archivedMemory],
+      data: mockedSourceMemories,
       isLoading: false,
       isFetching: false,
       refetch: vi.fn(async () => undefined),
@@ -545,6 +561,8 @@ describe("SpacePage", () => {
         ["preference", "coffee"],
       ),
     );
+    mockedPageMemories = [...defaultMemories];
+    mockedSourceMemories = [...defaultMemories];
     features.enableManualAdd = false;
     await i18n.changeLanguage("en");
     window.history.pushState({}, "", "/your-memory/space");
@@ -650,6 +668,38 @@ describe("SpacePage", () => {
         tags: ["preference", "coffee"],
       });
     });
+  });
+
+  it("hides empty-state manual-add affordance when manual add is gated off", async () => {
+    mockedPageMemories = [];
+    mockedSourceMemories = [];
+
+    renderSpacePage();
+
+    expect(screen.getByText("This space has no memories yet")).toBeInTheDocument();
+    expect(
+      screen.getByText("Memories are accumulated as you chat with your agent."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Save your first memory" }),
+    ).toBeNull();
+  });
+
+  it("shows empty-state manual-add affordance when manual add is enabled", async () => {
+    mockedPageMemories = [];
+    mockedSourceMemories = [];
+    features.enableManualAdd = true;
+
+    renderSpacePage();
+
+    expect(
+      screen.getByText(
+        "Memories are accumulated as you chat with your agent. You can also save the first one now.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Save your first memory" }),
+    ).toBeInTheDocument();
   });
 
   it("navigates to memory farm in the current tab from the single CTA", async () => {

--- a/dashboard/app/src/pages/space.tsx
+++ b/dashboard/app/src/pages/space.tsx
@@ -93,6 +93,7 @@ export function SpacePage() {
     try {
       await dataModel.createMutation.mutateAsync({
         content,
+        memory_type: "pinned",
         tags: tags.length ? tags : undefined,
       });
       setAddOpen(false);

--- a/dashboard/app/src/types/memory.ts
+++ b/dashboard/app/src/types/memory.ts
@@ -29,11 +29,17 @@ export interface MemoryListResponse {
 
 export interface MemoryCreateInput {
   content: string;
+  memory_type: "pinned";
+  tags?: string[];
+}
+
+export interface MemoryBatchCreateInput {
+  content: string;
   tags?: string[];
 }
 
 export interface MemoryBatchCreateRequest {
-  memories: MemoryCreateInput[];
+  memories: MemoryBatchCreateInput[];
 }
 
 export interface MemoryBatchCreateResponse {

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -25,14 +25,15 @@ var (
 )
 
 type createMemoryRequest struct {
-	Content   string                  `json:"content,omitempty"`
-	AgentID   string                  `json:"agent_id,omitempty"`
-	Tags      []string                `json:"tags,omitempty"`
-	Metadata  json.RawMessage         `json:"metadata,omitempty"`
-	Messages  []service.IngestMessage `json:"messages,omitempty"`
-	SessionID string                  `json:"session_id,omitempty"`
-	Mode      service.IngestMode      `json:"mode,omitempty"`
-	Sync      bool                    `json:"sync,omitempty"`
+	Content    string                  `json:"content,omitempty"`
+	MemoryType string                  `json:"memory_type,omitempty"`
+	AgentID    string                  `json:"agent_id,omitempty"`
+	Tags       []string                `json:"tags,omitempty"`
+	Metadata   json.RawMessage         `json:"metadata,omitempty"`
+	Messages   []service.IngestMessage `json:"messages,omitempty"`
+	SessionID  string                  `json:"session_id,omitempty"`
+	Mode       service.IngestMode      `json:"mode,omitempty"`
+	Sync       bool                    `json:"sync,omitempty"`
 }
 
 func isSyncIngestTimeout(ctx context.Context, err error) bool {
@@ -130,6 +131,27 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	tags := append([]string(nil), req.Tags...)
 	metadata := append(json.RawMessage(nil), req.Metadata...)
 	content := req.Content
+	explicitMemoryType := strings.TrimSpace(req.MemoryType)
+
+	if explicitMemoryType != "" {
+		if explicitMemoryType != string(domain.TypePinned) {
+			s.handleError(r.Context(), w, &domain.ValidationError{
+				Field:   "memory_type",
+				Message: fmt.Sprintf("unsupported value %q; only %q is supported on the explicit content path", explicitMemoryType, domain.TypePinned),
+			})
+			return
+		}
+
+		mem, written, err := svc.memory.CreatePinned(r.Context(), agentID, content, tags, metadata)
+		if err != nil {
+			slog.Error("pinned memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		go s.refreshWriteMetrics(auth, svc, int64(written))
+		respond(w, http.StatusCreated, mem)
+		return
+	}
 
 	if req.Sync {
 		// s.persistContentSession(r.Context(), auth, svc, req.SessionID, agentID, content, metadata)

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -63,6 +63,11 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if hasMessages && strings.TrimSpace(req.MemoryType) != "" {
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "memory_type", Message: "memory_type is only allowed with content, not messages"})
+		return
+	}
+
 	if hasMessages {
 		messages := append([]service.IngestMessage(nil), req.Messages...)
 		ingestReq := service.IngestRequest{

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -396,6 +396,23 @@ func TestCreateMemory_ContentWithUnsupportedExplicitMemoryType_Returns400(t *tes
 	}
 }
 
+func TestCreateMemory_MessagesWithMemoryType_Returns400(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+
+	body := map[string]any{
+		"messages":    []map[string]string{{"role": "user", "content": "hello"}},
+		"memory_type": "pinned",
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestCreateMemory_SyncContent_WithSessionID_DoesNotPersistRawSession(t *testing.T) {
 	sessRepo := &testSessionRepo{}
 	srv := newTestServer(&testMemoryRepo{}, sessRepo)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -26,6 +26,7 @@ import (
 type testMemoryRepo struct {
 	mu                   sync.Mutex
 	createCalls          []*domain.Memory
+	bulkCreateCalls      int
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordFilter    domain.MemoryFilter
@@ -73,8 +74,13 @@ func (m *testMemoryRepo) SetState(context.Context, string, domain.MemoryState) e
 func (m *testMemoryRepo) List(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
 	return nil, 0, nil
 }
-func (m *testMemoryRepo) Count(context.Context) (int, error)                 { return 0, nil }
-func (m *testMemoryRepo) BulkCreate(context.Context, []*domain.Memory) error { return nil }
+func (m *testMemoryRepo) Count(context.Context) (int, error) { return 0, nil }
+func (m *testMemoryRepo) BulkCreate(context.Context, []*domain.Memory) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.bulkCreateCalls++
+	return nil
+}
 func (m *testMemoryRepo) VectorSearch(context.Context, []float32, domain.MemoryFilter, int) ([]domain.Memory, error) {
 	return nil, nil
 }
@@ -290,7 +296,8 @@ func makeTenantRequest(t *testing.T, method, path string, body any) *http.Reques
 }
 
 func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
-	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
 
 	body := map[string]any{
 		"content": "test memory content",
@@ -303,6 +310,89 @@ func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp["status"] != "ok" {
+		t.Fatalf("expected status=ok, got %q", resp["status"])
+	}
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("expected legacy create path to write once, got %d", len(memRepo.createCalls))
+	}
+	if memRepo.bulkCreateCalls != 0 {
+		t.Fatalf("expected legacy create path to skip bulk create, got %d", memRepo.bulkCreateCalls)
+	}
+}
+
+func TestCreateMemory_ContentWithPinnedMemoryType_Returns201Memory(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	content := "remember I prefer pour-over coffee"
+
+	body := map[string]any{
+		"content":     content,
+		"memory_type": "pinned",
+		"tags":        []string{"preference", "coffee"},
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp domain.Memory
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.MemoryType != domain.TypePinned {
+		t.Fatalf("expected pinned memory type, got %q", resp.MemoryType)
+	}
+	if resp.Content != content {
+		t.Fatalf("expected content %q, got %q", content, resp.Content)
+	}
+	if memRepo.bulkCreateCalls != 1 {
+		t.Fatalf("expected pinned content path to use bulk create once, got %d", memRepo.bulkCreateCalls)
+	}
+	if len(memRepo.createCalls) != 0 {
+		t.Fatalf("expected pinned content path to skip legacy create, got %d", len(memRepo.createCalls))
+	}
+}
+
+func TestCreateMemory_ContentWithUnsupportedExplicitMemoryType_Returns400(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+
+	body := map[string]any{
+		"content":     "remember this",
+		"memory_type": "insight",
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(resp["error"], "memory_type") {
+		t.Fatalf("expected memory_type validation error, got %q", resp["error"])
+	}
+	if memRepo.bulkCreateCalls != 0 {
+		t.Fatalf("expected validation failure to skip bulk create, got %d", memRepo.bulkCreateCalls)
+	}
+	if len(memRepo.createCalls) != 0 {
+		t.Fatalf("expected validation failure to skip legacy create, got %d", len(memRepo.createCalls))
 	}
 }
 

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -141,6 +141,25 @@ func (s *MemoryService) Create(ctx context.Context, agentID, content string, tag
 
 }
 
+func (s *MemoryService) CreatePinned(ctx context.Context, agentID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, int, error) {
+	memories, err := s.BulkCreate(ctx, agentID, []BulkMemoryInput{
+		{
+			Content:  content,
+			Tags:     tags,
+			Metadata: metadata,
+		},
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(memories) == 0 {
+		return nil, 0, fmt.Errorf("bulk create returned no memories")
+	}
+
+	mem := memories[0]
+	return &mem, len(memories), nil
+}
+
 // Get returns a single memory by ID.
 func (s *MemoryService) Get(ctx context.Context, id string) (*domain.Memory, error) {
 	return s.memories.GetByID(ctx, id)

--- a/server/internal/service/memory_test.go
+++ b/server/internal/service/memory_test.go
@@ -19,6 +19,20 @@ func floatEqual(a, b float64) bool {
 	return math.Abs(a-b) < 1e-9
 }
 
+type bulkCreateCaptureRepo struct {
+	memoryRepoMock
+	bulkCreateCalls [][]domain.Memory
+}
+
+func (m *bulkCreateCaptureRepo) BulkCreate(_ context.Context, memories []*domain.Memory) error {
+	copied := make([]domain.Memory, len(memories))
+	for i, memory := range memories {
+		copied[i] = *memory
+	}
+	m.bulkCreateCalls = append(m.bulkCreateCalls, copied)
+	return nil
+}
+
 func TestApplyTypeWeights(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -476,6 +490,59 @@ func TestCreateFallsBackToRawWhenLLMUnavailable(t *testing.T) {
 	}
 	if mem.MemoryType != domain.TypeInsight {
 		t.Fatalf("expected insight memory type, got %s", mem.MemoryType)
+	}
+}
+
+func TestCreatePinnedUsesBulkCreateSemantics(t *testing.T) {
+	t.Parallel()
+
+	repo := &bulkCreateCaptureRepo{}
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	mem, written, err := svc.CreatePinned(
+		context.Background(),
+		"agent-1",
+		"user prefers pour-over coffee",
+		[]string{"preference", "coffee"},
+		json.RawMessage(`{"source":"manual"}`),
+	)
+	if err != nil {
+		t.Fatalf("CreatePinned() error = %v", err)
+	}
+	if mem == nil {
+		t.Fatal("expected created memory")
+	}
+	if written != 1 {
+		t.Fatalf("expected 1 written memory, got %d", written)
+	}
+	if len(repo.bulkCreateCalls) != 1 {
+		t.Fatalf("expected 1 bulk create call, got %d", len(repo.bulkCreateCalls))
+	}
+
+	created := repo.bulkCreateCalls[0][0]
+	if created.MemoryType != domain.TypePinned {
+		t.Fatalf("expected pinned memory type, got %s", created.MemoryType)
+	}
+	if created.Source != "agent-1" {
+		t.Fatalf("expected source agent-1, got %q", created.Source)
+	}
+	if created.UpdatedBy != "agent-1" {
+		t.Fatalf("expected updated_by agent-1, got %q", created.UpdatedBy)
+	}
+	if created.State != domain.StateActive {
+		t.Fatalf("expected active state, got %q", created.State)
+	}
+	if created.Content != "user prefers pour-over coffee" {
+		t.Fatalf("expected content preserved, got %q", created.Content)
+	}
+	if len(created.Tags) != 2 || created.Tags[0] != "preference" || created.Tags[1] != "coffee" {
+		t.Fatalf("expected tags preserved, got %v", created.Tags)
+	}
+	if string(created.Metadata) != `{"source":"manual"}` {
+		t.Fatalf("expected metadata preserved, got %s", string(created.Metadata))
+	}
+	if mem.MemoryType != domain.TypePinned {
+		t.Fatalf("expected returned memory type pinned, got %s", mem.MemoryType)
 	}
 }
 


### PR DESCRIPTION
## Summary
- align the dashboard connect flow with `MEM9_API_KEY` wording and clearer retrieval/security guidance
- make dashboard manual add create pinned memories through `POST /memories` and guard mixed-version server responses
- tighten the server contract so `memory_type` is only accepted on the explicit content create path
- add dashboard and handler test coverage for the new auth and manual-memory behavior

## Testing
- cd dashboard/app && pnpm test src/pages/connect.test.tsx
- cd dashboard/app && pnpm typecheck
- cd server && GOCACHE=$PWD/.tmp/gocache GOMODCACHE=$PWD/.tmp/gomodcache GOPATH=$PWD/.tmp/gopath go test ./internal/handler -run "TestCreateMemory_"