### PR TITLE
Aggregate active memory metrics at server level

### DIFF
--- a/docs/design/issue-305-active-memory-metrics-proposal.md
+++ b/docs/design/issue-305-active-memory-metrics-proposal.md
@@ -1,0 +1,202 @@
+---
+title: Issue 305 Active Memory Metrics Proposal
+---
+
+## Goal
+
+Fix issue #305 by changing:
+
+1. `mnemo_active_memory_total{cluster_id=...}`
+2. `mnemo_active_memory_7d_total{cluster_id=...}`
+
+Into unlabeled server-level gauges:
+
+1. `mnemo_active_memory_total`
+2. `mnemo_active_memory_7d_total`
+
+Keep tenant and cluster identity only in server-side aggregation, not Prometheus labels.
+
+## Current State
+
+1. Metrics are `GaugeVec` with `cluster_id` in `server/internal/metrics/metrics.go:137`.
+2. HTTP writes refresh per-cluster gauges from tenant DB `CountStats` in `server/internal/handler/memory.go:689`.
+3. Upload memory imports set the same per-cluster gauges in `server/internal/service/upload.go:336`.
+4. `tenant_activity` already stores one row per tenant, but only has `last_activity_at` in `server/schema.sql:27`.
+5. `ActivityTracker` already debounces control-plane aggregate refresh for active tenant count in `server/internal/service/activity.go:41`.
+
+## Proposed Design
+
+1. Extend `tenant_activity` in all control-plane schema files.
+
+TiDB `server/schema.sql` uses `TIMESTAMP NULL`:
+
+```sql
+ALTER TABLE tenant_activity
+  ADD COLUMN active_memory_total BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN active_memory_7d_total BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN memory_stats_observed_at TIMESTAMP NULL;
+```
+
+Postgres `server/schema_pg.sql` and db9 `server/schema_db9.sql` use the same count columns with `TIMESTAMPTZ NULL` for `memory_stats_observed_at`.
+
+2. Extend `repository.TenantRepo` with memory-stat methods:
+
+```go
+UpsertMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) error
+SumActiveMemoryStats(ctx context.Context) (total int64, last7d int64, err error)
+```
+
+3. Implement TiDB and Postgres/db9 SQL.
+
+Use greatest-timestamp semantics for `last_activity_at`. For memory stats, only overwrite counts when `observedAt` is newer than or equal to the stored `memory_stats_observed_at`, so concurrent delayed refreshes cannot replace newer counts with older snapshots.
+
+Example race: goroutine A counts `(100, 50)` at `T1`, goroutine B counts `(101, 51)` at `T2`, B upserts first, then A upserts later. The SQL guard must keep B's `(101, 51)` because `T1 < memory_stats_observed_at`.
+
+TiDB should implement this with `INSERT ... ON DUPLICATE KEY UPDATE` and conditional `IF(...)` expressions. Postgres and db9 should implement the same semantics with `ON CONFLICT (tenant_id) DO UPDATE` and `CASE WHEN EXCLUDED.memory_stats_observed_at >= tenant_activity.memory_stats_observed_at THEN ...`.
+
+4. Change active-memory metrics from `GaugeVec` to `Gauge`.
+
+Keep names unchanged, remove labels.
+
+5. Replace direct per-cluster gauge writes with this flow after successful memory write, delete, or import:
+
+```text
+tenant DB CountStats
+-> control-plane tenant_activity upsert
+-> debounced control-plane SUM over active tenants
+-> set unlabeled Prometheus gauges
+```
+
+6. Move the debounce point after the tenant snapshot upsert.
+
+The current debounce skips counting and setting for 30 seconds per `cluster_id`. The new design should always update the affected tenant snapshot after successful writes, but debounce the global aggregate refresh.
+
+7. Reuse or extend `ActivityTracker`.
+
+Preferred minimal path: add `RecordMemoryStats(...)` to `ActivityTracker`, because it already owns `tenant_activity`, control-plane aggregate refresh, and debounce behavior.
+
+Use explicit tracker method signatures:
+
+```go
+func (t *ActivityTracker) RecordMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time)
+func (t *ActivityTracker) refreshAggregateMetrics(ctx context.Context, now time.Time)
+```
+
+`activityAt` updates `last_activity_at`; `observedAt` guards memory-count snapshot ordering.
+
+`ActivityTracker` should use one debounce claim to refresh all control-plane aggregate gauges together:
+
+```text
+RecordMemoryActivity(...)
+-> UpsertMemoryActivity(...)
+-> refreshAggregateMetrics(ctx, now)
+
+RecordMemoryStats(...)
+-> UpsertMemoryStats(...)
+-> refreshAggregateMetrics(ctx, now)
+```
+
+`refreshAggregateMetrics(ctx, now)` should run both aggregate queries under one `shouldRefresh(now)` claim:
+
+1. `CountActiveTenantsSince(ctx, now.Add(-7*24*time.Hour))` -> `mnemo_active_tenants_7d_total`
+2. `SumActiveMemoryStats(ctx)` -> `mnemo_active_memory_total` and `mnemo_active_memory_7d_total`
+
+This avoids the ambiguous case where `RecordMemoryActivity` claims the only `lastRefresh` slot and `RecordMemoryStats` then skips memory-gauge refresh, or vice versa. If either aggregate query fails, log a warning, call the existing refresh-claim rollback path, and leave all control-plane gauges unchanged. This all-or-nothing behavior prevents partial gauge updates.
+
+If tenant DB `CountStats` fails after a successful write, still call `RecordMemoryActivity` so `last_activity_at` remains updated. Only skip `RecordMemoryStats` for that event because the snapshot counts are unavailable.
+
+## Handler Rewrite
+
+Rewrite `server/internal/handler/memory.go:689` so it still queries tenant DB stats through `svc.memory.CountStats(ctx)`, but no longer writes active-memory gauges directly.
+
+| Current code | Current behavior | New behavior |
+| --- | --- | --- |
+| `server/internal/handler/memory.go:704` | `gaugeDebounce.Load(clusterID)` skips per-cluster refresh | Remove; debounce moves to `ActivityTracker.refreshAggregateMetrics` |
+| `server/internal/handler/memory.go:709` | `svc.memory.CountStats(ctx)` queries tenant DB | Keep; handler must not bypass `MemoryService` |
+| `server/internal/handler/memory.go:714` | `ActiveMemoryTotal.WithLabelValues(clusterID).Set(...)` | Replace with `s.activity.RecordMemoryStats(ctx, auth.TenantID, now, total, last7d, observedAt)` |
+| `server/internal/handler/memory.go:715` | `ActiveMemory7dTotal.WithLabelValues(clusterID).Set(...)` | Removed; aggregate refresh sets unlabeled gauge |
+| `server/internal/handler/handler.go:45` | `gaugeDebounce sync.Map` | Remove if no other user remains |
+
+Preserve the existing nil guard pattern: if `s.activity == nil`, skip the control-plane stats path after logging at most a warning. `MemoryChangesTotal{cluster_id=...}` stays unchanged.
+
+## Call Sites
+
+All write/delete/import paths that currently refresh active-memory gauges must feed the new stats path.
+
+| Call site | Current behavior | New behavior |
+| --- | --- | --- |
+| `server/internal/handler/memory.go:103` POST memory | `go s.afterSuccessfulWrite(auth, svc, written)` | Existing path calls rewritten `refreshWriteMetrics` |
+| `server/internal/handler/memory.go:120` async ingest | `s.afterSuccessfulIngest(auth, svc, written)` | Existing path calls rewritten `refreshWriteMetrics` |
+| `server/internal/handler/memory.go:491` PUT memory | `go s.afterSuccessfulWrite(auth, svc, 1)` | Existing path calls rewritten `refreshWriteMetrics` |
+| `server/internal/handler/memory.go:506` DELETE memory | `go s.afterSuccessfulWrite(auth, svc, 0)` | Re-query `CountStats` after delete and record post-delete stats |
+| `server/internal/handler/memory.go:529` batch delete | `go s.afterSuccessfulWrite(auth, svc, 0)` | Re-query `CountStats` after delete and record post-delete stats |
+| `server/internal/service/upload.go:335` raw JSON import | Keep `MemoryChangesTotal.WithLabelValues(clusterID).Add(...)` | Keep unchanged |
+| `server/internal/service/upload.go:336` raw JSON import | `memRepo.CountStats(...)` then direct per-cluster gauges | Call `w.activity.RecordMemoryStats(taskCtx, task.TenantID, now, total, last7d, observedAt)` |
+| `server/internal/service/upload.go:260` memory file import | `w.recordActivity(task.TenantID)` only | Add `memRepo.CountStats(...)` after import and call `RecordMemoryStats(...)` |
+
+The upload worker can either extend `recordActivity` to accept optional stats or keep `recordActivity` unchanged and add a separate helper for `RecordMemoryStats`. Prefer a separate helper so activity recording still happens even when `CountStats` fails.
+
+## Aggregate Query
+
+```sql
+SELECT
+  COALESCE(SUM(ta.active_memory_total), 0),
+  COALESCE(SUM(ta.active_memory_7d_total), 0)
+FROM tenant_activity AS ta
+INNER JOIN tenants AS t ON t.id = ta.tenant_id
+WHERE t.status = 'active'
+  AND t.deleted_at IS NULL;
+```
+
+## Dashboard And Query Migration
+
+1. Replace `mnemo_active_memory_total{cluster_id=...}` with `mnemo_active_memory_total`.
+2. Replace `mnemo_active_memory_7d_total{cluster_id=...}` with `mnemo_active_memory_7d_total`.
+3. Existing `sum(mnemo_active_memory_total)` remains valid after the old labeled series are no longer returned by the active scrape path. During migration and historical/range queries, avoid summing old labeled series together with the new unlabeled series because that can double count.
+4. Cluster-level active-memory dashboards should move to a separate control-plane query/storage path, not Prometheus labels.
+
+## Consistency And Failure Modes
+
+1. Metrics are eventually consistent. The aggregate gauges can lag writes by up to `activityGaugeTTL` (`30s` today), matching the existing active-tenant gauge debounce. This is intentional to avoid tenant DB fanout during `/metrics` scrape.
+2. Process crash after tenant DB write but before `UpsertMemoryStats`: the affected tenant snapshot remains stale until that tenant's next successful write/import/delete. This is acceptable for best-effort metrics.
+3. Process crash after debounce claim but before aggregate refresh: gauges are process-local and restart at zero; the first post-restart write claims a fresh debounce and refreshes aggregates.
+4. Control-plane aggregate query failure: log, clear the refresh claim, keep the previous gauge values, and retry on the next write event.
+5. Concurrent writes for the same tenant: `memory_stats_observed_at` prevents an older count snapshot from replacing a newer one.
+
+## Tests
+
+1. Repository tests:
+   1. Upsert preserves greatest `last_activity_at`.
+   2. Older `memory_stats_observed_at` does not overwrite newer counts.
+   3. Aggregate excludes suspended/deleted tenants and `deleted_at IS NOT NULL`.
+
+2. Activity tracker tests:
+   1. Records tenant stats and sets unlabeled gauges.
+   2. Debounces aggregate refresh, not tenant snapshot writes.
+   3. Logs and leaves gauges unchanged on aggregate query failure.
+   4. One refresh claim updates active-tenant and active-memory aggregate gauges together.
+
+3. Handler/upload tests:
+   1. Mocks updated for new `TenantRepo` methods.
+   2. Successful writes/deletes/imports call the new stats path.
+   3. `MemoryChangesTotal{cluster_id=...}` remains unchanged.
+   4. `CountStats` failure still records tenant activity but skips memory stats.
+
+## Rollout
+
+1. Apply control-plane DB migration before deploying code.
+2. Deploy code that writes snapshots and exposes unlabeled gauges.
+3. Update dashboards and alerts to remove `cluster_id` filters.
+4. Avoid historical/range queries that sum old labeled series with new unlabeled series during the retention overlap.
+5. Accept that old labeled time series may remain visible until metrics retention expires, but new scrapes will not expose `cluster_id`.
+
+## Non-goals
+
+1. Do not preserve per-cluster active-memory Prometheus labels.
+2. Do not change `mnemo_memory_changes_total{cluster_id=...}` in this issue.
+3. Do not fan out across tenant databases during `/metrics` scrape.
+4. Do not add scrape-time tenant/cluster labels.
+
+## Estimate
+
+~150-250 LoC, mostly repository methods, schema/test updates, and replacing the active-memory gauge refresh path.

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -28,21 +28,20 @@ import (
 
 // Server holds the HTTP handlers and their dependencies.
 type Server struct {
-	tenant        *service.TenantService
-	uploadTasks   repository.UploadTaskRepo
-	uploadDir     string
-	embedder      *embed.Embedder
-	llmClient     *llm.Client
-	autoModel     string
-	ftsEnabled    bool
-	ingestMode    service.IngestMode
-	dbBackend     string
-	logger        *slog.Logger
-	metering      metering.Writer
-	activity      *service.ActivityTracker
-	startedAt     time.Time
-	svcCache      sync.Map
-	gaugeDebounce sync.Map // cluster_id -> time.Time of last Gauge refresh
+	tenant      *service.TenantService
+	uploadTasks repository.UploadTaskRepo
+	uploadDir   string
+	embedder    *embed.Embedder
+	llmClient   *llm.Client
+	autoModel   string
+	ftsEnabled  bool
+	ingestMode  service.IngestMode
+	dbBackend   string
+	logger      *slog.Logger
+	metering    metering.Writer
+	activity    *service.ActivityTracker
+	startedAt   time.Time
+	svcCache    sync.Map
 }
 
 // NewServer creates a new HTTP handler server.

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -687,6 +687,10 @@ func dedupStrings(ss []string) []string {
 }
 
 func (s *Server) refreshWriteMetrics(auth *domain.AuthInfo, svc resolvedSvc, written int64) {
+	if auth == nil || svc.memory == nil {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -699,18 +703,25 @@ func (s *Server) refreshWriteMetrics(auth *domain.AuthInfo, svc resolvedSvc, wri
 		metrics.MemoryChangesTotal.WithLabelValues(clusterID).Add(float64(written))
 	}
 
-	const gaugeTTL = 30 * time.Second
-	now := time.Now()
-	if last, ok := s.gaugeDebounce.Load(clusterID); ok && now.Sub(last.(time.Time)) < gaugeTTL {
+	if s.activity == nil || auth.TenantID == "" {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("refreshWriteMetrics: activity tracker unavailable", "tenant_id", auth.TenantID, "cluster_id", clusterID)
 		return
 	}
-	s.gaugeDebounce.Store(clusterID, now)
 
+	observedAt := time.Now().UTC()
 	total, last7d, err := svc.memory.CountStats(ctx)
 	if err != nil {
-		slog.Warn("refreshWriteMetrics: count stats failed", "err", err)
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("refreshWriteMetrics: count stats failed", "tenant_id", auth.TenantID, "cluster_id", clusterID, "err", err)
+		s.activity.RecordMemoryActivity(auth.TenantID, observedAt)
 		return
 	}
-	metrics.ActiveMemoryTotal.WithLabelValues(clusterID).Set(float64(total))
-	metrics.ActiveMemory7dTotal.WithLabelValues(clusterID).Set(float64(last7d))
+	s.activity.RecordMemoryStats(ctx, auth.TenantID, observedAt, total, last7d, observedAt)
 }

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -35,6 +35,7 @@ type testMemoryRepo struct {
 	countStatsTotal      int64
 	countStatsLast7d     int64
 	countStatsErr        error
+	countStatsCalls      int
 }
 
 func (m *testMemoryRepo) Create(_ context.Context, mem *domain.Memory) error {
@@ -114,6 +115,9 @@ func (m *testMemoryRepo) NearDupSearch(context.Context, string) (string, float64
 }
 
 func (m *testMemoryRepo) CountStats(context.Context) (int64, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.countStatsCalls++
 	return m.countStatsTotal, m.countStatsLast7d, m.countStatsErr
 }
 
@@ -221,11 +225,17 @@ func (w *blockingMeteringWriter) Record(evt metering.Event) {
 func (w *blockingMeteringWriter) Close(context.Context) error { return nil }
 
 type handlerActivityTenantRepo struct {
-	mu         sync.Mutex
-	touchErr   error
-	count      int64
-	touchCalls int
-	touched    chan string
+	mu              sync.Mutex
+	touchErr        error
+	upsertErr       error
+	count           int64
+	memoryTotal     int64
+	memoryLast7d    int64
+	touchCalls      int
+	upsertCalls     int
+	lastStatsTotal  int64
+	lastStatsLast7d int64
+	touched         chan string
 }
 
 func (r *handlerActivityTenantRepo) Create(context.Context, *domain.Tenant) error { return nil }
@@ -258,10 +268,34 @@ func (r *handlerActivityTenantRepo) TouchActivity(_ context.Context, tenantID st
 	return touchErr
 }
 
+func (r *handlerActivityTenantRepo) UpsertMemoryStats(_ context.Context, tenantID string, _ time.Time, total, last7d int64, _ time.Time) error {
+	r.mu.Lock()
+	r.upsertCalls++
+	r.lastStatsTotal = total
+	r.lastStatsLast7d = last7d
+	touched := r.touched
+	upsertErr := r.upsertErr
+	r.mu.Unlock()
+
+	if touched != nil {
+		select {
+		case touched <- tenantID:
+		default:
+		}
+	}
+	return upsertErr
+}
+
 func (r *handlerActivityTenantRepo) CountActiveTenantsSince(context.Context, time.Time) (int64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.count, nil
+}
+
+func (r *handlerActivityTenantRepo) SumActiveMemoryStats(context.Context) (int64, int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.memoryTotal, r.memoryLast7d, nil
 }
 
 func cloneMap(in map[string]any) map[string]any {
@@ -379,8 +413,8 @@ func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
 func TestCreateMemory_ActivityFailureDoesNotFailWrite(t *testing.T) {
 	memRepo := &testMemoryRepo{countStatsTotal: 1}
 	activityRepo := &handlerActivityTenantRepo{
-		touchErr: errors.New("activity unavailable"),
-		touched:  make(chan string, 1),
+		upsertErr: errors.New("activity unavailable"),
+		touched:   make(chan string, 1),
 	}
 	srv := newTestServer(memRepo, &testSessionRepo{}).
 		WithActivityTracker(service.NewActivityTracker(activityRepo, slog.Default()))
@@ -404,6 +438,84 @@ func TestCreateMemory_ActivityFailureDoesNotFailWrite(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for activity touch")
+	}
+}
+
+func TestRefreshWriteMetricsRecordsMemoryStats(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsTotal: 42, countStatsLast7d: 7}
+	activityRepo := &handlerActivityTenantRepo{
+		count:        1,
+		memoryTotal:  42,
+		memoryLast7d: 7,
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).
+		WithActivityTracker(service.NewActivityTracker(activityRepo, slog.Default()))
+	svc := resolvedSvc{memory: service.NewMemoryService(memRepo, nil, nil, "", service.ModeSmart)}
+	auth := &domain.AuthInfo{TenantID: "tenant-a", ClusterID: "10006636"}
+
+	srv.refreshWriteMetrics(auth, svc, 1)
+
+	activityRepo.mu.Lock()
+	upsertCalls := activityRepo.upsertCalls
+	touchCalls := activityRepo.touchCalls
+	statsTotal := activityRepo.lastStatsTotal
+	statsLast7d := activityRepo.lastStatsLast7d
+	activityRepo.mu.Unlock()
+	if upsertCalls != 1 || touchCalls != 0 || statsTotal != 42 || statsLast7d != 7 {
+		t.Fatalf("activity = upsert:%d touch:%d stats:%d/%d, want 1/0/42/7", upsertCalls, touchCalls, statsTotal, statsLast7d)
+	}
+}
+
+func TestRefreshWriteMetricsSkipsStatsWhenActivityTrackerMissing(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsTotal: 42, countStatsLast7d: 7}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	svc := resolvedSvc{memory: service.NewMemoryService(memRepo, nil, nil, "", service.ModeSmart)}
+	auth := &domain.AuthInfo{TenantID: "tenant-a", ClusterID: "10006636"}
+
+	srv.refreshWriteMetrics(auth, svc, 1)
+
+	memRepo.mu.Lock()
+	countStatsCalls := memRepo.countStatsCalls
+	memRepo.mu.Unlock()
+	if countStatsCalls != 0 {
+		t.Fatalf("CountStats calls = %d, want 0", countStatsCalls)
+	}
+}
+
+func TestCreateMemory_CountStatsFailureStillRecordsActivity(t *testing.T) {
+	memRepo := &testMemoryRepo{countStatsErr: errors.New("count failed")}
+	activityRepo := &handlerActivityTenantRepo{
+		touched: make(chan string, 1),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).
+		WithActivityTracker(service.NewActivityTracker(activityRepo, slog.Default()))
+
+	body := map[string]any{
+		"content": "test memory content",
+		"sync":    true,
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	select {
+	case tenantID := <-activityRepo.touched:
+		if tenantID != "tenant-a" {
+			t.Fatalf("activity tenant = %q, want tenant-a", tenantID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for activity touch")
+	}
+	activityRepo.mu.Lock()
+	touchCalls := activityRepo.touchCalls
+	upsertCalls := activityRepo.upsertCalls
+	activityRepo.mu.Unlock()
+	if touchCalls != 1 || upsertCalls != 0 {
+		t.Fatalf("activity calls = touch:%d upsert:%d, want 1/0", touchCalls, upsertCalls)
 	}
 }
 

--- a/server/internal/handler/metering.go
+++ b/server/internal/handler/metering.go
@@ -16,10 +16,6 @@ func (s *Server) afterSuccessfulWrite(auth *domain.AuthInfo, svc resolvedSvc, wr
 		return
 	}
 	s.refreshWriteMetrics(auth, svc, written)
-	if s.activity == nil || auth == nil {
-		return
-	}
-	s.activity.RecordMemoryActivity(auth.TenantID, time.Now().UTC())
 }
 
 func (s *Server) afterSuccessfulIngest(auth *domain.AuthInfo, svc resolvedSvc, written int64) {

--- a/server/internal/handler/tenant_test.go
+++ b/server/internal/handler/tenant_test.go
@@ -55,8 +55,16 @@ func (r *handlerTenantRepo) TouchActivity(ctx context.Context, tenantID string, 
 	return nil
 }
 
+func (r *handlerTenantRepo) UpsertMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) error {
+	return nil
+}
+
 func (r *handlerTenantRepo) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
 	return 0, nil
+}
+
+func (r *handlerTenantRepo) SumActiveMemoryStats(ctx context.Context) (int64, int64, error) {
+	return 0, 0, nil
 }
 
 type handlerProvisioner struct {

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -132,22 +132,20 @@ var (
 		},
 		[]string{"step", "model", "status"},
 	)
-	// ActiveMemoryTotal is the current total number of active memories per cluster.
-	// Use sum(mnemo_active_memory_total) for the global aggregate.
-	ActiveMemoryTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// ActiveMemoryTotal is the current server-level total number of active memories.
+	ActiveMemoryTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mnemo",
 		Name:      "active_memory_total",
-		Help:      "Total active memories for a cluster, refreshed on memory write or delete.",
-	}, []string{"cluster_id"})
+		Help:      "Total active memories across active tenants, refreshed after memory write, delete, or import.",
+	})
 
-	// ActiveMemory7dTotal is the current total number of active memories created in the
-	// last 7 days per cluster. Use sum(mnemo_active_memory_7d_total) for the global aggregate.
-	// Value reflects the state at the last write or delete event; it is not updated between events.
-	ActiveMemory7dTotal = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	// ActiveMemory7dTotal is the current server-level total number of active memories
+	// created in the last 7 days.
+	ActiveMemory7dTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mnemo",
 		Name:      "active_memory_7d_total",
-		Help:      "Active memories created in the last 7 days for a cluster, refreshed on memory write or delete.",
-	}, []string{"cluster_id"})
+		Help:      "Active memories created in the last 7 days across active tenants, refreshed after memory write, delete, or import.",
+	})
 
 	// ActiveTenants7dTotal is the current total number of active tenants with
 	// recorded memory activity in the last 7 days. Value reflects the state at

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -54,8 +54,16 @@ func (r stubTenantRepo) TouchActivity(context.Context, string, time.Time) error 
 	return nil
 }
 
