### PR TITLE
docs: clarify Codex plugin home paths

### DIFF
--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Persistent memory for Codex. Run $mem9:setup once, then mem9 recalls before prompts and saves recent turns on stop.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -14,7 +14,7 @@ The plugin exposes:
 - `$mem9:recall`
 - `$mem9:store`
 
-`$mem9:setup` is the main entrypoint. It manages shared profiles in `$MEM9_HOME/.credentials.json`, applies either global or project scope, and repairs the managed Codex hooks when needed.
+`$mem9:setup` is the main entrypoint. It manages shared profiles in the mem9 home, applies either global or project scope, and repairs the managed Codex hooks in the Codex home.
 
 ## Requirements
 
@@ -32,7 +32,7 @@ codex plugin marketplace add mem9-ai/mem9
 ```
 
 2. In Codex, run `/plugins`, search for `mem9`, open the `mem9-ai` marketplace entry, and choose `Install plugin`.
-3. Restart Codex or open a fresh Codex session with the same `CODEX_HOME`.
+3. Restart Codex or open a fresh Codex session with the same `CODEX_HOME`. For normal installs, that is `$HOME/.codex`.
 4. Run:
 
    ```text
@@ -48,6 +48,35 @@ codex plugin marketplace add mem9-ai/mem9
    ```
 
 You do not need to enable hooks manually first. `$mem9:setup` inspects the saved profiles, enables `codex_hooks`, and installs the managed hooks.
+
+## Where Files Are Stored
+
+The Codex plugin uses two home directories:
+
+| Variable | Default when unset | What lives there |
+|---|---|---|
+| `CODEX_HOME` | `~/.codex` on macOS/Linux | Codex user state, `hooks.json`, `config.toml`, and mem9-managed Codex runtime files under `$CODEX_HOME/mem9/` |
+| `MEM9_HOME` | `~/.mem9` on macOS/Linux | Shared mem9 credential profiles in `$MEM9_HOME/.credentials.json` |
+
+Most macOS/Linux users can leave both variables unset. With the defaults, Codex integration files live under `~/.codex/`, and mem9 credentials live in `~/.mem9/.credentials.json`. In shell commands, `~` means the same home directory as `$HOME`.
+
+The defaults are equivalent to starting Codex from a shell with:
+
+```bash
+export CODEX_HOME="$HOME/.codex"
+export MEM9_HOME="$HOME/.mem9"
+codex
+```
+
+On Windows PowerShell, the same defaults resolve under your user profile:
+
+```powershell
+$env:CODEX_HOME = "$env:USERPROFILE\.codex"
+$env:MEM9_HOME = "$env:USERPROFILE\.mem9"
+codex
+```
+
+Use the same `CODEX_HOME` and `MEM9_HOME` in trusted-shell commands that save or update profile keys. `$mem9:setup` keeps API key entry out of the Codex TUI and writes the key to `$MEM9_HOME/.credentials.json`.
 
 ## Daily Commands
 
@@ -199,6 +228,13 @@ Common issues:
 
 ### File Layout
 
+Runtime defaults:
+
+```text
+CODEX_HOME=~/.codex
+MEM9_HOME=~/.mem9
+```
+
 Global Codex integration:
 
 ```text
@@ -227,8 +263,6 @@ Shared credentials:
 ```text
 $MEM9_HOME/.credentials.json
 ```
-
-`MEM9_HOME` defaults to `$HOME/.mem9`.
 
 ### Config Files
 
@@ -273,10 +307,11 @@ Project override example:
 
 Remote update-check settings stay in the global config.
 
-### Runtime Overrides
+### Environment Overrides
 
-Runtime can still override request settings with environment variables:
+Runtime and setup can use environment variables:
 
 - `MEM9_API_URL`
 - `MEM9_API_KEY`
+- `CODEX_HOME`
 - `MEM9_HOME`

--- a/codex-plugin/package.json
+++ b/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/codex-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Persistent memory for Codex with setup-driven hooks, prompt recall, and stop-time save.",
   "type": "module",
   "license": "Apache-2.0",

--- a/codex-plugin/skills/setup/SKILL.md
+++ b/codex-plugin/skills/setup/SKILL.md
@@ -14,6 +14,32 @@ Resolve `./scripts/setup.mjs` relative to this skill directory.
 If you need the current CLI surface, flags, or examples, run `node ./scripts/setup.mjs --help` first.
 Use command-specific help when needed, for example `node ./scripts/setup.mjs profile save-key --help`.
 
+Know the two home directories before setup:
+
+- `CODEX_HOME` falls back to `~/.codex` on macOS/Linux.
+- `MEM9_HOME` falls back to `~/.mem9` on macOS/Linux.
+- Codex integration files live under `$CODEX_HOME`, including `$CODEX_HOME/hooks.json`, `$CODEX_HOME/config.toml`, and `$CODEX_HOME/mem9/`.
+- mem9 credential profiles live in `$MEM9_HOME/.credentials.json`.
+
+When you mention local paths to the user, use symbolic or home-relative paths such as `$CODEX_HOME/mem9/config.json`, `$MEM9_HOME/.credentials.json`, or `~/.mem9/.credentials.json`.
+Most users can leave both variables unset. On macOS/Linux, the defaults are equivalent to starting Codex from a shell with:
+
+```bash
+export CODEX_HOME="$HOME/.codex"
+export MEM9_HOME="$HOME/.mem9"
+codex
+```
+
+On Windows PowerShell, use:
+
+```powershell
+$env:CODEX_HOME = "$env:USERPROFILE\.codex"
+$env:MEM9_HOME = "$env:USERPROFILE\.mem9"
+codex
+```
+
+For isolated state, set different values before starting Codex and use the same values in trusted-shell `profile save-key` commands.
+
 Run this workflow:
 
 1. Inspect the current mem9 state first:
@@ -31,7 +57,7 @@ node ./scripts/setup.mjs inspect
    `profiles.items[*].manualSaveKeyCommand` is the exact trusted-shell command for saving a key onto an existing profile.
    `profiles.manualSaveKeyTemplate` is the placeholder version for a brand-new profile.
    Global `updateCheck` settings live under `globalConfig.summary.updateCheck`.
-3. After `inspect`, stop and present the available paths before you run anything else.
+3. After `inspect`, stop and present the available setup choices before you run anything else.
    Show:
    - saved profiles from `profiles.items[*].displaySummary`
      Example: `default (019d...4356) · https://api.mem9.ai`
@@ -55,6 +81,7 @@ node ./scripts/setup.mjs profile create \
 
 6. When the user wants to provide the key manually, do not ask them to paste the secret into Codex.
    Prefer a trusted shell plus `MEM9_API_KEY`.
+   The trusted shell must use the same `CODEX_HOME` and `MEM9_HOME` that Codex will use.
    If `inspect` already returned a matching `profiles.items[*].manualSaveKeyCommand`, show that exact command.
    Otherwise use `profiles.manualSaveKeyTemplate`.
    Only run `profile save-key` inside Codex when `MEM9_API_KEY` is already present in the process environment.


### PR DESCRIPTION
## Summary
- Clarify CODEX_HOME and MEM9_HOME defaults and file locations.
- Sync the setup skill guidance.
- Bump the Codex plugin version to 0.2.1.

## Testing
- git diff --check
- JSON parse check for package.json and plugin.json

No pnpm install or pnpm tests run for this docs-only change.