### PR TITLE
[codex] Fix OpenClaw conversation access for mem9

### DIFF
--- a/benchmark/MR-NIAH/README.md
+++ b/benchmark/MR-NIAH/README.md
@@ -11,7 +11,7 @@ Research teams have produced numerous memory benchmarks for chatbots, but their 
 - **Dataset mirroring (`fetch_data.py`)** – keeps a local `origin/` mirror of MiniMax’s MR-NIAH dumps.
 - **Transcript bridge (`mr-niah-transcript.py`)** – rewrites raw turns into OpenClaw `session` JSON plus an `index`.
 - **Batch execution (`run_batch.py`)** – rehydrates sessions into a profile, calls `openclaw agent`, and stores `results/`.
-- **Comparison runner (`run_mem_compare.sh`)** – clones the baseline profile, installs the mem9 plugin, provisions a fresh mem9 space on the hosted mem9 API (or another configured mem9 endpoint), runs both profiles, prints accuracy deltas, and (on successful full comparisons) writes a tar.gz archive containing results + logs. Supports `--model` / `--compact`, plus managed profiles (template + `.env`) to avoid baseline/mem drift; defaults to `benchmark/MR-NIAH/config/openclaw/`.
+- **Comparison runner (`run_mem_compare.sh`)** – clones the baseline profile, installs the mem9 plugin, enables OpenClaw 4.23+ conversation access for mem9, provisions a fresh mem9 space on the hosted mem9 API (or another configured mem9 endpoint), runs both profiles, prints accuracy deltas, and (on successful full comparisons) writes a tar.gz archive containing results + logs. Supports `--model` / `--compact`, plus managed profiles (template + `.env`) to avoid baseline/mem drift; defaults to `benchmark/MR-NIAH/config/openclaw/`.
 - **Scoring (`score.py`)** – invokes the MR-NIAH exact-match rubric so downstream results remain comparable to prior papers.
 
 Directory layout, helper scripts, and agent responsibilities are summarized below:

