### PR TITLE
fix(codex-plugin): support renamed hooks feature flag

### DIFF
--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Persistent memory for Codex. Run $mem9:setup once, then mem9 recalls before prompts and saves recent turns on stop.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -47,7 +47,7 @@ codex plugin marketplace add mem9-ai/mem9
    $mem9:store
    ```
 
-You do not need to enable hooks manually first. `$mem9:setup` inspects the saved profiles, enables `codex_hooks`, and installs the managed hooks.
+You do not need to enable hooks manually first. `$mem9:setup` inspects the saved profiles, enables the Codex hooks feature, and installs the managed hooks. Codex `0.129.0+` uses `hooks = true`; Codex `0.122.0` through `0.128.x` uses `codex_hooks = true`.
 
 ## Where Files Are Stored
 
@@ -89,7 +89,7 @@ What it does:
 - inspects the current runtime, profiles, and scope config
 - lets you create a new mem9 API key or reuse an existing global profile
 - applies either user scope or project scope
-- repairs `codex_hooks`, `$CODEX_HOME/hooks.json`, and the managed hook shims
+- repairs the Codex hooks feature flag, `$CODEX_HOME/hooks.json`, and the managed hook shims
 - keeps API key entry out of the Codex TUI
 
 Project scope keeps profile and timeout overrides.

--- a/codex-plugin/package.json
+++ b/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/codex-plugin",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Persistent memory for Codex with setup-driven hooks, prompt recall, and stop-time save.",
   "type": "module",
   "license": "Apache-2.0",

--- a/codex-plugin/skills/setup/SKILL.md
+++ b/codex-plugin/skills/setup/SKILL.md
@@ -151,7 +151,8 @@ Common flags:
 Most mem9 plugin releases take effect after a Codex restart. Migration releases may ask for `$mem9:setup` once after restart.
 
 `scope apply` and `scope clear` install or repair the managed mem9 runtime in `$CODEX_HOME`.
-They enable `codex_hooks`, repair `$CODEX_HOME/hooks.json`, install stable shims in `$CODEX_HOME/mem9/hooks/`, and write install metadata to `$CODEX_HOME/mem9/install.json`.
+They enable the Codex hooks feature, repair `$CODEX_HOME/hooks.json`, install stable shims in `$CODEX_HOME/mem9/hooks/`, and write install metadata to `$CODEX_HOME/mem9/install.json`.
+Codex `0.129.0+` uses `hooks = true`; Codex `0.122.0` through `0.128.x` uses `codex_hooks = true`.
 
 Do not ask the user to paste API keys into the Codex TUI.
 Prefer `MEM9_API_KEY` plus a trusted-shell `profile save-key` command.

--- a/codex-plugin/skills/setup/scripts/setup.mjs
+++ b/codex-plugin/skills/setup/scripts/setup.mjs
@@ -2,6 +2,9 @@
 // @ts-nocheck
 
 import {
+  execFileSync,
+} from "node:child_process";
+import {
   accessSync,
   constants,
   copyFileSync,
@@ -41,6 +44,14 @@ const DEFAULT_INSTALL_METADATA = {
   pluginName: "mem9",
   shimVersion: 1,
 };
+const CODEX_HOOKS_CANONICAL_RENAME_VERSION = {
+  major: 0,
+  minor: 129,
+  patch: 0,
+};
+const HOOKS_FEATURE_KEY = "hooks";
+const LEGACY_HOOKS_FEATURE_KEY = "codex_hooks";
+const HOOKS_FEATURE_KEYS = [HOOKS_FEATURE_KEY, LEGACY_HOOKS_FEATURE_KEY];
 const MEM9_EVENTS = ["SessionStart", "UserPromptSubmit", "Stop"];
 const HOOK_TEMPLATE_KEYS = {
   sessionStartCommand: "__MEM9_SESSION_START_COMMAND__",
@@ -90,6 +101,89 @@ function parseIntegerArg(flag, value) {
   }
 
   return parsed;
+}
+
+function parseSemver(value) {
+  const match = normalizeString(value).match(/(?:^|[^0-9])v?(\d+)\.(\d+)\.(\d+)(?:[^0-9]|$)/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number.parseInt(match[1], 10),
+    minor: Number.parseInt(match[2], 10),
+    patch: Number.parseInt(match[3], 10),
+  };
+}
+
+function compareSemver(left, right) {
+  if (!left || !right) {
+    return null;
+  }
+
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] > right[key]) {
+      return 1;
+    }
+    if (left[key] < right[key]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function detectCodexVersion(options = {}) {
+  const explicitVersion = normalizeString(options.codexVersion);
+  if (explicitVersion) {
+    return {
+      version: explicitVersion,
+      source: "test",
+    };
+  }
+
+  const execFile = options.execFileSync ?? execFileSync;
+  if (typeof execFile !== "function") {
+    return {
+      version: "",
+      source: "unavailable",
+    };
+  }
+
+  try {
+    const output = execFile("codex", ["--version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1000,
+    });
+    const detectedVersion = normalizeString(output);
+    if (detectedVersion) {
+      return {
+        version: detectedVersion,
+        source: "codex-cli",
+      };
+    }
+  } catch {}
+
+  return {
+    version: "",
+    source: "unavailable",
+  };
+}
+
+function selectHooksFeatureKey(options = {}) {
+  const detected = detectCodexVersion(options);
+  const parsed = parseSemver(detected.version);
+  const comparison = compareSemver(parsed, CODEX_HOOKS_CANONICAL_RENAME_VERSION);
+  const key = comparison != null && comparison >= 0
+    ? HOOKS_FEATURE_KEY
+    : LEGACY_HOOKS_FEATURE_KEY;
+
+  return {
+    key,
+    codexVersion: parsed ? detected.version : "",
+    source: detected.source,
+  };
 }
 
 function parseUpdateCheckMode(value) {
@@ -745,9 +839,11 @@ function stripTomlLineComment(line) {
   return text;
 }
 
-function parseFeaturesCodexHooksEnabled(configTomlText = "") {
+function parseFeaturesHooksState(configTomlText = "") {
   const lines = String(configTomlText ?? "").split(/\r?\n/);
   let inFeatures = false;
+  /** @type {{ key: string, enabled: boolean }[]} */
+  const features = [];
 
   for (const line of lines) {
     const normalized = stripTomlLineComment(line).trim();
@@ -761,13 +857,21 @@ function parseFeaturesCodexHooksEnabled(configTomlText = "") {
       continue;
     }
 
-    const match = normalized.match(/^codex_hooks\s*=\s*(true|false)$/i);
+    const match = normalized.match(/^(hooks|codex_hooks)\s*=\s*(true|false)$/i);
     if (match) {
-      return match[1].toLowerCase() === "true";
+      features.push({
+        key: match[1].toLowerCase(),
+        enabled: match[2].toLowerCase() === "true",
+      });
     }
   }
 
-  return false;
+  const enabledKey = features.find((feature) => feature.enabled)?.key ?? "";
+
+  return {
+    enabled: Boolean(enabledKey),
+    key: enabledKey || features[0]?.key || "",
+  };
 }
 
 function inspectJsonFile(filePath, fallback, fsOps = {}) {
@@ -1267,7 +1371,10 @@ export function mergeMem9Hooks(existingHooks, mem9Hooks) {
   return next;
 }
 
-export function applyCodexHooksPatch(sourceText = "") {
+export function applyCodexHooksPatch(sourceText = "", options = {}) {
+  const targetKey = HOOKS_FEATURE_KEYS.includes(normalizeString(options.featureKey))
+    ? normalizeString(options.featureKey)
+    : LEGACY_HOOKS_FEATURE_KEY;
   const text = String(sourceText ?? "");
   const eol = text.includes("\r\n") ? "\r\n" : "\n";
   const lines = text ? text.split(/\r?\n/) : [];
@@ -1300,31 +1407,35 @@ export function applyCodexHooksPatch(sourceText = "") {
     if (lines.length > 0) {
       lines.push("");
     }
-    lines.push("[features]", "codex_hooks = true");
+    lines.push("[features]", `${targetKey} = true`);
     return `${lines.join(eol)}${eol}`;
   }
 
   const before = lines.slice(0, sectionStart + 1);
   const inside = lines.slice(sectionStart + 1, sectionEnd);
   const after = lines.slice(sectionEnd);
-  let seenCodexHooks = false;
+  let seenTargetKey = false;
   const normalizedInside = [];
 
   for (const line of inside) {
-    if (/^\s*codex_hooks\s*=/.test(line)) {
-      if (seenCodexHooks) {
+    const match = line.match(/^\s*(hooks|codex_hooks)\s*=/);
+    if (match) {
+      if (match[1] !== targetKey) {
         continue;
       }
-      seenCodexHooks = true;
-      normalizedInside.push("codex_hooks = true");
+      if (seenTargetKey) {
+        continue;
+      }
+      seenTargetKey = true;
+      normalizedInside.push(`${targetKey} = true`);
       continue;
     }
 
     normalizedInside.push(line);
   }
 
-  if (!seenCodexHooks) {
-    normalizedInside.unshift("codex_hooks = true");
+  if (!seenTargetKey) {
+    normalizedInside.unshift(`${targetKey} = true`);
   }
 
   const rebuilt = [
@@ -1528,6 +1639,18 @@ function resolveCommandContext(args = {}, options = {}) {
   };
 }
 
+function resolveHooksFeature(options = {}) {
+  return options.hooksFeatureKey
+    ? {
+        key: HOOKS_FEATURE_KEYS.includes(normalizeString(options.hooksFeatureKey))
+          ? normalizeString(options.hooksFeatureKey)
+          : LEGACY_HOOKS_FEATURE_KEY,
+        codexVersion: "",
+        source: "configured",
+      }
+    : selectHooksFeatureKey(options);
+}
+
 function emitMachineSummary(summary, context, stdout) {
   stdout?.write?.(`${JSON.stringify(summary)}\n`);
 }
@@ -1621,6 +1744,15 @@ function prepareManagedRuntimeRepair(context, noteInvalidJson, options = {}) {
 }
 
 function applyManagedRuntimeRepair(context, prepared, options = {}) {
+  const existingHooksFeature = parseFeaturesHooksState(prepared.existingConfigToml);
+  const detectedHooksFeature = resolveHooksFeature(options);
+  const hooksFeature = detectedHooksFeature.source !== "unavailable"
+    ? detectedHooksFeature
+    : existingHooksFeature.enabled
+    ? {
+        key: existingHooksFeature.key,
+      }
+    : detectedHooksFeature;
   installHookShims(
     options.hookShimSourceDir ?? HOOK_SHIM_SOURCE_DIR,
     context.globalPaths.hooksDir,
@@ -1633,7 +1765,9 @@ function applyManagedRuntimeRepair(context, prepared, options = {}) {
   );
   writeTextFile(
     context.globalPaths.configTomlPath,
-    applyCodexHooksPatch(prepared.existingConfigToml),
+    applyCodexHooksPatch(prepared.existingConfigToml, {
+      featureKey: hooksFeature.key,
+    }),
     context.fsOps,
   );
   writeJsonFile(
@@ -1728,6 +1862,8 @@ export function inspectSetup(argv = process.argv.slice(2), options = {}) {
     "",
     context.fsOps,
   );
+  const hooksFeatureState = parseFeaturesHooksState(hooksTomlText);
+  const preferredHooksFeature = resolveHooksFeature(options);
   const hooksJson = inspectJsonFile(
     context.globalPaths.hooksPath,
     { hooks: {} },
@@ -1801,7 +1937,11 @@ export function inspectSetup(argv = process.argv.slice(2), options = {}) {
       effectiveLegacyPausedSource: runtimeState.effectiveLegacyPausedSource,
     },
     plugin: {
-      hooksFeatureEnabled: parseFeaturesCodexHooksEnabled(hooksTomlText),
+      hooksFeatureEnabled: hooksFeatureState.enabled,
+      hooksFeatureKey: hooksFeatureState.key,
+      preferredHooksFeatureKey: preferredHooksFeature.key,
+      codexVersion: preferredHooksFeature.codexVersion,
+      codexVersionSource: preferredHooksFeature.source,
       hooksInstalled: hooksJson.state === "valid"
         && detectManagedHooksInstalled(hooksJson.value),
       hookShimsInstalled: detectHookShimsInstalled(

--- a/codex-plugin/tests/plugin-files.test.mjs
+++ b/codex-plugin/tests/plugin-files.test.mjs
@@ -12,11 +12,11 @@ test("plugin manifest exposes mem9 setup skill and basic metadata", () => {
   );
 
   assert.equal(manifest.name, "mem9");
-  assert.equal(manifest.version, "0.2.0");
+  assert.equal(manifest.version, "0.2.2");
   assert.equal(manifest.skills, "./skills/");
   assert.equal(typeof manifest.description, "string");
   assert.match(manifest.description, /\$mem9:setup/);
-  assert.equal(packageManifest.version, "0.2.0");
+  assert.equal(packageManifest.version, "0.2.2");
   assert.equal(packageManifest.version, manifest.version);
   assert.equal(packageManifest.engines.node, ">=22");
   assert.equal(packageManifest.files.includes("lib/"), true);

--- a/codex-plugin/tests/setup.test.mjs
+++ b/codex-plugin/tests/setup.test.mjs
@@ -228,7 +228,7 @@ test("assertNodeVersion rejects runtimes below Node 22", () => {
   );
 });
 
-test("applyCodexHooksPatch enables codex hooks without removing existing feature keys", () => {
+test("applyCodexHooksPatch enables legacy codex hooks without removing existing feature keys", () => {
   const patched = applyCodexHooksPatch([
     "[features]",
     "foo = true",
@@ -242,10 +242,29 @@ test("applyCodexHooksPatch enables codex hooks without removing existing feature
   assert.match(patched, /\[features\]/);
   assert.match(patched, /foo = true/);
   assert.match(patched, /foo = true\ncodex_hooks = true/);
+  assert.doesNotMatch(patched, /^hooks = true$/m);
   assert.match(patched, /\[model\]/);
 });
 
-test("applyCodexHooksPatch inserts codex_hooks directly under features when missing", () => {
+test("applyCodexHooksPatch writes hooks for Codex 0.129+ and removes legacy aliases", () => {
+  const patched = applyCodexHooksPatch([
+    "[features]",
+    "foo = true",
+    "codex_hooks = true",
+    "hooks = false",
+    "",
+  ].join("\n"), {
+    featureKey: "hooks",
+  });
+
+  assert.match(patched, /\[features\]/);
+  assert.match(patched, /foo = true/);
+  assert.match(patched, /foo = true\nhooks = true/);
+  assert.doesNotMatch(patched, /codex_hooks = true/);
+  assert.doesNotMatch(patched, /hooks = false/);
+});
+
+test("applyCodexHooksPatch inserts the selected feature key directly under features when missing", () => {
   const patched = applyCodexHooksPatch([
     "[features]",
     "multi_agent = true",
@@ -262,6 +281,15 @@ test("applyCodexHooksPatch inserts codex_hooks directly under features when miss
     patched,
     /\[features\]\ncodex_hooks = true\nmulti_agent = true\n\n# \[mcp_servers\]/,
   );
+});
+
+test("applyCodexHooksPatch falls back to codex_hooks for unknown feature keys", () => {
+  const patched = applyCodexHooksPatch("[features]\nhooks = true\n", {
+    featureKey: "unknown",
+  });
+
+  assert.match(patched, /\[features\]\ncodex_hooks = true\n/);
+  assert.doesNotMatch(patched, /\nhooks = true\n/);
 });
 
 test("applyCodexHooksPatch handles commented features and next section headers", () => {
@@ -476,6 +504,9 @@ test("inspect reports runtime, plugin, configs, and saved profiles without expos
       codexHome,
       mem9Home,
       hookShimSourceDir: "./bootstrap-hooks",
+      execFileSync() {
+        throw new Error("codex unavailable");
+      },
     });
 
     assert.equal(summary.status, "ok");
@@ -485,6 +516,10 @@ test("inspect reports runtime, plugin, configs, and saved profiles without expos
     assert.deepEqual(summary.runtime.legacyPausedSources, ["global", "project"]);
     assert.equal(summary.runtime.effectiveLegacyPausedSource, "project");
     assert.equal(summary.plugin.hooksFeatureEnabled, true);
+    assert.equal(summary.plugin.hooksFeatureKey, "codex_hooks");
+    assert.equal(summary.plugin.preferredHooksFeatureKey, "codex_hooks");
+    assert.equal(summary.plugin.codexVersion, "");
+    assert.equal(summary.plugin.codexVersionSource, "unavailable");
     assert.equal(summary.plugin.hooksInstalled, true);
     assert.equal(summary.plugin.installMetadataPresent, true);
     assert.equal(summary.globalConfig.summary.profileId, "default");
@@ -602,6 +637,39 @@ test("inspect uses install metadata identity for setup script repair guidance", 
       summary.profiles.manualSaveKeyTemplate,
       /\$\{CODEX_HOME\}\/plugins\/cache\/acme-labs\/mem9-pro\/local\/skills\/setup\/scripts\/setup\.mjs/,
     );
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("inspect recognizes the renamed hooks feature key", () => {
+  const tempRoot = createTempRoot("setup");
+
+  try {
+    const projectRoot = path.join(tempRoot, "project");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const mem9Home = path.join(tempRoot, "mem9-home");
+    mkdirSync(path.join(projectRoot, ".git"), { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(mem9Home, { recursive: true });
+
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      "[features]\nhooks = true\n",
+    );
+
+    const summary = inspectSetup(["inspect"], {
+      cwd: projectRoot,
+      codexHome,
+      mem9Home,
+      codexVersion: "codex 0.129.0",
+    });
+
+    assert.equal(summary.plugin.hooksFeatureEnabled, true);
+    assert.equal(summary.plugin.hooksFeatureKey, "hooks");
+    assert.equal(summary.plugin.preferredHooksFeatureKey, "hooks");
+    assert.equal(summary.plugin.codexVersion, "codex 0.129.0");
+    assert.equal(summary.plugin.codexVersionSource, "test");
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }
@@ -1020,6 +1088,9 @@ test("scope apply user installs global config, hooks, metadata, and repairs lega
         codexHome,
         mem9Home,
         userWritable: true,
+        execFileSync() {
+          throw new Error("codex unavailable");
+        },
         stdout: {
           write(chunk) {
             stdoutText += chunk;
@@ -1092,6 +1163,111 @@ test("scope apply user installs global config, hooks, metadata, and repairs lega
     });
     assert.equal(stdoutText.includes("key-1"), false);
     assert.equal(JSON.stringify(stdoutSummary).includes("key-1"), false);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("scope apply preserves an existing renamed hooks feature key", async () => {
+  const tempRoot = createTempRoot();
+
+  try {
+    const projectRoot = path.join(tempRoot, "project");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const mem9Home = path.join(tempRoot, "mem9-home");
+    mkdirSync(path.join(projectRoot, ".git"), { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(mem9Home, { recursive: true });
+
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      "[features]\nhooks = true\ncodex_hooks = true\n",
+    );
+    writeJson(path.join(mem9Home, ".credentials.json"), {
+      schemaVersion: 1,
+      profiles: {
+        work: {
+          label: "Work",
+          baseUrl: "https://api.mem9.ai",
+          apiKey: "key-1",
+        },
+      },
+    });
+
+    await runSetup(
+      [
+        "scope",
+        "apply",
+        "--scope",
+        "user",
+        "--profile",
+        "work",
+      ],
+      {
+        cwd: projectRoot,
+        codexHome,
+        mem9Home,
+        userWritable: true,
+      },
+    );
+
+    const patchedToml = readFileSync(path.join(codexHome, "config.toml"), "utf8");
+    assert.match(patchedToml, /\[features\]\nhooks = true\n/);
+    assert.doesNotMatch(patchedToml, /codex_hooks = true/);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("scope apply migrates legacy codex_hooks to hooks for Codex 0.129+", async () => {
+  const tempRoot = createTempRoot();
+
+  try {
+    const projectRoot = path.join(tempRoot, "project");
+    const codexHome = path.join(tempRoot, "codex-home");
+    const mem9Home = path.join(tempRoot, "mem9-home");
+    mkdirSync(path.join(projectRoot, ".git"), { recursive: true });
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(mem9Home, { recursive: true });
+
+    writeFileSync(
+      path.join(codexHome, "config.toml"),
+      "[features]\ncodex_hooks = true\nother = true\n",
+    );
+    writeJson(path.join(mem9Home, ".credentials.json"), {
+      schemaVersion: 1,
+      profiles: {
+        work: {
+          label: "Work",
+          baseUrl: "https://api.mem9.ai",
+          apiKey: "key-1",
+        },
+      },
+    });
+
+    await runSetup(
+      [
+        "scope",
+        "apply",
+        "--scope",
+        "user",
+        "--profile",
+        "work",
+      ],
+      {
+        cwd: projectRoot,
+        codexHome,
+        mem9Home,
+        userWritable: true,
+        execFileSync() {
+          return "codex 0.129.0\n";
+        },
+      },
+    );
+
+    const patchedToml = readFileSync(path.join(codexHome, "config.toml"), "utf8");
+    assert.match(patchedToml, /\[features\]\nhooks = true\nother = true\n/);
+    assert.doesNotMatch(patchedToml, /codex_hooks = true/);
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- choose the Codex hooks feature key by detected Codex version
- migrate 0.129+ setups from codex_hooks to hooks
- bump the Codex plugin to 0.2.2

## Testing
- node --test ./tests/*.test.mjs
- pnpm --dir codex-plugin typecheck
- git diff --check