### PR TITLE
docs: repair AGENTS.md repo map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ title: mnemos — Agent context
 ## What this repo is
 
 mnemos is shared, cloud-persistent memory for coding agents. The core system is a Go
-REST server backed by TiDB/MySQL, plus three agent integrations, a standalone CLI,
+REST server backed by TiDB/MySQL, plus four agent integrations, a standalone CLI,
 and a small Astro site.
 
 ## Cross-repo relationship: `mem9` and `mem9-node`
@@ -27,6 +27,7 @@ and a small Astro site.
 | `openclaw-plugin/`   | OpenClaw memory plugin (`kind: "memory"`)                    |
 | `opencode-plugin/`   | OpenCode plugin (`@mem9/opencode`)                           |
 | `claude-plugin/`     | Claude Code plugin (hooks + skills)                          |
+| `codex-plugin/`      | Codex plugin (hooks + `$mem9:*` skills)                       |
 | `docs/design/`       | Architecture/proposal notes and design drafts                |
 | `site/`              | Astro static site — deployed to Netlify from `main` branch   |
 | `e2e/`               | Live end-to-end scripts against a running server             |
@@ -45,9 +46,13 @@ make test-integration
 # Single Go test
 cd server && go test -race -count=1 -run TestFunctionName ./internal/service/
 
-# TypeScript verification
+# TypeScript plugin verification
+cd openclaw-plugin && npm test
 cd openclaw-plugin && npm run typecheck
-cd opencode-plugin && npm run typecheck
+cd opencode-plugin && pnpm test
+cd opencode-plugin && pnpm run typecheck
+pnpm --dir codex-plugin test
+pnpm --dir codex-plugin typecheck
 
 # Site dev/build
 cd site && npm run dev
@@ -122,6 +127,7 @@ cd server && MNEMO_DSN="user:pass@tcp(host:4000)/db?parseTime=true" go run ./cmd
 | Dashboard backend (sibling repo) | `../mem9-node/apps/api/`        |
 | Dashboard worker (sibling repo) | `../mem9-node/apps/worker/`      |
 | Claude hooks         | `claude-plugin/hooks/`                      |
+| Codex hooks and skills | `codex-plugin/`                          |
 | Architecture notes   | `docs/design/`                              |
 | OpenCode wiring      | `opencode-plugin/src/index.ts`              |
 | OpenClaw wiring      | `openclaw-plugin/index.ts`                  |
@@ -158,11 +164,18 @@ Use the local file when you work in these areas:
 - `openclaw-plugin/AGENTS.md`
 - `opencode-plugin/AGENTS.md`
 - `claude-plugin/AGENTS.md`
+- `codex-plugin/AGENTS.md`
 - `site/AGENTS.md`
 - `dashboard/app/AGENTS.md`
 - `e2e/AGENTS.md`
 - `k8s/AGENTS.md`
 - `benchmark/MR-NIAH/AGENTS.md`