--- a/benchmark/MR-NIAH/USAGE.md
+++ b/benchmark/MR-NIAH/USAGE.md
@@ -167,7 +167,7 @@ When you run a full baseline-vs-mem comparison (not `--profile`, not `--compare`
 5. Chooses a mem9 history load strategy via `--mem9-load-method`:
    - `line-write` (default): replays the transcript by posting each JSONL message line to `v1alpha2 /memories` sequentially.
    - `import-session`: uploads the full transcript via `v1alpha1 /imports` (`file_type=session`) and polls the task.
-6. Installs the `openclaw-plugin` into the memory profile, adds `plugins.allow=["mem9"]`, and writes the tenant credentials into `plugins.entries.mem9.config`.
+6. Installs the `openclaw-plugin` into the memory profile, adds `plugins.allow=["mem9"]`, writes the tenant credentials into `plugins.entries.mem9.config`, and enables `plugins.entries.mem9.hooks.allowConversationAccess=true` on OpenClaw 4.23+ / 2026.4.22+.
 7. Calls `run_batch.py` twice (baseline vs mem), writing into `results-${profile}` for baseline and `results-${mem_profile}` for the mem run.
 8. Prints accuracy for both runs and the delta.
 

--- a/benchmark/MR-NIAH/run_batch.py
+++ b/benchmark/MR-NIAH/run_batch.py
@@ -53,10 +53,78 @@ SESS_OUT = OUTPUT / "sessions"
 META_SUFFIX = ".meta.json"
 PROFILE_MEMORY_DIR = "memory"
 OPENCLAW_DEFAULT_WORKSPACE_DIRNAME = ".openclaw"
+_openclaw_conversation_access_support: Optional[bool] = None
+_openclaw_conversation_access_skip_logged = False
 
 
 def now_ms() -> int:
     return int(time.time() * 1000)
+
+
+def _parse_openclaw_version_text(text: str) -> Optional[tuple[int, int, int]]:
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
+    if not match:
+        return None
+    return (
+        int(match.group(1)),
+        int(match.group(2)),
+        int(match.group(3) or 0),
+    )
+
+
+def openclaw_supports_conversation_access() -> bool:
+    global _openclaw_conversation_access_support
+    if _openclaw_conversation_access_support is not None:
+        return _openclaw_conversation_access_support
+
+    proc = subprocess.run(
+        ["openclaw", "--version"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    version = _parse_openclaw_version_text(f"{proc.stdout}\n{proc.stderr}")
+    if version is None:
+        _openclaw_conversation_access_support = False
+        return False
+
+    major, minor, patch = version
+    if major >= 2026:
+        _openclaw_conversation_access_support = (major, minor, patch) >= (2026, 4, 22)
+    else:
+        _openclaw_conversation_access_support = (major, minor, patch) >= (4, 23, 0)
+    return _openclaw_conversation_access_support
+
+
+def ensure_mem9_conversation_access(profile: str) -> None:
+    global _openclaw_conversation_access_skip_logged
+    if not openclaw_supports_conversation_access():
+        if not _openclaw_conversation_access_skip_logged:
+            print(
+                "[mem9] OpenClaw version does not support hooks.allowConversationAccess; "
+                "automatic conversation upload requires OpenClaw 4.23+ / 2026.4.22+",
+                file=sys.stderr,
+                flush=True,
+            )
+            _openclaw_conversation_access_skip_logged = True
+        return
+
+    subprocess.run(
+        [
+            "openclaw",
+            "--profile",
+            profile,
+            "config",
+            "set",
+            "plugins.entries.mem9.hooks.allowConversationAccess",
+            "true",
+        ],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
 
 
 def extract_last_compaction_event(session_file: Path) -> Optional[Dict[str, Any]]:
@@ -1563,6 +1631,7 @@ def main() -> int:
                         # The OpenClaw mem9 plugin treats apiKey as the primary v1alpha2 credential.
                         # Keep tenantID in sync for backward compatibility / debugging, but always
                         # set apiKey so the plugin does not keep using a stale placeholder.
+                        ensure_mem9_conversation_access(args.profile)
                         for key in (
                             "plugins.entries.mem9.config.apiKey",
                             "plugins.entries.mem9.config.tenantID",
@@ -1584,7 +1653,7 @@ def main() -> int:
                             )
                     except subprocess.CalledProcessError as e:
                         msg = (e.stderr or e.stdout or "").strip()
-                        raise RuntimeError(f"openclaw config set mem9 apiKey failed: {msg}") from e
+                        raise RuntimeError(f"openclaw config set mem9 profile config failed: {msg}") from e
                     # Restart gateway per case to ensure it picks up the new tenant config.
                     _stop_process(gateway_proc)
                     gateway_proc = None

--- a/benchmark/MR-NIAH/run_mem_compare.sh
+++ b/benchmark/MR-NIAH/run_mem_compare.sh
@@ -113,6 +113,26 @@ log() {
   echo "[$(date '+%H:%M:%S')] $*" >&2
 }
 
+openclaw_supports_conversation_access() {
+  local version
+  version="$(openclaw --version 2>/dev/null | head -n 1 || true)"
+  python3 - "$version" <<'PY'
+import re
+import sys
+
+match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", sys.argv[1])
+if not match:
+    raise SystemExit(1)
+
+major = int(match.group(1))
+minor = int(match.group(2))
+patch = int(match.group(3) or 0)
+if major >= 2026:
+    raise SystemExit(0 if (major, minor, patch) >= (2026, 4, 22) else 1)
+raise SystemExit(0 if (major, minor, patch) >= (4, 23, 0) else 1)
+PY
+}
+
 usage() {
   cat >&2 <<EOF
 Usage: $(basename "$0") [options]
@@ -801,6 +821,11 @@ PY
 
   openclaw --profile "$MEM_PROFILE" config set plugins.slots.memory mem9 >/dev/null
   openclaw --profile "$MEM_PROFILE" config set plugins.entries.mem9.enabled true >/dev/null
+  if openclaw_supports_conversation_access; then
+    openclaw --profile "$MEM_PROFILE" config set plugins.entries.mem9.hooks.allowConversationAccess true >/dev/null
+  else
+    log "OpenClaw version does not support hooks.allowConversationAccess; automatic conversation upload requires OpenClaw 4.23+ / 2026.4.22+"
+  fi
   openclaw --profile "$MEM_PROFILE" config set plugins.entries.mem9.config.apiUrl "$api_url" >/dev/null
   openclaw --profile "$MEM_PROFILE" config set plugins.entries.mem9.config.apiKey "$MEM9_SPACE_ID" >/dev/null
   # Keep tenantID in sync with apiKey (apiKey is the primary v1alpha2 credential; tenantID helps debug/back-compat).

--- a/benchmark/scripts/benchmark.sh
+++ b/benchmark/scripts/benchmark.sh
@@ -67,6 +67,26 @@ validate_anthropic_api_key() {
   exit 1
 }
 
+openclaw_supports_conversation_access() {
+  local version
+  version="$(openclaw --version 2>/dev/null | head -n 1 || true)"
+  python3 - "$version" <<'PY'
+import re
+import sys
+
+match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", sys.argv[1])
+if not match:
+    raise SystemExit(1)
+
+major = int(match.group(1))
+minor = int(match.group(2))
+patch = int(match.group(3) or 0)
+if major >= 2026:
+    raise SystemExit(0 if (major, minor, patch) >= (2026, 4, 22) else 1)
+raise SystemExit(0 if (major, minor, patch) >= (4, 23, 0) else 1)
+PY
+}
+
 if [[ -z "$BENCH_PROMPT_FILE" ]]; then
   echo "ERROR: BENCH_PROMPT_FILE is required but not set."
   echo "  export BENCH_PROMPT_FILE='path/to/prompts.yaml'"
@@ -170,6 +190,11 @@ openclaw --profile "$PROFILE_B" plugins install --link "$ROOT/openclaw-plugin"
 openclaw --profile "$PROFILE_B" config set --strict-json plugins.allow '["mem9"]'
 openclaw --profile "$PROFILE_B" config set plugins.slots.memory mem9
 openclaw --profile "$PROFILE_B" config set plugins.entries.mem9.enabled true
+if openclaw_supports_conversation_access; then
+  openclaw --profile "$PROFILE_B" config set plugins.entries.mem9.hooks.allowConversationAccess true
+else
+  echo "    OpenClaw version does not support hooks.allowConversationAccess; automatic conversation upload requires OpenClaw 4.23+ / 2026.4.22+"
+fi
 openclaw --profile "$PROFILE_B" config set plugins.entries.mem9.config.apiUrl "$MEM9_BASE_URL"
 openclaw --profile "$PROFILE_B" config set plugins.entries.mem9.config.apiKey "$MEM9_SPACE_ID"
 

--- a/docs/BENCHMARK.md
+++ b/docs/BENCHMARK.md
@@ -48,7 +48,7 @@ Stops any leftover gateways from previous runs and removes old temporary profile
 Sets up two OpenClaw profiles:
 
 - **Profile A (baseline)** — vanilla agent, no plugins.
-- **Profile B (treatment)** — mem9 plugin installed and configured to point at the mem9 API and space ID.
+- **Profile B (treatment)** — mem9 plugin installed and configured to point at the mem9 API and space ID. On OpenClaw 4.23+ / 2026.4.22+, the profile also enables `plugins.entries.mem9.hooks.allowConversationAccess` so `agent_end` can upload conversation messages.
 
 Both profiles use `anthropic/claude-sonnet-4-6` and are given the same API key.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -122,6 +122,9 @@ and saves new ones — all transparently.
     "entries": {
       "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "http://localhost:8080",
           "apiKey": "uuid"
@@ -558,6 +561,11 @@ the `X-API-Key` header. Legacy `tenantID` config remains supported as an alias
 for the same value; the plugin still uses `/v1alpha2/mem9s/...` rather than
 keeping a separate v1alpha1 codepath.
 
+On OpenClaw 4.23+ / 2026.4.22+, the config also sets the entry-level hook
+policy `plugins.entries.mem9.hooks.allowConversationAccess = true` so
+`agent_end` includes conversation messages for automatic upload. This is an
+OpenClaw plugin-entry permission, not part of `plugins.entries.mem9.config`.
+
 **Why plugin (kind: "memory") instead of skill?**
 
 | | Plugin (`kind: "memory"`) | Skill |
@@ -578,6 +586,9 @@ This is the same philosophy as the Claude Code side: Hooks (automatic) over MCP 
 {
   "mem9": {
     "enabled": true,
+    "hooks": {
+      "allowConversationAccess": true
+    },
     "config": {
       "apiUrl": "http://localhost:8080",
       "apiKey": "uuid"

--- a/docs/design/utm-skill-onboarding-proposal.md
+++ b/docs/design/utm-skill-onboarding-proposal.md
@@ -101,6 +101,9 @@ The OpenClaw plugin adds a new optional config field:
   "plugins": {
     "entries": {
       "mem9": {
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "provisionQueryParams": {
             "utm_source": "bosn"
@@ -127,9 +130,10 @@ of polluting all subsequent API traffic.
 
 The public setup docs now explicitly allow:
 
+- `plugins.entries.mem9.hooks.allowConversationAccess` for OpenClaw 4.23+ / 2026.4.22+
 - `plugins.entries.mem9.config.provisionQueryParams`
 
-but only for:
+The UTM field is only for:
 
 - remote `SKILL.md` onboarding
 - create-new branch

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -31,6 +31,9 @@ Add mem9 to your project's `openclaw.json`:
     "entries": {
       "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "http://localhost:8080",
           "apiKey": "uuid",
@@ -146,6 +149,9 @@ Each agent uses the same `apiKey` for the shared memory pool. The plugin sends t
     "entries": {
       "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "http://your-server:8080",
           "apiKey": "uuid"
@@ -156,7 +162,7 @@ Each agent uses the same `apiKey` for the shared memory pool. The plugin sends t
 }
 ```
 
-That's it. The server handles scoping and conflict resolution. Conceptually, the only required values are `apiUrl` + `apiKey`.
+That's it. The server handles scoping and conflict resolution. Conceptually, the required mem9 credential values are `apiUrl` + `apiKey`; OpenClaw 4.23+ also needs the entry-level hook permission shown above for automatic conversation upload.
 
 ### Verify
 
@@ -186,6 +192,8 @@ Defined in `openclaw.plugin.json`:
 
 > **Note**: `apiKey` takes precedence when both fields are set. If only `tenantID` is present, the plugin treats it as a legacy alias for `apiKey`, still uses v1alpha2, and logs a deprecation warning once at startup. `provisionToken` and `provisionQueryParams` are ignored after an `apiKey` is already configured, and non-`utm_*` keys are dropped before the provision request is sent. During create-new onboarding, the plugin shares one in-flight provision result across concurrent local registrations and reuses the persisted result for the same `provisionToken`, so repeated reloads or repeated setup retries do not create multiple keys. The only valid secret path is `plugins.entries.mem9.config.apiKey`; `plugins.entries.mem9.apiKey` at the entry top level is invalid on OpenClaw and prevents the gateway from loading.
 
+OpenClaw 4.23+ / 2026.4.22+ requires the entry-level hook policy `plugins.entries.mem9.hooks.allowConversationAccess = true` for `agent_end` to include conversation messages. Without it, mem9 can still load, but automatic conversation upload cannot read the conversation to ingest it. This is an OpenClaw plugin-entry permission, not a mem9 `config` field. Older OpenClaw builds that reject this hook policy should omit the `hooks` block and upgrade for full automatic conversation upload.
+
 For debugging, set `"debug": true` in the plugin config. The plugin will emit `[mem9][debug]` lines; current coverage shows how `before_prompt_build` stripped OpenClaw metadata wrappers before issuing the recall search. `"debugRecall": true` still works as a deprecated alias.
 
 ## Timeout Behavior
@@ -201,8 +209,11 @@ Example:
 {
   "plugins": {
     "entries": {
-      "openclaw": {
+      "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "http://your-server:8080",
           "apiKey": "uuid",
@@ -238,4 +249,5 @@ openclaw-plugin/
 | `config reload skipped (invalid config): plugins.entries.mem9: Unrecognized key: "apiKey"` | Setup wrote `plugins.entries.mem9.apiKey` instead of `plugins.entries.mem9.config.apiKey` | Remove the invalid top-level key and keep the secret only under `config.apiKey` |
 | Multiple auto-provisioned keys appear during create-new | Setup retriggered create-new provisioning before the first result was reused, or an older plugin still auto-provisions on startup | Upgrade to `@mem9/mem9@0.4.7+`; newer builds provision only from the first post-restart user message and reuse one local result across duplicate setup retries |
 | Search requests time out | Hybrid/vector search exceeds plugin timeout | Increase `searchTimeoutMs` in plugin config |
+| Conversations are not uploaded on OpenClaw 4.23+ | `agent_end` does not include conversation messages without explicit hook permission | Set `plugins.entries.mem9.hooks.allowConversationAccess` to `true` and restart OpenClaw |
 | Plugin not loading | Not in memory slot | Set `"slots": {"memory": "mem9"}` in openclaw.json |

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -212,6 +212,7 @@ export function registerHooks(
   },
 ): void {
   const maxIngestBytes = options?.maxIngestBytes ?? DEFAULT_MAX_INGEST_BYTES;
+  let loggedMissingConversationAccess = false;
 
   // --------------------------------------------------------------------------
   // before_prompt_build — inject relevant memories into every LLM call
@@ -335,7 +336,17 @@ export function registerHooks(
         agentId?: string;
       };
       const hookCtx = (context ?? {}) as HookContext;
-      if (!evt?.success || !evt.messages || evt.messages.length === 0) return;
+      if (!evt?.success) return;
+      if (!Array.isArray(evt.messages)) {
+        if (!loggedMissingConversationAccess) {
+          logger.info(
+            "[mem9] agent_end conversation messages are unavailable; on OpenClaw 4.23+ / 2026.4.22+ set plugins.entries.mem9.hooks.allowConversationAccess=true to enable automatic conversation upload",
+          );
+          loggedMissingConversationAccess = true;
+        }
+        return;
+      }
+      if (evt.messages.length === 0) return;
 
       // Skip cron/heartbeat-triggered runs — they produce low-value messages
       if (hookCtx.trigger === "cron" || hookCtx.trigger === "heartbeat") {

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -479,6 +479,27 @@ test("debugRecall still works as a deprecated alias for debug", async () => {
   }
 });
 
+test("agent_end logs conversation-access diagnostic once when messages are unavailable", async () => {
+  const infoLogs: string[] = [];
+  const api = createStubApi(
+    {
+      apiUrl: uniqueApiUrl("agent-end-no-messages"),
+      apiKey: "space-agent-end-no-messages",
+    },
+    { infoLogs },
+  );
+  mnemoPlugin.register(api);
+
+  const agentEnd = api.getHook("agent_end");
+  await agentEnd({ success: true });
+  await agentEnd({ success: true });
+
+  assert.equal(
+    infoLogs.filter((line) => line.includes("allowConversationAccess=true")).length,
+    1,
+  );
+});
+
 test("first post-restart prompt provisions once and unlocks memory access", async () => {
   const originalFetch = globalThis.fetch;
   const apiUrl = uniqueApiUrl("explicit-provision");

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/mem9",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "description": "OpenClaw shared memory plugin — cloud-persistent memory with hybrid vector + keyword search via mnemo-server",
   "type": "module",
   "license": "Apache-2.0",

--- a/site/public/SETUP.md
+++ b/site/public/SETUP.md
@@ -22,6 +22,8 @@ When this file is read, send ONLY the choice prompt below. Do not include enviro
 - Do not change the user's global npm registry config during setup unless the user explicitly asks for a permanent mirror change.
 - Reconnect and create-new are separate branches. Once one branch is selected, ignore the other branch unless the user explicitly changes their choice.
 - The allowed config scope is exhaustive. Never add fallback keys outside it. In particular, never write `plugins.entries.mem9.apiKey`; only `plugins.entries.mem9.config.apiKey` is valid.
+- On OpenClaw 4.23+ / 2026.4.22+, write `plugins.entries.mem9.hooks.allowConversationAccess = true` as an entry-level hook policy so mem9 can read conversation messages during `agent_end`. Do not put this under `plugins.entries.mem9.config`.
+- On older OpenClaw versions that reject `hooks.allowConversationAccess`, skip that key and state that full automatic conversation upload requires upgrading OpenClaw.
 - In create-new mode, generate `PROVISION_TOKEN` once immediately after the branch is selected, write it under `plugins.entries.mem9.config.provisionToken` before the first restart, and keep that exact value stable through the first successful post-restart provision on this machine.
 - Before taking any action, show one dry-run preview that covers install, config edits, expected restarts, and what the user must do after the restart.
 - Use one explicit approval for the entire disclosed flow. Do not ask for a second approval unless the scope materially changes.
@@ -67,6 +69,7 @@ When this file is read, send ONLY the choice prompt below. Do not include enviro
   - a short restart-and-return instruction in the user's language that says the gateway will restart automatically, the user should return to this chat in a few minutes, and the user should say `hi`
 - In create-new mode, the exact config keys list must explicitly include `plugins.entries.mem9.config.provisionToken`.
 - In create-new mode, if `REMOTE_SKILL_UTM_PARAMS` is non-empty, the exact config keys list must explicitly include `plugins.entries.mem9.config.provisionQueryParams`.
+- For OpenClaw 4.23+ / 2026.4.22+, the exact config keys list must explicitly include `plugins.entries.mem9.hooks.allowConversationAccess`.
 - Approval phrases:
   - reconnect after the key is already captured: `approve reconnect`
   - create-new: `approve create`
@@ -102,6 +105,7 @@ The dry-run preview must disclose:
 - reconnect path expects one restart after config is written and read back
 - create-new path expects one restart without `apiKey`; after the restart, the first user message must trigger exactly one create-new provision through the normal plugin hook path
 - create-new path will also write one unique `provisionToken` before the first restart so repeated post-restart retries on this machine collapse to the same key
+- OpenClaw 4.23+ / 2026.4.22+ will also get `plugins.entries.mem9.hooks.allowConversationAccess = true` before restart; older versions skip that key and require an OpenClaw upgrade for full automatic conversation upload
 - if create-new has `REMOTE_SKILL_UTM_PARAMS`, the dry-run must explicitly say those filtered `utm_*` values will be written under `plugins.entries.mem9.config.provisionQueryParams` before the first restart
 - local history will not be uploaded by this setup flow
 - one short restart-and-return instruction in the user's language
@@ -199,6 +203,8 @@ Routing rule:
 
 - If the version is `>= 2.2.0`, use the config shape with `plugins.allow`
 - If the version is `< 2.2.0`, use the config shape without `plugins.allow`
+- If the version is OpenClaw `4.23+` or date-style `2026.4.22+`, use the config shape with `plugins.entries.mem9.hooks.allowConversationAccess = true`
+- If the version is older than OpenClaw `4.23` / `2026.4.22`, skip `plugins.entries.mem9.hooks.allowConversationAccess` because older strict schemas may reject it, and tell the user that full automatic conversation upload requires upgrading OpenClaw
 - If the version is unavailable or unclear, stop and ask the user which OpenClaw version they are using before editing `openclaw.json`
 
 ## Step 3 — Edit openclaw.json
@@ -213,6 +219,7 @@ Before writing `openclaw.json`:
 - If create-new is selected, read back `plugins.entries.mem9.config.provisionToken` before the first restart and require an exact match to `PROVISION_TOKEN`
 - If create-new started from a remote `SKILL.md` URL with `utm_*` params, include `plugins.entries.mem9.config.provisionQueryParams` in the disclosed key list
 - If create-new has `REMOTE_SKILL_UTM_PARAMS`, read back `plugins.entries.mem9.config.provisionQueryParams` before the first restart and require an exact key/value match
+- If OpenClaw is `4.23+` / `2026.4.22+`, include `plugins.entries.mem9.hooks.allowConversationAccess` in the disclosed key list and read it back as `true` before the first restart
 - Apply the mem9 config in one contiguous update after install succeeds. Do not split it into a pre-install slot switch and a later config write.
 - `plugins.entries.mem9.apiKey` at the entry top level is invalid on OpenClaw. Never duplicate or mirror the secret there as a compatibility fallback.
 
@@ -222,6 +229,7 @@ Effective changes for OpenClaw `>= 2.2.0`:
 
 - `plugins.slots.memory = "mem9"`
 - `plugins.entries.mem9.enabled = true`
+- For OpenClaw `4.23+` / `2026.4.22+`, `plugins.entries.mem9.hooks.allowConversationAccess = true`
 - `plugins.entries.mem9.config.apiUrl = "https://api.mem9.ai"` unless the user chose another `apiUrl`
 - `plugins.entries.mem9.config.apiKey = "<USER_PROVIDED_MEM9_API_KEY>"`
 - `plugins.allow` includes `"mem9"`
@@ -231,6 +239,7 @@ Reconnect hard rules:
 - In reconnect mode, never leave `plugins.entries.mem9.config.apiKey` absent for the first restart.
 - The only valid reconnect secret path is `plugins.entries.mem9.config.apiKey`.
 - Do not write or test `plugins.entries.mem9.apiKey` at the entry top level. OpenClaw rejects it before the plugin loads.
+- On OpenClaw `4.23+` / `2026.4.22+`, do not restart until `plugins.entries.mem9.hooks.allowConversationAccess` reads back as `true`.
 - Immediately after writing config, read back `plugins.entries.mem9.config.apiKey`.
 - The read-back value must exactly match `USER_PROVIDED_MEM9_API_KEY` before the first restart.
 - If the read-back value is missing or different, fix config first. Do not restart yet.
@@ -245,6 +254,9 @@ Minimal shape if creating a fresh file:
     "entries": {
       "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "https://api.mem9.ai",
           "apiKey": "<your-api-key>"
@@ -256,7 +268,7 @@ Minimal shape if creating a fresh file:
 }
 ```
 
-For OpenClaw `< 2.2.0`, use the same shape without `plugins.allow`.
+For OpenClaw `< 2.2.0`, use the same shape without `plugins.allow`. For OpenClaw versions older than `4.23` / `2026.4.22`, also omit `plugins.entries.mem9.hooks.allowConversationAccess` and tell the user to upgrade OpenClaw for full automatic conversation upload.
 
 ### Create New API Key During Setup
 
@@ -264,6 +276,7 @@ Effective changes for OpenClaw `>= 2.2.0`:
 
 - `plugins.slots.memory = "mem9"`
 - `plugins.entries.mem9.enabled = true`
+- For OpenClaw `4.23+` / `2026.4.22+`, `plugins.entries.mem9.hooks.allowConversationAccess = true`
 - `plugins.entries.mem9.config.apiUrl = "https://api.mem9.ai"` unless the user chose another `apiUrl`
 - Leave `plugins.entries.mem9.config.apiKey` absent for the first restart
 - Set `plugins.entries.mem9.config.provisionToken = "<PROVISION_TOKEN>"` for the first restart
@@ -274,6 +287,7 @@ Create-new hard rules:
 
 - Only the create-new branch may leave `apiKey` absent for the first restart.
 - Only the create-new branch may accept a generated key as the final mem9 credential.
+- On OpenClaw `4.23+` / `2026.4.22+`, never start the first restart until `plugins.entries.mem9.hooks.allowConversationAccess` reads back as `true`.
 - Never start the first restart in create-new mode with `plugins.entries.mem9.config.provisionToken` absent, regenerated, or different from `PROVISION_TOKEN`.
 - Immediately after writing config in create-new mode, read back `plugins.entries.mem9.config.provisionToken`.
 - The read-back value must exactly match `PROVISION_TOKEN` before the first restart.
@@ -291,6 +305,9 @@ Minimal shape if creating a fresh file:
     "entries": {
       "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "https://api.mem9.ai",
           "provisionToken": "<generated-provision-token>"
@@ -309,6 +326,9 @@ If remote-skill `utm_*` params are present, add them under `config.provisionQuer
   "plugins": {
     "entries": {
       "mem9": {
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "https://api.mem9.ai",
           "provisionToken": "<generated-provision-token>",
@@ -323,7 +343,7 @@ If remote-skill `utm_*` params are present, add them under `config.provisionQuer
 }
 ```
 
-For OpenClaw `< 2.2.0`, use the same shape without `plugins.allow`.
+For OpenClaw `< 2.2.0`, use the same shape without `plugins.allow`. For OpenClaw versions older than `4.23` / `2026.4.22`, also omit `plugins.entries.mem9.hooks.allowConversationAccess` and tell the user to upgrade OpenClaw for full automatic conversation upload.
 
 ## Step 4 — Restart Flow
 
@@ -416,6 +436,7 @@ If any positive health signal is present, treat the plugin as operational and pr
 Reconnect is successful only if all of the following are true:
 
 - `plugins.entries.mem9.config.apiKey` was read back before the first restart and exactly matched `USER_PROVIDED_MEM9_API_KEY`
+- On OpenClaw `4.23+` / `2026.4.22+`, `plugins.entries.mem9.hooks.allowConversationAccess` was read back before the first restart and exactly matched `true`
 - The plugin can reach the mem9 API
 - OpenClaw loads the mem9 plugin without config or plugin errors
 - The first valid startup did not auto-provision a new key
@@ -434,6 +455,7 @@ Create-new is successful only if all of the following are true:
 - OpenClaw loads the mem9 plugin without config or plugin errors
 - The create-new flow produced a key from exactly one post-restart provision request after the first restart
 - `PROVISION_TOKEN` was written before the first restart and remained stable for the create-new run
+- On OpenClaw `4.23+` / `2026.4.22+`, `plugins.entries.mem9.hooks.allowConversationAccess` was read back before the first restart and exactly matched `true`
 - If `REMOTE_SKILL_UTM_PARAMS` is non-empty, `plugins.entries.mem9.config.provisionQueryParams` was read back before the first restart and exactly matched that map
 - No different additional key replaced `AUTO_PROVISIONED_MEM9_API_KEY` later in the same create-new run
 - The plugin is running with the generated key on this machine (confirmed by positive health signals or absence of startup errors)

--- a/site/public/SKILL.md
+++ b/site/public/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mem9
-version: 1.0.44
+version: 1.0.45
 homepage: "https://mem9.ai/openclaw-memory"
 description: "Persistent cloud memory plugin for OpenClaw. This document routes setup, troubleshooting, and uninstall flows and defines config boundaries."
 keywords: ["mem9", "openclaw memory", "persistent memory", "cloud memory", "memory plugin", "setup mem9", "install mem9", "reconnect mem9", "uninstall mem9"]
@@ -21,6 +21,7 @@ This top-level `SKILL.md` is a routing and safety document. It is the entry poin
 - Route local mem9 removal on this machine to `UNINSTALL.md`.
 - Preserve filtered `utm_*` params from a remote `SKILL.md` URL through the create-new setup flow and first restart.
 - Prevent invalid compatibility fallbacks: never write `plugins.entries.mem9.apiKey`; only `plugins.entries.mem9.config.apiKey` is valid.
+- Configure OpenClaw 4.23+ hook permission with `plugins.entries.mem9.hooks.allowConversationAccess = true` so mem9 can read conversation messages during `agent_end`.
 - Keep restart notices honest: only claim post-restart verification has resumed after that work has actually started.
 - Keep history import manual. Do not scan or upload local memory or session files from this skill.
 
@@ -38,6 +39,7 @@ Only these `openclaw.json` paths may be changed during setup:
 
 - `plugins.slots.memory`
 - `plugins.entries.mem9.enabled`
+- `plugins.entries.mem9.hooks.allowConversationAccess` for OpenClaw 4.23+ / 2026.4.22+ only
 - `plugins.entries.mem9.config.apiUrl`
 - `plugins.entries.mem9.config.apiKey`
 - `plugins.entries.mem9.config.provisionToken` for create-new only; generate it once per create-new run before the first restart and keep it stable through the first successful post-restart provision on this machine

--- a/site/public/TROUBLESHOOTING.md
+++ b/site/public/TROUBLESHOOTING.md
@@ -11,6 +11,7 @@ Confirm these first:
 - `plugins.entries.mem9.config.apiUrl` points to the intended mem9 API
 - `plugins.entries.mem9.config.apiKey` is present for the steady-state reconnect flow
 - In reconnect mode, the read-back value of `plugins.entries.mem9.config.apiKey` exactly matches the user's original key before the first restart
+- On OpenClaw `4.23+` / `2026.4.22+`, `plugins.entries.mem9.hooks.allowConversationAccess` is `true`
 - On OpenClaw `>= 2.2.0`, `plugins.allow` includes `mem9`
 
 ## Common Issues
@@ -95,6 +96,15 @@ Confirm these first:
 - Rewrite the original user-provided key to the correct field
 - Restart and verify again
 - If a new key is still auto-provisioned after that, stop the reconnect flow and keep troubleshooting instead of silently switching mem9 spaces
+
+### Plugin Loads But Conversations Are Not Uploaded
+
+- Treat this as missing OpenClaw hook permission before treating it as a mem9 API failure
+- Re-check whether gateway logs contain `[mem9] agent_end conversation messages are unavailable`
+- On OpenClaw `4.23+` / `2026.4.22+`, set `plugins.entries.mem9.hooks.allowConversationAccess = true`
+- Keep `allowConversationAccess` as a sibling of `enabled` and `config`; do not put it under `plugins.entries.mem9.config`
+- Restart OpenClaw after writing the hook policy
+- On older OpenClaw versions that reject `hooks.allowConversationAccess`, upgrade OpenClaw before expecting full automatic conversation upload from `agent_end`
 
 ### Reconnect Looked Broken, But Logs Already Show mem9 Activity
 

--- a/skills/mnemos-setup/SKILL.md
+++ b/skills/mnemos-setup/SKILL.md
@@ -52,6 +52,9 @@ Add to `openclaw.json`:
     "entries": {
       "mem9": {
         "enabled": true,
+        "hooks": {
+          "allowConversationAccess": true
+        },
         "config": {
           "apiUrl": "http://localhost:8080",
           "apiKey": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -71,6 +74,7 @@ Compatibility note:
 
 - Preferred config: `apiKey` -> plugin uses v1alpha2 with `X-API-Key`.
 - Legacy config: `tenantID` -> plugin treats it as an alias for `apiKey` and still uses v1alpha2.
+- OpenClaw 4.23+ / 2026.4.22+ requires `plugins.entries.mem9.hooks.allowConversationAccess = true` so mem9 can read conversation messages in `agent_end` and upload them. Older OpenClaw builds that reject this hook policy should omit the `hooks` block and upgrade for full automatic conversation upload.
 - The underlying value is the same UUID either way.
 
 ---


### PR DESCRIPTION
## Summary
- Add OpenClaw 4.23+ `plugins.entries.mem9.hooks.allowConversationAccess` guidance to mem9 setup docs and examples.
- Add a one-time runtime diagnostic when `agent_end` cannot see conversation messages, plus regression coverage.
- Update benchmark OpenClaw config writers to set the hook policy only on supported OpenClaw versions.

## Root Cause
OpenClaw 4.23+ gates conversation payloads for non-bundled plugin hooks unless `plugins.entries.<id>.hooks.allowConversationAccess` is enabled. mem9 relies on `agent_end` messages for automatic conversation upload, so it could load successfully while silently skipping ingest when those messages were unavailable.

## Validation
- `cd openclaw-plugin && npm run test`
- `cd openclaw-plugin && npm run typecheck`
- `cd site && npm run build`
- `bash -n benchmark/scripts/benchmark.sh benchmark/MR-NIAH/run_mem_compare.sh`
- `python3 -m py_compile benchmark/MR-NIAH/run_batch.py`
- `git diff --check`