### PR TITLE
feat: add mem9 key status endpoint

### DIFF
--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -88,6 +88,14 @@ const (
 	TenantDeleted      TenantStatus = "deleted"
 )
 
+// KeyStatus is the normalized API-key validation result exposed to console.
+type KeyStatus string
+
+const (
+	KeyStatusActive   KeyStatus = "active"
+	KeyStatusInactive KeyStatus = "inactive"
+)
+
 // Tenant represents a provisioned customer with a dedicated database.
 type Tenant struct {
 	ID   string `json:"id"`

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -170,6 +170,9 @@ func (s *Server) Router(
 	// Provision a new tenant — no auth, no body.
 	r.Post("/v1alpha1/mem9s", s.provisionMem9s)
 
+	// Key status validates X-API-Key against control-plane state only.
+	r.Get("/v1alpha2/status", s.getKeyStatus)
+
 	// Tenant-scoped routes — tenantMW resolves {tenantID} to DB connection.
 	r.Route("/v1alpha1/mem9s/{tenantID}", func(r chi.Router) {
 		r.Use(tenantMW)

--- a/server/internal/handler/tenant.go
+++ b/server/internal/handler/tenant.go
@@ -1,9 +1,14 @@
 package handler
 
 import (
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
+	"strings"
 
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
 
@@ -16,6 +21,10 @@ var allowedUTMKeys = map[string]struct{}{
 
 type provisionResponse struct {
 	ID string `json:"id"`
+}
+
+type keyStatusResponse struct {
+	Status domain.KeyStatus `json:"status"`
 }
 
 func (s *Server) provisionMem9s(w http.ResponseWriter, r *http.Request) {
@@ -58,6 +67,36 @@ func normalizeUTMParams(values url.Values) map[string]string {
 	}
 
 	return filtered
+}
+
+func (s *Server) getKeyStatus(w http.ResponseWriter, r *http.Request) {
+	apiKey := strings.TrimSpace(r.Header.Get(middleware.APIKeyHeader))
+	if apiKey == "" {
+		respondError(w, http.StatusUnauthorized, "missing or malformed X-API-Key")
+		return
+	}
+	if s.tenant == nil {
+		respondError(w, http.StatusInternalServerError, "auth backend unavailable")
+		return
+	}
+
+	status, err := s.tenant.KeyStatus(r.Context(), apiKey)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrNotFound):
+			respondError(w, http.StatusNotFound, "key not found")
+		default:
+			logger := s.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.ErrorContext(r.Context(), "key status lookup failed", "err", err)
+			respondError(w, http.StatusInternalServerError, "auth backend unavailable")
+		}
+		return
+	}
+
+	respond(w, http.StatusOK, keyStatusResponse{Status: status})
 }
 
 func (s *Server) getTenantInfo(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/tenant_test.go
+++ b/server/internal/handler/tenant_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,13 +19,22 @@ import (
 	"log/slog"
 )
 
-type handlerTenantRepo struct{}
+type handlerTenantRepo struct {
+	getTenant *domain.Tenant
+	getErr    error
+}
 
 func (r *handlerTenantRepo) Create(ctx context.Context, t *domain.Tenant) error {
 	return nil
 }
 
 func (r *handlerTenantRepo) GetByID(ctx context.Context, id string) (*domain.Tenant, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	if r.getTenant != nil {
+		return r.getTenant, nil
+	}
 	return nil, domain.ErrNotFound
 }
 
@@ -170,6 +180,121 @@ func TestProvisionMem9s_FiltersUTMParamsAndKeepsResponseShape(t *testing.T) {
 	}
 	if _, exists := utm["foo"]; exists {
 		t.Fatalf("non-utm param leaked into utm map: %#v", utm)
+	}
+}
+
+func TestGetKeyStatus(t *testing.T) {
+	repoErr := errors.New("repo failed")
+
+	tests := []struct {
+		name      string
+		apiKey    string
+		tenant    *domain.Tenant
+		repoErr   error
+		wantCode  int
+		wantField string
+		wantValue string
+	}{
+		{
+			name:      "missing key",
+			wantCode:  http.StatusUnauthorized,
+			wantField: "error",
+			wantValue: "missing or malformed X-API-Key",
+		},
+		{
+			name:      "whitespace key",
+			apiKey:    "   ",
+			wantCode:  http.StatusUnauthorized,
+			wantField: "error",
+			wantValue: "missing or malformed X-API-Key",
+		},
+		{
+			name:      "active key",
+			apiKey:    "key-active",
+			tenant:    &domain.Tenant{Status: domain.TenantActive},
+			wantCode:  http.StatusOK,
+			wantField: "status",
+			wantValue: string(domain.KeyStatusActive),
+		},
+		{
+			name:      "inactive key",
+			apiKey:    "key-provisioning",
+			tenant:    &domain.Tenant{Status: domain.TenantProvisioning},
+			wantCode:  http.StatusOK,
+			wantField: "status",
+			wantValue: string(domain.KeyStatusInactive),
+		},
+		{
+			name:      "missing tenant",
+			apiKey:    "key-missing",
+			wantCode:  http.StatusNotFound,
+			wantField: "error",
+			wantValue: "key not found",
+		},
+		{
+			name:      "repository failure",
+			apiKey:    "key-failure",
+			repoErr:   repoErr,
+			wantCode:  http.StatusInternalServerError,
+			wantField: "error",
+			wantValue: "auth backend unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+			tenantSvc := service.NewTenantService(
+				&handlerTenantRepo{getTenant: tt.tenant, getErr: tt.repoErr},
+				nil,
+				nil,
+				logger,
+				"",
+				0,
+				0,
+				false,
+				encrypt.NewPlainEncryptor(),
+			)
+			srv := NewServer(tenantSvc, nil, "", nil, nil, "", false, service.ModeSmart, "", logger)
+
+			apiKeyMWCalled := false
+			router := srv.Router(
+				func(h http.Handler) http.Handler { return h },
+				func(h http.Handler) http.Handler { return h },
+				func(h http.Handler) http.Handler {
+					return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						apiKeyMWCalled = true
+						respondError(w, http.StatusTeapot, "apiKeyMW called")
+					})
+				},
+			)
+
+			req := httptest.NewRequest(http.MethodGet, "/v1alpha2/status", nil)
+			if tt.apiKey != "" {
+				req.Header.Set("X-API-Key", tt.apiKey)
+			}
+			rr := httptest.NewRecorder()
+
+			router.ServeHTTP(rr, req)
+
+			if apiKeyMWCalled {
+				t.Fatal("apiKeyMW must not run for /v1alpha2/status")
+			}
+			if rr.Code != tt.wantCode {
+				t.Fatalf("status = %d, body = %s, want %d", rr.Code, rr.Body.String(), tt.wantCode)
+			}
+			var body map[string]string
+			if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body[tt.wantField] != tt.wantValue {
+				t.Fatalf("response %s = %q, want %q; body = %#v", tt.wantField, body[tt.wantField], tt.wantValue, body)
+			}
+			if strings.Contains(logBuf.String(), tt.apiKey) && tt.apiKey != "" {
+				t.Fatalf("logs leaked API key: %s", logBuf.String())
+			}
+		})
 	}
 }
 

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -225,7 +225,7 @@ func ResolveApiKey(
 				writeError(w, http.StatusBadRequest, "invalid API key")
 				return
 			}