+
+Validate this map after editing:
+
+```bash
+python3 -c 'from pathlib import Path; import re; text = Path("AGENTS.md").read_text(); paths = re.findall(r"`([^`]+/AGENTS\.md)`", text); missing = [p for p in paths if not Path(p).is_file()]; print("\n".join(missing)); raise SystemExit(1 if missing else 0)'
+```
 
 ## GitHub access
 
@@ -204,5 +217,5 @@ product or architecture decision that is not clearly implied by the PR.
 ## Explicitly absent
 
 - No `.cursor/rules/`, `.cursorrules`, or `.github/copilot-instructions.md` were found.
-- No TypeScript test runner is configured for the plugin packages.
-- No repo-wide lint config exists for the TypeScript code.
+- No repo-wide TypeScript test runner is configured; plugin tests are package-local.
+- No repo-wide TypeScript lint config exists, and the plugin packages do not expose `lint` scripts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,6 @@ and a small Astro site.
 | `docs/design/`       | Architecture/proposal notes and design drafts                |
 | `site/`              | Astro static site — deployed to Netlify from `main` branch   |
 | `e2e/`               | Live end-to-end scripts against a running server             |
-| `k8s/`               | Deployment and gateway manifests                             |
 | `benchmark/MR-NIAH/` | Benchmark harness for OpenClaw memory evaluation             |
 
 ## Commands
@@ -168,13 +167,12 @@ Use the local file when you work in these areas:
 - `site/AGENTS.md`
 - `dashboard/app/AGENTS.md`
 - `e2e/AGENTS.md`
-- `k8s/AGENTS.md`
 - `benchmark/MR-NIAH/AGENTS.md`
 
 Validate this map after editing:
 
 ```bash
-python3 -c 'from pathlib import Path; import re; text = Path("AGENTS.md").read_text(); paths = re.findall(r"`([^`]+/AGENTS\.md)`", text); missing = [p for p in paths if not Path(p).is_file()]; print("\n".join(missing)); raise SystemExit(1 if missing else 0)'
+python3 -c 'from pathlib import Path; import re, subprocess; text = Path("AGENTS.md").read_text(); paths = re.findall(r"`([^`]+/AGENTS\.md)`", text); tracked = set(subprocess.check_output(["git", "ls-files", "*AGENTS.md"], text=True).splitlines()); missing = [p for p in paths if p not in tracked]; print("\n".join(missing)); raise SystemExit(1 if missing else 0)'
 ```
 
 ## GitHub access

--- a/codex-plugin/AGENTS.md
+++ b/codex-plugin/AGENTS.md
@@ -1,0 +1,49 @@
+---
+title: codex-plugin — Codex hooks and skills
+---
+
+## Purpose
+
+Codex plugin package for mem9. It installs managed Codex hooks, exposes `$mem9:*` skills, reads shared mem9 profiles, and calls the mem9 HTTP API for recall and store flows.
+
+## Commands
+
+```bash
+pnpm --dir codex-plugin test
+pnpm --dir codex-plugin typecheck
+```
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Plugin manifest | `.codex-plugin/plugin.json` |
+| Hook templates | `templates/hooks.json` |
+| Runtime hooks | `hooks/` |
+| Bootstrap hook shims | `bootstrap-hooks/` |
+| Config/profile logic | `lib/config.mjs` |
+| HTTP client | `lib/http.mjs` |
+| Project root detection | `lib/project-root.mjs` |
+| Skill runtime helpers | `lib/skill-runtime.mjs` |
+| Setup skill | `skills/setup/SKILL.md` |
+| Cleanup skill | `skills/cleanup/SKILL.md` |
+| Recall skill | `skills/recall/SKILL.md` |
+| Store skill | `skills/store/SKILL.md` |
+| Node test suite | `tests/` |
+
+## Local conventions
+
+- Node.js 22 or newer is required.
+- This package is ESM-only; use `.mjs` for runtime scripts.
+- Shared credentials live at `$MEM9_HOME/.credentials.json`; `MEM9_HOME` defaults to `$HOME/.mem9`.
+- Codex runtime files live under `$CODEX_HOME/mem9/`.
+- Keep API key entry out of the Codex TUI.
+- Hook debug logs default to `$CODEX_HOME/mem9/logs/codex-hooks.jsonl`.
+- Use explicit HTTP timeouts from the active profile or project override.
+
+## Anti-patterns
+
+- Do NOT store API keys in repo-local project config.
+- Do NOT require users to edit Codex hook files manually before `$mem9:setup`.
+- Do NOT duplicate hook JSON mutation logic outside the setup/cleanup helpers.
+- Do NOT add TypeScript-only source files unless the package build/test flow is updated.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,48 @@
+---
+title: server — Go API server
+---
+
+## Purpose
+
+Go REST API server for mem9. This area owns HTTP routing, services, tenant provisioning, repositories, schemas, metrics, and the server binary.
+
+## Commands
+
+```bash
+make build
+make vet
+make test
+make test-integration
+cd server && go test -race -count=1 -run TestFunctionName ./internal/service/
+```
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Server entrypoint | `cmd/mnemo-server/main.go` |
+| HTTP router and error mapping | `internal/handler/handler.go` |
+| Memory business logic | `internal/service/memory.go` |
+| Ingest pipeline | `internal/service/ingest.go` |
+| Repository interfaces | `internal/repository/repository.go` |
+| TiDB repository | `internal/repository/tidb/` |
+| Tenant provisioning | `internal/tenant/` |
+| Config parsing | `internal/config/config.go` |
+| Domain types and errors | `internal/domain/` |
+| Database schema | `schema.sql` |
+
+## Local conventions
+
+- Keep the architecture boundary strict: `handler -> service -> repository`.
+- Use raw `database/sql`; do not add an ORM.
+- Format Go with `gofmt` only.
+- Prefer sentinel errors from `internal/domain/errors.go` and compare with `errors.Is()`.
+- Wrap errors with `fmt.Errorf("context: %w", err)`.
+- Keep route and domain error mapping centralized in `internal/handler/handler.go`.
+- Use `make` targets for server builds and Docker image work.
+
+## Anti-patterns
+
+- Do NOT build server binaries with ad hoc `go build` commands from the repo root; use `make build` or `make build-linux`.
+- Do NOT let handlers reach into SQL repositories directly.
+- Do NOT write generated embeddings when `MNEMO_EMBED_AUTO_MODEL` is set.

--- a/server/internal/handler/AGENTS.md
+++ b/server/internal/handler/AGENTS.md
@@ -1,0 +1,39 @@
+---
+title: server/internal/handler — HTTP layer
+---
+
+## Purpose
+
+HTTP handlers and router wiring for the mem9 API. This area translates requests into service calls and maps domain/service errors back to HTTP responses.
+
+## Commands
+
+```bash
+cd server && go test -race -count=1 ./internal/handler/
+cd server && go test -race -count=1 -run TestFunctionName ./internal/handler/
+```
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Router, middleware order, response helpers | `handler.go` |
+| Memory CRUD endpoints | `memory.go` |
+| Recall endpoint | `recall.go` |
+| Tenant endpoints | `tenant.go` |
+| Import task endpoints | `task.go` |
+| Metering admin endpoints | `metering.go` |
+
+## Local conventions
+
+- Keep handlers thin: parse/validate request shape, resolve services, call service methods, and respond.
+- Add or change routes in `handler.go`.
+- Keep HTTP/domain error mapping in `handler.go`.
+- Read `X-Mnemo-Agent-Id` through the existing request helpers instead of duplicating header parsing.
+- Use `respond()` and existing error helpers for JSON responses.
+
+## Anti-patterns
+
+- Do NOT put business reconciliation, embedding, or SQL logic in handlers.
+- Do NOT add one-off JSON response writers.
+- Do NOT bypass the tenant/API-key middleware when adding tenant-scoped routes.

--- a/server/internal/repository/tidb/AGENTS.md
+++ b/server/internal/repository/tidb/AGENTS.md
@@ -1,0 +1,42 @@
+---
+title: server/internal/repository/tidb — TiDB storage
+---
+
+## Purpose
+
+TiDB/MySQL repository implementations for memories, sessions, tenants, upload tasks, and attribution data. This area owns raw SQL and TiDB-specific search behavior.
+
+## Commands
+
+```bash
+cd server && go test -race -count=1 ./internal/repository/tidb/
+make test-integration
+```
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Memory persistence and search | `memory.go` |
+| Session persistence and search | `sessions.go` |
+| Tenant records | `tenant.go` |
+| Upload task records | `upload_task.go` |
+| DB connection helper | `tidb.go` |
+| TiDB schema | `../../../schema.sql` |
+
+## Local conventions
+
+- Use `database/sql` with placeholder arguments.
+- Store tags as JSON arrays; use `[]`, never `NULL`.
+- Filter tags with `JSON_CONTAINS`.
+- Every vector search must include `embedding IS NOT NULL`.
+- Keep `VEC_COSINE_DISTANCE(...)` byte-for-byte identical in `SELECT` and `ORDER BY`.
+- When `autoModel != ""`, omit the `embedding` column so TiDB generates it.
+- Use `INSERT ... ON DUPLICATE KEY UPDATE` for upserts.
+- Increment versions atomically in SQL with `version = version + 1`.
+
+## Anti-patterns
+
+- Do NOT build SQL by concatenating user input.
+- Do NOT scan nullable DB values directly into non-null domain fields without conversion helpers.
+- Do NOT add service-level policy decisions to repository methods.

--- a/server/internal/service/AGENTS.md
+++ b/server/internal/service/AGENTS.md
@@ -1,0 +1,40 @@
+---
+title: server/internal/service — Business logic
+---
+
+## Purpose
+
+Business logic for memory CRUD/search, recall, ingest reconciliation, sessions, uploads, and tenant orchestration. Services sit between handlers and repository interfaces.
+
+## Commands
+
+```bash
+cd server && go test -race -count=1 ./internal/service/
+cd server && go test -race -count=1 -run TestFunctionName ./internal/service/
+```
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Memory CRUD and search | `memory.go` |
+| Ingest reconciliation | `ingest.go` |
+| Recall candidate assembly | `recall.go` |
+| Session search helpers | `session.go` |
+| Source-turn search | `search_source_turns.go` |
+| Tenant service | `tenant.go` |
+| Upload service | `upload.go` |
+
+## Local conventions
+
+- Services depend on repository interfaces from `internal/repository`.
+- Validate user inputs in service methods before repository writes.
+- `embed.New()` and `llm.New()` callers must handle nil dependencies.
+- Vector and keyword search each fetch `limit * 3` before RRF merge.
+- Keep memory version bumps in repository SQL, not service-side arithmetic.
+
+## Anti-patterns
+
+- Do NOT import TiDB, Postgres, or DB9 concrete repository packages here.
+- Do NOT make HTTP response decisions in services.
+- Do NOT treat a nil embedder or nil LLM client as impossible.

--- a/server/internal/tenant/AGENTS.md
+++ b/server/internal/tenant/AGENTS.md
@@ -1,0 +1,39 @@
+---
+title: server/internal/tenant — Tenant provisioning
+---
+
+## Purpose
+
+Tenant cluster provisioning and schema initialization. This area abstracts TiDB Serverless provider flows and prepares tenant databases for the API server.
+
+## Commands
+
+```bash
+cd server && go test -race -count=1 ./internal/tenant/
+cd server && go test -race -count=1 -run TestFunctionName ./internal/tenant/
+```
+
+## Where to look
+
+| Task | File |
+|------|------|
+| Provisioner interface and cluster info | `provisioner.go` |
+| Provisioner selection | `starter.go` |
+| TiDB Cloud Starter provider | `starter.go` |
+| TiDB Zero provider | `zero.go` |
+| Tenant DB pool | `pool.go` |
+| Schema initialization | `schema.go` |
+| DSN helpers | `util.go` |
+
+## Local conventions
+
+- `Provisioner` implementations return tenant-facing IDs separately from provider cluster IDs.
+- Keep provider-specific API behavior behind the `Provisioner` interface.
+- Initialize tenant schema through `InitSchema()` instead of scattering DDL.
+- Preserve claim URL and expiration behavior for TiDB Zero tenants.
+
+## Anti-patterns
+
+- Do NOT leak provider credentials or API payloads into logs.
+- Do NOT bypass the tenant DB pool for normal request-time access.
+- Do NOT mix control-plane tenant records with tenant database schema setup.


### PR DESCRIPTION
## Summary

1. Add scoped AGENTS.md guidance for server areas and codex-plugin.
2. Update root AGENTS.md to include codex-plugin, current package-local plugin validation, and only scoped AGENTS.md paths that exist.
3. Refresh Explicitly absent notes for plugin tests and TypeScript linting.
4. Add a validation command for checking scoped AGENTS.md paths.

## Validation

1. Scoped AGENTS.md path check passes.
2. `git diff --check`

Fixes #295