### PR TITLE
feat(server): track active tenants in Prometheus

### DIFF
--- a/docs/design/issue-294-active-tenants-metric-proposal.md
+++ b/docs/design/issue-294-active-tenants-metric-proposal.md
@@ -1,0 +1,230 @@
+---
+title: Active tenants 7d Prometheus metric proposal
+---
+
+## Problem
+
+Issue 294 needs an unlabeled gauge, `mnemo_active_tenants_7d_total`, counting tenants where:
+
+1. `tenants.status = 'active'`
+2. `tenants.deleted_at IS NULL`
+3. The tenant has successful memory activity in the last 7 days
+
+Current metrics only expose memory-level gauges. `ActiveMemoryTotal` and `ActiveMemory7dTotal` are per-cluster gauges refreshed from tenant data-plane memory tables.
+
+## Proposed Design
+
+Add a control-plane `tenant_activity` table and keep activity telemetry out of `tenants`.
+
+Extend `repository.TenantRepo` with:
+
+1. `TouchActivity(ctx context.Context, tenantID string, at time.Time) error`
+2. `CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error)`
+
+Implement both for TiDB/MySQL and Postgres. `db9` continues using the Postgres tenant repository implementation.
+
+Add a shared `service.ActivityTracker` that is injected into both the HTTP handler and upload worker. The tracker owns best-effort activity writes and process-global active-tenant gauge refresh debounce.
+
+## Schema Changes
+
+Add `tenant_activity` to:
+
+1. `server/schema.sql`
+2. `server/schema_pg.sql`
+3. `server/schema_db9.sql`
+4. `server/internal/repository/tidb/testutil_test.go`
+
+Do not add activity columns to `tenants`.
+
+### TiDB/MySQL DDL
+
+```sql
+CREATE TABLE IF NOT EXISTS tenant_activity (
+  tenant_id        VARCHAR(36) NOT NULL PRIMARY KEY,
+  last_activity_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id),
+  INDEX idx_tenant_activity_last_activity (last_activity_at)
+);
+```
+
+### Postgres and db9 DDL
+
+```sql
+CREATE TABLE IF NOT EXISTS tenant_activity (
+    tenant_id        VARCHAR(36) PRIMARY KEY,
+    last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);
+```
+
+### Test Schema
+
+`server/internal/repository/tidb/testutil_test.go` must:
+
+1. Create `tenant_activity` after `tenants` and before tests use `TenantRepo`.
+2. Add `tenant_activity` to truncation before `tenants` to satisfy the foreign key.
+
+The truncation order should be `tenant_activity`, `tenants`, `memories`.
+
+## Repository SQL
+
+### TiDB/MySQL TouchActivity
+
+```sql
+INSERT INTO tenant_activity (tenant_id, last_activity_at)
+VALUES (?, ?)
+ON DUPLICATE KEY UPDATE
+  last_activity_at = GREATEST(last_activity_at, VALUES(last_activity_at));
+```
+
+### Postgres/db9 TouchActivity
+
+```sql
+INSERT INTO tenant_activity (tenant_id, last_activity_at)
+VALUES ($1, $2)
+ON CONFLICT (tenant_id) DO UPDATE SET
+  last_activity_at = GREATEST(tenant_activity.last_activity_at, EXCLUDED.last_activity_at);
+```
+
+`TouchActivity` preserves the greatest timestamp so a delayed background update cannot move activity backward.
+
+The foreign key is intentional. A non-existent tenant ID returns a repository error, and the activity tracker logs and suppresses it. This avoids orphaned activity rows without coupling user-facing writes to activity tracking success.
+
+### CountActiveTenantsSince
+
+TiDB/MySQL uses `?`; Postgres/db9 uses `$1`.
+
+```sql
+SELECT COUNT(*)
+FROM tenant_activity AS ta
+INNER JOIN tenants AS t ON t.id = ta.tenant_id
+WHERE t.status = 'active'
+  AND t.deleted_at IS NULL
+  AND ta.last_activity_at >= ?;
+```
+
+The `INNER JOIN` is deliberate. If an orphan row somehow exists, it is not counted.
+
+## Runtime Flow
+
+After successful memory write operations, call the shared activity tracker:
+
+1. Skip if `auth.TenantID == ""`.
+2. Run `TouchActivity` with `context.Background()` and a short timeout, not the request context.
+3. Log a warning and return on failure.
+4. Debounce `CountActiveTenantsSince(now.Add(-7 * 24 * time.Hour))` with a process-global timer.
+5. Set `metrics.ActiveTenants7dTotal`.
+
+This must stay outside memory repository transactions. User-facing memory writes must not fail, roll back, or return an error because activity tracking or metric refresh failed.
+
+The active-tenant gauge is write-driven, matching the existing memory gauges. During quiet periods it can become stale until the next write. That is acceptable for this issue; a future background refresh can be added if Prometheus needs wall-clock freshness.
+
+## Activity Tracker Wiring
+
+Add `server/internal/service/activity.go`:
+
+```go
+type ActivityTracker struct {
+    tenants repository.TenantRepo
+    logger  *slog.Logger
+    ttl     time.Duration
+
+    mu          sync.Mutex
+    lastRefresh time.Time
+}
+
+func NewActivityTracker(tenants repository.TenantRepo, logger *slog.Logger) *ActivityTracker
+func (t *ActivityTracker) RecordMemoryActivity(tenantID string, at time.Time)
+```
+
+`RecordMemoryActivity` is best-effort. It returns without error and is safe to call from handlers and background workers.
+
+Handler wiring:
+
+1. Add `activity *service.ActivityTracker` to `handler.Server`.
+2. Add `func (s *Server) WithActivityTracker(tracker *service.ActivityTracker) *Server`.
+3. Keep `NewServer` parameters unchanged to avoid updating handler tests.
+4. Add helper `afterSuccessfulWrite(auth, svc, written)` that calls `refreshWriteMetrics` and `activity.RecordMemoryActivity`.
+5. Keep `afterSuccessfulIngest` as the ingest-specific hook: it calls `afterSuccessfulWrite` and `recordIngestMetering`.
+
+Upload worker wiring:
+
+1. Add `activity *ActivityTracker` to `service.UploadWorker`.
+2. Add a final `activity *ActivityTracker` argument to `NewUploadWorker`.
+3. After successful session chunk ingest and memory bulk create, call `w.activity.RecordMemoryActivity(task.TenantID, time.Now().UTC())` if configured.
+
+Main wiring:
+
+1. Create one tracker after `tenantRepo := repository.NewTenantRepo(...)`:
+
+```go
+activityTracker := service.NewActivityTracker(tenantRepo, logger)
+```
+
+2. Pass it to the handler with `.WithActivityTracker(activityTracker)`.
+3. Pass it to `service.NewUploadWorker(..., activityTracker)`.
+
+This gives the process one shared debounce timer for the unlabeled gauge.
+
+## Write Sites
+
+Wire activity recording after successful writes in:
+
+1. Create memory: `server/internal/handler/memory.go`
+2. Update memory: `server/internal/handler/memory.go`
+3. Delete memory: `server/internal/handler/memory.go`
+4. Batch delete: `server/internal/handler/memory.go`
+5. Bulk create endpoint: `server/internal/handler/memory.go`
+6. Import worker memory bulk create: `server/internal/service/upload.go`
+7. Import worker session ingest: `server/internal/service/upload.go`
+
+The bulk-create endpoint currently returns without refreshing write metrics or recording ingest metering. Update it to use the same ingest post-write treatment as other successful ingest paths: memory gauge refresh, ingest metering, and activity tracking.
+
+## Metric
+
+Add `ActiveTenants7dTotal` in `server/internal/metrics/metrics.go`:
+
+1. Prometheus name: `mnemo_active_tenants_7d_total`
+2. Type: gauge
+3. Labels: none
+4. Help text: count of active tenants with recorded activity in the last 7 days
+
+Use a plain `prometheus.Gauge`, not `GaugeVec`.
+
+### Debounce
+
+Use a separate debounce from `Server.gaugeDebounce`, because the new metric is process-global and unlabeled.
+
+1. Default TTL: 30 seconds, matching the existing write gauge debounce.
+2. Keying: no map key; use one `lastRefresh time.Time` guarded by a mutex in `ActivityTracker`.
+3. First successful write after process start must always refresh the gauge.
+4. Store the debounce timestamp before running the count query to avoid concurrent write bursts stampeding the control-plane DB.
+
+## Tests
+
+Add focused coverage for:
+
+1. `TouchActivity` inserts a row.
+2. `TouchActivity` keeps the greatest timestamp.
+3. Recent active tenant is counted.
+4. Stale activity is not counted.
+5. Tenant with no activity row is not counted.
+6. Suspended or deleted tenant with recent activity is not counted.
+7. Activity tracking failure does not fail memory operations.
+8. Metric refresh sets `mnemo_active_tenants_7d_total`.
+9. `bulkCreateMemories` triggers post-write hooks.
+10. Upload worker session ingest and memory bulk create call the tracker.
+
+## Risks
+
+1. Handler-level wiring can miss non-HTTP paths; import worker activity must be wired explicitly.
+2. Debounce must avoid suppressing the first metric update after process start.
+3. Expanding `TenantRepo` requires updating all test doubles.
+4. Background goroutines should not use request contexts after the handler returns.
+5. `tenant_activity` foreign key failures are intentionally suppressed by the tracker, so logs are the only signal for unexpected tenant IDs.
+6. The gauge is write-driven and can be stale during quiet periods.
+
+## Estimated Scope
+
+~300-400 net LoC.

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -195,9 +195,12 @@ func main() {
 	defer rl.Stop()
 	rateMW := rl.Middleware()
 
+	activityTracker := service.NewActivityTracker(tenantRepo, logger)
+
 	// Handler.
 	srv := handler.NewServer(tenantSvc, uploadTaskRepo, cfg.UploadDir, embedder, llmClient, cfg.EmbedAutoModel, cfg.FTSEnabled, service.IngestMode(cfg.IngestMode), cfg.DBBackend, logger).
-		WithMetering(meteringWriter)
+		WithMetering(meteringWriter).
+		WithActivityTracker(activityTracker)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW)
 
 	httpSrv := &http.Server{
@@ -223,6 +226,7 @@ func main() {
 		logger,
 		cfg.WorkerConcurrency,
 		encryptor,
+		activityTracker,
 	)
 	go func() {
 		if err := uploadWorker.Run(workerCtx); err != nil {

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -39,6 +39,7 @@ type Server struct {
 	dbBackend     string
 	logger        *slog.Logger
 	metering      metering.Writer
+	activity      *service.ActivityTracker
 	startedAt     time.Time
 	svcCache      sync.Map
 	gaugeDebounce sync.Map // cluster_id -> time.Time of last Gauge refresh
@@ -74,6 +75,11 @@ func NewServer(
 
 func (s *Server) WithMetering(writer metering.Writer) *Server {
 	s.metering = writer
+	return s
+}
+
+func (s *Server) WithActivityTracker(tracker *service.ActivityTracker) *Server {
+	s.activity = tracker
 	return s
 }
 

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -100,7 +100,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				written = int64(result.MemoriesChanged)
 			}
 			s.recordIngestMetering(auth, svc)
-			go s.refreshWriteMetrics(auth, svc, written)
+			go s.afterSuccessfulWrite(auth, svc, written)
 			respond(w, http.StatusOK, map[string]string{"status": "ok"})
 		} else {
 			go func() {
@@ -153,7 +153,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			s.handleError(r.Context(), w, err)
 			return
 		}
-		go s.refreshWriteMetrics(auth, svc, int64(written))
+		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusCreated, mem)
 		return
 	}
@@ -167,7 +167,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		_ = mem
-		go s.refreshWriteMetrics(auth, svc, int64(written))
+		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusOK, map[string]string{"status": "ok"})
 	} else {
 		go func(auth *domain.AuthInfo, agentName, actorAgentID, sessionID, content string, tags []string, metadata json.RawMessage) {
@@ -182,7 +182,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			} else {
 				slog.Info("async memory create complete", "agent", actorAgentID, "actor", agentName, "memory_id", "")
 			}
-			s.refreshWriteMetrics(auth, svc, int64(written))
+			s.afterSuccessfulWrite(auth, svc, int64(written))
 		}(auth, auth.AgentName, agentID, req.SessionID, content, tags, metadata)
 
 		respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