-			if t.Status != domain.TenantActive {
+			if t.DeletedAt != nil || t.Status != domain.TenantActive {
 				writeError(w, http.StatusBadRequest, "invalid API key")
 				return
 			}

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -212,7 +212,7 @@ func ResolveApiKey(
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			authStart := time.Now()
-			apiKey := r.Header.Get(APIKeyHeader)
+			apiKey := strings.TrimSpace(r.Header.Get(APIKeyHeader))
 			if apiKey == "" {
 				writeError(w, http.StatusBadRequest, "missing API key")
 				return

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -106,6 +106,29 @@ func TestResolveApiKey_MissingHeader(t *testing.T) {
 	}
 }
 
+func TestResolveApiKey_WhitespaceOnlyHeader(t *testing.T) {
+	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
+	defer pool.Close()
+
+	enc := encrypt.NewPlainEncryptor()
+	mw := ResolveApiKey(stubTenantRepo{}, pool, enc, nil)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set(APIKeyHeader, "   ")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+	if got := rr.Body.String(); !strings.Contains(got, "missing API key") {
+		t.Fatalf("body = %q, want missing API key", got)
+	}
+}
+
 func TestResolveApiKey_InvalidKey(t *testing.T) {
 	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
 	defer pool.Close()
@@ -126,6 +149,51 @@ func TestResolveApiKey_InvalidKey(t *testing.T) {
 	}
 	if got := rr.Body.String(); !strings.Contains(got, "invalid API key") {
 		t.Fatalf("body = %q, want invalid API key", got)
+	}
+}
+
+func TestResolveApiKey_TrimsHeaderValue(t *testing.T) {
+	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
+	defer pool.Close()
+
+	db := sql.OpenDB(pingOKConnector{})
+	defer db.Close()
+	cacheTenantDB(t, pool, "tenant-1", db)
+
+	repo := stubTenantRepo{
+		tenants: map[string]*domain.Tenant{
+			"tenant-1": {
+				ID:       "tenant-1",
+				Status:   domain.TenantActive,
+				DBHost:   "127.0.0.1",
+				DBPort:   4000,
+				DBUser:   "user",
+				DBName:   "db",
+				Provider: "tidb",
+			},
+		},
+	}
+
+	enc := encrypt.NewPlainEncryptor()
+	mw := ResolveApiKey(repo, pool, enc, nil)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := AuthFromContext(r.Context())
+		if info == nil {
+			t.Fatal("auth info missing from context")
+		}
+		if info.TenantID != "tenant-1" {
+			t.Fatalf("tenant ID = %q, want %q", info.TenantID, "tenant-1")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set(APIKeyHeader, " tenant-1 ")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
 	}
 }
 

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -161,6 +161,40 @@ func TestResolveApiKey_InactiveTenant(t *testing.T) {
 	}
 }
 
+func TestResolveApiKey_DeletedAtRejectsKey(t *testing.T) {
+	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
+	defer pool.Close()
+
+	now := time.Now()
+	repo := stubTenantRepo{
+		tenants: map[string]*domain.Tenant{
+			"tenant-1": {
+				ID:        "tenant-1",
+				Status:    domain.TenantActive,
+				DeletedAt: &now,
+			},
+		},
+	}
+
+	enc := encrypt.NewPlainEncryptor()
+	mw := ResolveApiKey(repo, pool, enc, nil)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("next handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set(APIKeyHeader, "tenant-1")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+	}
+	if got := rr.Body.String(); !strings.Contains(got, "invalid API key") {
+		t.Fatalf("body = %q, want invalid API key", got)
+	}
+}
+
 func TestResolveApiKey_PopulatesAuthInfo(t *testing.T) {
 	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
 	defer pool.Close()

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -86,13 +86,10 @@ func (s *TenantService) KeyStatus(ctx context.Context, apiKey string) (domain.Ke
 		return "", fmt.Errorf("get tenant for key status: %w", err)
 	}
 
-	if t.DeletedAt != nil {
-		if t.Status != domain.TenantDeleted && s.logger != nil {
-			s.logger.WarnContext(ctx, "tenant deleted_at set with non-deleted status",
-				"status", t.Status,
-			)
-		}
-		return "", domain.ErrNotFound
+	if t.DeletedAt != nil && t.Status != domain.TenantDeleted && s.logger != nil {
+		s.logger.WarnContext(ctx, "tenant deleted_at set with non-deleted status",
+			"status", t.Status,
+		)
 	}
 
 	switch t.Status {

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -86,10 +86,13 @@ func (s *TenantService) KeyStatus(ctx context.Context, apiKey string) (domain.Ke
 		return "", fmt.Errorf("get tenant for key status: %w", err)
 	}
 
-	if t.DeletedAt != nil && t.Status != domain.TenantDeleted && s.logger != nil {
-		s.logger.WarnContext(ctx, "tenant deleted_at set with non-deleted status",
-			"status", t.Status,
-		)
+	if t.DeletedAt != nil {
+		if t.Status != domain.TenantDeleted && s.logger != nil {
+			s.logger.WarnContext(ctx, "tenant deleted_at set with non-deleted status",
+				"status", t.Status,
+			)
+		}
+		return "", domain.ErrNotFound
 	}
 
 	switch t.Status {

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -3,8 +3,10 @@ package service
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
@@ -64,6 +66,50 @@ func NewTenantService(
 func (s *TenantService) WithUTMRepo(r utmRepo) *TenantService {
 	s.utms = r
 	return s
+}
+
+// KeyStatus validates a candidate API key against the control-plane tenant row.
+func (s *TenantService) KeyStatus(ctx context.Context, apiKey string) (domain.KeyStatus, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
+	}
+	if s.tenants == nil {
+		return "", fmt.Errorf("tenant repository not configured")
+	}
+
+	t, err := s.tenants.GetByID(ctx, apiKey)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return "", domain.ErrNotFound
+		}
+		return "", fmt.Errorf("get tenant for key status: %w", err)
+	}
+
+	if t.DeletedAt != nil {
+		if t.Status != domain.TenantDeleted && s.logger != nil {
+			s.logger.WarnContext(ctx, "tenant deleted_at set with non-deleted status",
+				"status", t.Status,
+			)
+		}
+		return "", domain.ErrNotFound
+	}
+
+	switch t.Status {
+	case domain.TenantActive:
+		return domain.KeyStatusActive, nil
+	case domain.TenantProvisioning, domain.TenantSuspended:
+		return domain.KeyStatusInactive, nil
+	case domain.TenantDeleted:
+		return "", domain.ErrNotFound
+	default:
+		if s.logger != nil {
+			s.logger.WarnContext(ctx, "unknown tenant status for key status",
+				"status", t.Status,
+			)
+		}
+		return domain.KeyStatusInactive, nil
+	}
 }
 
 // ProvisionResult is the output of Provision.

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -148,10 +148,16 @@ func TestKeyStatus(t *testing.T) {
 			wantErr: domain.ErrNotFound,
 		},
 		{
-			name:    "deleted at",
+			name:    "deleted status with deleted at",
 			apiKey:  "key-deleted-at",
 			tenant:  &domain.Tenant{Status: domain.TenantDeleted, DeletedAt: &now},
 			wantErr: domain.ErrNotFound,
+		},
+		{
+			name:   "active with deleted at",
+			apiKey: "key-active-deleted-at",
+			tenant: &domain.Tenant{Status: domain.TenantActive, DeletedAt: &now},
+			want:   domain.KeyStatusActive,
 		},
 		{
 			name:    "missing",
@@ -248,9 +254,12 @@ func TestKeyStatusLogsDeletedAtMismatchWithoutAPIKey(t *testing.T) {
 		encrypt.NewPlainEncryptor(),
 	)
 
-	_, err := svc.KeyStatus(context.Background(), "secret-key")
-	if !errors.Is(err, domain.ErrNotFound) {
-		t.Fatalf("KeyStatus() err = %v, want %v", err, domain.ErrNotFound)
+	got, err := svc.KeyStatus(context.Background(), "secret-key")
+	if err != nil {
+		t.Fatalf("KeyStatus() err = %v", err)
+	}
+	if got != domain.KeyStatusActive {
+		t.Fatalf("KeyStatus() = %q, want %q", got, domain.KeyStatusActive)
 	}
 
 	raw := buf.String()

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -148,16 +148,10 @@ func TestKeyStatus(t *testing.T) {
 			wantErr: domain.ErrNotFound,
 		},
 		{
-			name:    "deleted status with deleted at",
+			name:    "deleted at",
 			apiKey:  "key-deleted-at",
 			tenant:  &domain.Tenant{Status: domain.TenantDeleted, DeletedAt: &now},
 			wantErr: domain.ErrNotFound,
-		},
-		{
-			name:   "active with deleted at",
-			apiKey: "key-active-deleted-at",
-			tenant: &domain.Tenant{Status: domain.TenantActive, DeletedAt: &now},
-			want:   domain.KeyStatusActive,
 		},
 		{
 			name:    "missing",
@@ -254,12 +248,9 @@ func TestKeyStatusLogsDeletedAtMismatchWithoutAPIKey(t *testing.T) {
 		encrypt.NewPlainEncryptor(),
 	)
 
-	got, err := svc.KeyStatus(context.Background(), "secret-key")
-	if err != nil {
-		t.Fatalf("KeyStatus() err = %v", err)
-	}
-	if got != domain.KeyStatusActive {
-		t.Fatalf("KeyStatus() = %q, want %q", got, domain.KeyStatusActive)
+	_, err := svc.KeyStatus(context.Background(), "secret-key")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("KeyStatus() err = %v, want %v", err, domain.ErrNotFound)
 	}
 
 	raw := buf.String()

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/encrypt"
@@ -105,6 +106,165 @@ func TestProvisionRejectsNonTiDBBackend(t *testing.T) {
 	}
 }
 
+func TestKeyStatus(t *testing.T) {
+	now := time.Now()
+	repoErr := errors.New("repo failed")
+
+	tests := []struct {
+		name    string
+		apiKey  string
+		tenant  *domain.Tenant
+		repoErr error
+		want    domain.KeyStatus
+		wantErr error
+	}{
+		{
+			name:    "empty key",
+			apiKey:  "   ",
+			wantErr: domain.ErrValidation,
+		},
+		{
+			name:   "active",
+			apiKey: "key-active",
+			tenant: &domain.Tenant{Status: domain.TenantActive},
+			want:   domain.KeyStatusActive,
+		},
+		{
+			name:   "provisioning",
+			apiKey: "key-provisioning",
+			tenant: &domain.Tenant{Status: domain.TenantProvisioning},
+			want:   domain.KeyStatusInactive,
+		},
+		{
+			name:   "suspended",
+			apiKey: "key-suspended",
+			tenant: &domain.Tenant{Status: domain.TenantSuspended},
+			want:   domain.KeyStatusInactive,
+		},
+		{
+			name:    "deleted status",
+			apiKey:  "key-deleted",
+			tenant:  &domain.Tenant{Status: domain.TenantDeleted},
+			wantErr: domain.ErrNotFound,
+		},
+		{
+			name:    "deleted at",
+			apiKey:  "key-deleted-at",
+			tenant:  &domain.Tenant{Status: domain.TenantDeleted, DeletedAt: &now},
+			wantErr: domain.ErrNotFound,
+		},
+		{
+			name:    "missing",
+			apiKey:  "key-missing",
+			wantErr: domain.ErrNotFound,
+		},
+		{
+			name:    "repo failure",
+			apiKey:  "key-repo-failure",
+			repoErr: repoErr,
+			wantErr: repoErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := NewTenantService(
+				&mockTenantRepo{getTenant: tt.tenant, getErr: tt.repoErr},
+				nil,
+				nil,
+				nil,
+				"",
+				0,
+				0,
+				false,
+				encrypt.NewPlainEncryptor(),
+			)
+
+			got, err := svc.KeyStatus(context.Background(), tt.apiKey)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("KeyStatus() err = %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("KeyStatus() err = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("KeyStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKeyStatusLogsUnknownStatusWithoutAPIKey(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	svc := NewTenantService(
+		&mockTenantRepo{getTenant: &domain.Tenant{Status: domain.TenantStatus("mystery")}},
+		nil,
+		nil,
+		logger,
+		"",
+		0,
+		0,
+		false,
+		encrypt.NewPlainEncryptor(),
+	)
+
+	got, err := svc.KeyStatus(context.Background(), "secret-key")
+	if err != nil {
+		t.Fatalf("KeyStatus() err = %v", err)
+	}
+	if got != domain.KeyStatusInactive {
+		t.Fatalf("KeyStatus() = %q, want %q", got, domain.KeyStatusInactive)
+	}
+
+	raw := buf.String()
+	if !strings.Contains(raw, "unknown tenant status for key status") {
+		t.Fatalf("log = %q, want unknown status warning", raw)
+	}
+	if !strings.Contains(raw, "mystery") {
+		t.Fatalf("log = %q, want status value", raw)
+	}
+	if strings.Contains(raw, "secret-key") {
+		t.Fatalf("log leaked API key: %q", raw)
+	}
+}
+
+func TestKeyStatusLogsDeletedAtMismatchWithoutAPIKey(t *testing.T) {
+	now := time.Now()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	svc := NewTenantService(
+		&mockTenantRepo{getTenant: &domain.Tenant{Status: domain.TenantActive, DeletedAt: &now}},
+		nil,
+		nil,
+		logger,
+		"",
+		0,
+		0,
+		false,
+		encrypt.NewPlainEncryptor(),
+	)
+
+	_, err := svc.KeyStatus(context.Background(), "secret-key")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("KeyStatus() err = %v, want %v", err, domain.ErrNotFound)
+	}
+
+	raw := buf.String()
+	if !strings.Contains(raw, "tenant deleted_at set with non-deleted status") {
+		t.Fatalf("log = %q, want deleted_at mismatch warning", raw)
+	}
+	if !strings.Contains(raw, string(domain.TenantActive)) {
+		t.Fatalf("log = %q, want status value", raw)
+	}
+	if strings.Contains(raw, "secret-key") {
+		t.Fatalf("log leaked API key: %q", raw)
+	}
+}
+
 // TestProvision_WithEncryptor tests that Provision encrypts password for storage
 // but uses plaintext for DSN connection.
 func TestProvision_WithEncryptor(t *testing.T) {
@@ -191,6 +351,8 @@ func (m *mockProvisioner) ProviderType() string {
 // mockTenantRepo is a test double for repository.TenantRepo
 type mockTenantRepo struct {
 	createdTenant *domain.Tenant
+	getTenant     *domain.Tenant
+	getErr        error
 }
 
 func (m *mockTenantRepo) Create(ctx context.Context, t *domain.Tenant) error {
@@ -199,6 +361,12 @@ func (m *mockTenantRepo) Create(ctx context.Context, t *domain.Tenant) error {
 }
 
 func (m *mockTenantRepo) GetByID(ctx context.Context, id string) (*domain.Tenant, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if m.getTenant != nil {
+		return m.getTenant, nil
+	}
 	return nil, domain.ErrNotFound
 }
 


### PR DESCRIPTION
## Summary
- Add `GET /v1alpha2/status` for console-server key validation.
- Validate `X-API-Key` against the control-plane tenant row without using `apiKeyMW` or opening tenant DB connections.
- Normalize tenant state to `active`, `inactive`, or `key not found`, including deleted_at precedence and unknown-status handling.

## Behavior
- Missing or whitespace-only `X-API-Key` returns `401`.
- Active tenants return `200 {"status":"active"}`.
- Provisioning, suspended, and unknown statuses return `200 {"status":"inactive"}`.
- Deleted or missing tenants return `404 {"error":"key not found"}`.
- Raw API keys are not logged.

## Tests
- `go test ./internal/service ./internal/handler`
- `make test`
- `make vet`