### PR TITLE
fix(dashboard): improve Your Memory mobile layouts

### DIFF
--- a/dashboard/app/src/components/space/deep-analysis-tab.tsx
+++ b/dashboard/app/src/components/space/deep-analysis-tab.tsx
@@ -972,6 +972,11 @@ export function DeepAnalysisTab({
     }
   };
 
+  // The empty-state card below already surfaces a primary "Create report" CTA
+  // when there are no reports yet, so we hide the redundant header CTA in that
+  // case to avoid duplicate prompts.
+  const showHeaderCreateButton = reports.length > 0;
+
   return (
     <div className="space-y-4">
       <DeepAnalysisOverlay active={hasActiveReport} />
@@ -987,16 +992,18 @@ export function DeepAnalysisTab({
             {t("deep_analysis.subtitle")}
           </p>
         </div>
-        <Button
-          onClick={() => {
-            void handleCreateReport();
-          }}
-          disabled={isCreating || hasActiveReport}
-          className="gap-2"
-        >
-          {isCreating ? <Loader2 className="size-4 animate-spin" /> : <Sparkles className="size-4" />}
-          {t("deep_analysis.create")}
-        </Button>
+        {showHeaderCreateButton && (
+          <Button
+            onClick={() => {
+              void handleCreateReport();
+            }}
+            disabled={isCreating || hasActiveReport}
+            className="gap-2"
+          >
+            {isCreating ? <Loader2 className="size-4 animate-spin" /> : <Sparkles className="size-4" />}
+            {t("deep_analysis.create")}
+          </Button>
+        )}
       </div>
 
       {inlineError && (

--- a/dashboard/app/src/components/space/delete-dialog.tsx
+++ b/dashboard/app/src/components/space/delete-dialog.tsx
@@ -29,11 +29,17 @@ export function DeleteDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
+        <DialogHeader className="min-w-0">
           <DialogTitle>{t("delete.title")}</DialogTitle>
           <DialogDescription asChild>
-            <div>
-              <p className="my-3 rounded-lg bg-secondary p-3 text-sm italic leading-relaxed text-muted-foreground">
+            <div className="min-w-0">
+              {/*
+                Memory content can include long paths, URLs or hashes with no
+                soft-break opportunities. `break-words` + `overflow-wrap:
+                anywhere` make sure the preview block stays inside the modal
+                regardless of what the user is about to delete.
+              */}
+              <p className="my-3 whitespace-pre-wrap break-words [overflow-wrap:anywhere] rounded-lg bg-secondary p-3 text-sm italic leading-relaxed text-muted-foreground">
                 &ldquo;
                 {memory.content.length > 120
                   ? memory.content.slice(0, 120) + "…"

--- a/dashboard/app/src/components/space/detail-panel.tsx
+++ b/dashboard/app/src/components/space/detail-panel.tsx
@@ -156,9 +156,17 @@ export const DetailPanelContent = ({
   }, [m.id, sessionMessages, sessionMessagesLoading]);
 
   return (
-    <div className={cn("relative flex h-full min-h-0 flex-col bg-background/50 backdrop-blur-sm", className)}>
-      <div className="flex items-center justify-between border-b border-border/40 bg-secondary/30 px-6 py-4">
-        <div className="flex items-center gap-2">
+    <div
+      className={cn(
+        // `min-w-0 overflow-hidden` keep the panel chrome (header buttons,
+        // delete CTA in the footer) anchored even when long unbreakable
+        // content inside the scroll area tries to expand the column.
+        "relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-background/50 backdrop-blur-sm",
+        className,
+      )}
+    >
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/40 bg-secondary/30 px-6 py-4">
+        <div className="flex min-w-0 items-center gap-2">
           <div
             className={`inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-medium ${
               isPinned
@@ -175,7 +183,7 @@ export const DetailPanelContent = ({
           </div>
           {facet && <FacetBadge facet={facet} t={t} />}
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex shrink-0 items-center gap-1">
           {isPinned && onEdit && (
             <Button
               variant="ghost"
@@ -221,16 +229,22 @@ export const DetailPanelContent = ({
       <div
         ref={scrollAreaRef}
         data-testid="detail-scroll-area"
-        className={cn("flex-1 overflow-y-auto px-7 py-6", scrollAreaClassName)}
+        className={cn(
+          // Vertical scroll only; horizontal must always be clipped so the
+          // panel chrome (header / delete footer) cannot get pushed offscreen
+          // by long codeblocks or paths inside the memory or session preview.
+          "min-w-0 flex-1 overflow-x-hidden overflow-y-auto px-7 py-6",
+          scrollAreaClassName,
+        )}
       >
-        <div className="space-y-6">
+        <div className="min-w-0 space-y-6">
           {/* Memory Insight */}
-          <div>
+          <div className="min-w-0">
             <div className="flex items-center gap-2 mb-3 text-[11px] font-semibold uppercase tracking-wider text-type-insight">
               <Sparkles className="size-3.5" />
               {t("detail.metadata", { defaultValue: "Extracted Memory" })}
             </div>
-            <p className="whitespace-pre-wrap text-[15px] leading-relaxed text-foreground/90 font-medium">
+            <p className="whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-[15px] leading-relaxed text-foreground/90 font-medium">
               {m.content}
             </p>
           </div>

--- a/dashboard/app/src/components/space/memory-insight-relations.tsx
+++ b/dashboard/app/src/components/space/memory-insight-relations.tsx
@@ -1595,7 +1595,12 @@ export function MemoryInsightRelations({
               ? t("memory_insight.relations.detail_entity")
               : t("memory_insight.relations.detail_global")}
           closeLabel={t("detail.close")}
-          contentClassName="top-auto right-0 bottom-0 left-0 h-[75vh] max-h-[75vh] w-full max-w-full rounded-t-[1.5rem] rounded-b-none sm:max-w-full"
+          // Bottom sheet on phones / portrait tablets, right-edge drawer at
+          // ≥1024px (iPad landscape and small desktop windows). Without the
+          // `lg:` upgrade the default md:w-[30rem] from `side-drawer` would
+          // collide with the sheet's positioning and pin it as a 480px-wide
+          // card to the bottom-left corner.
+          variant="responsive-sheet"
         >
           <div className="px-4 py-4">
             <RelationDetailPanel

--- a/dashboard/app/src/components/space/memory-overview-tabs.test.tsx
+++ b/dashboard/app/src/components/space/memory-overview-tabs.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import "@/i18n";
 import { MemoryOverviewTabs } from "./memory-overview-tabs";
 import {
@@ -19,6 +19,20 @@ vi.mock("@/components/space/deep-analysis-tab", () => ({
     active: boolean;
   }) => <div data-testid="deep-analysis-tab">{`${spaceId}:${String(active)}`}</div>,
 }));
+
+const ORIGINAL_INNER_WIDTH = window.innerWidth;
+
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+afterEach(() => {
+  setViewportWidth(ORIGINAL_INNER_WIDTH);
+});
 
 function createMemory(id: string): Memory {
   return {
@@ -40,6 +54,7 @@ function createMemory(id: string): Memory {
 
 describe("MemoryOverviewTabs", () => {
   it("defaults to Memory Pulse and resets all local insight lanes when leaving the insight tab", async () => {
+    setViewportWidth(1400);
     const memory = createMemory("mem-1");
     const secondMemory = createMemory("mem-2");
     const matchMap = new Map<string, MemoryAnalysisMatch>([
@@ -122,6 +137,7 @@ describe("MemoryOverviewTabs", () => {
   });
 
   it("forwards insight leaf clicks as insight-sourced memory selections", async () => {
+    setViewportWidth(1400);
     const onMemorySelect = vi.fn();
     const memory: Memory = {
       ...createMemory("mem-insight-1"),
@@ -195,6 +211,7 @@ describe("MemoryOverviewTabs", () => {
   });
 
   it("exposes the Memory Analysis tab and mounts the analysis content on selection", () => {
+    setViewportWidth(1400);
     render(
       <MemoryOverviewTabs
         spaceId="space-1"
@@ -227,5 +244,152 @@ describe("MemoryOverviewTabs", () => {
     fireEvent.keyDown(pulseTab, { key: "Enter" });
 
     expect(screen.getByTestId("deep-analysis-tab")).toHaveTextContent("space-1:false");
+  });
+
+  it("renders short labels and replaces the insight workspace with a desktop redirect on mobile", () => {
+    setViewportWidth(390);
+    const memory = createMemory("mem-mobile-1");
+
+    render(
+      <MemoryOverviewTabs
+        spaceId="space-mobile"
+        stats={{ total: 1, pinned: 0, insight: 1 }}
+        pulseMemories={[memory]}
+        insightMemories={[memory]}
+        cards={[{ category: "project", count: 1, confidence: 1 }]}
+        snapshot={null}
+        range="all"
+        loading={false}
+        compact={false}
+        matchMap={new Map()}
+        onTypeSelect={() => {}}
+        onTagSelect={() => {}}
+        onMemorySelect={() => {}}
+        onTimelineSelect={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("memory-overview-tab-pulse")).toHaveTextContent("Pulse");
+    expect(screen.getByTestId("memory-overview-tab-insight")).toHaveTextContent("Insight");
+    expect(screen.getByTestId("memory-overview-tab-analysis")).toHaveTextContent("Analysis");
+
+    expect(screen.getByRole("tab", { name: "Memory Pulse" })).toBe(
+      screen.getByTestId("memory-overview-tab-pulse"),
+    );
+
+    const insightTab = screen.getByTestId("memory-overview-tab-insight");
+    insightTab.focus();
+    fireEvent.keyDown(insightTab, { key: "Enter" });
+
+    expect(
+      screen.getByTestId("memory-insight-desktop-only-hint"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("memory-insight-overview")).not.toBeInTheDocument();
+  });
+
+  it("renders the full Memory Insight workspace at iPad mini landscape width (1024px)", async () => {
+    // 1024px is the floor for `useIsLargeViewport`. iPads in landscape report
+    // exactly this width (or wider), so we expect the full workspace, the
+    // desktop tab styling, and the long "Memory ___" labels — not the mobile
+    // segmented control / redirect hint.
+    setViewportWidth(1024);
+    const memory = createMemory("mem-tablet-1");
+    const matchMap = new Map<string, MemoryAnalysisMatch>([
+      [
+        memory.id,
+        {
+          memoryId: memory.id,
+          categories: ["project"],
+          categoryScores: { project: 1 },
+        },
+      ],
+    ]);
+
+    render(
+      <MemoryOverviewTabs
+        spaceId="space-tablet"
+        stats={{ total: 1, pinned: 0, insight: 1 }}
+        pulseMemories={[memory]}
+        insightMemories={[memory]}
+        cards={[{ category: "project", count: 1, confidence: 1 }]}
+        snapshot={null}
+        range="all"
+        loading={false}
+        compact={false}
+        matchMap={matchMap}
+        onTypeSelect={() => {}}
+        onTagSelect={() => {}}
+        onMemorySelect={() => {}}
+        onTimelineSelect={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("memory-overview-tab-insight")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Memory Insight" })).toBeInTheDocument();
+
+    const insightTab = screen.getByRole("tab", { name: "Memory Insight" });
+    insightTab.focus();
+    fireEvent.keyDown(insightTab, { key: "Enter" });
+
+    expect(
+      await screen.findByTestId("memory-insight-overview"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("memory-insight-desktop-only-hint"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("swaps the insight workspace for the redirect hint when the viewport shrinks below the large breakpoint", async () => {
+    setViewportWidth(1400);
+    const memory = createMemory("mem-resize-1");
+    const matchMap = new Map<string, MemoryAnalysisMatch>([
+      [
+        memory.id,
+        {
+          memoryId: memory.id,
+          categories: ["project"],
+          categoryScores: { project: 1 },
+        },
+      ],
+    ]);
+
+    render(
+      <MemoryOverviewTabs
+        spaceId="space-resize"
+        stats={{ total: 1, pinned: 0, insight: 1 }}
+        pulseMemories={[memory]}
+        insightMemories={[memory]}
+        cards={[{ category: "project", count: 1, confidence: 1 }]}
+        snapshot={null}
+        range="all"
+        loading={false}
+        compact={false}
+        matchMap={matchMap}
+        onTypeSelect={() => {}}
+        onTagSelect={() => {}}
+        onMemorySelect={() => {}}
+        onTimelineSelect={() => {}}
+      />,
+    );
+
+    const insightTab = screen.getByRole("tab", { name: "Memory Insight" });
+    insightTab.focus();
+    fireEvent.keyDown(insightTab, { key: "Enter" });
+
+    expect(
+      await screen.findByTestId("memory-insight-overview"),
+    ).toBeInTheDocument();
+
+    setViewportWidth(390);
+    fireEvent(window, new Event("resize"));
+
+    expect(
+      await screen.findByTestId("memory-insight-desktop-only-hint"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("memory-insight-overview")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Memory Insight" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
   });
 });

--- a/dashboard/app/src/components/space/memory-overview-tabs.tsx
+++ b/dashboard/app/src/components/space/memory-overview-tabs.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
+import { Monitor, Network } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { DeepAnalysisTab } from "@/components/space/deep-analysis-tab";
 import { MemoryInsightWorkspace } from "@/components/space/memory-insight-workspace";
 import { MemoryPulseOverview } from "@/components/space/memory-pulse-overview";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useIsLargeViewport } from "@/components/space/space-view-utils";
 import { cn } from "@/lib/utils";
 import type { MemoryInsightTab } from "@/lib/memory-insight";
 import type {
@@ -16,6 +18,8 @@ import type { Memory, MemoryStats, MemoryType } from "@/types/memory";
 import type { TimeRangePreset, TimelineSelection } from "@/types/time-range";
 
 export type OverviewMemorySelectionSource = "list" | "insight";
+
+const TAB_VALUES = ["pulse", "insight", "analysis"] as const;
 
 export function MemoryOverviewTabs({
   spaceId,
@@ -60,10 +64,20 @@ export function MemoryOverviewTabs({
   onTimelineClear?: () => void;
   onEntitySearch?: (query: string) => void;
 }) {
-  const { t } = useTranslation();
+  // Memory Insight only needs a wide canvas to lay out the relations bubbles
+  // legibly — it doesn't depend on the full three-column desktop layout. Gating
+  // it on the *large* breakpoint (1024px / Tailwind `lg`) instead of the desktop
+  // breakpoint (1280px) lets every iPad in landscape orientation render the
+  // workspace, while phones and iPads in portrait still get the redirect hint.
+  const isLargeViewport = useIsLargeViewport();
   const [tab, setTab] = useState<MemoryInsightTab>("pulse");
   const [hasVisitedAnalysisTab, setHasVisitedAnalysisTab] = useState(false);
   const [insightResetToken, setInsightResetToken] = useState(0);
+
+  // Below the large breakpoint we replace the workspace with a redirect hint,
+  // but keep the tab reachable so users can still discover the surface and
+  // learn how to access it.
+  const insightUnavailableOnDevice = !isLargeViewport;
 
   return (
     <Tabs
@@ -81,26 +95,11 @@ export function MemoryOverviewTabs({
       className="mt-5"
       data-testid="memory-overview-tabs"
     >
-      <div className="relative mb-0 flex items-end px-1">
-        <TabsList
-          className="inline-flex h-auto gap-0 rounded-none border-0 bg-transparent p-0 shadow-none"
-          data-testid="memory-overview-tablist"
-        >
-          {(["pulse", "insight", "analysis"] as const).map((value) => (
-            <TabsTrigger
-              key={value}
-              value={value}
-              className={cn(
-                "relative z-10 -mb-px rounded-t-md rounded-b-none border border-transparent border-b-border bg-transparent px-5 py-2.5 text-sm font-medium tracking-[-0.02em] text-foreground/40 transition-colors hover:text-foreground/70",
-                "data-[state=active]:border-border data-[state=active]:border-b-transparent data-[state=active]:bg-card data-[state=active]:font-semibold data-[state=active]:text-foreground data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]",
-              )}
-            >
-              {t(`memory_overview.tabs.${value}`)}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-        <div className="absolute bottom-0 left-0 right-0 h-px bg-border" />
-      </div>
+      {isLargeViewport ? (
+        <DesktopOverviewTabsList />
+      ) : (
+        <MobileOverviewTabsList />
+      )}
 
       <TabsContent value="pulse" className="-mt-px mt-0">
         <MemoryPulseOverview
@@ -123,16 +122,20 @@ export function MemoryOverviewTabs({
       </TabsContent>
 
       <TabsContent value="insight" className="-mt-px mt-0">
-        <MemoryInsightWorkspace
-          cards={cards}
-          memories={insightMemories}
-          matchMap={matchMap}
-          compact={compact}
-          resetToken={insightResetToken}
-          activeCategory={activeCategory}
-          activeTag={activeTag}
-          onMemorySelect={(memory) => onMemorySelect(memory, "insight")}
-        />
+        {insightUnavailableOnDevice ? (
+          <MemoryInsightDesktopOnlyHint />
+        ) : (
+          <MemoryInsightWorkspace
+            cards={cards}
+            memories={insightMemories}
+            matchMap={matchMap}
+            compact={compact}
+            resetToken={insightResetToken}
+            activeCategory={activeCategory}
+            activeTag={activeTag}
+            onMemorySelect={(memory) => onMemorySelect(memory, "insight")}
+          />
+        )}
       </TabsContent>
 
       {hasVisitedAnalysisTab && (
@@ -149,5 +152,90 @@ export function MemoryOverviewTabs({
         </TabsContent>
       )}
     </Tabs>
+  );
+}
+
+function DesktopOverviewTabsList() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="relative mb-0 flex items-end px-1">
+      <TabsList
+        className="inline-flex h-auto gap-0 rounded-none border-0 bg-transparent p-0 shadow-none"
+        data-testid="memory-overview-tablist"
+      >
+        {TAB_VALUES.map((value) => (
+          <TabsTrigger
+            key={value}
+            value={value}
+            className={cn(
+              "relative z-10 -mb-px rounded-t-md rounded-b-none border border-transparent border-b-border bg-transparent px-5 py-2.5 text-sm font-medium tracking-[-0.02em] text-foreground/40 transition-colors hover:text-foreground/70",
+              "data-[state=active]:border-border data-[state=active]:border-b-transparent data-[state=active]:bg-card data-[state=active]:font-semibold data-[state=active]:text-foreground data-[state=active]:shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]",
+            )}
+          >
+            {t(`memory_overview.tabs.${value}`)}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      <div className="absolute bottom-0 left-0 right-0 h-px bg-border" />
+    </div>
+  );
+}
+
+function MobileOverviewTabsList() {
+  const { t } = useTranslation();
+
+  // Use shadcn's default segmented control look (rounded-lg muted bar + rounded-md
+  // chip on the active trigger). Stretching the list to the full row width with
+  // `grid w-full grid-cols-3` keeps each trigger evenly sized and avoids the
+  // horizontal overflow we saw with the long "Memory ___" labels.
+  return (
+    <TabsList
+      className="grid w-full grid-cols-3"
+      data-testid="memory-overview-tablist"
+    >
+      {TAB_VALUES.map((value) => (
+        <TabsTrigger
+          key={value}
+          value={value}
+          data-testid={`memory-overview-tab-${value}`}
+          aria-label={t(`memory_overview.tabs.${value}`)}
+          className="min-w-0 px-2"
+        >
+          <span className="block truncate">
+            {t(`memory_overview.tabs_short.${value}`)}
+          </span>
+        </TabsTrigger>
+      ))}
+    </TabsList>
+  );
+}
+
+function MemoryInsightDesktopOnlyHint() {
+  const { t } = useTranslation();
+
+  return (
+    <section
+      data-testid="memory-insight-desktop-only-hint"
+      className="surface-card mt-5 flex flex-col items-center gap-4 rounded-2xl px-5 py-8 text-center"
+    >
+      <span className="relative flex size-14 items-center justify-center rounded-2xl bg-foreground/[0.04] text-foreground/70">
+        <Network className="size-7" aria-hidden />
+        <span className="absolute -bottom-1 -right-1 flex size-6 items-center justify-center rounded-full border border-border bg-background text-foreground/80 shadow-sm">
+          <Monitor className="size-3.5" aria-hidden />
+        </span>
+      </span>
+      <div className="space-y-1.5">
+        <p className="text-base font-semibold tracking-tight text-foreground">
+          {t("memory_overview.desktop_only.title")}
+        </p>
+        <p className="mx-auto max-w-sm text-sm text-muted-foreground">
+          {t("memory_overview.desktop_only.body")}
+        </p>
+      </div>
+      <p className="text-xs text-soft-foreground">
+        {t("memory_overview.desktop_only.hint")}
+      </p>
+    </section>
   );
 }

--- a/dashboard/app/src/components/space/mobile-panel-shell.tsx
+++ b/dashboard/app/src/components/space/mobile-panel-shell.tsx
@@ -4,6 +4,51 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
+// Two visual layouts the dashboard uses for slide-up / slide-in panels:
+//
+//  - `side-drawer` (default): right-edge drawer. Full width on phones,
+//    sm:26rem / md:30rem on larger screens. Used for the memory detail and
+//    analysis side panels.
+//  - `responsive-sheet`: bottom sheet on narrow viewports (so it doesn't fight
+//    with the vertical content list), then upgrades to the same right-edge
+//    drawer at the `lg` (1024px) breakpoint. Used for surfaces that float over
+//    a wide canvas like the Memory Insight relations entity detail — at
+//    tablet-landscape or desktop widths a 75vh bottom sheet would obscure
+//    most of the canvas, so we slide it into the side instead.
+export type MobilePanelVariant = "side-drawer" | "responsive-sheet";
+
+const SIDE_DRAWER_CLASSNAME = cn(
+  "inset-y-0 right-0 left-auto top-0 h-dvh w-full max-w-full",
+  "translate-x-0 translate-y-0 gap-0 rounded-none border-0 bg-background p-0 shadow-none",
+  "sm:w-[26rem] sm:max-w-[26rem] sm:border-y-0 sm:border-r-0 sm:border-l",
+  "md:w-[30rem] md:max-w-[30rem]",
+);
+
+const RESPONSIVE_SHEET_CLASSNAME = cn(
+  // Bottom sheet (phones / portrait tablets). We override every smaller
+  // breakpoint that the side-drawer styling would normally activate so the
+  // sheet stays full width all the way up to the `lg` upgrade point below.
+  "top-auto bottom-0 left-0 right-0 h-[75vh] max-h-[75vh] w-full max-w-full",
+  "sm:w-full sm:max-w-full md:w-full md:max-w-full",
+  "translate-x-0 translate-y-0 gap-0 bg-background p-0 shadow-none",
+  "rounded-t-[1.5rem] rounded-b-none border-x-0 border-b-0 border-t",
+  // Tablet landscape and up: behave like the side drawer so the canvas
+  // underneath stays visible while the detail is open. Each `lg:` utility
+  // here cancels its narrower-viewport counterpart from the block above.
+  // Most importantly we have to neutralise `max-h-[75vh]` with
+  // `lg:max-h-none` — without it the sheet's max-height clamps the desired
+  // `lg:h-dvh` and the panel ends up as a 75vh-tall card glued to the top
+  // edge instead of a full-height side drawer.
+  "lg:inset-y-0 lg:right-0 lg:left-auto lg:top-0 lg:bottom-auto",
+  "lg:h-dvh lg:max-h-none lg:w-[30rem] lg:max-w-[30rem]",
+  // Reset every corner explicitly. `lg:rounded-none` *should* override
+  // `rounded-t-[1.5rem]` on its own, but tailwind-merge can be inconsistent
+  // when the source utilities mix shorthand (rounded-t-*) and full
+  // (rounded-none) forms across breakpoints, so we spell each side out.
+  "lg:rounded-none lg:rounded-t-none lg:rounded-b-none",
+  "lg:border-l lg:border-t-0",
+);
+
 export function MobilePanelShell({
   open,
   onOpenChange,
@@ -13,6 +58,7 @@ export function MobilePanelShell({
   children,
   showHeader = true,
   bodyScrollable = true,
+  variant = "side-drawer",
   contentClassName,
   bodyClassName,
 }: {
@@ -24,6 +70,7 @@ export function MobilePanelShell({
   children: ReactNode;
   showHeader?: boolean;
   bodyScrollable?: boolean;
+  variant?: MobilePanelVariant;
   contentClassName?: string;
   bodyClassName?: string;
 }) {
@@ -49,16 +96,26 @@ export function MobilePanelShell({
         showCloseButton={false}
         portalContainer={portalContainer}
         className={cn(
-          "inset-y-0 right-0 left-auto top-0 h-dvh w-full max-w-full translate-x-0 translate-y-0 gap-0 rounded-none border-0 bg-background p-0 shadow-none sm:w-[26rem] sm:max-w-[26rem] sm:border-y-0 sm:border-r-0 sm:border-l md:w-[30rem] md:max-w-[30rem]",
+          variant === "responsive-sheet"
+            ? RESPONSIVE_SHEET_CLASSNAME
+            : SIDE_DRAWER_CLASSNAME,
           contentClassName,
         )}
       >
         <DialogTitle className="sr-only">{title}</DialogTitle>
         <DialogDescription className="sr-only">{description}</DialogDescription>
-        <div className="flex h-full min-h-0 flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+        {/*
+          The outer column constrains every child within the dialog viewport so
+          that long, unbreakable content (e.g. wide codeblocks or long paths in
+          memory text) cannot shove the chrome — close button and footer
+          actions — outside the visible right edge. `min-w-0` allows flex
+          children to shrink below their min-content; `overflow-x-hidden` is
+          the last-line defense if anything inside still tries to push wider.
+        */}
+        <div className="flex h-full min-h-0 min-w-0 flex-col overflow-x-hidden pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
           {showHeader && (
-            <div className="flex h-14 items-center justify-between border-b bg-background/95 px-4 backdrop-blur-sm">
-              <h2 className="truncate text-sm font-semibold text-foreground">
+            <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b bg-background/95 px-4 backdrop-blur-sm">
+              <h2 className="min-w-0 truncate text-sm font-semibold text-foreground">
                 {title}
               </h2>
               <Button
@@ -68,7 +125,7 @@ export function MobilePanelShell({
                 aria-label={closeLabel}
                 title={closeLabel}
                 data-mp-event="Dashboard/MobilePanel/CloseClicked"
-                className="text-soft-foreground hover:text-foreground"
+                className="shrink-0 text-soft-foreground hover:text-foreground"
               >
                 <X className="size-4" />
               </Button>
@@ -77,8 +134,10 @@ export function MobilePanelShell({
 
           <div
             className={cn(
-              "min-h-0 flex-1",
-              bodyScrollable ? "overflow-y-auto" : "overflow-hidden",
+              "min-h-0 min-w-0 flex-1",
+              bodyScrollable
+                ? "overflow-y-auto overflow-x-hidden"
+                : "overflow-hidden",
               bodyClassName,
             )}
           >

--- a/dashboard/app/src/components/space/session-preview.tsx
+++ b/dashboard/app/src/components/space/session-preview.tsx
@@ -365,7 +365,9 @@ const SessionMarkdownContent = ({ content }: { content: string }) => {
               <code
                 {...props}
                 className={cn(
-                  "rounded bg-secondary/80 px-1.5 py-0.5 font-mono text-[12px]",
+                  // `break-all` so a long inline token (path / id / hash)
+                  // wraps mid-string instead of pushing the bubble wider.
+                  "rounded bg-secondary/80 px-1.5 py-0.5 font-mono text-[12px] break-all",
                   className,
                 )}
               >
@@ -396,7 +398,10 @@ const SessionMarkdownContent = ({ content }: { content: string }) => {
           <pre
             {...props}
             className={cn(
-              "my-3 overflow-x-auto rounded-xl border border-border/50 bg-secondary/70 px-4 py-3",
+              // `max-w-full` caps the codeblock at the bubble's content area;
+              // `overflow-x-auto` then scrolls long lines internally instead
+              // of pushing the bubble — and the panel chrome — outward.
+              "my-3 max-w-full overflow-x-auto rounded-xl border border-border/50 bg-secondary/70 px-4 py-3",
               className,
             )}
           />
@@ -488,8 +493,8 @@ const ToolResultMessageRow = ({
             {toggleLabel}
           </button>
         </div>
-        <div className="w-full break-words rounded-2xl rounded-tl-sm border border-primary/10 bg-primary/[0.03] px-4 py-2.5 text-[13px] leading-relaxed text-foreground/90">
-          <div className="break-words">
+        <div className="w-full max-w-full break-words rounded-2xl rounded-tl-sm border border-primary/10 bg-primary/[0.03] px-4 py-2.5 text-[13px] leading-relaxed text-foreground/90">
+          <div className="min-w-0 break-words [overflow-wrap:anywhere]">
             <ToolResultMessageContent
               message={message}
               compactMetadata={compactMetadata}
@@ -569,13 +574,18 @@ export const DetailSessionPreview = ({
                   <div
                     className={cn(
                       "break-words rounded-2xl px-4 py-2.5 text-[13px] leading-relaxed",
-                      "inline-block max-w-full",
+                      // `block w-fit max-w-full` is more deterministic than
+                      // `inline-block max-w-full` when the bubble contains a
+                      // <pre> with `overflow-x: auto` — `fit-content` clamps
+                      // the bubble to min(intrinsic, parent width) instead of
+                      // shrink-to-fit's browser-dependent inline-block sizing.
+                      "block w-fit max-w-full",
                       isUser
                         ? "rounded-tl-sm bg-secondary/60 text-foreground/90"
                         : "rounded-tl-sm border border-primary/10 bg-primary/[0.03] text-foreground/90",
                     )}
                   >
-                    <div className="break-words">
+                    <div className="min-w-0 break-words [overflow-wrap:anywhere]">
                       <SessionMessageContent
                         content={message.content}
                         compactMetadata={compactMetadata}

--- a/dashboard/app/src/components/space/space-view-utils.ts
+++ b/dashboard/app/src/components/space/space-view-utils.ts
@@ -1,25 +1,55 @@
 import { useEffect, useState } from "react";
 
+// We deliberately keep two breakpoints rather than a single "is mobile" flag,
+// because the dashboard has two different "minimum width" requirements that
+// shouldn't be conflated:
+//
+//  - DESKTOP_BREAKPOINT (1280px) is the floor for the full three-column layout
+//    (analysis rail + memory list + inline detail panel). Below this we fall
+//    back to the single-column layout with a mobile detail sheet.
+//  - LARGE_BREAKPOINT (1024px) is the floor for content surfaces that just
+//    need a wide canvas to render — primarily the Memory Insight relations
+//    workspace. 1024 is the standard "tablet landscape" / "small desktop"
+//    boundary (Tailwind `lg`, Bootstrap `lg`, iPadOS desktop website mode), and
+//    matches what every iPad reports in landscape orientation.
+//
+// Using two breakpoints lets an iPad in landscape (1024–1279px) get the full
+// Memory Insight experience while still using the single-column layout that
+// fits its width, instead of being lumped together with phones.
 export const DESKTOP_BREAKPOINT = 1280;
+export const LARGE_BREAKPOINT = 1024;
 
 export function getIsDesktopViewport(): boolean {
   if (typeof window === "undefined") return true;
   return window.innerWidth >= DESKTOP_BREAKPOINT;
 }
 
-export function useIsDesktopViewport(): boolean {
-  const [isDesktop, setIsDesktop] = useState(getIsDesktopViewport);
+export function getIsLargeViewport(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.innerWidth >= LARGE_BREAKPOINT;
+}
+
+function useViewportFlag(getter: () => boolean): boolean {
+  const [flag, setFlag] = useState(getter);
 
   useEffect(() => {
     const handleResize = () => {
-      setIsDesktop(getIsDesktopViewport());
+      setFlag(getter());
     };
 
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  }, [getter]);
 
-  return isDesktop;
+  return flag;
+}
+
+export function useIsDesktopViewport(): boolean {
+  return useViewportFlag(getIsDesktopViewport);
+}
+
+export function useIsLargeViewport(): boolean {
+  return useViewportFlag(getIsLargeViewport);
 }
 
 export function scrollToMemoryList(): void {

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -219,6 +219,16 @@
       "pulse": "Memory Pulse",
       "insight": "Memory Insight",
       "analysis": "Memory Analysis"
+    },
+    "tabs_short": {
+      "pulse": "Pulse",
+      "insight": "Insight",
+      "analysis": "Analysis"
+    },
+    "desktop_only": {
+      "title": "Memory Insight needs a wider screen",
+      "body": "The relations canvas needs at least a tablet in landscape (1024px wide) to lay the bubbles out legibly.",
+      "hint": "Rotate your tablet to landscape, or open mem9.ai/your-memory on a desktop browser."
     }
   },
   "analysis": {

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -219,6 +219,16 @@
       "pulse": "Memory Pulse",
       "insight": "Memory Insight",
       "analysis": "Memory Analysis"
+    },
+    "tabs_short": {
+      "pulse": "节奏",
+      "insight": "洞察",
+      "analysis": "分析"
+    },
+    "desktop_only": {
+      "title": "Memory Insight 需要更宽的屏幕",
+      "body": "关系画布需要至少平板横屏（1024px 宽）才能完整铺开。",
+      "hint": "把平板转为横屏，或在桌面浏览器打开 mem9.ai/your-memory。"
     }
   },
   "analysis": {


### PR DESCRIPTION
## Summary

- Makes the Your Memory overview tabs scale cleanly from phone widths through tablet landscape, with compact segmented tabs on smaller screens and the full Memory Insight workspace from 1024px up.
- Keeps long memory content inside the detail and delete flows so paths, URLs, and identifiers wrap without pushing panel or modal controls offscreen. Closes #231.
- Cleans up adjacent mobile states by removing the duplicate Deep Analysis empty-state CTA and using a responsive sheet/drawer layout for Insight relation details.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm test` (232 / 232 passing, including 1024px tab boundary and mobile resize coverage)
- [x] Manual smoke at 390, 768, 1024, 1180, and 1280+ widths