+func (r stubTenantRepo) UpsertMemoryStats(context.Context, string, time.Time, int64, int64, time.Time) error {
+	return nil
+}
+
 func (r stubTenantRepo) CountActiveTenantsSince(context.Context, time.Time) (int64, error) {
 	return 0, nil
+}
+
+func (r stubTenantRepo) SumActiveMemoryStats(context.Context) (int64, int64, error) {
+	return 0, 0, nil
 }
 
 type pingOKConnector struct{}

--- a/server/internal/repository/postgres/tenant.go
+++ b/server/internal/repository/postgres/tenant.go
@@ -84,6 +84,32 @@ func (r *TenantRepoImpl) TouchActivity(ctx context.Context, tenantID string, at 
 	return nil
 }
 
+func (r *TenantRepoImpl) UpsertMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO tenant_activity (tenant_id, last_activity_at, active_memory_total, active_memory_7d_total, memory_stats_observed_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id) DO UPDATE SET
+		   last_activity_at = GREATEST(tenant_activity.last_activity_at, EXCLUDED.last_activity_at),
+		   active_memory_total = CASE
+		     WHEN tenant_activity.memory_stats_observed_at IS NULL OR EXCLUDED.memory_stats_observed_at >= tenant_activity.memory_stats_observed_at THEN EXCLUDED.active_memory_total
+		     ELSE tenant_activity.active_memory_total
+		   END,
+		   active_memory_7d_total = CASE
+		     WHEN tenant_activity.memory_stats_observed_at IS NULL OR EXCLUDED.memory_stats_observed_at >= tenant_activity.memory_stats_observed_at THEN EXCLUDED.active_memory_7d_total
+		     ELSE tenant_activity.active_memory_7d_total
+		   END,
+		   memory_stats_observed_at = CASE
+		     WHEN tenant_activity.memory_stats_observed_at IS NULL OR EXCLUDED.memory_stats_observed_at >= tenant_activity.memory_stats_observed_at THEN EXCLUDED.memory_stats_observed_at
+		     ELSE tenant_activity.memory_stats_observed_at
+		   END`,
+		tenantID, activityAt, total, last7d, observedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert tenant memory stats: %w", err)
+	}
+	return nil
+}
+
 func (r *TenantRepoImpl) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
 	var count int64
 	// INNER JOIN deliberately skips orphan activity rows.
@@ -100,6 +126,22 @@ func (r *TenantRepoImpl) CountActiveTenantsSince(ctx context.Context, since time
 		return 0, fmt.Errorf("count active tenants since: %w", err)
 	}
 	return count, nil
+}
+
+func (r *TenantRepoImpl) SumActiveMemoryStats(ctx context.Context) (total int64, last7d int64, err error) {
+	err = r.db.QueryRowContext(ctx,
+		`SELECT
+		   COALESCE(SUM(ta.active_memory_total), 0),
+		   COALESCE(SUM(ta.active_memory_7d_total), 0)
+		 FROM tenant_activity AS ta
+		 INNER JOIN tenants AS t ON t.id = ta.tenant_id
+		 WHERE t.status = 'active'
+		   AND t.deleted_at IS NULL`,
+	).Scan(&total, &last7d)
+	if err != nil {
+		return 0, 0, fmt.Errorf("sum active memory stats: %w", err)
+	}
+	return total, last7d, nil
 }
 
 func scanTenant(row *sql.Row) (*domain.Tenant, error) {

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -55,7 +55,9 @@ type TenantRepo interface {
 	UpdateStatus(ctx context.Context, id string, status domain.TenantStatus) error
 	UpdateSchemaVersion(ctx context.Context, id string, version int) error
 	TouchActivity(ctx context.Context, tenantID string, at time.Time) error
+	UpsertMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) error
 	CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error)
+	SumActiveMemoryStats(ctx context.Context) (total int64, last7d int64, err error)
 }
 
 // UploadTaskRepo manages upload task records in the control plane DB.

--- a/server/internal/repository/tidb/tenant.go
+++ b/server/internal/repository/tidb/tenant.go
@@ -84,6 +84,23 @@ func (r *TenantRepoImpl) TouchActivity(ctx context.Context, tenantID string, at 
 	return nil
 }
 
+func (r *TenantRepoImpl) UpsertMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO tenant_activity (tenant_id, last_activity_at, active_memory_total, active_memory_7d_total, memory_stats_observed_at)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON DUPLICATE KEY UPDATE
+		   last_activity_at = GREATEST(last_activity_at, VALUES(last_activity_at)),
+		   active_memory_total = IF(memory_stats_observed_at IS NULL OR VALUES(memory_stats_observed_at) >= memory_stats_observed_at, VALUES(active_memory_total), active_memory_total),
+		   active_memory_7d_total = IF(memory_stats_observed_at IS NULL OR VALUES(memory_stats_observed_at) >= memory_stats_observed_at, VALUES(active_memory_7d_total), active_memory_7d_total),
+		   memory_stats_observed_at = IF(memory_stats_observed_at IS NULL OR VALUES(memory_stats_observed_at) >= memory_stats_observed_at, VALUES(memory_stats_observed_at), memory_stats_observed_at)`,
+		tenantID, activityAt, total, last7d, observedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert tenant memory stats: %w", err)
+	}
+	return nil
+}
+
 func (r *TenantRepoImpl) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
 	var count int64
 	// INNER JOIN deliberately skips orphan activity rows.
