### PR TITLE
fix(ingest): align Rule 8 example with language preservation rule

### DIFF
--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -681,7 +681,7 @@ atomic facts from a conversation.
 8. Keep concerns, risks, and worries the user expresses about their work, systems, platforms, or ongoing operations,
 	 even when stated as background context for a direct action request. These signals have lasting value.
    Examples to keep:
-     - "小红书最近数据不好 老可能被封号" -> "User is concerned their Xiaohongshu account may be at risk of being banned due to poor recent metrics"
+      - "小红书账号最近数据不好，担心可能被封号"
      - "The API keeps returning 500s, something might be broken upstream"
      - "I think the deployment pipeline is getting flaky"
    Examples to skip:
@@ -828,7 +828,7 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
 8. Keep concerns, risks, and worries the user expresses about their work, systems, platforms, or ongoing operations,
 	 even when stated as background context for a direct action request. These signals have lasting value.
    Examples to keep:
-     - "小红书最近数据不好 老可能被封号" -> "User is concerned their Xiaohongshu account may be at risk of being banned due to poor recent metrics"
+     - "小红书账号最近数据不好，担心可能被封号"
      - "The API keeps returning 500s, something might be broken upstream"
      - "I think the deployment pipeline is getting flaky"
    Examples to skip:


### PR DESCRIPTION
The Rule 8 example showed Chinese input → English output, which contradicted Rule 4 ("Preserve the user's original language") and taught the LLM to translate Chinese facts to English. This caused language-inconsistent extraction when processing Chinese content where some facts were translated and others were not.

Changed the Chinese example to a standalone Chinese fact without the → translation signal, matching the format of every other example in the prompt where same-language input produces same-language output.