@@ -488,7 +488,7 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.refreshWriteMetrics(auth, svc, 1)
+	go s.afterSuccessfulWrite(auth, svc, 1)
 	w.Header().Set("ETag", strconv.Itoa(mem.Version))
 	respond(w, http.StatusOK, mem)
 }
@@ -503,7 +503,7 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.refreshWriteMetrics(auth, svc, 0)
+	go s.afterSuccessfulWrite(auth, svc, 0)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -526,7 +526,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	go s.refreshWriteMetrics(auth, svc, 0)
+	go s.afterSuccessfulWrite(auth, svc, 0)
 	respond(w, http.StatusOK, map[string]any{
 		"deleted": deleted,
 	})
@@ -551,6 +551,7 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	go s.afterSuccessfulIngest(auth, svc, int64(len(memories)))
 	respond(w, http.StatusCreated, map[string]any{
 		"ok":       true,
 		"memories": memories,

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -220,6 +220,50 @@ func (w *blockingMeteringWriter) Record(evt metering.Event) {
 
 func (w *blockingMeteringWriter) Close(context.Context) error { return nil }
 
+type handlerActivityTenantRepo struct {
+	mu         sync.Mutex
+	touchErr   error
+	count      int64
+	touchCalls int
+	touched    chan string
+}
+
+func (r *handlerActivityTenantRepo) Create(context.Context, *domain.Tenant) error { return nil }
+func (r *handlerActivityTenantRepo) GetByID(context.Context, string) (*domain.Tenant, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *handlerActivityTenantRepo) GetByName(context.Context, string) (*domain.Tenant, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *handlerActivityTenantRepo) UpdateStatus(context.Context, string, domain.TenantStatus) error {
+	return nil
+}
+func (r *handlerActivityTenantRepo) UpdateSchemaVersion(context.Context, string, int) error {
+	return nil
+}
+
+func (r *handlerActivityTenantRepo) TouchActivity(_ context.Context, tenantID string, _ time.Time) error {
+	r.mu.Lock()
+	r.touchCalls++
+	touched := r.touched
+	touchErr := r.touchErr
+	r.mu.Unlock()
+
+	if touched != nil {
+		select {
+		case touched <- tenantID:
+		default:
+		}
+	}
+	return touchErr
+}
+
+func (r *handlerActivityTenantRepo) CountActiveTenantsSince(context.Context, time.Time) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.count, nil
+}
+
 func cloneMap(in map[string]any) map[string]any {
 	if in == nil {
 		return nil
@@ -329,6 +373,37 @@ func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
 	}
 	if memRepo.bulkCreateCalls != 0 {
 		t.Fatalf("expected legacy create path to skip bulk create, got %d", memRepo.bulkCreateCalls)
+	}
+}
+
+func TestCreateMemory_ActivityFailureDoesNotFailWrite(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsTotal: 1}
+	activityRepo := &handlerActivityTenantRepo{
+		touchErr: errors.New("activity unavailable"),
+		touched:  make(chan string, 1),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).
+		WithActivityTracker(service.NewActivityTracker(activityRepo, slog.Default()))
+
+	body := map[string]any{
+		"content": "test memory content",
+		"sync":    true,
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	select {
+	case tenantID := <-activityRepo.touched:
+		if tenantID != "tenant-a" {
+			t.Fatalf("activity tenant = %q, want tenant-a", tenantID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for activity touch")
 	}
 }
 
@@ -679,6 +754,47 @@ func TestCreateMemory_AsyncMessages_ReconcileFailed_DoesNotRecordIngestMetering(
 		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
 	}
 	ensureNoMeteringEvents(t, meteringWriter, 100*time.Millisecond)
+}
+
+func TestBulkCreateMemoriesTriggersPostWriteHooks(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsTotal: 2}
+	meteringWriter := &captureMeteringWriter{}
+	activityRepo := &handlerActivityTenantRepo{
+		count:   1,
+		touched: make(chan string, 1),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).
+		WithMetering(meteringWriter).
+		WithActivityTracker(service.NewActivityTracker(activityRepo, slog.Default()))
+
+	body := map[string]any{
+		"memories": []map[string]any{
+			{"content": "bulk memory"},
+		},
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories/bulk", body)
+	rr := httptest.NewRecorder()
+
+	srv.bulkCreateMemories(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if memRepo.bulkCreateCalls != 1 {
+		t.Fatalf("bulk create calls = %d, want 1", memRepo.bulkCreateCalls)
+	}
+	select {
+	case tenantID := <-activityRepo.touched:
+		if tenantID != "tenant-a" {
+			t.Fatalf("activity tenant = %q, want tenant-a", tenantID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for activity touch")
+	}
+	events := waitForMeteringEvents(t, meteringWriter, 1, time.Second)
+	if got := events[0].Data["event_type"]; got != "ingest" {
+		t.Fatalf("event_type = %v, want ingest", got)
+	}
 }
 
 // failSearchMemoryRepo embeds testMemoryRepo but makes KeywordSearch fail,

--- a/server/internal/handler/metering.go
+++ b/server/internal/handler/metering.go
@@ -11,8 +11,19 @@ import (
 
 const meteringCategoryAPI = "mem9-api"
 
-func (s *Server) afterSuccessfulIngest(auth *domain.AuthInfo, svc resolvedSvc, written int64) {
+func (s *Server) afterSuccessfulWrite(auth *domain.AuthInfo, svc resolvedSvc, written int64) {
+	if s == nil {
+		return
+	}
 	s.refreshWriteMetrics(auth, svc, written)
+	if s.activity == nil || auth == nil {
+		return
+	}
+	s.activity.RecordMemoryActivity(auth.TenantID, time.Now().UTC())
+}
+
+func (s *Server) afterSuccessfulIngest(auth *domain.AuthInfo, svc resolvedSvc, written int64) {
+	s.afterSuccessfulWrite(auth, svc, written)
 	s.recordIngestMetering(auth, svc)
 }
 

--- a/server/internal/handler/tenant_test.go
+++ b/server/internal/handler/tenant_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/encrypt"
@@ -48,6 +49,14 @@ func (r *handlerTenantRepo) UpdateStatus(ctx context.Context, id string, status 
 
 func (r *handlerTenantRepo) UpdateSchemaVersion(ctx context.Context, id string, version int) error {
 	return nil
+}
+
+func (r *handlerTenantRepo) TouchActivity(ctx context.Context, tenantID string, at time.Time) error {
+	return nil
+}
+
+func (r *handlerTenantRepo) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
+	return 0, nil
 }
 
 type handlerProvisioner struct {

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -149,6 +149,15 @@ var (
 		Help:      "Active memories created in the last 7 days for a cluster, refreshed on memory write or delete.",
 	}, []string{"cluster_id"})
 
+	// ActiveTenants7dTotal is the current total number of active tenants with
+	// recorded memory activity in the last 7 days. Value reflects the state at
+	// the last write event; it is not updated between events.
+	ActiveTenants7dTotal = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "mnemo",
+		Name:      "active_tenants_7d_total",
+		Help:      "Active tenants with recorded memory activity in the last 7 days.",
+	})
+
 	// MemoryChangesTotal counts the number of memory-level changes (ADD, UPDATE, and
 	// post-reconcile tag/metadata patches) per cluster. One UPDATE counts as one change
 	// even though it produces two DB rows (archive + create). DELETE actions are not

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -50,6 +50,14 @@ func (r stubTenantRepo) UpdateSchemaVersion(context.Context, string, int) error 
 	return nil
 }
 
+func (r stubTenantRepo) TouchActivity(context.Context, string, time.Time) error {
+	return nil
+}
+
+func (r stubTenantRepo) CountActiveTenantsSince(context.Context, time.Time) (int64, error) {
+	return 0, nil
+}
+
 type pingOKConnector struct{}
 
 func (pingOKConnector) Connect(context.Context) (driver.Conn, error) {

--- a/server/internal/repository/postgres/tenant.go
+++ b/server/internal/repository/postgres/tenant.go
@@ -70,6 +70,38 @@ func (r *TenantRepoImpl) UpdateSchemaVersion(ctx context.Context, id string, ver
 	return nil
 }
 
+func (r *TenantRepoImpl) TouchActivity(ctx context.Context, tenantID string, at time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO tenant_activity (tenant_id, last_activity_at)
+		 VALUES ($1, $2)
+		 ON CONFLICT (tenant_id) DO UPDATE SET
+		   last_activity_at = GREATEST(tenant_activity.last_activity_at, EXCLUDED.last_activity_at)`,
+		tenantID, at,
+	)
+	if err != nil {
+		return fmt.Errorf("touch tenant activity: %w", err)
+	}
+	return nil
+}
+
+func (r *TenantRepoImpl) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
+	var count int64
+	// INNER JOIN deliberately skips orphan activity rows.
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		 FROM tenant_activity AS ta
+		 INNER JOIN tenants AS t ON t.id = ta.tenant_id
+		 WHERE t.status = 'active'
+		   AND t.deleted_at IS NULL
+		   AND ta.last_activity_at >= $1`,
+		since,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active tenants since: %w", err)
+	}
+	return count, nil
+}
+
 func scanTenant(row *sql.Row) (*domain.Tenant, error) {
 	var t domain.Tenant
 	var clusterID, claimURL sql.NullString

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -54,6 +54,8 @@ type TenantRepo interface {
 	GetByName(ctx context.Context, name string) (*domain.Tenant, error)
 	UpdateStatus(ctx context.Context, id string, status domain.TenantStatus) error
 	UpdateSchemaVersion(ctx context.Context, id string, version int) error
+	TouchActivity(ctx context.Context, tenantID string, at time.Time) error
+	CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error)
 }
 
 // UploadTaskRepo manages upload task records in the control plane DB.

--- a/server/internal/repository/tidb/tenant.go
+++ b/server/internal/repository/tidb/tenant.go
@@ -70,6 +70,38 @@ func (r *TenantRepoImpl) UpdateSchemaVersion(ctx context.Context, id string, ver
 	return nil
 }
 
+func (r *TenantRepoImpl) TouchActivity(ctx context.Context, tenantID string, at time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO tenant_activity (tenant_id, last_activity_at)
+		 VALUES (?, ?)
+		 ON DUPLICATE KEY UPDATE
+		   last_activity_at = GREATEST(last_activity_at, VALUES(last_activity_at))`,
+		tenantID, at,
+	)
+	if err != nil {
+		return fmt.Errorf("touch tenant activity: %w", err)
+	}
+	return nil
+}
+
+func (r *TenantRepoImpl) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
+	var count int64
+	// INNER JOIN deliberately skips orphan activity rows.
+	err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		 FROM tenant_activity AS ta
+		 INNER JOIN tenants AS t ON t.id = ta.tenant_id
+		 WHERE t.status = 'active'
+		   AND t.deleted_at IS NULL
+		   AND ta.last_activity_at >= ?`,
+		since,
+	).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count active tenants since: %w", err)
+	}
+	return count, nil
+}
+
 func scanTenant(row *sql.Row) (*domain.Tenant, error) {
 	var t domain.Tenant
 	var clusterID, claimURL sql.NullString

--- a/server/internal/repository/tidb/tenant_integration_test.go
+++ b/server/internal/repository/tidb/tenant_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/qiffang/mnemos/server/internal/domain"
@@ -160,5 +161,85 @@ func TestTenantUpdateSchemaVersion(t *testing.T) {
 	}
 	if got.SchemaVersion != 5 {
 		t.Fatalf("schema_version mismatch: got %d want 5", got.SchemaVersion)
+	}
+}
+
+func TestTenantTouchActivityKeepsGreatestTimestamp(t *testing.T) {
+	if err := truncateAll(testDB); err != nil {
+		t.Fatalf("truncateAll: %v", err)
+	}
+	repo := NewTenantRepo(testDB)
+	ctx := context.Background()
+
+	tenant := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	if err := repo.Create(ctx, tenant); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	later := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	earlier := later.Add(-24 * time.Hour)
+	if err := repo.TouchActivity(ctx, tenant.ID, later); err != nil {
+		t.Fatalf("TouchActivity later: %v", err)
+	}
+	if err := repo.TouchActivity(ctx, tenant.ID, earlier); err != nil {
+		t.Fatalf("TouchActivity earlier: %v", err)
+	}
+
+	var got time.Time
+	if err := testDB.QueryRowContext(ctx,
+		`SELECT last_activity_at FROM tenant_activity WHERE tenant_id = ?`,
+		tenant.ID,
+	).Scan(&got); err != nil {
+		t.Fatalf("query last_activity_at: %v", err)
+	}
+	if !got.Equal(later) {
+		t.Fatalf("last_activity_at = %s, want %s", got, later)
+	}
+}
+
+func TestTenantCountActiveTenantsSince(t *testing.T) {
+	if err := truncateAll(testDB); err != nil {
+		t.Fatalf("truncateAll: %v", err)
+	}
+	repo := NewTenantRepo(testDB)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+	since := now.Add(-7 * 24 * time.Hour)
+
+	recentActive := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	staleActive := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	noActivity := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	suspended := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantSuspended })
+	deleted := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantDeleted })
+	deletedAt := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+
+	for _, tenant := range []*domain.Tenant{recentActive, staleActive, noActivity, suspended, deleted, deletedAt} {
+		if err := repo.Create(ctx, tenant); err != nil {
+			t.Fatalf("Create(%s): %v", tenant.ID, err)
+		}
+	}
+	if _, err := testDB.ExecContext(ctx, `UPDATE tenants SET deleted_at = ? WHERE id = ?`, now, deletedAt.ID); err != nil {
+		t.Fatalf("mark deleted_at: %v", err)
+	}
+
+	touches := map[string]time.Time{
+		recentActive.ID: now,
+		staleActive.ID:  since.Add(-time.Second),
+		suspended.ID:    now,
+		deleted.ID:      now,
+		deletedAt.ID:    now,
+	}
+	for tenantID, at := range touches {
+		if err := repo.TouchActivity(ctx, tenantID, at); err != nil {
+			t.Fatalf("TouchActivity(%s): %v", tenantID, err)
+		}
+	}
+
+	got, err := repo.CountActiveTenantsSince(ctx, since)
+	if err != nil {
+		t.Fatalf("CountActiveTenantsSince: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("active tenants since = %d, want 1", got)
 	}
 }