@@ -100,6 +117,22 @@ func (r *TenantRepoImpl) CountActiveTenantsSince(ctx context.Context, since time
 		return 0, fmt.Errorf("count active tenants since: %w", err)
 	}
 	return count, nil
+}
+
+func (r *TenantRepoImpl) SumActiveMemoryStats(ctx context.Context) (total int64, last7d int64, err error) {
+	err = r.db.QueryRowContext(ctx,
+		`SELECT
+		   COALESCE(SUM(ta.active_memory_total), 0),
+		   COALESCE(SUM(ta.active_memory_7d_total), 0)
+		 FROM tenant_activity AS ta
+		 INNER JOIN tenants AS t ON t.id = ta.tenant_id
+		 WHERE t.status = 'active'
+		   AND t.deleted_at IS NULL`,
+	).Scan(&total, &last7d)
+	if err != nil {
+		return 0, 0, fmt.Errorf("sum active memory stats: %w", err)
+	}
+	return total, last7d, nil
 }
 
 func scanTenant(row *sql.Row) (*domain.Tenant, error) {

--- a/server/internal/repository/tidb/tenant_integration_test.go
+++ b/server/internal/repository/tidb/tenant_integration_test.go
@@ -243,3 +243,93 @@ func TestTenantCountActiveTenantsSince(t *testing.T) {
 		t.Fatalf("active tenants since = %d, want 1", got)
 	}
 }
