### PR TITLE
feat: add local-session gap fill for recall

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -97,7 +97,7 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		svc := resolvedSvc{
-			memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+			memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode, sessRepo),
 			ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 			session: service.NewSessionService(sessRepo, s.embedder, s.autoModel),
 		}
@@ -120,7 +120,7 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	svc := resolvedSvc{
-		memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+		memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode, sessRepo),
 		ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 		session: service.NewSessionService(sessRepo, s.embedder, s.autoModel),
 	}

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,18 +36,39 @@ const (
 	// threshold the query likely has no strong match (e.g. adversarial), so
 	// second-hop is skipped to avoid injecting noise.
 	secondHopGateScore = 0.5
+	// sourceSeqAdjacentTurnWeight applies a moderate boost to raw turns expanded
+	// from insight memories' source provenance. Lower than direct first-hop hits
+	// because the added turns come from adjacent local dialogue sessions rather
+	// than from the matched source band itself.
+	sourceSeqAdjacentTurnWeight = 0.6
+	sourceSeqAdjacentTurnRadius = 1
+	sourceSeqAdjacentTurnTopN   = 4
+	sourceSeqAdjacentTurnSpan   = 4
+	sourceSeqAdjacentTurnCap    = 6
+	// sourceSeqLocalSessionFetchSlack keeps the raw-turn fetch bounded while
+	// still allowing the helper to reconstruct the local dialogue-session
+	// containing the source band plus its immediate neighbors.
+	sourceSeqLocalSessionFetchSlack = 96
+	sourceSeqBoundaryTurnRadius     = 1
+	sourceSeqBoundaryMinSeedCount   = 2
 )
 
 type MemoryService struct {
 	memories  repository.MemoryRepo
+	sessions  repository.SessionRepo
 	embedder  *embed.Embedder
 	autoModel string
 	ingest    *IngestService
 }
 
-func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, embedder *embed.Embedder, autoModel string, ingestMode IngestMode) *MemoryService {
+func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, embedder *embed.Embedder, autoModel string, ingestMode IngestMode, sessions ...repository.SessionRepo) *MemoryService {
+	var sessionRepo repository.SessionRepo
+	if len(sessions) > 0 {
+		sessionRepo = sessions[0]
+	}
 	return &MemoryService{
 		memories:  memories,
+		sessions:  sessionRepo,
 		embedder:  embedder,
 		autoModel: autoModel,
 		ingest:    NewIngestService(memories, llmClient, embedder, autoModel, ingestMode),
@@ -429,7 +451,19 @@ func (s *MemoryService) hybridCandidates(ctx context.Context, filter domain.Memo
 		}
 	}
 
-	return dedupRecallCandidatesByContent(mergeRecallCandidates(sourcePool, kwResults, vecResults, nil)), nil
+	baseCandidates := mergeRecallCandidates(sourcePool, kwResults, vecResults, nil)
+	adjacentTurns, adjacentCluster, err := s.sourceSeqLocalSessionGapFillMemories(ctx, sourcePool, baseCandidates)
+	if err != nil {
+		slog.WarnContext(ctx, "memory source-seq local-session gap fill skipped", "err", err)
+		adjacentTurns = nil
+		adjacentCluster = nil
+	}
+
+	merged := mergeRecallCandidatesWithExtraWeight(sourcePool, kwResults, vecResults, adjacentTurns, sourceSeqAdjacentTurnWeight)
+	if adjacentCluster != nil && len(adjacentTurns) > 0 {
+		merged = pruneSourceSeqOverlapCandidates(merged, adjacentCluster)
+	}
+	return dedupRecallCandidatesByContent(merged), nil
 }
 
 func (s *MemoryService) autoHybridSearch(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
@@ -564,6 +598,16 @@ func (s *MemoryService) autoHybridCandidates(
 	}
 	secondHopDuration := time.Since(secondHopStart)
 
+	baseCandidates := mergeRecallCandidates(sourcePool, kwResults, vecResults, secondHopResults)
+	adjacentTurnStart := time.Now()
+	adjacentTurns, adjacentCluster, err := s.sourceSeqLocalSessionGapFillMemories(ctx, sourcePool, baseCandidates)
+	if err != nil {
+		slog.WarnContext(ctx, "memory source-seq local-session gap fill skipped", "err", err)
+		adjacentTurns = nil
+		adjacentCluster = nil
+	}
+	adjacentTurnDuration := time.Since(adjacentTurnStart)
+
 	slog.InfoContext(ctx, "memory recall candidate search",
 		"query_len", len(filter.Query),
 		"source_pool", string(sourcePool),
@@ -572,12 +616,22 @@ func (s *MemoryService) autoHybridCandidates(
 		"vector_ms", vectorDuration.Milliseconds(),
 		"keyword_ms", keywordDuration.Milliseconds(),
 		"second_hop_ms", secondHopDuration.Milliseconds(),
+		"source_seq_local_session_gap_fill_ms", adjacentTurnDuration.Milliseconds(),
 		"second_hop_enabled", opts.EnableSecondHop,
 		"second_hop_count", len(secondHopResults),
+		"source_seq_local_session_gap_fill_count", len(adjacentTurns),
 		"total_ms", time.Since(start).Milliseconds(),
 	)
 
-	return dedupRecallCandidatesByContent(mergeRecallCandidates(sourcePool, kwResults, vecResults, secondHopResults)), nil
+	extraResults := make([]domain.Memory, 0, len(secondHopResults)+len(adjacentTurns))
+	extraResults = append(extraResults, secondHopResults...)
+	extraResults = append(extraResults, adjacentTurns...)
+
+	merged := mergeRecallCandidatesWithExtraWeight(sourcePool, kwResults, vecResults, extraResults, sourceSeqAdjacentTurnWeight)
+	if adjacentCluster != nil && len(adjacentTurns) > 0 {
+		merged = pruneSourceSeqOverlapCandidates(merged, adjacentCluster)
+	}
+	return dedupRecallCandidatesByContent(merged), nil
 }
 
 // secondHopAutoSearch runs concurrent AutoVectorSearch calls using the top-N
@@ -682,6 +736,529 @@ func collectMems(kwResults, vecResults []domain.Memory) map[string]domain.Memory
 		}
 	}
 	return mems
