### PR TITLE
chore(dashboard): rename dashboard mem9 agent id

### DIFF
--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -39,7 +39,7 @@ describe("httpProvider", () => {
     expect(url).toBe("/your-memory/api/memories?limit=1");
     expect(url).not.toContain("space-1");
     expect(headers.get("X-API-Key")).toBe("space-1");
-    expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
+    expect(headers.get("X-Mnemo-Agent-Id")).toBe("mem9-dashboard");
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
@@ -82,7 +82,7 @@ describe("httpProvider", () => {
       }),
     );
     expect(headers.get("X-API-Key")).toBe("space-1");
-    expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
+    expect(headers.get("X-Mnemo-Agent-Id")).toBe("mem9-dashboard");
     expect(upsertCachedMemories).toHaveBeenCalledWith(
       "space-1",
       [expect.objectContaining({ id: "mem-1", memory_type: "pinned" })],
@@ -148,7 +148,7 @@ describe("httpProvider", () => {
     expect(url).toBe("/your-memory/api/imports");
     expect(url).not.toContain("space-1");
     expect(headers.get("X-API-Key")).toBe("space-1");
-    expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
+    expect(headers.get("X-Mnemo-Agent-Id")).toBe("mem9-dashboard");
     expect(headers.has("Content-Type")).toBe(false);
     expect(init?.body).toBeInstanceOf(FormData);
   });
@@ -192,7 +192,7 @@ describe("httpProvider", () => {
     const headers = init?.headers as Headers;
     expect(url).toBe("/your-memory/api/session-messages?session_id=sess-1");
     expect(headers.get("X-API-Key")).toBe("space-1");
-    expect(headers.get("X-Mnemo-Agent-Id")).toBe("dashboard");
+    expect(headers.get("X-Mnemo-Agent-Id")).toBe("mem9-dashboard");
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -24,7 +24,7 @@ const API_BASE = (import.meta.env.VITE_API_BASE || "/your-memory/api").replace(
   /\/+$/,
   "",
 );
-const AGENT_ID = "dashboard";
+const AGENT_ID = "mem9-dashboard";
 const EMPTY_TIMESTAMP = new Date(0).toISOString();
 
 function normalizeTags(tags: unknown): string[] {

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -30,7 +30,7 @@ import {
   mockSpaceInfo,
 } from "./mock-data";
 
-const AGENT_ID = "dashboard";
+const AGENT_ID = "mem9-dashboard";
 
 function delay(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -42,7 +42,7 @@ const mockImportTaskStore: ImportTask[] = [
   {
     id: "task-001",
     tenant_id: "demo",
-    agent_id: "dashboard",
+    agent_id: AGENT_ID,
     file_name: "memories-backup.json",
     file_type: "memory",
     status: "done",
@@ -55,7 +55,7 @@ const mockImportTaskStore: ImportTask[] = [
   {
     id: "task-002",
     tenant_id: "demo",
-    agent_id: "dashboard",
+    agent_id: AGENT_ID,
     file_name: "team-knowledge.json",
     file_type: "memory",
     status: "done",
@@ -68,7 +68,7 @@ const mockImportTaskStore: ImportTask[] = [
   {
     id: "task-003",
     tenant_id: "demo",
-    agent_id: "dashboard",
+    agent_id: AGENT_ID,
     file_name: "invalid-format.json",
     file_type: "memory",
     status: "failed",
@@ -81,7 +81,7 @@ const mockImportTaskStore: ImportTask[] = [
   {
     id: "task-004",
     tenant_id: "demo",
-    agent_id: "dashboard",
+    agent_id: AGENT_ID,
     file_name: "latest-export.json",
     file_type: "memory",
     status: "processing",


### PR DESCRIPTION
## Summary
- rename the shared dashboard mem9 agent id from `dashboard` to `mem9-dashboard`
- keep the mock provider and seeded mock import tasks aligned with the new identity
- update provider-http tests to assert the new header value

## Testing
- pnpm test src/api/provider-mock.test.ts src/api/provider-http.test.ts
- pnpm typecheck