+
+func TestTenantUpsertMemoryStatsKeepsNewestObservedCounts(t *testing.T) {
+	if err := truncateAll(testDB); err != nil {
+		t.Fatalf("truncateAll: %v", err)
+	}
+	repo := NewTenantRepo(testDB)
+	ctx := context.Background()
+
+	tenant := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	if err := repo.Create(ctx, tenant); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	observedNew := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+	observedOld := observedNew.Add(-time.Minute)
+	activityOld := observedNew
+	activityNew := observedNew.Add(time.Minute)
+
+	if err := repo.UpsertMemoryStats(ctx, tenant.ID, activityOld, 100, 50, observedNew); err != nil {
+		t.Fatalf("UpsertMemoryStats newer: %v", err)
+	}
+	if err := repo.UpsertMemoryStats(ctx, tenant.ID, activityNew, 1, 1, observedOld); err != nil {
+		t.Fatalf("UpsertMemoryStats older: %v", err)
+	}
+
+	var gotActivity time.Time
+	var total, last7d int64
+	var gotObserved time.Time
+	if err := testDB.QueryRowContext(ctx,
+		`SELECT last_activity_at, active_memory_total, active_memory_7d_total, memory_stats_observed_at
+		 FROM tenant_activity WHERE tenant_id = ?`,
+		tenant.ID,
+	).Scan(&gotActivity, &total, &last7d, &gotObserved); err != nil {
+		t.Fatalf("query tenant_activity: %v", err)
+	}
+	if !gotActivity.Equal(activityNew) {
+		t.Fatalf("last_activity_at = %s, want %s", gotActivity, activityNew)
+	}
+	if total != 100 || last7d != 50 {
+		t.Fatalf("memory stats = %d/%d, want 100/50", total, last7d)
+	}
+	if !gotObserved.Equal(observedNew) {
+		t.Fatalf("memory_stats_observed_at = %s, want %s", gotObserved, observedNew)
+	}
+}
+
+func TestTenantSumActiveMemoryStats(t *testing.T) {
+	if err := truncateAll(testDB); err != nil {
+		t.Fatalf("truncateAll: %v", err)
+	}
+	repo := NewTenantRepo(testDB)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	activeA := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	activeB := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+	suspended := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantSuspended })
+	deleted := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantDeleted })
+	deletedAt := newTestTenant(func(t *domain.Tenant) { t.Status = domain.TenantActive })
+
+	for _, tenant := range []*domain.Tenant{activeA, activeB, suspended, deleted, deletedAt} {
+		if err := repo.Create(ctx, tenant); err != nil {
+			t.Fatalf("Create(%s): %v", tenant.ID, err)
+		}
+	}
+	if _, err := testDB.ExecContext(ctx, `UPDATE tenants SET deleted_at = ? WHERE id = ?`, now, deletedAt.ID); err != nil {
+		t.Fatalf("mark deleted_at: %v", err)
+	}
+
+	stats := map[string][2]int64{
+		activeA.ID:   {10, 4},
+		activeB.ID:   {3, 2},
+		suspended.ID: {100, 100},
+		deleted.ID:   {100, 100},
+		deletedAt.ID: {100, 100},
+	}
+	for tenantID, counts := range stats {
+		if err := repo.UpsertMemoryStats(ctx, tenantID, now, counts[0], counts[1], now); err != nil {
+			t.Fatalf("UpsertMemoryStats(%s): %v", tenantID, err)
+		}
+	}
+
+	total, last7d, err := repo.SumActiveMemoryStats(ctx)
+	if err != nil {
+		t.Fatalf("SumActiveMemoryStats: %v", err)
+	}
+	if total != 13 || last7d != 6 {
+		t.Fatalf("active memory stats = %d/%d, want 13/6", total, last7d)
+	}
+}