--- a/server/internal/repository/tidb/testutil_test.go
+++ b/server/internal/repository/tidb/testutil_test.go
@@ -89,6 +89,16 @@ func createTables(db *sql.DB) error {
 		return fmt.Errorf("create tenants table: %w", err)
 	}
 
+	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS tenant_activity (
+		tenant_id        VARCHAR(36) NOT NULL PRIMARY KEY,
+		last_activity_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id),
+		INDEX idx_tenant_activity_last_activity (last_activity_at)
+	)`)
+	if err != nil {
+		return fmt.Errorf("create tenant_activity table: %w", err)
+	}
+
 	// Data plane table (memories). Note: VECTOR column omitted for MySQL compatibility.
 	// TiDB-specific VECTOR(1536) replaced with TEXT NULL for cross-DB compatibility.
 	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS memories (
@@ -124,7 +134,7 @@ func createTables(db *sql.DB) error {
 func truncateAll(db *sql.DB) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	for _, table := range []string{"tenants", "memories"} {
+	for _, table := range []string{"tenant_activity", "tenants", "memories"} {
 		if _, err := db.ExecContext(ctx, "DELETE FROM "+table); err != nil {
 			return fmt.Errorf("truncate %s: %w", table, err)
 		}
@@ -145,6 +155,9 @@ func truncateTenants(t *testing.T) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+	if _, err := testDB.ExecContext(ctx, "DELETE FROM tenant_activity"); err != nil {
+		t.Fatalf("truncate tenant_activity: %v", err)
+	}
 	if _, err := testDB.ExecContext(ctx, "DELETE FROM tenants"); err != nil {
 		t.Fatalf("truncate tenants: %v", err)
 	}

--- a/server/internal/service/activity.go
+++ b/server/internal/service/activity.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/repository"
+)
+
+const (
+	activityTrackerTimeout = 10 * time.Second
+	activityGaugeTTL       = 30 * time.Second
+	activeTenantWindow     = 7 * 24 * time.Hour
+)
+
+// ActivityTracker records tenant-level memory activity and refreshes the
+// process-global active-tenant metric on a debounce.
+type ActivityTracker struct {
+	tenants repository.TenantRepo
+	logger  *slog.Logger
+	ttl     time.Duration
+
+	mu          sync.Mutex
+	lastRefresh time.Time
+}
+
+func NewActivityTracker(tenants repository.TenantRepo, logger *slog.Logger) *ActivityTracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ActivityTracker{
+		tenants: tenants,
+		logger:  logger,
+		ttl:     activityGaugeTTL,
+	}
+}
+
+func (t *ActivityTracker) RecordMemoryActivity(tenantID string, at time.Time) {
+	if t == nil || t.tenants == nil || tenantID == "" {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), activityTrackerTimeout)
+	defer cancel()
+
+	if err := t.tenants.TouchActivity(ctx, tenantID, at); err != nil {
+		t.logger.Warn("record tenant activity failed", "tenant_id", tenantID, "err", err)
+		return
+	}
+
+	now := time.Now().UTC()
+	if !t.shouldRefresh(now) {
+		return
+	}
+
+	count, err := t.tenants.CountActiveTenantsSince(ctx, now.Add(-activeTenantWindow))
+	if err != nil {
+		t.clearRefreshClaim(now)
+		t.logger.Warn("refresh active tenants metric failed", "err", err)
+		return
+	}
+	metrics.ActiveTenants7dTotal.Set(float64(count))
+}
+
+func (t *ActivityTracker) shouldRefresh(now time.Time) bool {
+	ttl := t.ttl
+	if ttl <= 0 {
+		ttl = activityGaugeTTL
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.lastRefresh.IsZero() && now.Sub(t.lastRefresh) < ttl {
+		return false
+	}
+	t.lastRefresh = now
+	return true
+}
+
+func (t *ActivityTracker) clearRefreshClaim(claimedAt time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.lastRefresh.Equal(claimedAt) {
+		t.lastRefresh = time.Time{}
+	}
+}

--- a/server/internal/service/activity_test.go
+++ b/server/internal/service/activity_test.go
@@ -1,0 +1,153 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
+)
+
+type activityTenantRepo struct {
+	mu         sync.Mutex
+	touchErr   error
+	countErr   error
+	count      int64
+	touchCalls int
+	countCalls int
+}
+
+func (r *activityTenantRepo) Create(context.Context, *domain.Tenant) error { return nil }
+func (r *activityTenantRepo) GetByID(context.Context, string) (*domain.Tenant, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *activityTenantRepo) GetByName(context.Context, string) (*domain.Tenant, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *activityTenantRepo) UpdateStatus(context.Context, string, domain.TenantStatus) error {
+	return nil
+}
+func (r *activityTenantRepo) UpdateSchemaVersion(context.Context, string, int) error {
+	return nil
+}
+
+func (r *activityTenantRepo) TouchActivity(context.Context, string, time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.touchCalls++
+	return r.touchErr
+}
+
+func (r *activityTenantRepo) CountActiveTenantsSince(context.Context, time.Time) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.countCalls++
+	return r.count, r.countErr
+}
+
+func TestActivityTrackerRefreshesActiveTenantGauge(t *testing.T) {
+	metrics.ActiveTenants7dTotal.Set(0)
+	repo := &activityTenantRepo{count: 3}
+	tracker := NewActivityTracker(repo, nil)
+
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 3 {
+		t.Fatalf("active tenant gauge = %v, want 3", got)
+	}
+	repo.mu.Lock()
+	touchCalls := repo.touchCalls
+	countCalls := repo.countCalls
+	repo.mu.Unlock()
+	if touchCalls != 1 || countCalls != 1 {
+		t.Fatalf("calls = touch:%d count:%d, want 1/1", touchCalls, countCalls)
+	}
+}
+
+func TestActivityTrackerSuppressesTouchFailure(t *testing.T) {
+	metrics.ActiveTenants7dTotal.Set(0)
+	repo := &activityTenantRepo{touchErr: errors.New("fk failure"), count: 7}
+	tracker := NewActivityTracker(repo, nil)
+
+	tracker.RecordMemoryActivity("missing-tenant", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 0 {
+		t.Fatalf("active tenant gauge = %v, want 0", got)
+	}
+	repo.mu.Lock()
+	countCalls := repo.countCalls
+	repo.mu.Unlock()
+	if countCalls != 0 {
+		t.Fatalf("count calls = %d, want 0", countCalls)
+	}
+}
+
+func TestActivityTrackerRetriesMetricRefreshAfterCountFailure(t *testing.T) {
+	metrics.ActiveTenants7dTotal.Set(0)
+	repo := &activityTenantRepo{count: 5, countErr: errors.New("transient count failure")}
+	tracker := NewActivityTracker(repo, nil)
+	tracker.ttl = time.Hour
+
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 0 {
+		t.Fatalf("active tenant gauge = %v, want 0", got)
+	}
+
+	repo.mu.Lock()
+	repo.countErr = nil
+	repo.mu.Unlock()
+
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 5 {
+		t.Fatalf("active tenant gauge = %v, want 5", got)
+	}
+	repo.mu.Lock()
+	touchCalls := repo.touchCalls
+	countCalls := repo.countCalls
+	repo.mu.Unlock()
+	if touchCalls != 2 || countCalls != 2 {
+		t.Fatalf("calls = touch:%d count:%d, want 2/2", touchCalls, countCalls)
+	}
+}
+
+func TestActivityTrackerDebouncesMetricRefresh(t *testing.T) {
+	metrics.ActiveTenants7dTotal.Set(0)
+	repo := &activityTenantRepo{count: 4}
+	tracker := NewActivityTracker(repo, nil)
+	tracker.ttl = time.Hour
+
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+	repo.count = 9
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 4 {
+		t.Fatalf("active tenant gauge = %v, want 4", got)
+	}
+	repo.mu.Lock()
+	touchCalls := repo.touchCalls
+	countCalls := repo.countCalls
+	repo.mu.Unlock()
+	if touchCalls != 2 || countCalls != 1 {
+		t.Fatalf("calls = touch:%d count:%d, want 2/1", touchCalls, countCalls)
+	}
+}
+
+func activeTenantGaugeValue(t *testing.T) float64 {
+	t.Helper()
+
+	var pb dto.Metric
+	if err := metrics.ActiveTenants7dTotal.Write(&pb); err != nil {
+		t.Fatalf("write active tenant gauge: %v", err)
+	}
+	if pb.Gauge == nil {
+		return 0
+	}
+	return pb.Gauge.GetValue()
+}

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -382,6 +382,14 @@ func (m *mockTenantRepo) UpdateSchemaVersion(ctx context.Context, id string, ver
 	return nil
 }
 
+func (m *mockTenantRepo) TouchActivity(ctx context.Context, tenantID string, at time.Time) error {
+	return nil
+}
+
+func (m *mockTenantRepo) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
+	return 0, nil
+}
+
 type mockPool struct {
 	backend string
 	db      *sql.DB

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -62,6 +62,7 @@ type UploadWorker struct {
 	pollInterval time.Duration
 	concurrency  int
 	encryptor    encrypt.Encryptor
+	activity     *ActivityTracker
 }
 
 // NewUploadWorker creates a new UploadWorker.
@@ -77,6 +78,7 @@ func NewUploadWorker(
 	logger *slog.Logger,
 	concurrency int,
 	encryptor encrypt.Encryptor,
+	activity *ActivityTracker,
 ) *UploadWorker {
 	if logger == nil {
 		logger = slog.Default()
@@ -97,6 +99,7 @@ func NewUploadWorker(
 		pollInterval: 5 * time.Second,
 		concurrency:  concurrency,
 		encryptor:    encryptor,
+		activity:     activity,
 	}
 }
 
@@ -254,6 +257,8 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 			if err != nil {
 				return w.failTask(ctx, task, fmt.Errorf("ingest session chunk: %w", err), logger)
 			}
+			// recordActivity uses context.Background internally per the best-effort contract.
+			w.recordActivity(task.TenantID)
 			doneChunks = i + 1
 		}
 
@@ -332,6 +337,8 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 				metrics.ActiveMemoryTotal.WithLabelValues(clusterID).Set(float64(total))
 				metrics.ActiveMemory7dTotal.WithLabelValues(clusterID).Set(float64(last7d))
 			}
+			// recordActivity uses context.Background internally per the best-effort contract.
+			w.recordActivity(task.TenantID)
 			batchIdx++
 			doneChunks = batchIdx
 		}
@@ -351,6 +358,13 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 	logger.Info("upload task completed", "task_id", task.TaskID)
 	return nil
 
+}
+
+func (w *UploadWorker) recordActivity(tenantID string) {
+	if w == nil || w.activity == nil {
+		return
+	}
+	w.activity.RecordMemoryActivity(tenantID, time.Now().UTC())
 }
 
 // failTask marks task as failed and cleans up the file.

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -251,6 +251,21 @@ func TestParseMemoryFile(t *testing.T) {
 	}
 }
 
+func TestUploadWorkerRecordActivity(t *testing.T) {
+	repo := &activityTenantRepo{count: 1}
+	worker := &UploadWorker{activity: NewActivityTracker(repo, nil)}
+
+	worker.recordActivity("tenant-a")
+
+	repo.mu.Lock()
+	touchCalls := repo.touchCalls
+	countCalls := repo.countCalls
+	repo.mu.Unlock()
+	if touchCalls != 1 || countCalls != 1 {
+		t.Fatalf("calls = touch:%d count:%d, want 1/1", touchCalls, countCalls)
+	}
+}
+
 func makeMessages(n int) []IngestMessage {
 	msgs := make([]IngestMessage, n)
 	for i := range msgs {

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -24,6 +24,13 @@ CREATE TABLE IF NOT EXISTS tenants (
   INDEX idx_tenant_provider (provider)
 );
 
+CREATE TABLE IF NOT EXISTS tenant_activity (
+  tenant_id        VARCHAR(36) NOT NULL PRIMARY KEY,
+  last_activity_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id),
+  INDEX idx_tenant_activity_last_activity (last_activity_at)
+);
+
 -- Tenant data plane schema (per-tenant TiDB Serverless).
 CREATE TABLE IF NOT EXISTS memories (
   id              VARCHAR(36)     PRIMARY KEY,

--- a/server/schema_db9.sql
+++ b/server/schema_db9.sql
@@ -44,6 +44,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_name ON tenants(name);
 CREATE INDEX IF NOT EXISTS idx_tenant_status ON tenants(status);
 CREATE INDEX IF NOT EXISTS idx_tenant_provider ON tenants(provider);
 
+CREATE TABLE IF NOT EXISTS tenant_activity (
+    tenant_id        VARCHAR(36) PRIMARY KEY,
+    last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);
+
 -- memories table with auto-embedding column.
 -- Note: The embedding column definition depends on whether auto-embedding is enabled.
 -- When using schema_db9.sql directly (manual setup), use this version with GENERATED ALWAYS.

--- a/server/schema_pg.sql
+++ b/server/schema_pg.sql
@@ -26,6 +26,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_name ON tenants(name);
 CREATE INDEX IF NOT EXISTS idx_tenant_status ON tenants(status);
 CREATE INDEX IF NOT EXISTS idx_tenant_provider ON tenants(provider);
 
+CREATE TABLE IF NOT EXISTS tenant_activity (
+    tenant_id        VARCHAR(36) PRIMARY KEY,
+    last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);
+
 CREATE TABLE IF NOT EXISTS memories (
     id              VARCHAR(36)     PRIMARY KEY,
     content         TEXT            NOT NULL,


### PR DESCRIPTION
## Summary

1. Add a control-plane `tenant_activity` table and tenant repository activity APIs for TiDB/MySQL and Postgres/db9 schemas.
2. Add `ActivityTracker` and expose the unlabeled `mnemo_active_tenants_7d_total` Prometheus gauge with best-effort write-path refresh.
3. Wire HTTP memory writes, bulk create, upload worker imports, and server startup to record tenant memory activity.
4. Add focused unit/integration coverage and move the accepted proposal to `docs/design/`.

## Tests

1. `go test ./internal/service ./internal/handler ./internal/middleware ./internal/repository/tidb ./internal/repository/postgres ./cmd/mnemo-server`
2. `make test`
