### PR TITLE
fix(server): decode TiDB Cloud spend limit payload

### DIFF
--- a/server/internal/tenant/starter.go
+++ b/server/internal/tenant/starter.go
@@ -126,18 +126,16 @@ func (p *TiDBCloudProvisioner) GetSpendLimit(ctx context.Context, clusterID stri
 	}
 
 	var result struct {
-		Cluster struct {
-			SpendingLimit struct {
-				Monthly int `json:"monthly"`
-			} `json:"spendingLimit"`
-		} `json:"cluster"`
+		SpendingLimit struct {
+			Monthly int `json:"monthly"`
+		} `json:"spendingLimit"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return 0, fmt.Errorf("get spend limit: decode response: %w", err)
 	}
 
-	return result.Cluster.SpendingLimit.Monthly, nil
+	return result.SpendingLimit.Monthly, nil
 }
 
 // IncreaseSpendLimit updates the monthly spend limit in USD cents.

--- a/server/internal/tenant/starter_test.go
+++ b/server/internal/tenant/starter_test.go
@@ -93,7 +93,7 @@ func TestTiDBCloudProvisioner_SpendLimit_GetSpendLimit_Success(t *testing.T) {
 	server := newSpendLimitDigestServer(t, spendLimitMockConfig{
 		expectedMethod: http.MethodGet,
 		responseStatus: http.StatusOK,
-		responseBody:   `{"cluster":{"spendingLimit":{"monthly":500}}}`,
+		responseBody:   `{"clusterId":"cluster-123","spendingLimit":{"monthly":500}}`,
 	})
 	defer server.Close()
 
@@ -113,7 +113,7 @@ func TestTiDBCloudProvisioner_SpendLimit_GetSpendLimit_InvalidJSON(t *testing.T)
 	server := newSpendLimitDigestServer(t, spendLimitMockConfig{
 		expectedMethod: http.MethodGet,
 		responseStatus: http.StatusOK,
-		responseBody:   `{"cluster":{"spendingLimit":{"monthly":500}}`,
+		responseBody:   `{"clusterId":"cluster-123","spendingLimit":{"monthly":500}`,
 	})
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
- Decode TiDB Cloud cluster detail responses using top-level `spendingLimit.monthly`
- Update spend-limit GET fixtures to match the real TiDB Cloud payload shape
- Prevent auto spend-limit bumps from treating missing nested fields as `0`

## Verification
- `go test -count=1 -run 'TestTiDBCloudProvisioner_SpendLimit' ./internal/tenant`