--- a/server/internal/repository/tidb/testutil_test.go
+++ b/server/internal/repository/tidb/testutil_test.go
@@ -90,8 +90,11 @@ func createTables(db *sql.DB) error {
 	}
 
 	_, err = db.ExecContext(ctx, `CREATE TABLE IF NOT EXISTS tenant_activity (
-		tenant_id        VARCHAR(36) NOT NULL PRIMARY KEY,
-		last_activity_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		tenant_id                VARCHAR(36) NOT NULL PRIMARY KEY,
+		last_activity_at         TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+		active_memory_total      BIGINT      NOT NULL DEFAULT 0,
+		active_memory_7d_total   BIGINT      NOT NULL DEFAULT 0,
+		memory_stats_observed_at TIMESTAMP   NULL,
 		CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id),
 		INDEX idx_tenant_activity_last_activity (last_activity_at)
 	)`)

--- a/server/internal/service/activity.go
+++ b/server/internal/service/activity.go
@@ -39,6 +39,14 @@ func NewActivityTracker(tenants repository.TenantRepo, logger *slog.Logger) *Act
 }
 
 func (t *ActivityTracker) RecordMemoryActivity(tenantID string, at time.Time) {
+	t.recordMemoryActivity(tenantID, at, true)
+}
+
+func (t *ActivityTracker) RecordMemoryActivityOnly(tenantID string, at time.Time) {
+	t.recordMemoryActivity(tenantID, at, false)
+}
+
+func (t *ActivityTracker) recordMemoryActivity(tenantID string, at time.Time, refresh bool) {
 	if t == nil || t.tenants == nil || tenantID == "" {
 		return
 	}
@@ -54,6 +62,9 @@ func (t *ActivityTracker) RecordMemoryActivity(tenantID string, at time.Time) {
 		return
 	}
 
+	if !refresh {
+		return
+	}
 	t.refreshAggregateMetrics(ctx, time.Now().UTC())
 }
 

--- a/server/internal/service/activity.go
+++ b/server/internal/service/activity.go
@@ -17,7 +17,7 @@ const (
 )
 
 // ActivityTracker records tenant-level memory activity and refreshes the