+}
+
+type sourceSeqAdjacentTurnSeed struct {
+	Candidate  RecallCandidate
+	SourceSeqs []int
+}
+
+type sourceSeqClusterPoint struct {
+	SessionID string
+	Seq       int
+	SeedID    string
+	SeedRank  int
+}
+
+type sourceSeqAdjacentCluster struct {
+	SourceSeqs   []int
+	SourceSeqSet map[int]struct{}
+	SeedIDs      map[string]struct{}
+	SessionIDs   []string
+	MinSeq       int
+	MaxSeq       int
+	Center       float64
+}
+
+func sourceSeqsFromMemory(memory domain.Memory) []int {
+	if len(memory.Metadata) == 0 {
+		return nil
+	}
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(memory.Metadata, &metadata); err != nil {
+		return nil
+	}
+	return normalizeSourceSeqs(parseSourceSeqsRaw(metadata[sourceSeqsMetadataKey]))
+}
+
+func topSourceSeqAdjacentTurnSeeds(candidates []RecallCandidate, topN int) []sourceSeqAdjacentTurnSeed {
+	if topN <= 0 {
+		topN = sourceSeqAdjacentTurnTopN
+	}
+	seeds := make([]sourceSeqAdjacentTurnSeed, 0, min(topN, len(candidates)))
+	seen := make(map[string]struct{}, topN)
+	for _, candidate := range candidates {
+		if candidate.Memory.ID == "" || candidate.Memory.SessionID == "" {
+			continue
+		}
+		if _, ok := seen[candidate.Memory.ID]; ok {
+			continue
+		}
+		sourceSeqs := sourceSeqsFromMemory(candidate.Memory)
+		if len(sourceSeqs) == 0 {
+			continue
+		}
+		seen[candidate.Memory.ID] = struct{}{}
+		seeds = append(seeds, sourceSeqAdjacentTurnSeed{
+			Candidate:  candidate,
+			SourceSeqs: sourceSeqs,
+		})
+		if len(seeds) >= topN {
+			break
+		}
+	}
+	return seeds
+}
+
+func cloneStringSet(in map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for key := range in {
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func cloneIntSet(in map[int]struct{}) map[int]struct{} {
+	out := make(map[int]struct{}, len(in))
+	for key := range in {
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func bestSourceSeqAdjacentCluster(seeds []sourceSeqAdjacentTurnSeed, maxSpan int) *sourceSeqAdjacentCluster {
+	if maxSpan <= 0 {
+		maxSpan = sourceSeqAdjacentTurnSpan
+	}
+
+	pointsBySession := make(map[string][]sourceSeqClusterPoint)
+	for _, seed := range seeds {
+		if seed.Candidate.Memory.ID == "" || seed.Candidate.Memory.SessionID == "" {
+			continue
+		}
+		for _, seq := range seed.SourceSeqs {
+			sessionID := seed.Candidate.Memory.SessionID
+			pointsBySession[sessionID] = append(pointsBySession[sessionID], sourceSeqClusterPoint{
+				SessionID: sessionID,
+				Seq:       seq,
+				SeedID:    seed.Candidate.Memory.ID,
+				SeedRank:  seed.Candidate.RRFRank,
+			})
+		}
+	}
+	if len(pointsBySession) == 0 {
+		return nil
+	}
+
+	type clusterScore struct {
+		distinctSeeds int
+		uniqueSeqs    int
+		span          int
+		bestRank      int
+	}
+
+	var best *sourceSeqAdjacentCluster
+	bestScore := clusterScore{}
+
+	for sessionID, points := range pointsBySession {
+		sort.Slice(points, func(i, j int) bool {
+			if points[i].Seq == points[j].Seq {
+				if points[i].SeedRank == points[j].SeedRank {
+					return points[i].SeedID < points[j].SeedID
+				}
+				return points[i].SeedRank < points[j].SeedRank
+			}
+			return points[i].Seq < points[j].Seq
+		})
+
+		for start := range points {
+			seedIDs := make(map[string]struct{})
+			seqSet := make(map[int]struct{})
+			bestRank := 0
+			for end := start; end < len(points); end++ {
+				span := points[end].Seq - points[start].Seq
+				if span > maxSpan {
+					break
+				}
+				seedIDs[points[end].SeedID] = struct{}{}
+				seqSet[points[end].Seq] = struct{}{}
+				if bestRank == 0 || points[end].SeedRank < bestRank {
+					bestRank = points[end].SeedRank
+				}
+				if len(seedIDs) < 2 {
+					continue
+				}
+
+				score := clusterScore{
+					distinctSeeds: len(seedIDs),
+					uniqueSeqs:    len(seqSet),
+					span:          span,
+					bestRank:      bestRank,
+				}
+				if best != nil {
+					if score.distinctSeeds < bestScore.distinctSeeds {
+						continue
+					}
+					if score.distinctSeeds == bestScore.distinctSeeds && score.uniqueSeqs < bestScore.uniqueSeqs {
+						continue
+					}
+					if score.distinctSeeds == bestScore.distinctSeeds && score.uniqueSeqs == bestScore.uniqueSeqs && score.span > bestScore.span {
+						continue
+					}
+					if score.distinctSeeds == bestScore.distinctSeeds && score.uniqueSeqs == bestScore.uniqueSeqs && score.span == bestScore.span && score.bestRank > bestScore.bestRank {
+						continue
+					}
+				}
+
+				sourceSeqs := make([]int, 0, len(seqSet))
+				for seq := range seqSet {
+					sourceSeqs = append(sourceSeqs, seq)
+				}
+				sort.Ints(sourceSeqs)
+
+				best = &sourceSeqAdjacentCluster{
+					SourceSeqs:   sourceSeqs,
+					SourceSeqSet: cloneIntSet(seqSet),
+					SeedIDs:      cloneStringSet(seedIDs),
+					SessionIDs:   []string{sessionID},
+					MinSeq:       sourceSeqs[0],
+					MaxSeq:       sourceSeqs[len(sourceSeqs)-1],
+					Center:       float64(sourceSeqs[0]+sourceSeqs[len(sourceSeqs)-1]) / 2.0,
+				}
+				bestScore = score
+			}
+		}
+	}
+
+	return best
+}
+
+func sourceSeqLocalSessionFetchLimit(cluster *sourceSeqAdjacentCluster) int {
+	if cluster == nil || len(cluster.SourceSeqs) == 0 {
+		return 0
+	}
+	return cluster.MaxSeq + sourceSeqLocalSessionFetchSlack + 2
+}
+
+func (s *MemoryService) sourceSeqLocalSessionGapFillMemories(
+	ctx context.Context,
+	sourcePool RecallSourcePool,
+	candidates []RecallCandidate,
+) ([]domain.Memory, *sourceSeqAdjacentCluster, error) {
+	if sourcePool != RecallSourceInsight || s.sessions == nil {
+		return nil, nil, nil
+	}
+
+	seeds := topSourceSeqAdjacentTurnSeeds(candidates, sourceSeqAdjacentTurnTopN)
+	if len(seeds) == 0 {
+		return nil, nil, nil
+	}
+
+	cluster := bestSourceSeqAdjacentCluster(seeds, sourceSeqAdjacentTurnSpan)
+	if cluster == nil || len(cluster.SessionIDs) == 0 || len(cluster.SourceSeqs) == 0 {
+		return nil, nil, nil
+	}
+
+	fetchLimit := sourceSeqLocalSessionFetchLimit(cluster)
+	if fetchLimit <= 0 {
+		return nil, nil, nil
+	}
+
+	start := time.Now()
+	sessions, err := s.sessions.ListBySessionIDs(ctx, cluster.SessionIDs, fetchLimit)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotSupported) {
+			return nil, nil, nil
+		}
+		return nil, nil, fmt.Errorf("source-seq local-session gap-fill lookup: %w", err)
+	}
+	adjacent := sourceSeqLocalSessionGapFillResults(cluster, sessions, sourceSeqAdjacentTurnCap)
+	slog.InfoContext(ctx, "memory source-seq local-session gap fill",
+		"source_pool", string(sourcePool),
+		"seed_count", len(seeds),
+		"session_count", len(cluster.SessionIDs),
+		"cluster_span", cluster.MaxSeq-cluster.MinSeq,
+		"cluster_seq_count", len(cluster.SourceSeqs),
+		"fetch_limit", fetchLimit,
+		"gap_fill_count", len(adjacent),
+		"total_ms", time.Since(start).Milliseconds(),
+	)
+	return adjacent, cluster, nil
+}
+
+type reconstructedLocalSession struct {
+	DateLabel string
+	MaxSeq    int
+	MinSeq    int
+	Turns     []*domain.Session
+}
+
+func sourceSeqLocalSessionGapFillResults(cluster *sourceSeqAdjacentCluster, sessions []*domain.Session, maxTurns int) []domain.Memory {
+	if cluster == nil || len(cluster.SourceSeqs) == 0 {
+		return nil
+	}
+	if maxTurns <= 0 {
+		maxTurns = sourceSeqAdjacentTurnCap
+	}
+
+	localSessions, seqToLocalSession, ok := reconstructLocalSessions(sessions)
+	if !ok || len(localSessions) == 0 {
+		return nil
+	}
+
+	touched := touchedLocalSessionIndexes(cluster.SourceSeqs, seqToLocalSession)
+	if len(touched) != 1 {
+		return nil
+	}
+
+	if !hasBoundaryAnchoredSourceSeqs(cluster.SourceSeqs, localSessions[touched[0]], seqToLocalSession) {
+		return nil
+	}
+	targetIndexes := localSessionGapFillTargetIndexes(touched, len(localSessions))
+	if len(targetIndexes) == 0 {
+		return nil
+	}
+
+	bandMin, bandMax := touched[0], touched[len(touched)-1]
+	type rankedGapFillTurn struct {
+		boundaryDistance int
+		memory           domain.Memory
+		seq              int
+		targetIndex      int
+	}
+	ranked := make([]rankedGapFillTurn, 0, maxTurns)
+	seen := make(map[string]struct{})
+	for _, targetIndex := range targetIndexes {
+		target := localSessions[targetIndex]
+		for _, turn := range target.Turns {
+			if turn == nil || turn.ID == "" {
+				continue
+			}
+			if _, ok := seen[turn.ID]; ok {
+				continue
+			}
+			seen[turn.ID] = struct{}{}
+			boundaryDistance := 0
+			switch {
+			case targetIndex < bandMin:
+				boundaryDistance = cluster.MinSeq - turn.Seq
+			case targetIndex > bandMax:
+				boundaryDistance = turn.Seq - cluster.MaxSeq
+			default:
+				left := absInt(turn.Seq - cluster.MinSeq)
+				right := absInt(turn.Seq - cluster.MaxSeq)
+				boundaryDistance = left
+				if right < boundaryDistance {
+					boundaryDistance = right
+				}
+			}
+			if boundaryDistance < 0 {
+				boundaryDistance = 0
+			}
+			ranked = append(ranked, rankedGapFillTurn{
+				boundaryDistance: boundaryDistance,
+				memory:           sessionToMemory(turn),
+				seq:              turn.Seq,
+				targetIndex:      targetIndex,
+			})
+		}
+	}
+	if len(ranked) == 0 {
+		return nil
+	}
+
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].boundaryDistance != ranked[j].boundaryDistance {
+			return ranked[i].boundaryDistance < ranked[j].boundaryDistance
+		}
+		if ranked[i].targetIndex != ranked[j].targetIndex {
+			return ranked[i].targetIndex < ranked[j].targetIndex
+		}
+		if ranked[i].seq != ranked[j].seq {
+			return ranked[i].seq < ranked[j].seq
+		}
+		return ranked[i].memory.ID < ranked[j].memory.ID
+	})
+	if len(ranked) > maxTurns {
+		ranked = ranked[:maxTurns]
+	}
+
+	results := make([]domain.Memory, 0, len(ranked))
+	for _, candidate := range ranked {
+		results = append(results, candidate.memory)
+	}
+	return results
+}
+
+func hasBoundaryAnchoredSourceSeqs(sourceSeqs []int, localSession reconstructedLocalSession, seqToLocalSession map[int]int) bool {
+	if len(sourceSeqs) == 0 {
+		return false
+	}
+
+	boundaryCount := 0
+	seenSeqs := make(map[int]struct{}, len(sourceSeqs))
+	for _, seq := range sourceSeqs {
+		if _, ok := seenSeqs[seq]; ok {
+			continue
+		}
+		seenSeqs[seq] = struct{}{}
+
+		localIndex, ok := seqToLocalSession[seq]
+		if !ok || localIndex != seqToLocalSession[localSession.MinSeq] {
+			continue
+		}
+
+		leftDistance := absInt(seq - localSession.MinSeq)
+		rightDistance := absInt(localSession.MaxSeq - seq)
+		if leftDistance <= sourceSeqBoundaryTurnRadius || rightDistance <= sourceSeqBoundaryTurnRadius {
+			boundaryCount++
+			if boundaryCount >= sourceSeqBoundaryMinSeedCount {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func reconstructLocalSessions(sessions []*domain.Session) ([]reconstructedLocalSession, map[int]int, bool) {
+	if len(sessions) == 0 {
+		return nil, nil, false
+	}
+	sortedSessions := append([]*domain.Session(nil), sessions...)
+	sort.Slice(sortedSessions, func(i, j int) bool {
+		if sortedSessions[i] == nil || sortedSessions[j] == nil {
+			return sortedSessions[j] != nil
+		}
+		if sortedSessions[i].Seq != sortedSessions[j].Seq {
+			return sortedSessions[i].Seq < sortedSessions[j].Seq
+		}
+		return sortedSessions[i].ID < sortedSessions[j].ID
+	})
+
+	localSessions := make([]reconstructedLocalSession, 0, 8)
+	seqToLocalSession := make(map[int]int, len(sortedSessions))
+	for _, turn := range sortedSessions {
+		if turn == nil {
+			continue
+		}
+		dateLabel, ok := sessionDateLabel(turn.Content)
+		if !ok {
+			return nil, nil, false
+		}
+		lastIndex := len(localSessions) - 1
+		if lastIndex < 0 || localSessions[lastIndex].DateLabel != dateLabel {
+			localSessions = append(localSessions, reconstructedLocalSession{
+				DateLabel: dateLabel,
+				MinSeq:    turn.Seq,
+				MaxSeq:    turn.Seq,
+				Turns:     []*domain.Session{turn},
+			})
+			seqToLocalSession[turn.Seq] = len(localSessions) - 1
+			continue
+		}
+		localSessions[lastIndex].Turns = append(localSessions[lastIndex].Turns, turn)
+		localSessions[lastIndex].MaxSeq = turn.Seq
+		seqToLocalSession[turn.Seq] = lastIndex
+	}
+	return localSessions, seqToLocalSession, len(localSessions) > 0
+}
+
+func sessionDateLabel(content string) (string, bool) {
+	if !strings.HasPrefix(content, "[date:") {
+		return "", false
+	}
+	end := strings.Index(content, "]")
+	if end <= len("[date:") {
+		return "", false
+	}
+	return content[len("[date:"):end], true
+}
+
+func touchedLocalSessionIndexes(sourceSeqs []int, seqToLocalSession map[int]int) []int {
+	if len(sourceSeqs) == 0 || len(seqToLocalSession) == 0 {
+		return nil
+	}
+	seen := make(map[int]struct{}, len(sourceSeqs))
+	indexes := make([]int, 0, len(sourceSeqs))
+	for _, seq := range sourceSeqs {
+		localIndex, ok := seqToLocalSession[seq]
+		if !ok {
+			continue
+		}
+		if _, ok := seen[localIndex]; ok {
+			continue
+		}
+		seen[localIndex] = struct{}{}
+		indexes = append(indexes, localIndex)
+	}
+	sort.Ints(indexes)
+	return indexes
+}
+
+func localSessionGapFillTargetIndexes(touched []int, total int) []int {
+	if len(touched) == 0 || total <= 0 {
+		return nil
+	}
+	minTouched := touched[0]
+	maxTouched := touched[len(touched)-1]
+	if maxTouched-minTouched > 1 {
+		return nil
+	}
+	touchedSet := make(map[int]struct{}, len(touched))
+	for _, idx := range touched {
+		touchedSet[idx] = struct{}{}
+	}
+	targets := make([]int, 0, 2)
+	for _, idx := range []int{minTouched - 1, maxTouched + 1} {
+		if idx < 0 || idx >= total {
+			continue
+		}
+		if _, ok := touchedSet[idx]; ok {
+			continue
+		}
+		targets = append(targets, idx)
+	}
+	return targets
+}
+
+func absFloat(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func absInt(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func pruneSourceSeqOverlapCandidates(candidates []RecallCandidate, cluster *sourceSeqAdjacentCluster) []RecallCandidate {
+	if cluster == nil || len(candidates) == 0 {
+		return candidates
+	}
+	windowMin := cluster.MinSeq - sourceSeqAdjacentTurnRadius
+	windowMax := cluster.MaxSeq + sourceSeqAdjacentTurnRadius
+	keptOverlapSummary := false
+	out := make([]RecallCandidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate.Memory.MemoryType != domain.TypeInsight {
+			out = append(out, candidate)
+			continue
+		}
+		sourceSeqs := sourceSeqsFromMemory(candidate.Memory)
+		if len(sourceSeqs) == 0 || !sourceSeqWindowOverlap(sourceSeqs, windowMin, windowMax) {
+			out = append(out, candidate)
+			continue
+		}
+		if keptOverlapSummary {
+			continue
+		}
+		out = append(out, candidate)
+		keptOverlapSummary = true
+	}
+	return out
+}
+
+func sourceSeqWindowOverlap(sourceSeqs []int, windowMin, windowMax int) bool {
+	for _, seq := range sourceSeqs {
+		if seq >= windowMin && seq <= windowMax {
+			return true
+		}
+	}
+	return false
 }
 
 func sortByScore(mems map[string]domain.Memory, scores map[string]float64) []domain.Memory {

--- a/server/internal/service/memory_test.go
+++ b/server/internal/service/memory_test.go
@@ -469,6 +469,349 @@ func TestSearchIgnoresSessionAndSourceFilters(t *testing.T) {
 	}
 }
 
+func TestSearchCandidatesAddsClusterScopedLocalSessionGapFillTurnsForInsightRecall(t *testing.T) {
+	t.Parallel()
+
+	scoreA := 0.91
+	scoreB := 0.89
+	memRepo := &memoryRepoMock{
+		ftsAvail: false,
+		autoVectorSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{
+					ID:         "insight-1",
+					Content:    "summary seeded from seq 2",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[2]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreA,
+				},
+				{
+					ID:         "insight-2",
+					Content:    "summary seeded from seq 3",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[3]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreB,
+				},
+			}, nil
+		},
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return nil, nil
+		},
+	}
+	sessionRepo := &stubSessionRepo{
+		sessionRows: []*domain.Session{
+			{ID: "turn-0", SessionID: "conv-30", Seq: 0, Role: "user", Content: "[date:2024-01-01] before one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-1", SessionID: "conv-30", Seq: 1, Role: "user", Content: "[date:2024-01-01] before two", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-2", SessionID: "conv-30", Seq: 2, Role: "user", Content: "[date:2024-01-02] seed one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-3", SessionID: "conv-30", Seq: 3, Role: "user", Content: "[date:2024-01-02] seed two", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-4", SessionID: "conv-30", Seq: 4, Role: "user", Content: "[date:2024-01-03] after one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-5", SessionID: "conv-30", Seq: 5, Role: "user", Content: "[date:2024-01-03] after two", ContentType: "text", State: domain.StateActive},
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart, sessionRepo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{
+		Query: "what happened next?",
+		Limit: 5,
+	}, RecallSourceInsight, RecallCandidateOptions{})
+	if err != nil {
+		t.Fatalf("SearchCandidates() error = %v", err)
+	}
+
+	if len(sessionRepo.listSessionIDs) != 1 || sessionRepo.listSessionIDs[0] != "conv-30" {
+		t.Fatalf("expected raw session lookup for conv-30, got %v", sessionRepo.listSessionIDs)
+	}
+	if sessionRepo.listLimit != 101 {
+		t.Fatalf("expected raw session fetch limit 101, got %d", sessionRepo.listLimit)
+	}
+
+	hasTurn0 := false
+	hasTurn1 := false
+	hasTurn4 := false
+	hasTurn5 := false
+	hasTurn2 := false
+	hasTurn3 := false
+	summaryCount := 0
+	for _, candidate := range candidates {
+		switch candidate.Memory.ID {
+		case "insight-1", "insight-2":
+			summaryCount++
+		case "turn-0":
+			hasTurn0 = true
+		case "turn-1":
+			hasTurn1 = true
+		case "turn-2":
+			hasTurn2 = true
+		case "turn-3":
+			hasTurn3 = true
+		case "turn-4":
+			hasTurn4 = true
+		case "turn-5":
+			hasTurn5 = true
+		}
+	}
+
+	if !hasTurn0 || !hasTurn1 || !hasTurn4 || !hasTurn5 {
+		t.Fatalf("expected adjacent local-session turns from both neighboring sessions, got %+v", candidates)
+	}
+	if hasTurn2 || hasTurn3 {
+		t.Fatalf("did not expect in-band source seq turns turn-2/turn-3 to be injected, got %+v", candidates)
+	}
+	if summaryCount != 1 {
+		t.Fatalf("expected only one overlapping insight summary after prune, got %d candidates: %+v", summaryCount, candidates)
+	}
+}
+
+func TestSearchCandidatesSkipsLocalSessionGapFillWithoutDateHeaders(t *testing.T) {
+	t.Parallel()
+
+	scoreA := 0.91
+	scoreB := 0.89
+	memRepo := &memoryRepoMock{
+		ftsAvail: false,
+		autoVectorSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{
+					ID:         "insight-1",
+					Content:    "summary seeded from seq 2",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[2]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreA,
+				},
+				{
+					ID:         "insight-2",
+					Content:    "summary seeded from seq 3",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[3]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreB,
+				},
+			}, nil
+		},
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return nil, nil
+		},
+	}
+	sessionRepo := &stubSessionRepo{
+		sessionRows: []*domain.Session{
+			{ID: "turn-0", SessionID: "conv-30", Seq: 0, Role: "user", Content: "before one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-1", SessionID: "conv-30", Seq: 1, Role: "user", Content: "before two", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-2", SessionID: "conv-30", Seq: 2, Role: "user", Content: "seed one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-3", SessionID: "conv-30", Seq: 3, Role: "user", Content: "seed two", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-4", SessionID: "conv-30", Seq: 4, Role: "user", Content: "after one", ContentType: "text", State: domain.StateActive},
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart, sessionRepo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{
+		Query: "what happened next?",
+		Limit: 5,
+	}, RecallSourceInsight, RecallCandidateOptions{})
+	if err != nil {
+		t.Fatalf("SearchCandidates() error = %v", err)
+	}
+
+	for _, candidate := range candidates {
+		switch candidate.Memory.ID {
+		case "turn-0", "turn-1", "turn-2", "turn-3", "turn-4":
+			t.Fatalf("did not expect local-session gap fill without date headers, got %+v", candidates)
+		}
+	}
+}
+
+func TestSearchCandidatesSkipsSourceSeqAdjacentTurnsWithoutTightCluster(t *testing.T) {
+	t.Parallel()
+
+	scoreA := 0.91
+	scoreB := 0.89
+	memRepo := &memoryRepoMock{
+		ftsAvail: false,
+		autoVectorSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{
+					ID:         "insight-1",
+					Content:    "summary seeded from seq 5",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[5]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreA,
+				},
+				{
+					ID:         "insight-2",
+					Content:    "summary seeded from seq 12",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[12]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreB,
+				},
+			}, nil
+		},
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return nil, nil
+		},
+	}
+	sessionRepo := &stubSessionRepo{
+		sessionRows: []*domain.Session{
+			{ID: "turn-4", SessionID: "conv-30", Seq: 4, Role: "user", Content: "neighbor before", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-6", SessionID: "conv-30", Seq: 6, Role: "user", Content: "neighbor after", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-11", SessionID: "conv-30", Seq: 11, Role: "user", Content: "other before", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-13", SessionID: "conv-30", Seq: 13, Role: "user", Content: "other after", ContentType: "text", State: domain.StateActive},
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart, sessionRepo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{
+		Query: "what happened next?",
+		Limit: 5,
+	}, RecallSourceInsight, RecallCandidateOptions{})
+	if err != nil {
+		t.Fatalf("SearchCandidates() error = %v", err)
+	}
+
+	if len(sessionRepo.listSessionIDs) != 0 {
+		t.Fatalf("expected no raw session lookup without a tight cluster, got %v", sessionRepo.listSessionIDs)
+	}
+
+	for _, candidate := range candidates {
+		switch candidate.Memory.ID {
+		case "turn-4", "turn-6", "turn-11", "turn-13":
+			t.Fatalf("did not expect adjacent raw turn injection without a tight cluster, got %+v", candidates)
+		}
+	}
+}
+
+func TestSearchCandidatesSkipsLocalSessionGapFillWhenSeedsAreNotBoundaryAnchored(t *testing.T) {
+	t.Parallel()
+
+	scoreA := 0.91
+	scoreB := 0.89
+	memRepo := &memoryRepoMock{
+		ftsAvail: false,
+		autoVectorSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{
+					ID:         "insight-1",
+					Content:    "summary seeded from seq 3",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[3]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreA,
+				},
+				{
+					ID:         "insight-2",
+					Content:    "summary seeded from seq 4",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[4]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreB,
+				},
+			}, nil
+		},
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return nil, nil
+		},
+	}
+	sessionRepo := &stubSessionRepo{
+		sessionRows: []*domain.Session{
+			{ID: "turn-0", SessionID: "conv-30", Seq: 0, Role: "user", Content: "[date:2024-01-01] before one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-1", SessionID: "conv-30", Seq: 1, Role: "user", Content: "[date:2024-01-02] anchor start", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-2", SessionID: "conv-30", Seq: 2, Role: "user", Content: "[date:2024-01-02] anchor left", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-3", SessionID: "conv-30", Seq: 3, Role: "user", Content: "[date:2024-01-02] seed one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-4", SessionID: "conv-30", Seq: 4, Role: "user", Content: "[date:2024-01-02] seed two", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-5", SessionID: "conv-30", Seq: 5, Role: "user", Content: "[date:2024-01-02] anchor right", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-6", SessionID: "conv-30", Seq: 6, Role: "user", Content: "[date:2024-01-02] anchor end", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-7", SessionID: "conv-30", Seq: 7, Role: "user", Content: "[date:2024-01-03] after one", ContentType: "text", State: domain.StateActive},
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart, sessionRepo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{
+		Query: "what happened next?",
+		Limit: 5,
+	}, RecallSourceInsight, RecallCandidateOptions{})
+	if err != nil {
+		t.Fatalf("SearchCandidates() error = %v", err)
+	}
+
+	for _, candidate := range candidates {
+		switch candidate.Memory.ID {
+		case "turn-0", "turn-7":
+			t.Fatalf("did not expect local-session gap fill when source seqs are not boundary-anchored, got %+v", candidates)
+		}
+	}
+}
+
+func TestSearchCandidatesSkipsLocalSessionGapFillWhenClusterTouchesTwoSessions(t *testing.T) {
+	t.Parallel()
+
+	scoreA := 0.91
+	scoreB := 0.89
+	memRepo := &memoryRepoMock{
+		ftsAvail: false,
+		autoVectorSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{
+					ID:         "insight-1",
+					Content:    "summary seeded from seq 1",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[1]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreA,
+				},
+				{
+					ID:         "insight-2",
+					Content:    "summary seeded from seq 2",
+					SessionID:  "conv-30",
+					Metadata:   json.RawMessage(`{"source_seqs":[2]}`),
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					Score:      &scoreB,
+				},
+			}, nil
+		},
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return nil, nil
+		},
+	}
+	sessionRepo := &stubSessionRepo{
+		sessionRows: []*domain.Session{
+			{ID: "turn-0", SessionID: "conv-30", Seq: 0, Role: "user", Content: "[date:2024-01-01] before one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-1", SessionID: "conv-30", Seq: 1, Role: "user", Content: "[date:2024-01-01] seed one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-2", SessionID: "conv-30", Seq: 2, Role: "user", Content: "[date:2024-01-02] seed two", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-3", SessionID: "conv-30", Seq: 3, Role: "user", Content: "[date:2024-01-02] after one", ContentType: "text", State: domain.StateActive},
+			{ID: "turn-4", SessionID: "conv-30", Seq: 4, Role: "user", Content: "[date:2024-01-03] after two", ContentType: "text", State: domain.StateActive},
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart, sessionRepo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{
+		Query: "what happened next?",
+		Limit: 5,
+	}, RecallSourceInsight, RecallCandidateOptions{})
+	if err != nil {
+		t.Fatalf("SearchCandidates() error = %v", err)
+	}
+
+	for _, candidate := range candidates {
+		switch candidate.Memory.ID {
+		case "turn-0", "turn-4":
+			t.Fatalf("did not expect local-session gap fill when source seqs already touch two sessions, got %+v", candidates)
+		}
+	}
+}
+
 func TestCreateFallsBackToRawWhenLLMUnavailable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add source-seq anchored local-session gap fill on the hybrid recall path
- reconstruct local dialogue boundaries from nearby raw turns instead of trusting sample-level `SessionID`
- inject only tightly gated adjacent evidence turns and prune overlapping summary noise
- cover the new behavior with targeted service tests

## Why
Cross-sample `wrong_session_miss` analysis showed a stable failure mode: summary/insight hits often land near the right local region, but the exact evidence turn is absent. The old path had no safe way to recover those adjacent raw turns.

This change uses `source_seqs` provenance from insight hits, detects a tight local cluster, reconstructs the local dialogue boundary, and only then adds nearby raw evidence turns with a strong cap/prune policy.

## Validation
- `cd server && go test ./internal/service ./internal/handler ./cmd/mnemo-server`
- focused subset validation previously showed strong lift on the targeted slice
- full benchmark rerun on latest `main` baseline and latest `main` + this branch is in progress per `@okJiang` request; I will append final numbers here