-// process-global active-tenant metric on a debounce.
+// process-global activity metrics on a debounce.
 type ActivityTracker struct {
 	tenants repository.TenantRepo
 	logger  *slog.Logger
@@ -54,18 +54,63 @@ func (t *ActivityTracker) RecordMemoryActivity(tenantID string, at time.Time) {
 		return
 	}
 
-	now := time.Now().UTC()
+	t.refreshAggregateMetrics(ctx, time.Now().UTC())
+}
+
+func (t *ActivityTracker) RecordMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) {
+	if t == nil || t.tenants == nil || tenantID == "" {
+		return
+	}
+	if activityAt.IsZero() {
+		activityAt = time.Now().UTC()
+	}
+	if observedAt.IsZero() {
+		observedAt = time.Now().UTC()
+	}
+
+	callCtx := ctx
+	var cancel context.CancelFunc
+	if callCtx == nil {
+		callCtx = context.Background()
+	}
+	callCtx, cancel = context.WithTimeout(callCtx, activityTrackerTimeout)
+	defer cancel()
+
+	if err := t.tenants.UpsertMemoryStats(callCtx, tenantID, activityAt, total, last7d, observedAt); err != nil {
+		t.logger.Warn("record tenant memory stats failed", "tenant_id", tenantID, "err", err)
+		return
+	}
+
+	t.refreshAggregateMetrics(callCtx, time.Now().UTC())
+}
+
+func (t *ActivityTracker) refreshAggregateMetrics(ctx context.Context, now time.Time) {
+	if t == nil || t.tenants == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
 	if !t.shouldRefresh(now) {
 		return
 	}
 
-	count, err := t.tenants.CountActiveTenantsSince(ctx, now.Add(-activeTenantWindow))
+	activeTenants, err := t.tenants.CountActiveTenantsSince(ctx, now.Add(-activeTenantWindow))
 	if err != nil {
 		t.clearRefreshClaim(now)
-		t.logger.Warn("refresh active tenants metric failed", "err", err)
+		t.logger.Warn("refresh aggregate metrics failed", "metric", "active_tenants_7d_total", "err", err)
 		return
 	}
-	metrics.ActiveTenants7dTotal.Set(float64(count))
+	activeMemory, activeMemory7d, err := t.tenants.SumActiveMemoryStats(ctx)
+	if err != nil {
+		t.clearRefreshClaim(now)
+		t.logger.Warn("refresh aggregate metrics failed", "metric", "active_memory", "err", err)
+		return
+	}
+
+	metrics.ActiveTenants7dTotal.Set(float64(activeTenants))
+	metrics.ActiveMemoryTotal.Set(float64(activeMemory))
+	metrics.ActiveMemory7dTotal.Set(float64(activeMemory7d))
 }
 
 func (t *ActivityTracker) shouldRefresh(now time.Time) bool {

--- a/server/internal/service/activity.go
+++ b/server/internal/service/activity.go
@@ -68,7 +68,7 @@ func (t *ActivityTracker) recordMemoryActivity(tenantID string, at time.Time, re
 	t.refreshAggregateMetrics(ctx, time.Now().UTC())
 }
 
-func (t *ActivityTracker) RecordMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) {
+func (t *ActivityTracker) RecordMemoryStats(_ context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) {
 	if t == nil || t.tenants == nil || tenantID == "" {
 		return
 	}
@@ -79,12 +79,7 @@ func (t *ActivityTracker) RecordMemoryStats(ctx context.Context, tenantID string
 		observedAt = time.Now().UTC()
 	}
 
-	callCtx := ctx
-	var cancel context.CancelFunc
-	if callCtx == nil {
-		callCtx = context.Background()
-	}
-	callCtx, cancel = context.WithTimeout(callCtx, activityTrackerTimeout)
+	callCtx, cancel := context.WithTimeout(context.Background(), activityTrackerTimeout)
 	defer cancel()
 
 	if err := t.tenants.UpsertMemoryStats(callCtx, tenantID, activityAt, total, last7d, observedAt); err != nil {

--- a/server/internal/service/activity_test.go
+++ b/server/internal/service/activity_test.go
@@ -228,6 +228,25 @@ func TestActivityTrackerRecordsMemoryStatsAndRefreshesGauges(t *testing.T) {
 	}
 }
 
+func TestActivityTrackerRecordMemoryStatsUsesIndependentContext(t *testing.T) {
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 1, memoryTotal: 9, memoryLast7d: 4}
+	tracker := NewActivityTracker(repo, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tracker.RecordMemoryStats(ctx, "tenant-a", time.Now(), 9, 4, time.Now())
+
+	repo.mu.Lock()
+	upsertCalls := repo.upsertCalls
+	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
+	repo.mu.Unlock()
+	if upsertCalls != 1 || countCalls != 1 || sumCalls != 1 {
+		t.Fatalf("calls = upsert:%d count:%d sum:%d, want 1/1/1", upsertCalls, countCalls, sumCalls)
+	}
+}
+
 func TestActivityTrackerDebouncesAggregateRefreshButNotStatsUpsert(t *testing.T) {
 	resetActivityGauges()
 	repo := &activityTenantRepo{count: 1, memoryTotal: 20, memoryLast7d: 8}

--- a/server/internal/service/activity_test.go
+++ b/server/internal/service/activity_test.go
@@ -14,12 +14,20 @@ import (
 )
 
 type activityTenantRepo struct {
-	mu         sync.Mutex
-	touchErr   error
-	countErr   error
-	count      int64
-	touchCalls int
-	countCalls int
+	mu              sync.Mutex
+	touchErr        error
+	upsertErr       error
+	countErr        error
+	sumErr          error
+	count           int64
+	memoryTotal     int64
+	memoryLast7d    int64
+	touchCalls      int
+	upsertCalls     int
+	countCalls      int
+	sumCalls        int
+	lastStatsTotal  int64
+	lastStatsLast7d int64
 }
 
 func (r *activityTenantRepo) Create(context.Context, *domain.Tenant) error { return nil }
@@ -43,6 +51,15 @@ func (r *activityTenantRepo) TouchActivity(context.Context, string, time.Time) e
 	return r.touchErr
 }
 
+func (r *activityTenantRepo) UpsertMemoryStats(_ context.Context, _ string, _ time.Time, total, last7d int64, _ time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.upsertCalls++
+	r.lastStatsTotal = total
+	r.lastStatsLast7d = last7d
+	return r.upsertErr
+}
+
 func (r *activityTenantRepo) CountActiveTenantsSince(context.Context, time.Time) (int64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -50,9 +67,16 @@ func (r *activityTenantRepo) CountActiveTenantsSince(context.Context, time.Time)
 	return r.count, r.countErr
 }
 
+func (r *activityTenantRepo) SumActiveMemoryStats(context.Context) (int64, int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sumCalls++
+	return r.memoryTotal, r.memoryLast7d, r.sumErr
+}
+
 func TestActivityTrackerRefreshesActiveTenantGauge(t *testing.T) {
-	metrics.ActiveTenants7dTotal.Set(0)
-	repo := &activityTenantRepo{count: 3}
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 3, memoryTotal: 8, memoryLast7d: 2}
 	tracker := NewActivityTracker(repo, nil)
 
 	tracker.RecordMemoryActivity("tenant-a", time.Now())
@@ -60,17 +84,24 @@ func TestActivityTrackerRefreshesActiveTenantGauge(t *testing.T) {
 	if got := activeTenantGaugeValue(t); got != 3 {
 		t.Fatalf("active tenant gauge = %v, want 3", got)
 	}
+	if got := activeMemoryGaugeValue(t); got != 8 {
+		t.Fatalf("active memory gauge = %v, want 8", got)
+	}
+	if got := activeMemory7dGaugeValue(t); got != 2 {
+		t.Fatalf("active memory 7d gauge = %v, want 2", got)
+	}
 	repo.mu.Lock()
 	touchCalls := repo.touchCalls
 	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
 	repo.mu.Unlock()
-	if touchCalls != 1 || countCalls != 1 {
-		t.Fatalf("calls = touch:%d count:%d, want 1/1", touchCalls, countCalls)
+	if touchCalls != 1 || countCalls != 1 || sumCalls != 1 {
+		t.Fatalf("calls = touch:%d count:%d sum:%d, want 1/1/1", touchCalls, countCalls, sumCalls)
 	}
 }
 
 func TestActivityTrackerSuppressesTouchFailure(t *testing.T) {
-	metrics.ActiveTenants7dTotal.Set(0)
+	resetActivityGauges()
 	repo := &activityTenantRepo{touchErr: errors.New("fk failure"), count: 7}
 	tracker := NewActivityTracker(repo, nil)
 
@@ -88,8 +119,8 @@ func TestActivityTrackerSuppressesTouchFailure(t *testing.T) {
 }
 
 func TestActivityTrackerRetriesMetricRefreshAfterCountFailure(t *testing.T) {
-	metrics.ActiveTenants7dTotal.Set(0)
-	repo := &activityTenantRepo{count: 5, countErr: errors.New("transient count failure")}
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 5, memoryTotal: 10, memoryLast7d: 4, countErr: errors.New("transient count failure")}
 	tracker := NewActivityTracker(repo, nil)
 	tracker.ttl = time.Hour
 
@@ -108,35 +139,135 @@ func TestActivityTrackerRetriesMetricRefreshAfterCountFailure(t *testing.T) {
 	if got := activeTenantGaugeValue(t); got != 5 {
 		t.Fatalf("active tenant gauge = %v, want 5", got)
 	}
+	if got := activeMemoryGaugeValue(t); got != 10 {
+		t.Fatalf("active memory gauge = %v, want 10", got)
+	}
 	repo.mu.Lock()
 	touchCalls := repo.touchCalls
 	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
 	repo.mu.Unlock()
-	if touchCalls != 2 || countCalls != 2 {
-		t.Fatalf("calls = touch:%d count:%d, want 2/2", touchCalls, countCalls)
+	if touchCalls != 2 || countCalls != 2 || sumCalls != 1 {
+		t.Fatalf("calls = touch:%d count:%d sum:%d, want 2/2/1", touchCalls, countCalls, sumCalls)
 	}
 }
 
 func TestActivityTrackerDebouncesMetricRefresh(t *testing.T) {
-	metrics.ActiveTenants7dTotal.Set(0)
-	repo := &activityTenantRepo{count: 4}
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 4, memoryTotal: 12, memoryLast7d: 6}
 	tracker := NewActivityTracker(repo, nil)
 	tracker.ttl = time.Hour
 
 	tracker.RecordMemoryActivity("tenant-a", time.Now())
 	repo.count = 9
+	repo.memoryTotal = 99
 	tracker.RecordMemoryActivity("tenant-a", time.Now())
 
 	if got := activeTenantGaugeValue(t); got != 4 {
 		t.Fatalf("active tenant gauge = %v, want 4", got)
 	}
+	if got := activeMemoryGaugeValue(t); got != 12 {
+		t.Fatalf("active memory gauge = %v, want 12", got)
+	}
 	repo.mu.Lock()
 	touchCalls := repo.touchCalls
 	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
 	repo.mu.Unlock()
-	if touchCalls != 2 || countCalls != 1 {
-		t.Fatalf("calls = touch:%d count:%d, want 2/1", touchCalls, countCalls)
+	if touchCalls != 2 || countCalls != 1 || sumCalls != 1 {
+		t.Fatalf("calls = touch:%d count:%d sum:%d, want 2/1/1", touchCalls, countCalls, sumCalls)
 	}
+}
+
+func TestActivityTrackerRecordsMemoryStatsAndRefreshesGauges(t *testing.T) {
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 2, memoryTotal: 14, memoryLast7d: 5}
+	tracker := NewActivityTracker(repo, nil)
+
+	tracker.RecordMemoryStats(context.Background(), "tenant-a", time.Now(), 7, 3, time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 2 {
+		t.Fatalf("active tenant gauge = %v, want 2", got)
+	}
+	if got := activeMemoryGaugeValue(t); got != 14 {
+		t.Fatalf("active memory gauge = %v, want 14", got)
+	}
+	if got := activeMemory7dGaugeValue(t); got != 5 {
+		t.Fatalf("active memory 7d gauge = %v, want 5", got)
+	}
+	repo.mu.Lock()
+	upsertCalls := repo.upsertCalls
+	lastStatsTotal := repo.lastStatsTotal
+	lastStatsLast7d := repo.lastStatsLast7d
+	repo.mu.Unlock()
+	if upsertCalls != 1 || lastStatsTotal != 7 || lastStatsLast7d != 3 {
+		t.Fatalf("stats upsert = calls:%d total:%d last7d:%d, want 1/7/3", upsertCalls, lastStatsTotal, lastStatsLast7d)
+	}
+}
+
+func TestActivityTrackerDebouncesAggregateRefreshButNotStatsUpsert(t *testing.T) {
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 1, memoryTotal: 20, memoryLast7d: 8}
+	tracker := NewActivityTracker(repo, nil)
+	tracker.ttl = time.Hour
+
+	tracker.RecordMemoryStats(context.Background(), "tenant-a", time.Now(), 20, 8, time.Now())
+	repo.memoryTotal = 30
+	tracker.RecordMemoryStats(context.Background(), "tenant-a", time.Now(), 30, 9, time.Now())
+
+	if got := activeMemoryGaugeValue(t); got != 20 {
+		t.Fatalf("active memory gauge = %v, want 20", got)
+	}
+	repo.mu.Lock()
+	upsertCalls := repo.upsertCalls
+	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
+	repo.mu.Unlock()
+	if upsertCalls != 2 || countCalls != 1 || sumCalls != 1 {
+		t.Fatalf("calls = upsert:%d count:%d sum:%d, want 2/1/1", upsertCalls, countCalls, sumCalls)
+	}
+}
+
+func TestActivityTrackerLeavesGaugesUnchangedOnAggregateSumFailure(t *testing.T) {
+	resetActivityGauges()
+	metrics.ActiveTenants7dTotal.Set(9)
+	metrics.ActiveMemoryTotal.Set(30)
+	metrics.ActiveMemory7dTotal.Set(11)
+	repo := &activityTenantRepo{
+		count:        4,
+		memoryTotal:  40,
+		memoryLast7d: 12,
+		sumErr:       errors.New("sum failed"),
+	}
+	tracker := NewActivityTracker(repo, nil)
+	tracker.ttl = time.Hour
+
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 9 {
+		t.Fatalf("active tenant gauge = %v, want 9", got)
+	}
+	if got := activeMemoryGaugeValue(t); got != 30 {
+		t.Fatalf("active memory gauge = %v, want 30", got)
+	}
+
+	repo.mu.Lock()
+	repo.sumErr = nil
+	repo.mu.Unlock()
+	tracker.RecordMemoryActivity("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 4 {
+		t.Fatalf("active tenant gauge after retry = %v, want 4", got)
+	}
+	if got := activeMemoryGaugeValue(t); got != 40 {
+		t.Fatalf("active memory gauge after retry = %v, want 40", got)
+	}
+}
+
+func resetActivityGauges() {
+	metrics.ActiveTenants7dTotal.Set(0)
+	metrics.ActiveMemoryTotal.Set(0)
+	metrics.ActiveMemory7dTotal.Set(0)
 }
 
 func activeTenantGaugeValue(t *testing.T) float64 {
@@ -145,6 +276,32 @@ func activeTenantGaugeValue(t *testing.T) float64 {
 	var pb dto.Metric
 	if err := metrics.ActiveTenants7dTotal.Write(&pb); err != nil {
 		t.Fatalf("write active tenant gauge: %v", err)
+	}
+	if pb.Gauge == nil {
+		return 0
+	}
+	return pb.Gauge.GetValue()
+}
+
+func activeMemoryGaugeValue(t *testing.T) float64 {
+	t.Helper()
+
+	var pb dto.Metric
+	if err := metrics.ActiveMemoryTotal.Write(&pb); err != nil {
+		t.Fatalf("write active memory gauge: %v", err)
+	}
+	if pb.Gauge == nil {
+		return 0
+	}
+	return pb.Gauge.GetValue()
+}
+
+func activeMemory7dGaugeValue(t *testing.T) float64 {
+	t.Helper()
+
+	var pb dto.Metric
+	if err := metrics.ActiveMemory7dTotal.Write(&pb); err != nil {
+		t.Fatalf("write active memory 7d gauge: %v", err)
 	}
 	if pb.Gauge == nil {
 		return 0

--- a/server/internal/service/activity_test.go
+++ b/server/internal/service/activity_test.go
@@ -179,6 +179,29 @@ func TestActivityTrackerDebouncesMetricRefresh(t *testing.T) {
 	}
 }
 
+func TestActivityTrackerRecordMemoryActivityOnlyDoesNotRefresh(t *testing.T) {
+	resetActivityGauges()
+	repo := &activityTenantRepo{count: 4, memoryTotal: 12, memoryLast7d: 6}
+	tracker := NewActivityTracker(repo, nil)
+
+	tracker.RecordMemoryActivityOnly("tenant-a", time.Now())
+
+	if got := activeTenantGaugeValue(t); got != 0 {
+		t.Fatalf("active tenant gauge = %v, want 0", got)
+	}
+	if got := activeMemoryGaugeValue(t); got != 0 {
+		t.Fatalf("active memory gauge = %v, want 0", got)
+	}
+	repo.mu.Lock()
+	touchCalls := repo.touchCalls
+	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
+	repo.mu.Unlock()
+	if touchCalls != 1 || countCalls != 0 || sumCalls != 0 {
+		t.Fatalf("calls = touch:%d count:%d sum:%d, want 1/0/0", touchCalls, countCalls, sumCalls)
+	}
+}
+
 func TestActivityTrackerRecordsMemoryStatsAndRefreshesGauges(t *testing.T) {
 	resetActivityGauges()
 	repo := &activityTenantRepo{count: 2, memoryTotal: 14, memoryLast7d: 5}

--- a/server/internal/service/tenant_test.go
+++ b/server/internal/service/tenant_test.go
@@ -386,8 +386,16 @@ func (m *mockTenantRepo) TouchActivity(ctx context.Context, tenantID string, at 
 	return nil
 }
 
+func (m *mockTenantRepo) UpsertMemoryStats(ctx context.Context, tenantID string, activityAt time.Time, total, last7d int64, observedAt time.Time) error {
+	return nil
+}
+
 func (m *mockTenantRepo) CountActiveTenantsSince(ctx context.Context, since time.Time) (int64, error) {
 	return 0, nil
+}
+
+func (m *mockTenantRepo) SumActiveMemoryStats(ctx context.Context) (int64, int64, error) {
+	return 0, 0, nil
 }
 
 type mockPool struct {

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -260,8 +260,7 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 			if i == len(chunks)-1 {
 				w.recordMemoryStats(taskCtx, task.TenantID, memRepo)
 			} else {
-				// recordActivity uses context.Background internally per the best-effort contract.
-				w.recordActivity(task.TenantID)
+				w.recordActivityOnly(task.TenantID)
 			}
 			doneChunks = i + 1
 		}
@@ -337,7 +336,11 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 				clusterID = "default"
 			}
 			metrics.MemoryChangesTotal.WithLabelValues(clusterID).Add(float64(len(memories)))
-			w.recordMemoryStats(taskCtx, task.TenantID, memRepo)
+			if batchIdx == totalBatches-1 {
+				w.recordMemoryStats(taskCtx, task.TenantID, memRepo)
+			} else {
+				w.recordActivityOnly(task.TenantID)
+			}
 			batchIdx++
 			doneChunks = batchIdx
 		}
@@ -364,6 +367,13 @@ func (w *UploadWorker) recordActivity(tenantID string) {
 		return
 	}
 	w.activity.RecordMemoryActivity(tenantID, time.Now().UTC())
+}
+
+func (w *UploadWorker) recordActivityOnly(tenantID string) {
+	if w == nil || w.activity == nil {
+		return
+	}
+	w.activity.RecordMemoryActivityOnly(tenantID, time.Now().UTC())
 }
 
 func (w *UploadWorker) recordMemoryStats(ctx context.Context, tenantID string, memRepo repository.MemoryRepo) {

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -257,8 +257,12 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 			if err != nil {
 				return w.failTask(ctx, task, fmt.Errorf("ingest session chunk: %w", err), logger)
 			}
-			// recordActivity uses context.Background internally per the best-effort contract.
-			w.recordActivity(task.TenantID)
+			if i == len(chunks)-1 {
+				w.recordMemoryStats(taskCtx, task.TenantID, memRepo)
+			} else {
+				// recordActivity uses context.Background internally per the best-effort contract.
+				w.recordActivity(task.TenantID)
+			}
 			doneChunks = i + 1
 		}
 
@@ -333,12 +337,7 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 				clusterID = "default"
 			}
 			metrics.MemoryChangesTotal.WithLabelValues(clusterID).Add(float64(len(memories)))
-			if total, last7d, err := memRepo.CountStats(taskCtx); err == nil {
-				metrics.ActiveMemoryTotal.WithLabelValues(clusterID).Set(float64(total))
-				metrics.ActiveMemory7dTotal.WithLabelValues(clusterID).Set(float64(last7d))
-			}
-			// recordActivity uses context.Background internally per the best-effort contract.
-			w.recordActivity(task.TenantID)
+			w.recordMemoryStats(taskCtx, task.TenantID, memRepo)
 			batchIdx++
 			doneChunks = batchIdx
 		}
@@ -365,6 +364,25 @@ func (w *UploadWorker) recordActivity(tenantID string) {
 		return
 	}
 	w.activity.RecordMemoryActivity(tenantID, time.Now().UTC())
+}
+
+func (w *UploadWorker) recordMemoryStats(ctx context.Context, tenantID string, memRepo repository.MemoryRepo) {
+	if w == nil || w.activity == nil || memRepo == nil {
+		return
+	}
+
+	observedAt := time.Now().UTC()
+	total, last7d, err := memRepo.CountStats(ctx)
+	if err != nil {
+		logger := w.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("upload memory stats skipped: count stats failed", "tenant_id", tenantID, "err", err)
+		w.recordActivity(tenantID)
+		return
+	}
+	w.activity.RecordMemoryStats(ctx, tenantID, observedAt, total, last7d, observedAt)
 }
 
 // failTask marks task as failed and cleans up the file.

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -268,6 +268,22 @@ func TestUploadWorkerRecordActivity(t *testing.T) {
 	}
 }
 
+func TestUploadWorkerRecordActivityOnlyDoesNotRefresh(t *testing.T) {
+	repo := &activityTenantRepo{count: 1}
+	worker := &UploadWorker{activity: NewActivityTracker(repo, nil)}
+
+	worker.recordActivityOnly("tenant-a")
+
+	repo.mu.Lock()
+	touchCalls := repo.touchCalls
+	countCalls := repo.countCalls
+	sumCalls := repo.sumCalls
+	repo.mu.Unlock()
+	if touchCalls != 1 || countCalls != 0 || sumCalls != 0 {
+		t.Fatalf("calls = touch:%d count:%d sum:%d, want 1/0/0", touchCalls, countCalls, sumCalls)
+	}
+}
+
 type uploadMemoryStatsRepo struct {
 	memoryRepoMock
 	total  int64

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"errors"
 	"testing"
 )
 
@@ -263,6 +265,51 @@ func TestUploadWorkerRecordActivity(t *testing.T) {
 	repo.mu.Unlock()
 	if touchCalls != 1 || countCalls != 1 {
 		t.Fatalf("calls = touch:%d count:%d, want 1/1", touchCalls, countCalls)
+	}
+}
+
+type uploadMemoryStatsRepo struct {
+	memoryRepoMock
+	total  int64
+	last7d int64
+	err    error
+}
+
+func (r *uploadMemoryStatsRepo) CountStats(context.Context) (int64, int64, error) {
+	return r.total, r.last7d, r.err
+}
+
+func TestUploadWorkerRecordMemoryStats(t *testing.T) {
+	repo := &activityTenantRepo{count: 1, memoryTotal: 7, memoryLast7d: 3}
+	worker := &UploadWorker{activity: NewActivityTracker(repo, nil)}
+	memRepo := &uploadMemoryStatsRepo{total: 7, last7d: 3}
+
+	worker.recordMemoryStats(context.Background(), "tenant-a", memRepo)
+
+	repo.mu.Lock()
+	upsertCalls := repo.upsertCalls
+	touchCalls := repo.touchCalls
+	statsTotal := repo.lastStatsTotal
+	statsLast7d := repo.lastStatsLast7d
+	repo.mu.Unlock()
+	if upsertCalls != 1 || touchCalls != 0 || statsTotal != 7 || statsLast7d != 3 {
+		t.Fatalf("calls = upsert:%d touch:%d stats:%d/%d, want 1/0/7/3", upsertCalls, touchCalls, statsTotal, statsLast7d)
+	}
+}
+
+func TestUploadWorkerRecordMemoryStatsFallsBackToActivity(t *testing.T) {
+	repo := &activityTenantRepo{count: 1}
+	worker := &UploadWorker{activity: NewActivityTracker(repo, nil)}
+	memRepo := &uploadMemoryStatsRepo{err: errors.New("count failed")}
+
+	worker.recordMemoryStats(context.Background(), "tenant-a", memRepo)
+
+	repo.mu.Lock()
+	upsertCalls := repo.upsertCalls
+	touchCalls := repo.touchCalls
+	repo.mu.Unlock()
+	if upsertCalls != 0 || touchCalls != 1 {
+		t.Fatalf("calls = upsert:%d touch:%d, want 0/1", upsertCalls, touchCalls)
 	}
 }
 

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -25,8 +25,11 @@ CREATE TABLE IF NOT EXISTS tenants (
 );
 
 CREATE TABLE IF NOT EXISTS tenant_activity (
-  tenant_id        VARCHAR(36) NOT NULL PRIMARY KEY,
-  last_activity_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  tenant_id                  VARCHAR(36) NOT NULL PRIMARY KEY,
+  last_activity_at           TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  active_memory_total        BIGINT      NOT NULL DEFAULT 0,
+  active_memory_7d_total     BIGINT      NOT NULL DEFAULT 0,
+  memory_stats_observed_at   TIMESTAMP   NULL,
   CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id),
   INDEX idx_tenant_activity_last_activity (last_activity_at)
 );

--- a/server/schema_db9.sql
+++ b/server/schema_db9.sql
@@ -45,8 +45,11 @@ CREATE INDEX IF NOT EXISTS idx_tenant_status ON tenants(status);
 CREATE INDEX IF NOT EXISTS idx_tenant_provider ON tenants(provider);
 
 CREATE TABLE IF NOT EXISTS tenant_activity (
-    tenant_id        VARCHAR(36) PRIMARY KEY,
-    last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    tenant_id                  VARCHAR(36) PRIMARY KEY,
+    last_activity_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active_memory_total        BIGINT      NOT NULL DEFAULT 0,
+    active_memory_7d_total     BIGINT      NOT NULL DEFAULT 0,
+    memory_stats_observed_at   TIMESTAMPTZ NULL,
     CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id)
 );
 CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);

--- a/server/schema_pg.sql
+++ b/server/schema_pg.sql
@@ -27,8 +27,11 @@ CREATE INDEX IF NOT EXISTS idx_tenant_status ON tenants(status);
 CREATE INDEX IF NOT EXISTS idx_tenant_provider ON tenants(provider);
 
 CREATE TABLE IF NOT EXISTS tenant_activity (
-    tenant_id        VARCHAR(36) PRIMARY KEY,
-    last_activity_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    tenant_id                  VARCHAR(36) PRIMARY KEY,
+    last_activity_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active_memory_total        BIGINT      NOT NULL DEFAULT 0,
+    active_memory_7d_total     BIGINT      NOT NULL DEFAULT 0,
+    memory_stats_observed_at   TIMESTAMPTZ NULL,
     CONSTRAINT fk_tenant_activity FOREIGN KEY (tenant_id) REFERENCES tenants(id)
 );
 CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);


### PR DESCRIPTION
## Summary

- Replace `mnemo_active_memory_total{cluster_id=...}` and `mnemo_active_memory_7d_total{cluster_id=...}` with unlabeled server-level gauges.
- Store per-tenant memory count snapshots in `tenant_activity` and aggregate active tenants through `ActivityTracker`.
- Preserve `mnemo_memory_changes_total{cluster_id=...}` and move the proposal to `docs/design/issue-305-active-memory-metrics-proposal.md`.

Fixes #305

## Validation

- `go test ./internal/handler ./internal/service`
- `make test`
- `make vet`
- `git diff --check`
- `make test-integration` skipped integration DB because `MNEMO_TEST_DSN` / `MNEMO_DSN` was not set.

## Rollout

Apply the control-plane schema migration before deploying the server change, then update dashboards and alerts to remove active-memory `cluster_id` filters.