### PR TITLE
Add Space Chain runtime support

### DIFF
--- a/docs/design/space-chain-console-plan.md
+++ b/docs/design/space-chain-console-plan.md
@@ -1,0 +1,125 @@
+# Space Chain Web Console Management Plan
+
+## Summary
+
+Add Space Chain management to `mem9-console-server` and `mem9-console-fe` with
+`mem9/server` as the single source of truth for chain runtime state.
+`mem9-console-server` stores only project/user ownership metadata and one active
+management `chain_` key for proxying mem9/server OpenAPI calls. Nodes,
+bindings, key status, and runtime chain details are always read from or changed
+through mem9/server.
+
+## Key Changes
+
+### mem9/server Contract
+
+- Ensure OpenAPI includes chain management endpoints for create/get/update/delete
+  chain, get-by-key import, replace/list nodes, create/list/disable bindings,
+  and status.
+- Add or keep `GET /v1alpha2/space-chains/by-key`, authorized by
+  `X-API-Key: chain_...`, so console can import an existing chain from only its
+  key.
+- Keep node positions 0-based. Chain nodes include `tenant_id`,
+  `external_space_id`, `display_name`, and `position`.
+- Chain key bindings are never deleted when disabled. Add a `disabled` field that
+  defaults to `0`; when `disabled = 1`, mem9/server must reject that key for
+  memory reads, writes, status-authenticated runtime access, and management
+  calls. Disabled keys remain visible to console.
+- Block disabling the final active `chain_` key so console cannot lose its
+  management credential.
+
+### mem9-console-server
+
+- Add a minimal metadata table, not a node source of truth:
+  - `space_chains`: local ownership mirror with `chain_id` from mem9/server,
+    `project_id`, display `name`, `description`, `created_by_user_id`, one active
+    management `chain_api_key`, soft-delete fields, and timestamps.
+  - Do not store `space_chain_nodes`; node reads and writes always proxy
+    mem9/server.
+  - Do not treat local metadata as runtime truth.
+- Use project-scoped authorization and record `created_by_user_id` from the Auth0
+  user for audit and ownership metadata.
+- Add `mem9client` methods for all mem9/server Space Chain OpenAPI calls.
+- Add console APIs:
+  - `GET /api/space-chains?project_id=...` lists local metadata; live counts may
+    be fetched from mem9/server, not persisted.
+  - `POST /api/space-chains` creates a chain in mem9/server, then stores the
+    returned chain id and first `chain_` key locally.
+  - `POST /api/space-chains/import` validates/imports an existing `chain_` key
+    via the mem9/server by-key endpoint and stores local metadata.
+  - `GET/PATCH/DELETE /api/space-chains/{id}` proxies canonical chain data from
+    mem9/server while preserving local project/user metadata.
+  - `GET/PUT /api/space-chains/{id}/nodes` proxies mem9/server list/replace
+    nodes.
+  - `GET/POST /api/space-chains/{id}/bindings`,
+    `POST /api/space-chains/{id}/bind`, and
+    `PATCH /api/space-chains/{id}/bindings/{bindingID}` proxy mem9/server key
+    management. Disabling a binding sets `disabled = 1`; it does not delete or
+    hide the key. The local management key is updated when needed.
+  - `GET /api/spaces/{id}/delete-impact` checks local chains in the project, then
+    queries mem9/server nodes for each chain and matches by
+    `external_space_id == space.id` or by `tenant_id` in the Space's active keys.
+- Temporary node tenant selection: when adding a Space node, choose the oldest
+  active Space binding ordered by `created_at ASC, id ASC`; add a TODO noting
+  this is a compatibility bridge until Space:key becomes 1:1.
+- Space deletion: preview impacted chains; confirmed delete first calls
+  mem9/server to remove matching nodes from each impacted chain, aborts if any
+  proxy call fails, then soft-deletes Space locally.
+
+### mem9-console-fe
+
+- Add `/console/space-chains` list page and
+  `/console/space-chains/$chainId` detail editor.
+- Sidebar ACTIVITY adds `Space Chain` as a separate item under `Space`.
+- List page supports create empty chain, import existing `chain_` key, edit
+  metadata, open detail, and soft-delete.
+- Detail editor reads nodes and bindings through the console-server proxy on
+  page load/refetch.
+- Node editor:
+  - add only active Spaces that have at least one active key.
+  - prevent duplicate Spaces client-side and rely on backend validation.
+  - reorder with up/down icon buttons.
+  - save nodes with one ordered replace request.
+- Key manager:
+  - list masked `chain_` keys, copy, create new key, bind existing key, and
+    disable key.
+  - show disabled keys with a disabled/inactive state instead of removing them.
+  - prevent disabling the last active key in UI; backend enforces this too.
+- API Keys page shows both Space keys and Space Chain keys with a resource
+  type/owner column.
+- Space delete modal calls delete-impact preview and shows impacted chain names
+  and node positions before final confirmation.
+
+## Test Plan
+
+- mem9-console-server:
+  - repository tests for local metadata CRUD and project/user authorization.
+  - service tests for create/import sync, live node proxying, oldest active Space
+    key selection, duplicate node validation, delete-impact matching,
+    abort-on-node-removal-failure, disabled-key visibility, disabled-key runtime
+    rejection, and last-key disable protection.
+  - handler tests for all new routes and error mappings.
+  - run `make test`.
+- mem9-console-fe:
+  - regenerate client with `pnpm api:generate`.
+  - tests for route helpers, node filtering/reorder helpers, duplicate
+    prevention, combined API key rows, and delete-impact display logic.
+  - run `pnpm test`, `pnpm build`, and `pnpm lint`.
+- Integration smoke:
+  - create chain, import chain, add/reorder nodes, create/bind/disable keys,
+    verify disabled keys remain visible but are rejected by mem9/server runtime
+    access, reload detail page, delete impacted Space, and verify mem9/server
+    nodes changed.
+
+## Assumptions And Defaults
+
+- mem9/server is the single source of truth for nodes, bindings, key status, and
+  runtime chain data.
+- mem9-console-server stores one usable `chain_` key in plain form as the
+  management credential, with logging redaction.
+- mem9-console-server metadata is project-scoped and creator-audited, not
+  creator-private.
+- Imported chains become console-managed; deleting them in console soft-deletes
+  them in mem9/server.
+- Existing imported chains without `external_space_id` can still be matched to
+  Spaces by comparing node `tenant_id` to active Space keys.

--- a/docs/design/space-chain-prd.md
+++ b/docs/design/space-chain-prd.md
@@ -1,0 +1,403 @@
+---
+title: "Space Chain PRD"
+status: draft
+created: 2026-05-13
+---
+
+# Space Chain PRD
+
+## 1. Summary
+
+Space Chain is a first-class open-source mem9/server capability for sharing
+memory through an ordered chain of Spaces. A Space Chain has its own API keys
+with the `chain_` prefix. When a client uses a `chain_` key, mem9/server resolves
+the chain, reads its nodes in order, and searches each underlying Space until a
+high-quality recall result is found. The behavior is intentionally similar to
+JavaScript prototype-chain lookup: search starts at the first node and proceeds
+up the chain only when the earlier nodes do not satisfy the query.
+
+The runtime source of truth lives in mem9/server. mem9-console-server keeps a
+lightweight mirror only for project ownership, UI listing, permission checks,
+and delete-impact confirmation. mem9-console-fe talks only to
+mem9-console-server through the generated console API client.
+
+## 2. Goals
+
+- Let users compose multiple existing Spaces into one ordered recall chain.
+- Let agents use one `chain_` key instead of choosing a single Space key.
+- Preserve predictable chain semantics: earlier Spaces get the first chance to
+  answer.
+- Still allow cross-Space recall when earlier nodes are weak or empty.
+- Keep Space Chain available to open-source mem9/server users without requiring
+  the closed-source console stack.
+- Give console users safe management flows, including duplicate-node prevention
+  and warnings when deleting a Space affects existing chains.
+
+## 3. Non-goals
+
+- Do not solve the existing console issue where one Space can currently have
+  multiple mem9 API keys. This PRD assumes the intended model is effectively
+  Space:API key = 1:1. In V1, node editing may pick one active key.
+- Do not implement arbitrary graph traversal. V1 supports only an ordered linear
+  chain of Spaces.
+- Do not allow Space Chain nodes to point to other Space Chains. Nodes are
+  Spaces only.
+- Do not make mem9-console-server part of the runtime query path.
+
+## 4. Data Model
+
+### 4.1 mem9/server source of truth
+
+mem9/server adds three control-plane tables.
+
+`space_chains`:
+
+| Column | Notes |
+|---|---|
+| `id` | Primary key. |
+| `project_id` | Opaque external project id. mem9/server stores but does not authorize against it. |
+| `name` | Human-readable chain name. |
+| `description` | Optional description. |
+| `created_by_user_id` | Opaque external user id. |
+| `deleted_at` | Soft-delete timestamp. |
+| `deleted_by_user_id` | Opaque external user id for deletion. |
+| `created_at`, `updated_at` | Timestamps. |
+
+`space_chain_bindings`:
+
+| Column | Notes |
+|---|---|
+| `id` | Primary key. |
+| `chain_id` | References `space_chains.id`. |
+| `chain_api_key` | Unique active API key with `chain_` prefix. |
+| `created_by_user_id` | Opaque external user id. |
+| `disabled` | Boolean flag. Defaults to `0`; disabled keys remain visible but cannot be used. |
+| `disabled_at`, `disabled_by_user_id` | Disable metadata. |
+| `created_at` | Timestamp. |
+
+`space_chain_nodes`:
+
+| Column | Notes |
+|---|---|
+| `id` | Primary key. |
+| `chain_id` | References `space_chains.id`. |
+| `tenant_id` | Existing mem9 tenant/API key that identifies the underlying Space at runtime. |
+| `external_space_id` | Opaque console Space id for duplicate prevention and delete-impact lookup. |
+| `display_name` | Optional snapshot for management UI and logs. |
+| `position` | 0-based ordered position. |
+| `created_at`, `updated_at` | Timestamps. |
+
+Required constraints:
+
+- Active `chain_api_key` values are globally unique and always begin with
+  `chain_`.
+- A chain cannot contain duplicate `tenant_id`.
+- A chain cannot contain duplicate `external_space_id` when it is present.
+- A chain node cannot point to another `chain_` key.
+- Chain deletion is soft delete.
+- Key disable is soft disable: disabled bindings stay visible and are rejected by mem9/server.
+
+### 4.2 mem9-console-server mirror
+
+mem9-console-server keeps a lightweight mirror for project-level UX and
+permission checks:
+
+- Mirror `space_chains` linked to console `project_id`.
+- Mirror chain bindings storing `chain_` keys returned by mem9/server.
+- Optional cached node metadata for fast list views and delete-impact previews.
+
+The mirror is not runtime truth. mem9/server remains the source for chain
+resolution, node order, key validity, and chain recall behavior.
+
+## 5. API Requirements
+
+### 5.1 mem9/server management API
+
+mem9/server exposes OpenAPI-documented management endpoints for:
+
+- Create Space Chain and return the first `chain_` key.
+- Get/update/soft-delete a Space Chain.
+- Replace or reorder chain nodes.
+- Create/list/disable chain key bindings.
+- Validate `chain_` key status through the existing status shape.
+
+Creation follows existing provision semantics: the create endpoint can bootstrap
+a new chain and return the initial `chain_` key. Subsequent management calls for
+that chain are authorized by the chain API key itself.
+
+`GET /v1alpha2/status` must accept both normal mem9 keys and `chain_` keys and
+return the existing active/inactive response shape. It should not require clients
+to call a separate status endpoint only for chains.
+
+### 5.2 mem9-console-server API
+
+mem9-console-server exposes project-scoped APIs for:
+
+- List, create, get, update, and soft-delete Space Chains in a project.
+- Create/list/disable chain keys.
+- Read and replace ordered chain nodes.
+- Preview Space deletion impact, including impacted Space Chains and node
+  positions.
+- Confirm Space deletion and propagate node removal to mem9/server.
+
+mem9-console-server owns user, org, and project authorization. It then calls
+mem9/server Space Chain management APIs using the relevant `chain_` key and
+updates its local mirror.
+
+### 5.3 mem9-console-fe API usage
+
+mem9-console-fe must not call mem9/server Space Chain management endpoints
+directly. It should use generated console API client methods after
+mem9-console-server OpenAPI is updated.
+
+## 6. Runtime Behavior
+
+### 6.1 Key resolution
+
+When `X-API-Key` starts with `chain_`, mem9/server resolves it as a Space Chain
+binding instead of a single tenant key.
+
+Resolution failures:
+
+- Unknown or disabled `chain_` key: invalid API key.
+- Deleted chain: invalid API key.
+- Active chain with no active nodes: explicit empty-chain error.
+- Deleted or inactive node tenant: skip only when the node was removed as part
+  of an expected Space deletion; otherwise surface an operational error with
+  enough logging to diagnose stale chain configuration.
+
+### 6.2 Recall order and short-circuiting
+
+For query-based recall:
+
+1. Load active nodes ordered by `position`.
+2. Search node 1 using the existing memory/session recall path.
+3. Add node 1 candidates to the visited candidate set.
+4. If node 1's top fused score is greater than or equal to
+   `MNEMO_CHAIN_RECALL_STOP_SCORE`, stop.
+5. Otherwise continue to node 2, and repeat.
+6. If no node reaches the threshold, all nodes are visited.
+7. Return a final reranked result set built from all visited nodes.
+
+Configuration:
+
+- `MNEMO_CHAIN_RECALL_STOP_SCORE`
+- Default: `0.5`
+
+The final result set must merge facts and raw session results across visited
+nodes. Existing per-node recall behavior, type weighting, session recall, and
+fallback search behavior should be reused rather than reimplemented.
+
+### 6.3 Non-query list behavior
+
+For list operations without a query, a `chain_` key aggregates active nodes in
+chain order. Results should preserve the existing list response shape while
+including chain provenance metadata. Pagination should be deterministic and
+documented by implementation; V1 may use merged timestamp ordering after
+fetching from each node.
+
+### 6.4 Writes through chain keys
+
+Space Chain keys support write behavior so agents can operate with a single key:
+
+- Create memory: write to the first active node.
+- Import/session ingest: write to the first active node.
+- Get/update/delete memory by id: locate the memory by checking nodes in chain
+  order, then operate on the node where the memory exists.
+- Batch delete: apply by locating each id across nodes.
+
+If the chain has no active nodes, all write operations fail with the empty-chain
+error.
+
+### 6.5 Provenance
+
+Results returned through a `chain_` key include provenance metadata per item.
+The field name should be `chain_source` unless implementation discovers a
+stronger local naming convention.
+
+Suggested shape:
+
+```json
+{
+  "chain_source": {
+    "chain_id": "chain-id",
+    "node_position": 1,
+    "tenant_id": "tenant-id",
+    "external_space_id": "console-space-id"
+  }
+}
+```
+
+Provenance appears only for chain responses. Normal single-Space key responses
+must remain unchanged.
+
+## 7. Console UX
+
+### 7.1 Navigation
+
+mem9-console-fe adds a `Space Chain` item under the main Space area. The page is
+project-scoped, matching the existing project Space page.
+
+### 7.2 List and detail page
+
+The Space Chain page supports:
+
+- List chains in the active project.
+- Create chain with name and optional description.
+- Show chain key count and node count.
+- Open a chain detail/editor view.
+- Soft-delete a chain.
+
+### 7.3 Chain editor
+
+The editor supports:
+
+- Add Space nodes from active Spaces in the project.
+- Reorder nodes.
+- Remove nodes.
+- Prevent duplicate Space nodes.
+- Show each node's display name and key status.
+- Save changes as one ordered node replacement.
+
+Current V1 assumption: console Space and mem9 API key are intended to be 1:1.
+If multiple active keys exist for a Space during the transition period, the UI
+may pick one active key explicitly.
+
+### 7.4 Chain key management
+
+The editor supports minimal multi-key management:
+
+- List active chain keys.
+- Create a new chain key.
+- Disable an active chain key without removing it from the visible key list.
+- Mask key values by default, following existing Space key UX.
+
+### 7.5 Space deletion impact
+
+When a user deletes a Space, console must check whether the Space is used in any
+Space Chain.
+
+If no chains are affected, deletion follows the existing Space delete flow.
+
+If chains are affected:
+
+- Show a second confirmation prompt.
+- Include impacted chain names and node positions.
+- Explain that deleting the Space will remove that node from each impacted
+  chain.
+- On confirmation, soft-delete the Space in console, update console mirrors, and
+  call mem9/server to remove the corresponding nodes.
+
+Example copy:
+
+> This Space is used by 2 Space Chains. Deleting it will remove the Space from
+> those chains. Chain recall will skip this Space and continue to the next node.
+
+## 8. Error Handling
+
+Required user-facing errors:
+
+- Empty chain: "Space Chain has no nodes."
+- Duplicate node: "This Space is already in the chain."
+- Disabled chain key: existing invalid key error behavior.
+- Deleted chain: existing invalid key error behavior.
+- Node tenant unavailable: service unavailable with server logs identifying
+  chain id, node position, tenant id, and underlying connection error.
+
+Required logging:
+
+- chain id
+- chain key fingerprint or redacted key marker, never raw key
+- visited node count
+- stop reason: threshold hit, exhausted chain, or error
+- stop score when threshold hit
+- per-node tenant id and position
+
+## 9. Acceptance Criteria
+
+### mem9/server
+
+- Can create a Space Chain and receive a `chain_` key.
+- `chain_` key status returns active/inactive through existing status response.
+- Duplicate nodes are rejected.
+- Empty chain reads and writes return a clear error.
+- Recall visits nodes in order and stops when top score is at least
+  `MNEMO_CHAIN_RECALL_STOP_SCORE`.
+- If no node reaches the threshold, recall searches all nodes and reranks the
+  aggregate candidate set.
+- Returned chain results include `chain_source`.
+- Normal key responses are unchanged.
+- Create/import/session ingest with a `chain_` key writes to the first active
+  node.
+- Get/update/delete by id locates the target node in chain order.
+
+### mem9-console-server
+
+- Users can list only chains mirrored in projects they can access.
+- Chain creation calls mem9/server, persists the mirror, and stores the returned
+  `chain_` key.
+- Node edits reject duplicate Spaces before calling mem9/server.
+- Key create/list/disable flows stay in sync with mem9/server.
+- Space deletion preview returns impacted chains and positions.
+- Confirmed Space deletion removes affected nodes from mem9/server and mirror
+  state.
+
+### mem9-console-fe
+
+- Sidebar includes Space Chain under Space activity.
+- Project Space Chain page lists chains and supports create/delete.
+- Chain editor can add, remove, and reorder unique Space nodes.
+- Chain key UI supports create/list/disable with masked key display and keeps disabled keys visible.
+- Space delete modal shows second confirmation when chains are affected.
+
+## 10. Test Plan
+
+### mem9/server tests
+
+- Unit tests for chain key parsing and binding resolution.
+- Repository tests for `space_chains`, `space_chain_bindings`, and
+  `space_chain_nodes` constraints.
+- Handler tests for chain create/status/node/key management.
+- Recall tests:
+  - first node hits threshold and later nodes are not queried;
+  - first node misses and second node hits;
+  - all nodes miss threshold and all visited candidates rerank together;
+  - facts and sessions can both appear in the final result set;
+  - provenance appears only for chain responses.
+- Write tests:
+  - create writes to first node;
+  - update/delete locates target memory by id;
+  - empty chain write fails.
+
+### mem9-console-server tests
+
+- Service tests for project-scoped chain list authorization.
+- Service tests for create-chain sync and mirror persistence.
+- Duplicate node validation tests.
+- Key create/disable sync tests.
+- Delete-impact preview and confirmed cleanup tests.
+
+### mem9-console-fe tests
+
+- Route/path tests for Space Chain navigation.
+- Pure helper tests for node ordering and duplicate prevention.
+- Component-level smoke coverage for chain editor states where practical.
+
+## 11. Rollout Notes
+
+- Ship mem9/server schema and OpenAPI first.
+- Add console-server mirror and sync APIs after mem9/server management APIs are
+  available.
+- Regenerate mem9-console-fe API client from console-server OpenAPI.
+- Gate console UI with backend capability checks if deployment order can vary.
+- Monitor chain recall latency, visited node count, threshold stop rate, and
+  empty-chain errors.
+
+## 12. Open Questions
+
+- Exact `chain_source` placement: top-level field on each memory/session result
+  or nested under metadata. Default recommendation is a top-level field to avoid
+  mutating user metadata.
+- Exact pagination semantics for non-query chain list. Default recommendation
+  is merged timestamp ordering after per-node fetch.
+- Whether V1 should expose chain-specific metrics in Prometheus or only logs.

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -97,6 +97,7 @@ func main() {
 
 	// Repositories.
 	tenantRepo := repository.NewTenantRepo(cfg.DBBackend, db)
+	spaceChainRepo := repository.NewSpaceChainRepo(cfg.DBBackend, db)
 	var utmRepo repository.UTMRepo
 	if cfg.UTMEnabled {
 		if err := db.QueryRowContext(context.Background(), "SELECT 1 FROM tenant_utm LIMIT 0").Err(); err != nil {
@@ -180,16 +181,17 @@ func main() {
 	if utmRepo != nil {
 		tenantSvc.WithUTMRepo(utmRepo)
 	}
+	spaceChainSvc := service.NewSpaceChainService(spaceChainRepo)
 
 	// Middleware.
 	var tenantMW func(http.Handler) http.Handler
 	var apiKeyMW func(http.Handler) http.Handler
 	if spendLimitAdjuster != nil {
 		tenantMW = middleware.ResolveTenant(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist, middleware.WithSpendLimitAdjuster(spendLimitAdjuster, spendLimitCooldown, autoSpendLimitCfg))
-		apiKeyMW = middleware.ResolveApiKey(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist, middleware.WithSpendLimitAdjuster(spendLimitAdjuster, spendLimitCooldown, autoSpendLimitCfg))
+		apiKeyMW = middleware.ResolveApiKey(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist, middleware.WithSpendLimitAdjuster(spendLimitAdjuster, spendLimitCooldown, autoSpendLimitCfg), middleware.WithSpaceChainRepo(spaceChainRepo))
 	} else {
 		tenantMW = middleware.ResolveTenant(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist)
-		apiKeyMW = middleware.ResolveApiKey(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist)
+		apiKeyMW = middleware.ResolveApiKey(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist, middleware.WithSpaceChainRepo(spaceChainRepo))
 	}
 	rl := middleware.NewRateLimiter(cfg.RateLimit, cfg.RateBurst)
 	defer rl.Stop()
@@ -199,6 +201,7 @@ func main() {
 
 	// Handler.
 	srv := handler.NewServer(tenantSvc, uploadTaskRepo, cfg.UploadDir, embedder, llmClient, cfg.EmbedAutoModel, cfg.FTSEnabled, service.IngestMode(cfg.IngestMode), cfg.DBBackend, logger).
+		WithSpaceChainService(spaceChainSvc, cfg.ChainRecallStopScore).
 		WithMetering(meteringWriter).
 		WithActivityTracker(activityTracker)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	TenantPoolConnectTimeout time.Duration
 	TenantPoolIdleTimeout    time.Duration
 	TenantPoolTotalLimit     int
+	ChainRecallStopScore     float64
 
 	// TiDB Cloud Pool configuration
 	TiDBCloudAPIURL string
@@ -148,6 +149,7 @@ func Load() (*Config, error) {
 		TenantPoolConnectTimeout: envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
 		TenantPoolIdleTimeout:    envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
 		TenantPoolTotalLimit:     envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
+		ChainRecallStopScore:     envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.5),
 		UploadDir:                envOr("MNEMO_UPLOAD_DIR", "./uploads"),
 		FTSEnabled:               envBool("MNEMO_FTS_ENABLED", false),
 		WorkerConcurrency:        envInt("MNEMO_WORKER_CONCURRENCY", 5),
@@ -188,6 +190,9 @@ func Load() (*Config, error) {
 	}
 	if cfg.AutoSpendLimitCooldown <= 0 {
 		return nil, fmt.Errorf("MNEMO_AUTO_SPEND_LIMIT_COOLDOWN must be positive")
+	}
+	if cfg.ChainRecallStopScore < 0 || cfg.ChainRecallStopScore > 1 {
+		return nil, fmt.Errorf("MNEMO_CHAIN_RECALL_STOP_SCORE must be between 0 and 1")
 	}
 
 	return cfg, nil

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -53,6 +53,19 @@ type Memory struct {
 	// RelativeAge is a human-readable recency string (e.g. "3 days ago").
 	// Populated server-side at query time for search results only; never stored.
 	RelativeAge string `json:"relative_age,omitempty"`
+
+	// ChainSource is populated only when the response was produced through a Space Chain.
+	ChainSource *ChainSource `json:"chain_source,omitempty"`
+}
+
+const ChainKeyPrefix = "chain_"
+
+// ChainSource identifies which Space Chain node produced a response item.
+type ChainSource struct {
+	ChainID         string `json:"chain_id"`
+	NodePosition    int    `json:"node_position"`
+	TenantID        string `json:"tenant_id"`
+	ExternalSpaceID string `json:"external_space_id,omitempty"`
 }
 
 type AuthInfo struct {
@@ -62,6 +75,65 @@ type AuthInfo struct {
 	TenantID  string
 	TenantDB  *sql.DB
 	ClusterID string
+
+	// Chain is non-nil when X-API-Key resolved to a Space Chain key.
+	Chain *ChainAuth
+}
+
+func (a *AuthInfo) IsChain() bool {
+	return a != nil && a.Chain != nil
+}
+
+// ChainAuth is request auth material resolved from a chain_ API key.
+type ChainAuth struct {
+	ChainID string
+	APIKey  string
+	Nodes   []ChainAuthNode
+}
+
+// ChainAuthNode is a resolved Space Chain node with an open tenant DB handle.
+type ChainAuthNode struct {
+	SpaceChainNode
+	TenantDB  *sql.DB
+	ClusterID string
+}
+
+// SpaceChain is the control-plane source of truth for an ordered chain of Spaces.
+type SpaceChain struct {
+	ID              string     `json:"id"`
+	ProjectID       string     `json:"project_id,omitempty"`
+	Name            string     `json:"name"`
+	Description     string     `json:"description,omitempty"`
+	CreatedByUserID string     `json:"created_by_user_id,omitempty"`
+	DeletedAt       *time.Time `json:"deleted_at,omitempty"`
+	DeletedByUserID string     `json:"deleted_by_user_id,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+
+	Bindings []SpaceChainBinding `json:"bindings,omitempty"`
+	Nodes    []SpaceChainNode    `json:"nodes,omitempty"`
+}
+
+type SpaceChainBinding struct {
+	ID               string     `json:"id"`
+	ChainID          string     `json:"chain_id"`
+	ChainAPIKey      string     `json:"chain_api_key,omitempty"`
+	CreatedByUserID  string     `json:"created_by_user_id,omitempty"`
+	Disabled         bool       `json:"disabled"`
+	DisabledAt       *time.Time `json:"disabled_at,omitempty"`
+	DisabledByUserID string     `json:"disabled_by_user_id,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+}
+
+type SpaceChainNode struct {
+	ID              string    `json:"id"`
+	ChainID         string    `json:"chain_id"`
+	TenantID        string    `json:"tenant_id"`
+	ExternalSpaceID string    `json:"external_space_id,omitempty"`
+	DisplayName     string    `json:"display_name,omitempty"`
+	Position        int       `json:"position"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // MemoryFilter encapsulates search/list query parameters.

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -1,0 +1,351 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sort"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func (s *Server) firstChainNodeAuth(auth *domain.AuthInfo) (*domain.AuthInfo, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	return chainNodeAuth(auth, auth.Chain.Nodes[0]), nil
+}
+
+func chainNodeAuth(auth *domain.AuthInfo, node domain.ChainAuthNode) *domain.AuthInfo {
+	return &domain.AuthInfo{
+		AgentName: auth.AgentName,
+		TenantID:  node.TenantID,
+		TenantDB:  node.TenantDB,
+		ClusterID: node.ClusterID,
+	}
+}
+
+func chainSource(auth *domain.AuthInfo, node domain.ChainAuthNode) *domain.ChainSource {
+	return &domain.ChainSource{
+		ChainID:         auth.Chain.ChainID,
+		NodePosition:    node.Position,
+		TenantID:        node.TenantID,
+		ExternalSpaceID: node.ExternalSpaceID,
+	}
+}
+
+func applyChainSource(memories []domain.Memory, source *domain.ChainSource) {
+	for i := range memories {
+		memories[i].ChainSource = source
+	}
+}
+
+func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, 0, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	requestLimit := filter.Limit
+	requestOffset := filter.Offset
+	if requestLimit <= 0 {
+		requestLimit = 20
+	}
+
+	visited := make([]domain.Memory, 0, requestLimit*len(auth.Chain.Nodes))
+	visitedNodes := 0
+	stopReason := "exhausted_chain"
+	stopScore := 0.0
+	queryMode := filter.Query != ""
+
+	perNodeFilter := filter
+	perNodeFilter.Offset = 0
+	perNodeFilter.Limit = requestLimit + requestOffset
+	if perNodeFilter.Limit <= 0 {
+		perNodeFilter.Limit = requestLimit
+	}
+
+	for _, node := range auth.Chain.Nodes {
+		nodeAuth := chainNodeAuth(auth, node)
+		svc := s.resolveServices(nodeAuth)
+		visitedNodes++
+
+		var (
+			memories []domain.Memory
+			err      error
+		)
+		switch {
+		case perNodeFilter.Query != "" && perNodeFilter.MemoryType == "":
+			memories, _, err = s.defaultConfidenceRecallSearch(ctx, nodeAuth, svc, perNodeFilter)
+		case perNodeFilter.Query != "" && (perNodeFilter.MemoryType == string(domain.TypeSession) ||
+			perNodeFilter.MemoryType == string(domain.TypePinned) ||
+			perNodeFilter.MemoryType == string(domain.TypeInsight)):
+			memories, _, err = s.singlePoolConfidenceRecallSearch(ctx, nodeAuth, svc, perNodeFilter)
+		case perNodeFilter.MemoryType != string(domain.TypeSession):
+			memories, _, err = svc.memory.Search(ctx, perNodeFilter)
+		}
+		if err != nil {
+			return nil, 0, err
+		}
+		applyChainSource(memories, chainSource(auth, node))
+		visited = append(visited, memories...)
+
+		if queryMode {
+			nodeTopScore := topChainScore(memories)
+			if nodeTopScore > stopScore {
+				stopScore = nodeTopScore
+			}
+			if nodeTopScore >= s.chainRecallStopScore {
+				stopReason = "threshold_hit"
+				break
+			}
+		}
+	}
+
+	totalBeforePage := len(uniqueChainMemories(visited))
+	memories := finalizeChainMemories(visited, requestLimit, requestOffset, queryMode)
+	slog.InfoContext(ctx, "space chain recall",
+		"chain_id", auth.Chain.ChainID,
+		"visited_node_count", visitedNodes,
+		"stop_reason", stopReason,
+		"stop_score", stopScore,
+		"threshold", s.chainRecallStopScore,
+		"returned", len(memories),
+	)
+	return memories, totalBeforePage, nil
+}
+
+func (s *Server) getChainMemory(ctx context.Context, auth *domain.AuthInfo, id string) (*domain.Memory, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	for _, node := range auth.Chain.Nodes {
+		nodeAuth := chainNodeAuth(auth, node)
+		svc := s.resolveServices(nodeAuth)
+		mem, err := svc.memory.Get(ctx, id)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		mem.ChainSource = chainSource(auth, node)
+		return mem, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (s *Server) updateChainMemory(ctx context.Context, auth *domain.AuthInfo, id string, req updateMemoryRequest, ifMatch int) (*domain.Memory, *domain.AuthInfo, resolvedSvc, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, nil, resolvedSvc{}, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	for _, node := range auth.Chain.Nodes {
+		nodeAuth := chainNodeAuth(auth, node)
+		svc := s.resolveServices(nodeAuth)
+		if _, err := svc.memory.Get(ctx, id); err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				continue
+			}
+			return nil, nil, resolvedSvc{}, err
+		}
+		mem, err := svc.memory.Update(ctx, auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
+		if err != nil {
+			return nil, nil, resolvedSvc{}, err
+		}
+		mem.ChainSource = chainSource(auth, node)
+		return mem, nodeAuth, svc, nil
+	}
+	return nil, nil, resolvedSvc{}, domain.ErrNotFound
+}
+
+func (s *Server) deleteChainMemory(ctx context.Context, auth *domain.AuthInfo, id string) (*domain.AuthInfo, resolvedSvc, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, resolvedSvc{}, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	for _, node := range auth.Chain.Nodes {
+		nodeAuth := chainNodeAuth(auth, node)
+		svc := s.resolveServices(nodeAuth)
+		if _, err := svc.memory.Get(ctx, id); err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				continue
+			}
+			return nil, resolvedSvc{}, err
+		}
+		if err := svc.memory.Delete(ctx, id, auth.AgentName); err != nil {
+			return nil, resolvedSvc{}, err
+		}
+		return nodeAuth, svc, nil
+	}
+	return nil, resolvedSvc{}, domain.ErrNotFound
+}
+
+func (s *Server) batchDeleteChainMemories(ctx context.Context, auth *domain.AuthInfo, ids []string) (int64, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return 0, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	if len(ids) == 0 {
+		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
+	}
+	if len(ids) > 1000 {
+		return 0, &domain.ValidationError{Field: "ids", Message: "too many (max 1000)"}
+	}
+	seen := make(map[string]struct{}, len(ids))
+	unique := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		unique = append(unique, id)
+	}
+	if len(unique) == 0 {
+		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
+	}
+	var deleted int64
+	for _, id := range unique {
+		for _, node := range auth.Chain.Nodes {
+			nodeAuth := chainNodeAuth(auth, node)
+			svc := s.resolveServices(nodeAuth)
+			if _, err := svc.memory.Get(ctx, id); err != nil {
+				if errors.Is(err, domain.ErrNotFound) {
+					continue
+				}
+				return deleted, err
+			}
+			if err := svc.memory.Delete(ctx, id, auth.AgentName); err != nil {
+				return deleted, err
+			}
+			go s.afterSuccessfulWrite(nodeAuth, svc, 0)
+			deleted++
+			break
+		}
+	}
+	return deleted, nil
+}
+
+func topChainScore(memories []domain.Memory) float64 {
+	var best float64
+	for _, mem := range memories {
+		score := chainRankScore(mem)
+		if score > best {
+			best = score
+		}
+	}
+	return best
+}
+
+func chainRankScore(mem domain.Memory) float64 {
+	if mem.Score != nil {
+		return *mem.Score
+	}
+	if mem.Confidence != nil {
+		return float64(*mem.Confidence) / 100
+	}
+	return 0
+}
+
+func finalizeChainMemories(memories []domain.Memory, limit, offset int, queryMode bool) []domain.Memory {
+	memories = uniqueChainMemories(memories)
+	if queryMode {
+		sort.SliceStable(memories, func(i, j int) bool {
+			left := chainRankScore(memories[i])
+			right := chainRankScore(memories[j])
+			if left != right {
+				return left > right
+			}
+			return memories[i].UpdatedAt.After(memories[j].UpdatedAt)
+		})
+	} else {
+		sort.SliceStable(memories, func(i, j int) bool {
+			if !memories[i].UpdatedAt.Equal(memories[j].UpdatedAt) {
+				return memories[i].UpdatedAt.After(memories[j].UpdatedAt)
+			}
+			if memories[i].ChainSource != nil && memories[j].ChainSource != nil && memories[i].ChainSource.NodePosition != memories[j].ChainSource.NodePosition {
+				return memories[i].ChainSource.NodePosition < memories[j].ChainSource.NodePosition
+			}
+			return memories[i].ID < memories[j].ID
+		})
+	}
+	if offset >= len(memories) {
+		return []domain.Memory{}
+	}
+	end := offset + limit
+	if limit <= 0 || end > len(memories) {
+		end = len(memories)
+	}
+	return memories[offset:end]
+}
+
+func uniqueChainMemories(memories []domain.Memory) []domain.Memory {
+	out := make([]domain.Memory, 0, len(memories))
+	seen := make(map[string]struct{}, len(memories))
+	for _, mem := range memories {
+		key := mem.ID
+		if mem.ChainSource != nil {
+			key = mem.ChainSource.TenantID + ":" + mem.ID
+		}
+		if key == "" {
+			key = mem.Content
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, mem)
+	}
+	return out
+}
+
+func (s *Server) listChainSessionMessages(ctx context.Context, auth *domain.AuthInfo, sessionIDs []string, limitPerSession int) ([]sessionMessageResponse, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	messages := []sessionMessageResponse{}
+	for _, node := range auth.Chain.Nodes {
+		nodeAuth := chainNodeAuth(auth, node)
+		svc := s.resolveServices(nodeAuth)
+		sessions, err := svc.session.ListBySessionIDs(ctx, sessionIDs, limitPerSession)
+		if err != nil {
+			return nil, err
+		}
+		source := chainSource(auth, node)
+		for _, sess := range sessions {
+			messages = append(messages, sessionMessageResponse{
+				ID:          sess.ID,
+				SessionID:   sess.SessionID,
+				AgentID:     sess.AgentID,
+				Source:      sess.Source,
+				Seq:         sess.Seq,
+				Role:        sess.Role,
+				Content:     sess.Content,
+				ContentType: sess.ContentType,
+				Tags:        sess.Tags,
+				State:       sess.State,
+				CreatedAt:   sess.CreatedAt,
+				UpdatedAt:   sess.UpdatedAt,
+				ChainSource: source,
+			})
+		}
+	}
+	sortChainSessionMessages(messages)
+	return messages, nil
+}
+
+func sortChainSessionMessages(messages []sessionMessageResponse) {
+	sort.SliceStable(messages, func(i, j int) bool {
+		if messages[i].SessionID != messages[j].SessionID {
+			return messages[i].SessionID < messages[j].SessionID
+		}
+		if !messages[i].CreatedAt.Equal(messages[j].CreatedAt) {
+			return messages[i].CreatedAt.Before(messages[j].CreatedAt)
+		}
+		if messages[i].Seq != messages[j].Seq {
+			return messages[i].Seq < messages[j].Seq
+		}
+		if messages[i].ChainSource != nil && messages[j].ChainSource != nil && messages[i].ChainSource.NodePosition != messages[j].ChainSource.NodePosition {
+			return messages[i].ChainSource.NodePosition < messages[j].ChainSource.NodePosition
+		}
+		return messages[i].ID < messages[j].ID
+	})
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -28,20 +28,22 @@ import (
 
 // Server holds the HTTP handlers and their dependencies.
 type Server struct {
-	tenant      *service.TenantService
-	uploadTasks repository.UploadTaskRepo
-	uploadDir   string
-	embedder    *embed.Embedder
-	llmClient   *llm.Client
-	autoModel   string
-	ftsEnabled  bool
-	ingestMode  service.IngestMode
-	dbBackend   string
-	logger      *slog.Logger
-	metering    metering.Writer
-	activity    *service.ActivityTracker
-	startedAt   time.Time
-	svcCache    sync.Map
+	tenant               *service.TenantService
+	chains               *service.SpaceChainService
+	uploadTasks          repository.UploadTaskRepo
+	uploadDir            string
+	embedder             *embed.Embedder
+	llmClient            *llm.Client
+	autoModel            string
+	ftsEnabled           bool
+	ingestMode           service.IngestMode
+	dbBackend            string
+	logger               *slog.Logger
+	metering             metering.Writer
+	activity             *service.ActivityTracker
+	startedAt            time.Time
+	svcCache             sync.Map
+	chainRecallStopScore float64
 }
 
 // NewServer creates a new HTTP handler server.
@@ -58,18 +60,27 @@ func NewServer(
 	logger *slog.Logger,
 ) *Server {
 	return &Server{
-		tenant:      tenantSvc,
-		uploadTasks: uploadTasks,
-		uploadDir:   uploadDir,
-		embedder:    embedder,
-		llmClient:   llmClient,
-		autoModel:   autoModel,
-		ftsEnabled:  ftsEnabled,
-		ingestMode:  ingestMode,
-		dbBackend:   dbBackend,
-		logger:      logger,
-		startedAt:   time.Now().UTC(),
+		tenant:               tenantSvc,
+		uploadTasks:          uploadTasks,
+		uploadDir:            uploadDir,
+		embedder:             embedder,
+		llmClient:            llmClient,
+		autoModel:            autoModel,
+		ftsEnabled:           ftsEnabled,
+		ingestMode:           ingestMode,
+		dbBackend:            dbBackend,
+		logger:               logger,
+		startedAt:            time.Now().UTC(),
+		chainRecallStopScore: 0.5,
 	}
+}
+
+func (s *Server) WithSpaceChainService(chains *service.SpaceChainService, stopScore float64) *Server {
+	s.chains = chains
+	if stopScore >= 0 {
+		s.chainRecallStopScore = stopScore
+	}
+	return s
 }
 
 func (s *Server) WithMetering(writer metering.Writer) *Server {
@@ -177,6 +188,19 @@ func (s *Server) Router(
 
 	// Key status validates X-API-Key against control-plane state only.
 	r.Get("/v1alpha2/status", s.getKeyStatus)
+
+	r.Post("/v1alpha2/space-chains", s.createSpaceChain)
+	r.Get("/v1alpha2/space-chains/by-key", s.getSpaceChainByKey)
+	r.Route("/v1alpha2/space-chains/{chainID}", func(r chi.Router) {
+		r.Get("/", s.getSpaceChain)
+		r.Patch("/", s.updateSpaceChain)
+		r.Delete("/", s.deleteSpaceChain)
+		r.Get("/nodes", s.listSpaceChainNodes)
+		r.Put("/nodes", s.replaceSpaceChainNodes)
+		r.Get("/bindings", s.listSpaceChainBindings)
+		r.Post("/bindings", s.createSpaceChainBinding)
+		r.Patch("/bindings/{bindingID}", s.disableSpaceChainBinding)
+	})
 
 	// Tenant-scoped routes — tenantMW resolves {tenantID} to DB connection.
 	r.Route("/v1alpha1/mem9s/{tenantID}", func(r chi.Router) {

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -48,6 +48,18 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	auth := authInfo(r)
+	var writeChainSource *domain.ChainSource
+	if auth.IsChain() {
+		var err error
+		if len(auth.Chain.Nodes) > 0 {
+			writeChainSource = chainSource(auth, auth.Chain.Nodes[0])
+		}
+		auth, err = s.firstChainNodeAuth(auth)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+	}
 	svc := s.resolveServices(auth)
 
 	agentID := req.AgentID
@@ -153,6 +165,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			s.handleError(r.Context(), w, err)
 			return
 		}
+		mem.ChainSource = writeChainSource
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusCreated, mem)
 		return
@@ -325,23 +338,26 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		Limit:      limit,
 		Offset:     offset,
 	}
-	svc := s.resolveServices(auth)
-
 	onlySession := filter.MemoryType == string(domain.TypeSession)
 
 	var memories []domain.Memory
 	var total int
 	var err error
 
-	switch {
-	case filter.Query != "" && filter.MemoryType == "":
-		memories, total, err = s.defaultConfidenceRecallSearch(r.Context(), auth, svc, filter)
-	case filter.Query != "" && (filter.MemoryType == string(domain.TypeSession) ||
-		filter.MemoryType == string(domain.TypePinned) ||
-		filter.MemoryType == string(domain.TypeInsight)):
-		memories, total, err = s.singlePoolConfidenceRecallSearch(r.Context(), auth, svc, filter)
-	case !onlySession:
-		memories, total, err = svc.memory.Search(r.Context(), filter)
+	if auth.IsChain() {
+		memories, total, err = s.listChainMemories(r.Context(), auth, filter)
+	} else {
+		svc := s.resolveServices(auth)
+		switch {
+		case filter.Query != "" && filter.MemoryType == "":
+			memories, total, err = s.defaultConfidenceRecallSearch(r.Context(), auth, svc, filter)
+		case filter.Query != "" && (filter.MemoryType == string(domain.TypeSession) ||
+			filter.MemoryType == string(domain.TypePinned) ||
+			filter.MemoryType == string(domain.TypeInsight)):
+			memories, total, err = s.singlePoolConfidenceRecallSearch(r.Context(), auth, svc, filter)
+		case !onlySession:
+			memories, total, err = svc.memory.Search(r.Context(), filter)
+		}
 	}
 
 	if err != nil {
@@ -447,9 +463,19 @@ func trimUniqueMemories(mems []domain.Memory, limit int) []domain.Memory {
 
 func (s *Server) getMemory(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
-	svc := s.resolveServices(auth)
 	id := chi.URLParam(r, "id")
 
+	if auth.IsChain() {
+		mem, err := s.getChainMemory(r.Context(), auth, id)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		respond(w, http.StatusOK, mem)
+		return
+	}
+
+	svc := s.resolveServices(auth)
 	mem, err := svc.memory.Get(r.Context(), id)
 	if err != nil {
 		s.handleError(r.Context(), w, err)
@@ -474,7 +500,6 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	auth := authInfo(r)
-	svc := s.resolveServices(auth)
 	id := chi.URLParam(r, "id")
 
 	var ifMatch int
@@ -482,6 +507,19 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		ifMatch, _ = strconv.Atoi(h)
 	}
 
+	if auth.IsChain() {
+		mem, nodeAuth, nodeSvc, err := s.updateChainMemory(r.Context(), auth, id, req, ifMatch)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		go s.afterSuccessfulWrite(nodeAuth, nodeSvc, 1)
+		w.Header().Set("ETag", strconv.Itoa(mem.Version))
+		respond(w, http.StatusOK, mem)
+		return
+	}
+
+	svc := s.resolveServices(auth)
 	mem, err := svc.memory.Update(r.Context(), auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
 	if err != nil {
 		s.handleError(r.Context(), w, err)
@@ -495,9 +533,20 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
-	svc := s.resolveServices(auth)
 	id := chi.URLParam(r, "id")
 
+	if auth.IsChain() {
+		nodeAuth, nodeSvc, err := s.deleteChainMemory(r.Context(), auth, id)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		go s.afterSuccessfulWrite(nodeAuth, nodeSvc, 0)
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	svc := s.resolveServices(auth)
 	if err := svc.memory.Delete(r.Context(), id, auth.AgentName); err != nil {
 		s.handleError(r.Context(), w, err)
 		return
@@ -519,6 +568,18 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	auth := authInfo(r)
+	if auth.IsChain() {
+		deleted, err := s.batchDeleteChainMemories(r.Context(), auth, req.IDs)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		respond(w, http.StatusOK, map[string]any{
+			"deleted": deleted,
+		})
+		return
+	}
+
 	svc := s.resolveServices(auth)
 	deleted, err := svc.memory.BulkDelete(r.Context(), req.IDs, auth.AgentName)
 	if err != nil {
@@ -544,12 +605,25 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	auth := authInfo(r)
+	var writeChainSource *domain.ChainSource
+	if auth.IsChain() {
+		var err error
+		if len(auth.Chain.Nodes) > 0 {
+			writeChainSource = chainSource(auth, auth.Chain.Nodes[0])
+		}
+		auth, err = s.firstChainNodeAuth(auth)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+	}
 	svc := s.resolveServices(auth)
 	memories, err := svc.memory.BulkCreate(r.Context(), auth.AgentName, req.Memories)
 	if err != nil {
 		s.handleError(r.Context(), w, err)
 		return
 	}
+	applyChainSource(memories, writeChainSource)
 
 	go s.afterSuccessfulIngest(auth, svc, int64(len(memories)))
 	respond(w, http.StatusCreated, map[string]any{
@@ -560,6 +634,15 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) bootstrapMemories(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
+	if auth.IsChain() {
+		var err error
+		auth, err = s.firstChainNodeAuth(auth)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+	}
+
 	svc := s.resolveServices(auth)
 
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
@@ -596,23 +679,23 @@ const (
 )
 
 type sessionMessageResponse struct {
-	ID          string             `json:"id"`
-	SessionID   string             `json:"session_id,omitempty"`
-	AgentID     string             `json:"agent_id,omitempty"`
-	Source      string             `json:"source,omitempty"`
-	Seq         int                `json:"seq"`
-	Role        string             `json:"role"`
-	Content     string             `json:"content"`
-	ContentType string             `json:"content_type"`
-	Tags        []string           `json:"tags"`
-	State       domain.MemoryState `json:"state"`
-	CreatedAt   time.Time          `json:"created_at"`
-	UpdatedAt   time.Time          `json:"updated_at"`
+	ID          string              `json:"id"`
+	SessionID   string              `json:"session_id,omitempty"`
+	AgentID     string              `json:"agent_id,omitempty"`
+	Source      string              `json:"source,omitempty"`
+	Seq         int                 `json:"seq"`
+	Role        string              `json:"role"`
+	Content     string              `json:"content"`
+	ContentType string              `json:"content_type"`
+	Tags        []string            `json:"tags"`
+	State       domain.MemoryState  `json:"state"`
+	CreatedAt   time.Time           `json:"created_at"`
+	UpdatedAt   time.Time           `json:"updated_at"`
+	ChainSource *domain.ChainSource `json:"chain_source,omitempty"`
 }
 
 func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
-	svc := s.resolveServices(auth)
 
 	rawIDs := r.URL.Query()["session_id"]
 	if len(rawIDs) == 0 {
@@ -643,6 +726,20 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 		}
 	}
 
+	if auth.IsChain() {
+		messages, err := s.listChainSessionMessages(r.Context(), auth, sessionIDs, limitPerSession)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		respond(w, http.StatusOK, map[string]any{
+			"messages":          messages,
+			"limit_per_session": limitPerSession,
+		})
+		return
+	}
+
+	svc := s.resolveServices(auth)
 	sessions, err := svc.session.ListBySessionIDs(r.Context(), sessionIDs, limitPerSession)
 	if err != nil {
 		s.handleError(r.Context(), w, err)

--- a/server/internal/handler/space_chain.go
+++ b/server/internal/handler/space_chain.go
@@ -1,0 +1,207 @@
+package handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/middleware"
+	"github.com/qiffang/mnemos/server/internal/service"
+)
+
+type createSpaceChainRequest = service.CreateSpaceChainRequest
+
+type updateSpaceChainRequest = service.UpdateSpaceChainRequest
+
+type replaceSpaceChainNodesRequest = service.ReplaceSpaceChainNodesRequest
+
+type createSpaceChainBindingRequest = service.CreateSpaceChainBindingRequest
+
+type deleteSpaceChainRequest struct {
+	DeletedByUserID string `json:"deleted_by_user_id,omitempty"`
+}
+
+type disableSpaceChainBindingRequest struct {
+	Disabled         bool   `json:"disabled"`
+	DisabledByUserID string `json:"disabled_by_user_id,omitempty"`
+}
+
+func (s *Server) createSpaceChain(w http.ResponseWriter, r *http.Request) {
+	if s.chains == nil {
+		respondError(w, http.StatusServiceUnavailable, "space chain service unavailable")
+		return
+	}
+	var req createSpaceChainRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	result, err := s.chains.Create(r.Context(), req)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusCreated, result)
+}
+
+func (s *Server) getSpaceChain(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChain(w, r)
+	if !ok {
+		return
+	}
+	respond(w, http.StatusOK, chain)
+}
+
+func (s *Server) getSpaceChainByKey(w http.ResponseWriter, r *http.Request) {
+	if s.chains == nil {
+		respondError(w, http.StatusServiceUnavailable, "space chain service unavailable")
+		return
+	}
+	apiKey := strings.TrimSpace(r.Header.Get(middleware.APIKeyHeader))
+	if apiKey == "" || !strings.HasPrefix(apiKey, domain.ChainKeyPrefix) {
+		respondError(w, http.StatusUnauthorized, "missing or malformed X-API-Key")
+		return
+	}
+	chain, err := s.chains.GetByKey(r.Context(), apiKey)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, chain)
+}
+
+func (s *Server) updateSpaceChain(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+		return
+	}
+	var req updateSpaceChainRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	chain, err := s.chains.Update(r.Context(), chi.URLParam(r, "chainID"), req)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, chain)
+}
+
+func (s *Server) deleteSpaceChain(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+		return
+	}
+	var req deleteSpaceChainRequest
+	if r.Body != nil {
+		_ = decode(r, &req)
+	}
+	if err := s.chains.Delete(r.Context(), chi.URLParam(r, "chainID"), req.DeletedByUserID); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) listSpaceChainNodes(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChain(w, r)
+	if !ok {
+		return
+	}
+	respond(w, http.StatusOK, map[string]any{"nodes": chain.Nodes})
+}
+
+func (s *Server) replaceSpaceChainNodes(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+		return
+	}
+	var req replaceSpaceChainNodesRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	nodes, err := s.chains.ReplaceNodes(r.Context(), chi.URLParam(r, "chainID"), req)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, map[string]any{"nodes": nodes})
+}
+
+func (s *Server) listSpaceChainBindings(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChain(w, r)
+	if !ok {
+		return
+	}
+	respond(w, http.StatusOK, map[string]any{"bindings": chain.Bindings})
+}
+
+func (s *Server) createSpaceChainBinding(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+		return
+	}
+	var req createSpaceChainBindingRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	binding, err := s.chains.CreateBinding(r.Context(), chi.URLParam(r, "chainID"), req)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusCreated, binding)
+}
+
+func (s *Server) disableSpaceChainBinding(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+		return
+	}
+	var req disableSpaceChainBindingRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	if !req.Disabled {
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "disabled", Message: "must be true"})
+		return
+	}
+	if err := s.chains.DisableBinding(r.Context(), chi.URLParam(r, "chainID"), chi.URLParam(r, "bindingID"), req.DisabledByUserID); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) authorizeSpaceChain(w http.ResponseWriter, r *http.Request) (*domain.SpaceChain, bool) {
+	if s.chains == nil {
+		respondError(w, http.StatusServiceUnavailable, "space chain service unavailable")
+		return nil, false
+	}
+	apiKey := strings.TrimSpace(r.Header.Get(middleware.APIKeyHeader))
+	if apiKey == "" || !strings.HasPrefix(apiKey, domain.ChainKeyPrefix) {
+		respondError(w, http.StatusUnauthorized, "missing or malformed X-API-Key")
+		return nil, false
+	}
+	chain, err := s.chains.Authorize(r.Context(), chi.URLParam(r, "chainID"), apiKey)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrNotFound):
+			respondError(w, http.StatusNotFound, "space chain not found")
+		case errors.Is(err, domain.ErrValidation):
+			s.handleError(r.Context(), w, err)
+		default:
+			logger := s.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			logger.ErrorContext(r.Context(), "space chain auth failed", "err", err)
+			respondError(w, http.StatusInternalServerError, "space chain auth failed")
+		}
+		return nil, false
+	}
+	return chain, true
+}

--- a/server/internal/handler/space_chain.go
+++ b/server/internal/handler/space_chain.go
@@ -49,7 +49,7 @@ func (s *Server) createSpaceChain(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) getSpaceChain(w http.ResponseWriter, r *http.Request) {
-	chain, ok := s.authorizeSpaceChain(w, r)
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
 	if !ok {
 		return
 	}
@@ -75,7 +75,7 @@ func (s *Server) getSpaceChainByKey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) updateSpaceChain(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+	if _, ok := s.authorizeSpaceChainManagement(w, r); !ok {
 		return
 	}
 	var req updateSpaceChainRequest
@@ -92,7 +92,7 @@ func (s *Server) updateSpaceChain(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) deleteSpaceChain(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+	if _, ok := s.authorizeSpaceChainManagement(w, r); !ok {
 		return
 	}
 	var req deleteSpaceChainRequest
@@ -107,7 +107,7 @@ func (s *Server) deleteSpaceChain(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) listSpaceChainNodes(w http.ResponseWriter, r *http.Request) {
-	chain, ok := s.authorizeSpaceChain(w, r)
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
 	if !ok {
 		return
 	}
@@ -115,7 +115,7 @@ func (s *Server) listSpaceChainNodes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) replaceSpaceChainNodes(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+	if _, ok := s.authorizeSpaceChainManagement(w, r); !ok {
 		return
 	}
 	var req replaceSpaceChainNodesRequest
@@ -132,7 +132,7 @@ func (s *Server) replaceSpaceChainNodes(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) listSpaceChainBindings(w http.ResponseWriter, r *http.Request) {
-	chain, ok := s.authorizeSpaceChain(w, r)
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
 	if !ok {
 		return
 	}
@@ -140,7 +140,7 @@ func (s *Server) listSpaceChainBindings(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *Server) createSpaceChainBinding(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+	if _, ok := s.authorizeSpaceChainManagement(w, r); !ok {
 		return
 	}
 	var req createSpaceChainBindingRequest
@@ -157,7 +157,7 @@ func (s *Server) createSpaceChainBinding(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) disableSpaceChainBinding(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.authorizeSpaceChain(w, r); !ok {
+	if _, ok := s.authorizeSpaceChainManagement(w, r); !ok {
 		return
 	}
 	var req disableSpaceChainBindingRequest
@@ -176,7 +176,7 @@ func (s *Server) disableSpaceChainBinding(w http.ResponseWriter, r *http.Request
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s *Server) authorizeSpaceChain(w http.ResponseWriter, r *http.Request) (*domain.SpaceChain, bool) {
+func (s *Server) authorizeSpaceChainManagement(w http.ResponseWriter, r *http.Request) (*domain.SpaceChain, bool) {
 	if s.chains == nil {
 		respondError(w, http.StatusServiceUnavailable, "space chain service unavailable")
 		return nil, false
@@ -186,7 +186,7 @@ func (s *Server) authorizeSpaceChain(w http.ResponseWriter, r *http.Request) (*d
 		respondError(w, http.StatusUnauthorized, "missing or malformed X-API-Key")
 		return nil, false
 	}
-	chain, err := s.chains.Authorize(r.Context(), chi.URLParam(r, "chainID"), apiKey)
+	chain, err := s.chains.AuthorizeManagement(r.Context(), chi.URLParam(r, "chainID"), apiKey)
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrNotFound):
@@ -198,7 +198,7 @@ func (s *Server) authorizeSpaceChain(w http.ResponseWriter, r *http.Request) (*d
 			if logger == nil {
 				logger = slog.Default()
 			}
-			logger.ErrorContext(r.Context(), "space chain auth failed", "err", err)
+			logger.ErrorContext(r.Context(), "space chain management auth failed", "err", err)
 			respondError(w, http.StatusInternalServerError, "space chain auth failed")
 		}
 		return nil, false

--- a/server/internal/handler/task.go
+++ b/server/internal/handler/task.go
@@ -65,6 +65,14 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 	defer file.Close()
 
 	auth := authInfo(r)
+	if auth.IsChain() {
+		var err error
+		auth, err = s.firstChainNodeAuth(auth)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+	}
 
 	agentID := r.FormValue("agent_id")
 	if agentID == "" {
@@ -183,6 +191,14 @@ func (s *Server) createTask(w http.ResponseWriter, r *http.Request) {
 // GET /v1alpha1/mem9s/{tenantID}/imports
 func (s *Server) listTasks(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
+	if auth.IsChain() {
+		var err error
+		auth, err = s.firstChainNodeAuth(auth)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+	}
 	tasks, err := s.uploadTasks.ListByTenant(r.Context(), auth.TenantID)
 	if err != nil {
 		s.handleError(r.Context(), w, err)
@@ -238,6 +254,14 @@ func (s *Server) getTask(w http.ResponseWriter, r *http.Request) {
 
 	// Verify tenant ownership.
 	auth := authInfo(r)
+	if auth.IsChain() {
+		var err error
+		auth, err = s.firstChainNodeAuth(auth)
+		if err != nil {
+			s.handleError(r.Context(), w, err)
+			return
+		}
+	}
 	if task.TenantID != auth.TenantID {
 		s.handleError(r.Context(), w, domain.ErrNotFound)
 		return

--- a/server/internal/handler/tenant.go
+++ b/server/internal/handler/tenant.go
@@ -80,6 +80,30 @@ func (s *Server) getKeyStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasPrefix(apiKey, domain.ChainKeyPrefix) {
+		if s.chains == nil {
+			respondError(w, http.StatusInternalServerError, "auth backend unavailable")
+			return
+		}
+		status, err := s.chains.KeyStatus(r.Context(), apiKey)
+		if err != nil {
+			switch {
+			case errors.Is(err, domain.ErrNotFound):
+				respondError(w, http.StatusNotFound, "key not found")
+			default:
+				logger := s.logger
+				if logger == nil {
+					logger = slog.Default()
+				}
+				logger.ErrorContext(r.Context(), "chain key status lookup failed", "err", err)
+				respondError(w, http.StatusInternalServerError, "auth backend unavailable")
+			}
+			return
+		}
+		respond(w, http.StatusOK, keyStatusResponse{Status: status})
+		return
+	}
+
 	status, err := s.tenant.KeyStatus(r.Context(), apiKey)
 	if err != nil {
 		switch {

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -35,6 +35,7 @@ type authConfig struct {
 	spendLimitAdjuster tenant.SpendLimitAdjuster
 	spendLimitCooldown *SpendLimitCooldown
 	autoSpendLimitCfg  AutoSpendLimitConfig
+	spaceChains        repository.SpaceChainRepo
 }
 
 // AutoSpendLimitConfig controls auto spend-limit adjustment behavior.
@@ -50,6 +51,12 @@ func WithSpendLimitAdjuster(adjuster tenant.SpendLimitAdjuster, cooldown *SpendL
 		c.spendLimitAdjuster = adjuster
 		c.spendLimitCooldown = cooldown
 		c.autoSpendLimitCfg = cfg
+	}
+}
+
+func WithSpaceChainRepo(chains repository.SpaceChainRepo) authOption {
+	return func(c *authConfig) {
+		c.spaceChains = chains
 	}
 }
 
@@ -215,6 +222,94 @@ func ResolveApiKey(
 			apiKey := strings.TrimSpace(r.Header.Get(APIKeyHeader))
 			if apiKey == "" {
 				writeError(w, http.StatusBadRequest, "missing API key")
+				return
+			}
+
+			if strings.HasPrefix(apiKey, domain.ChainKeyPrefix) {
+				if state.spaceChains == nil {
+					writeError(w, http.StatusServiceUnavailable, "space chain auth unavailable")
+					return
+				}
+				chainLookupStart := time.Now()
+				chain, err := state.spaceChains.GetByKey(r.Context(), apiKey)
+				chainLookupDuration := time.Since(chainLookupStart)
+				if err != nil {
+					writeError(w, http.StatusBadRequest, "invalid API key")
+					return
+				}
+				if len(chain.Nodes) == 0 {
+					writeError(w, http.StatusBadRequest, "Space Chain has no nodes.")
+					return
+				}
+
+				info := &domain.AuthInfo{
+					Chain: &domain.ChainAuth{
+						ChainID: chain.ID,
+						APIKey:  apiKey,
+						Nodes:   make([]domain.ChainAuthNode, 0, len(chain.Nodes)),
+					},
+				}
+				if agentID := r.Header.Get(AgentIDHeader); agentID != "" {
+					info.AgentName = agentID
+				}
+
+				var totalPoolDuration time.Duration
+				for _, node := range chain.Nodes {
+					t, err := tenantRepo.GetByID(r.Context(), node.TenantID)
+					if err != nil || t.DeletedAt != nil || t.Status != domain.TenantActive {
+						slog.ErrorContext(r.Context(), "space chain node tenant unavailable",
+							"chain_id", chain.ID,
+							"node_position", node.Position,
+							"tenant_id", node.TenantID,
+							"err", err)
+						writeError(w, http.StatusServiceUnavailable, "chain node tenant unavailable")
+						return
+					}
+
+					decryptedPassword, err := enc.Decrypt(r.Context(), t.DBPassword)
+					if err != nil {
+						writeError(w, http.StatusInternalServerError, "failed to decrypt tenant credentials")
+						return
+					}
+					t.DBPassword = decryptedPassword
+
+					poolStart := time.Now()
+					db, err := pool.Get(r.Context(), t.ID, t.DSNForBackend(pool.Backend()))
+					poolDuration := time.Since(poolStart)
+					totalPoolDuration += poolDuration
+					if err != nil {
+						slog.ErrorContext(r.Context(), "cannot connect to space chain node database",
+							"chain_id", chain.ID,
+							"node_position", node.Position,
+							"tenant_id", t.ID,
+							"cluster_id", t.ClusterID,
+							"duration_ms", poolDuration.Milliseconds(),
+							"classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err),
+							"err", err)
+						if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
+							writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
+							return
+						}
+						writeError(w, http.StatusServiceUnavailable, "chain node tenant unavailable")
+						return
+					}
+					info.Chain.Nodes = append(info.Chain.Nodes, domain.ChainAuthNode{
+						SpaceChainNode: node,
+						TenantDB:       db,
+						ClusterID:      t.ClusterID,
+					})
+				}
+
+				slog.InfoContext(r.Context(), "tenant auth resolved",
+					"auth_mode", "space_chain_key",
+					"chain_id", chain.ID,
+					"nodes", len(info.Chain.Nodes),
+					"chain_lookup_ms", chainLookupDuration.Milliseconds(),
+					"pool_get_ms", totalPoolDuration.Milliseconds(),
+					"total_ms", time.Since(authStart).Milliseconds(),
+				)
+				ctx := context.WithValue(r.Context(), authInfoKey, info)
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 

--- a/server/internal/repository/db9/space_chain.go
+++ b/server/internal/repository/db9/space_chain.go
@@ -1,0 +1,13 @@
+package db9
+
+import (
+	"database/sql"
+
+	"github.com/qiffang/mnemos/server/internal/repository/postgres"
+)
+
+// NewSpaceChainRepo creates the db9 Space Chain repository.
+// Phase 1 delegates to PostgreSQL SQL implementation.
+func NewSpaceChainRepo(db *sql.DB) *postgres.SpaceChainRepoImpl {
+	return postgres.NewSpaceChainRepo(db)
+}

--- a/server/internal/repository/factory.go
+++ b/server/internal/repository/factory.go
@@ -37,6 +37,18 @@ func NewTenantRepo(backend string, db *sql.DB) TenantRepo {
 	}
 }
 
+// NewSpaceChainRepo creates a SpaceChainRepo for the specified backend.
+func NewSpaceChainRepo(backend string, db *sql.DB) SpaceChainRepo {
+	switch backend {
+	case "db9":
+		return db9.NewSpaceChainRepo(db)
+	case "postgres":
+		return postgres.NewSpaceChainRepo(db)
+	default:
+		return tidb.NewSpaceChainRepo(db)
+	}
+}
+
 // NewUploadTaskRepo creates an UploadTaskRepo for the specified backend.
 func NewUploadTaskRepo(backend string, db *sql.DB) UploadTaskRepo {
 	switch backend {

--- a/server/internal/repository/postgres/space_chain.go
+++ b/server/internal/repository/postgres/space_chain.go
@@ -79,6 +79,24 @@ func (r *SpaceChainRepoImpl) GetByKey(ctx context.Context, key string) (*domain.
 	return chain, nil
 }
 
+func (r *SpaceChainRepoImpl) GetByKeyIncludingDisabled(ctx context.Context, key string) (*domain.SpaceChain, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT sc.id, sc.project_id, sc.name, sc.description, sc.created_by_user_id, sc.deleted_at, sc.deleted_by_user_id, sc.created_at, sc.updated_at
+		 FROM space_chain_bindings AS b
+		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
+		 WHERE b.chain_api_key = $1 AND sc.deleted_at IS NULL`,
+		key,
+	)
+	chain, err := scanSpaceChain(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.hydrate(ctx, chain); err != nil {
+		return nil, err
+	}
+	return chain, nil
+}
+
 func (r *SpaceChainRepoImpl) Update(ctx context.Context, chain *domain.SpaceChain) error {
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE space_chains
@@ -136,7 +154,7 @@ func (r *SpaceChainRepoImpl) ListBindings(ctx context.Context, chainID string) (
 		`SELECT id, chain_id, chain_api_key, created_by_user_id, disabled, disabled_at, disabled_by_user_id, created_at
 		 FROM space_chain_bindings
 		 WHERE chain_id = $1
-		 ORDER BY created_at ASC, id ASC`,
+		 ORDER BY created_at DESC, id DESC`,
 		chainID,
 	)
 	if err != nil {

--- a/server/internal/repository/postgres/space_chain.go
+++ b/server/internal/repository/postgres/space_chain.go
@@ -1,0 +1,317 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+type SpaceChainRepoImpl struct {
+	db *sql.DB
+}
+
+func NewSpaceChainRepo(db *sql.DB) *SpaceChainRepoImpl {
+	return &SpaceChainRepoImpl{db: db}
+}
+
+func (r *SpaceChainRepoImpl) Create(ctx context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin create space chain: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO space_chains (id, project_id, name, description, created_by_user_id, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())`,
+		chain.ID, nullString(chain.ProjectID), chain.Name, nullString(chain.Description), nullString(chain.CreatedByUserID),
+	); err != nil {
+		return fmt.Errorf("create space chain: %w", err)
+	}
+	if binding != nil {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO space_chain_bindings (id, chain_id, chain_api_key, created_by_user_id, created_at)
+			 VALUES ($1, $2, $3, $4, NOW())`,
+			binding.ID, binding.ChainID, binding.ChainAPIKey, nullString(binding.CreatedByUserID),
+		); err != nil {
+			return fmt.Errorf("create space chain binding: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit create space chain: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) GetByID(ctx context.Context, id string) (*domain.SpaceChain, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, project_id, name, description, created_by_user_id, deleted_at, deleted_by_user_id, created_at, updated_at
+		 FROM space_chains WHERE id = $1`,
+		id,
+	)
+	chain, err := scanSpaceChain(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.hydrate(ctx, chain); err != nil {
+		return nil, err
+	}
+	return chain, nil
+}
+
+func (r *SpaceChainRepoImpl) GetByKey(ctx context.Context, key string) (*domain.SpaceChain, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT sc.id, sc.project_id, sc.name, sc.description, sc.created_by_user_id, sc.deleted_at, sc.deleted_by_user_id, sc.created_at, sc.updated_at
+		 FROM space_chain_bindings AS b
+		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
+		 WHERE b.chain_api_key = $1 AND b.disabled = FALSE AND sc.deleted_at IS NULL`,
+		key,
+	)
+	chain, err := scanSpaceChain(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.hydrate(ctx, chain); err != nil {
+		return nil, err
+	}
+	return chain, nil
+}
+
+func (r *SpaceChainRepoImpl) Update(ctx context.Context, chain *domain.SpaceChain) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE space_chains
+		 SET name = $1, description = $2, updated_at = NOW()
+		 WHERE id = $3 AND deleted_at IS NULL`,
+		chain.Name, nullString(chain.Description), chain.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update space chain: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update space chain rows: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) SoftDelete(ctx context.Context, id, deletedByUserID string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE space_chains
+		 SET deleted_at = NOW(), deleted_by_user_id = $1, updated_at = NOW()
+		 WHERE id = $2 AND deleted_at IS NULL`,
+		nullString(deletedByUserID), id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft delete space chain: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete space chain rows: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) CreateBinding(ctx context.Context, binding *domain.SpaceChainBinding) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO space_chain_bindings (id, chain_id, chain_api_key, created_by_user_id, created_at)
+		 VALUES ($1, $2, $3, $4, NOW())`,
+		binding.ID, binding.ChainID, binding.ChainAPIKey, nullString(binding.CreatedByUserID),
+	)
+	if err != nil {
+		return fmt.Errorf("create space chain binding: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) ListBindings(ctx context.Context, chainID string) ([]domain.SpaceChainBinding, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, chain_id, chain_api_key, created_by_user_id, disabled, disabled_at, disabled_by_user_id, created_at
+		 FROM space_chain_bindings
+		 WHERE chain_id = $1
+		 ORDER BY created_at ASC, id ASC`,
+		chainID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list space chain bindings: %w", err)
+	}
+	defer rows.Close()
+	return scanSpaceChainBindings(rows)
+}
+
+func (r *SpaceChainRepoImpl) DisableBinding(ctx context.Context, chainID, bindingID, disabledByUserID string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE space_chain_bindings
+		 SET disabled = TRUE, disabled_at = NOW(), disabled_by_user_id = $1
+		 WHERE chain_id = $2 AND id = $3 AND disabled = FALSE`,
+		nullString(disabledByUserID), chainID, bindingID,
+	)
+	if err != nil {
+		return fmt.Errorf("disable space chain binding: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("disable space chain binding rows: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) ListNodes(ctx context.Context, chainID string) ([]domain.SpaceChainNode, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, created_at, updated_at
+		 FROM space_chain_nodes
+		 WHERE chain_id = $1
+		 ORDER BY position ASC, id ASC`,
+		chainID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list space chain nodes: %w", err)
+	}
+	defer rows.Close()
+	return scanSpaceChainNodes(rows)
+}
+
+func (r *SpaceChainRepoImpl) ReplaceNodes(ctx context.Context, chainID string, nodes []domain.SpaceChainNode) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin replace space chain nodes: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM space_chain_nodes WHERE chain_id = $1`, chainID); err != nil {
+		return fmt.Errorf("clear space chain nodes: %w", err)
+	}
+	for _, node := range nodes {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO space_chain_nodes (id, chain_id, tenant_id, external_space_id, display_name, position, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())`,
+			node.ID, chainID, node.TenantID, nullString(node.ExternalSpaceID), nullString(node.DisplayName), node.Position,
+		); err != nil {
+			return fmt.Errorf("insert space chain node: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit replace space chain nodes: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) RemoveNodeByExternalSpaceID(ctx context.Context, externalSpaceID string) error {
+	if externalSpaceID == "" {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM space_chain_nodes WHERE external_space_id = $1`,
+		externalSpaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove space chain node by external space id: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) KeyStatus(ctx context.Context, key string) (domain.KeyStatus, error) {
+	var disabled bool
+	var deletedAt sql.NullTime
+	err := r.db.QueryRowContext(ctx,
+		`SELECT b.disabled, sc.deleted_at
+		 FROM space_chain_bindings AS b
+		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
+		 WHERE b.chain_api_key = $1`,
+		key,
+	).Scan(&disabled, &deletedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", domain.ErrNotFound
+		}
+		return "", fmt.Errorf("space chain key status: %w", err)
+	}
+	if disabled || deletedAt.Valid {
+		return domain.KeyStatusInactive, nil
+	}
+	return domain.KeyStatusActive, nil
+}
+
+func (r *SpaceChainRepoImpl) hydrate(ctx context.Context, chain *domain.SpaceChain) error {
+	bindings, err := r.ListBindings(ctx, chain.ID)
+	if err != nil {
+		return err
+	}
+	nodes, err := r.ListNodes(ctx, chain.ID)
+	if err != nil {
+		return err
+	}
+	chain.Bindings = bindings
+	chain.Nodes = nodes
+	return nil
+}
+
+func scanSpaceChain(row *sql.Row) (*domain.SpaceChain, error) {
+	var chain domain.SpaceChain
+	var projectID, description, createdByUserID, deletedByUserID sql.NullString
+	var deletedAt sql.NullTime
+	if err := row.Scan(&chain.ID, &projectID, &chain.Name, &description, &createdByUserID, &deletedAt, &deletedByUserID, &chain.CreatedAt, &chain.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("scan space chain: %w", err)
+	}
+	chain.ProjectID = projectID.String
+	chain.Description = description.String
+	chain.CreatedByUserID = createdByUserID.String
+	chain.DeletedByUserID = deletedByUserID.String
+	if deletedAt.Valid {
+		chain.DeletedAt = &deletedAt.Time
+	}
+	return &chain, nil
+}
+
+func scanSpaceChainBindings(rows *sql.Rows) ([]domain.SpaceChainBinding, error) {
+	out := []domain.SpaceChainBinding{}
+	for rows.Next() {
+		var binding domain.SpaceChainBinding
+		var createdByUserID, disabledByUserID sql.NullString
+		var disabledAt sql.NullTime
+		if err := rows.Scan(&binding.ID, &binding.ChainID, &binding.ChainAPIKey, &createdByUserID, &binding.Disabled, &disabledAt, &disabledByUserID, &binding.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan space chain binding: %w", err)
+		}
+		binding.CreatedByUserID = createdByUserID.String
+		binding.DisabledByUserID = disabledByUserID.String
+		if disabledAt.Valid {
+			binding.DisabledAt = &disabledAt.Time
+		}
+		out = append(out, binding)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate space chain bindings: %w", err)
+	}
+	return out, nil
+}
+
+func scanSpaceChainNodes(rows *sql.Rows) ([]domain.SpaceChainNode, error) {
+	out := []domain.SpaceChainNode{}
+	for rows.Next() {
+		var node domain.SpaceChainNode
+		var externalSpaceID, displayName sql.NullString
+		if err := rows.Scan(&node.ID, &node.ChainID, &node.TenantID, &externalSpaceID, &displayName, &node.Position, &node.CreatedAt, &node.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan space chain node: %w", err)
+		}
+		node.ExternalSpaceID = externalSpaceID.String
+		node.DisplayName = displayName.String
+		out = append(out, node)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate space chain nodes: %w", err)
+	}
+	return out, nil
+}

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -65,6 +65,7 @@ type SpaceChainRepo interface {
 	Create(ctx context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error
 	GetByID(ctx context.Context, id string) (*domain.SpaceChain, error)
 	GetByKey(ctx context.Context, key string) (*domain.SpaceChain, error)
+	GetByKeyIncludingDisabled(ctx context.Context, key string) (*domain.SpaceChain, error)
 	Update(ctx context.Context, chain *domain.SpaceChain) error
 	SoftDelete(ctx context.Context, id, deletedByUserID string) error
 

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -60,6 +60,25 @@ type TenantRepo interface {
 	SumActiveMemoryStats(ctx context.Context) (total int64, last7d int64, err error)
 }
 
+// SpaceChainRepo manages Space Chain control-plane records.
+type SpaceChainRepo interface {
+	Create(ctx context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error
+	GetByID(ctx context.Context, id string) (*domain.SpaceChain, error)
+	GetByKey(ctx context.Context, key string) (*domain.SpaceChain, error)
+	Update(ctx context.Context, chain *domain.SpaceChain) error
+	SoftDelete(ctx context.Context, id, deletedByUserID string) error
+
+	CreateBinding(ctx context.Context, binding *domain.SpaceChainBinding) error
+	ListBindings(ctx context.Context, chainID string) ([]domain.SpaceChainBinding, error)
+	DisableBinding(ctx context.Context, chainID, bindingID, disabledByUserID string) error
+
+	ListNodes(ctx context.Context, chainID string) ([]domain.SpaceChainNode, error)
+	ReplaceNodes(ctx context.Context, chainID string, nodes []domain.SpaceChainNode) error
+	RemoveNodeByExternalSpaceID(ctx context.Context, externalSpaceID string) error
+
+	KeyStatus(ctx context.Context, key string) (domain.KeyStatus, error)
+}
+
 // UploadTaskRepo manages upload task records in the control plane DB.
 type UploadTaskRepo interface {
 	Create(ctx context.Context, task *domain.UploadTask) error

--- a/server/internal/repository/tidb/space_chain.go
+++ b/server/internal/repository/tidb/space_chain.go
@@ -1,0 +1,319 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+type SpaceChainRepoImpl struct {
+	db *sql.DB
+}
+
+func NewSpaceChainRepo(db *sql.DB) *SpaceChainRepoImpl {
+	return &SpaceChainRepoImpl{db: db}
+}
+
+func (r *SpaceChainRepoImpl) Create(ctx context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin create space chain: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO space_chains (id, project_id, name, description, created_by_user_id, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, NOW(), NOW())`,
+		chain.ID, nullString(chain.ProjectID), chain.Name, nullString(chain.Description), nullString(chain.CreatedByUserID),
+	); err != nil {
+		return fmt.Errorf("create space chain: %w", err)
+	}
+	if binding != nil {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO space_chain_bindings (id, chain_id, chain_api_key, created_by_user_id, created_at)
+			 VALUES (?, ?, ?, ?, NOW())`,
+			binding.ID, binding.ChainID, binding.ChainAPIKey, nullString(binding.CreatedByUserID),
+		); err != nil {
+			return fmt.Errorf("create space chain binding: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit create space chain: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) GetByID(ctx context.Context, id string) (*domain.SpaceChain, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, project_id, name, description, created_by_user_id, deleted_at, deleted_by_user_id, created_at, updated_at
+		 FROM space_chains WHERE id = ?`,
+		id,
+	)
+	chain, err := scanSpaceChain(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.hydrate(ctx, chain); err != nil {
+		return nil, err
+	}
+	return chain, nil
+}
+
+func (r *SpaceChainRepoImpl) GetByKey(ctx context.Context, key string) (*domain.SpaceChain, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT sc.id, sc.project_id, sc.name, sc.description, sc.created_by_user_id, sc.deleted_at, sc.deleted_by_user_id, sc.created_at, sc.updated_at
+		 FROM space_chain_bindings AS b
+		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
+		 WHERE b.chain_api_key = ? AND b.disabled = 0 AND sc.deleted_at IS NULL`,
+		key,
+	)
+	chain, err := scanSpaceChain(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.hydrate(ctx, chain); err != nil {
+		return nil, err
+	}
+	return chain, nil
+}
+
+func (r *SpaceChainRepoImpl) Update(ctx context.Context, chain *domain.SpaceChain) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE space_chains
+		 SET name = ?, description = ?, updated_at = NOW()
+		 WHERE id = ? AND deleted_at IS NULL`,
+		chain.Name, nullString(chain.Description), chain.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update space chain: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("update space chain rows: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) SoftDelete(ctx context.Context, id, deletedByUserID string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE space_chains
+		 SET deleted_at = NOW(), deleted_by_user_id = ?, updated_at = NOW()
+		 WHERE id = ? AND deleted_at IS NULL`,
+		nullString(deletedByUserID), id,
+	)
+	if err != nil {
+		return fmt.Errorf("soft delete space chain: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete space chain rows: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) CreateBinding(ctx context.Context, binding *domain.SpaceChainBinding) error {
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO space_chain_bindings (id, chain_id, chain_api_key, created_by_user_id, created_at)
+		 VALUES (?, ?, ?, ?, NOW())`,
+		binding.ID, binding.ChainID, binding.ChainAPIKey, nullString(binding.CreatedByUserID),
+	)
+	if err != nil {
+		return fmt.Errorf("create space chain binding: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) ListBindings(ctx context.Context, chainID string) ([]domain.SpaceChainBinding, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, chain_id, chain_api_key, created_by_user_id, disabled, disabled_at, disabled_by_user_id, created_at
+		 FROM space_chain_bindings
+		 WHERE chain_id = ?
+		 ORDER BY created_at ASC, id ASC`,
+		chainID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list space chain bindings: %w", err)
+	}
+	defer rows.Close()
+	return scanSpaceChainBindings(rows)
+}
+
+func (r *SpaceChainRepoImpl) DisableBinding(ctx context.Context, chainID, bindingID, disabledByUserID string) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE space_chain_bindings
+		 SET disabled = 1, disabled_at = NOW(), disabled_by_user_id = ?
+		 WHERE chain_id = ? AND id = ? AND disabled = 0`,
+		nullString(disabledByUserID), chainID, bindingID,
+	)
+	if err != nil {
+		return fmt.Errorf("disable space chain binding: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("disable space chain binding rows: %w", err)
+	}
+	if n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) ListNodes(ctx context.Context, chainID string) ([]domain.SpaceChainNode, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, created_at, updated_at
+		 FROM space_chain_nodes
+		 WHERE chain_id = ?
+		 ORDER BY position ASC, id ASC`,
+		chainID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list space chain nodes: %w", err)
+	}
+	defer rows.Close()
+	return scanSpaceChainNodes(rows)
+}
+
+func (r *SpaceChainRepoImpl) ReplaceNodes(ctx context.Context, chainID string, nodes []domain.SpaceChainNode) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin replace space chain nodes: %w", err)
+	}
+	defer tx.Rollback()
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM space_chain_nodes WHERE chain_id = ?`, chainID)
+	if err != nil {
+		return fmt.Errorf("clear space chain nodes: %w", err)
+	}
+	_ = res
+	for _, node := range nodes {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO space_chain_nodes (id, chain_id, tenant_id, external_space_id, display_name, position, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, NOW(), NOW())`,
+			node.ID, chainID, node.TenantID, nullString(node.ExternalSpaceID), nullString(node.DisplayName), node.Position,
+		); err != nil {
+			return fmt.Errorf("insert space chain node: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit replace space chain nodes: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) RemoveNodeByExternalSpaceID(ctx context.Context, externalSpaceID string) error {
+	if externalSpaceID == "" {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx,
+		`DELETE FROM space_chain_nodes WHERE external_space_id = ?`,
+		externalSpaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("remove space chain node by external space id: %w", err)
+	}
+	return nil
+}
+
+func (r *SpaceChainRepoImpl) KeyStatus(ctx context.Context, key string) (domain.KeyStatus, error) {
+	var disabled bool
+	var deletedAt sql.NullTime
+	err := r.db.QueryRowContext(ctx,
+		`SELECT b.disabled, sc.deleted_at
+		 FROM space_chain_bindings AS b
+		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
+		 WHERE b.chain_api_key = ?`,
+		key,
+	).Scan(&disabled, &deletedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return "", domain.ErrNotFound
+		}
+		return "", fmt.Errorf("space chain key status: %w", err)
+	}
+	if disabled || deletedAt.Valid {
+		return domain.KeyStatusInactive, nil
+	}
+	return domain.KeyStatusActive, nil
+}
+
+func (r *SpaceChainRepoImpl) hydrate(ctx context.Context, chain *domain.SpaceChain) error {
+	bindings, err := r.ListBindings(ctx, chain.ID)
+	if err != nil {
+		return err
+	}
+	nodes, err := r.ListNodes(ctx, chain.ID)
+	if err != nil {
+		return err
+	}
+	chain.Bindings = bindings
+	chain.Nodes = nodes
+	return nil
+}
+
+func scanSpaceChain(row *sql.Row) (*domain.SpaceChain, error) {
+	var chain domain.SpaceChain
+	var projectID, description, createdByUserID, deletedByUserID sql.NullString
+	var deletedAt sql.NullTime
+	if err := row.Scan(&chain.ID, &projectID, &chain.Name, &description, &createdByUserID, &deletedAt, &deletedByUserID, &chain.CreatedAt, &chain.UpdatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("scan space chain: %w", err)
+	}
+	chain.ProjectID = projectID.String
+	chain.Description = description.String
+	chain.CreatedByUserID = createdByUserID.String
+	chain.DeletedByUserID = deletedByUserID.String
+	if deletedAt.Valid {
+		chain.DeletedAt = &deletedAt.Time
+	}
+	return &chain, nil
+}
+
+func scanSpaceChainBindings(rows *sql.Rows) ([]domain.SpaceChainBinding, error) {
+	out := []domain.SpaceChainBinding{}
+	for rows.Next() {
+		var binding domain.SpaceChainBinding
+		var createdByUserID, disabledByUserID sql.NullString
+		var disabledAt sql.NullTime
+		if err := rows.Scan(&binding.ID, &binding.ChainID, &binding.ChainAPIKey, &createdByUserID, &binding.Disabled, &disabledAt, &disabledByUserID, &binding.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan space chain binding: %w", err)
+		}
+		binding.CreatedByUserID = createdByUserID.String
+		binding.DisabledByUserID = disabledByUserID.String
+		if disabledAt.Valid {
+			binding.DisabledAt = &disabledAt.Time
+		}
+		out = append(out, binding)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate space chain bindings: %w", err)
+	}
+	return out, nil
+}
+
+func scanSpaceChainNodes(rows *sql.Rows) ([]domain.SpaceChainNode, error) {
+	out := []domain.SpaceChainNode{}
+	for rows.Next() {
+		var node domain.SpaceChainNode
+		var externalSpaceID, displayName sql.NullString
+		if err := rows.Scan(&node.ID, &node.ChainID, &node.TenantID, &externalSpaceID, &displayName, &node.Position, &node.CreatedAt, &node.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan space chain node: %w", err)
+		}
+		node.ExternalSpaceID = externalSpaceID.String
+		node.DisplayName = displayName.String
+		out = append(out, node)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate space chain nodes: %w", err)
+	}
+	return out, nil
+}

--- a/server/internal/repository/tidb/space_chain.go
+++ b/server/internal/repository/tidb/space_chain.go
@@ -79,6 +79,24 @@ func (r *SpaceChainRepoImpl) GetByKey(ctx context.Context, key string) (*domain.
 	return chain, nil
 }
 
+func (r *SpaceChainRepoImpl) GetByKeyIncludingDisabled(ctx context.Context, key string) (*domain.SpaceChain, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT sc.id, sc.project_id, sc.name, sc.description, sc.created_by_user_id, sc.deleted_at, sc.deleted_by_user_id, sc.created_at, sc.updated_at
+		 FROM space_chain_bindings AS b
+		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
+		 WHERE b.chain_api_key = ? AND sc.deleted_at IS NULL`,
+		key,
+	)
+	chain, err := scanSpaceChain(row)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.hydrate(ctx, chain); err != nil {
+		return nil, err
+	}
+	return chain, nil
+}
+
 func (r *SpaceChainRepoImpl) Update(ctx context.Context, chain *domain.SpaceChain) error {
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE space_chains
@@ -136,7 +154,7 @@ func (r *SpaceChainRepoImpl) ListBindings(ctx context.Context, chainID string) (
 		`SELECT id, chain_id, chain_api_key, created_by_user_id, disabled, disabled_at, disabled_by_user_id, created_at
 		 FROM space_chain_bindings
 		 WHERE chain_id = ?
-		 ORDER BY created_at ASC, id ASC`,
+		 ORDER BY created_at DESC, id DESC`,
 		chainID,
 	)
 	if err != nil {

--- a/server/internal/service/space_chain.go
+++ b/server/internal/service/space_chain.go
@@ -1,0 +1,298 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/repository"
+)
+
+type SpaceChainService struct {
+	chains repository.SpaceChainRepo
+}
+
+func NewSpaceChainService(chains repository.SpaceChainRepo) *SpaceChainService {
+	return &SpaceChainService{chains: chains}
+}
+
+type CreateSpaceChainRequest struct {
+	ProjectID       string `json:"project_id,omitempty"`
+	Name            string `json:"name"`
+	Description     string `json:"description,omitempty"`
+	CreatedByUserID string `json:"created_by_user_id,omitempty"`
+}
+
+type CreateSpaceChainResult struct {
+	Chain      *domain.SpaceChain `json:"chain"`
+	ChainKey   string             `json:"chain_api_key"`
+	BindingID  string             `json:"binding_id"`
+	KeyPrefix  string             `json:"key_prefix"`
+	KeyPreview string             `json:"key_preview"`
+}
+
+type UpdateSpaceChainRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+type ReplaceSpaceChainNodesRequest struct {
+	Nodes []SpaceChainNodeInput `json:"nodes"`
+}
+
+type SpaceChainNodeInput struct {
+	TenantID        string `json:"tenant_id"`
+	ExternalSpaceID string `json:"external_space_id,omitempty"`
+	DisplayName     string `json:"display_name,omitempty"`
+}
+
+type CreateSpaceChainBindingRequest struct {
+	ChainAPIKey     string `json:"chain_api_key,omitempty"`
+	CreatedByUserID string `json:"created_by_user_id,omitempty"`
+}
+
+func (s *SpaceChainService) Create(ctx context.Context, req CreateSpaceChainRequest) (*CreateSpaceChainResult, error) {
+	if s == nil || s.chains == nil {
+		return nil, fmt.Errorf("space chain repository not configured")
+	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, &domain.ValidationError{Field: "name", Message: "required"}
+	}
+
+	chain := &domain.SpaceChain{
+		ID:              uuid.New().String(),
+		ProjectID:       strings.TrimSpace(req.ProjectID),
+		Name:            name,
+		Description:     strings.TrimSpace(req.Description),
+		CreatedByUserID: strings.TrimSpace(req.CreatedByUserID),
+	}
+	binding := &domain.SpaceChainBinding{
+		ID:              uuid.New().String(),
+		ChainID:         chain.ID,
+		ChainAPIKey:     generateChainKey(),
+		CreatedByUserID: chain.CreatedByUserID,
+	}
+	if err := s.chains.Create(ctx, chain, binding); err != nil {
+		return nil, err
+	}
+
+	created, err := s.chains.GetByID(ctx, chain.ID)
+	if err != nil {
+		return nil, err
+	}
+	return &CreateSpaceChainResult{
+		Chain:      created,
+		ChainKey:   binding.ChainAPIKey,
+		BindingID:  binding.ID,
+		KeyPrefix:  domain.ChainKeyPrefix,
+		KeyPreview: keyPreview(binding.ChainAPIKey),
+	}, nil
+}
+
+func (s *SpaceChainService) Get(ctx context.Context, id string) (*domain.SpaceChain, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, &domain.ValidationError{Field: "id", Message: "required"}
+	}
+	return s.chains.GetByID(ctx, id)
+}
+
+func (s *SpaceChainService) GetByKey(ctx context.Context, key string) (*domain.SpaceChain, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
+	}
+	if !strings.HasPrefix(key, domain.ChainKeyPrefix) {
+		return nil, &domain.ValidationError{Field: "X-API-Key", Message: "not a chain key"}
+	}
+	return s.chains.GetByKey(ctx, key)
+}
+
+func (s *SpaceChainService) Authorize(ctx context.Context, chainID, key string) (*domain.SpaceChain, error) {
+	chain, err := s.GetByKey(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if chain.ID != chainID {
+		return nil, domain.ErrNotFound
+	}
+	return chain, nil
+}
+
+func (s *SpaceChainService) Update(ctx context.Context, chainID string, req UpdateSpaceChainRequest) (*domain.SpaceChain, error) {
+	chainID = strings.TrimSpace(chainID)
+	name := strings.TrimSpace(req.Name)
+	if chainID == "" {
+		return nil, &domain.ValidationError{Field: "id", Message: "required"}
+	}
+	if name == "" {
+		return nil, &domain.ValidationError{Field: "name", Message: "required"}
+	}
+	if err := s.chains.Update(ctx, &domain.SpaceChain{
+		ID:          chainID,
+		Name:        name,
+		Description: strings.TrimSpace(req.Description),
+	}); err != nil {
+		return nil, err
+	}
+	return s.chains.GetByID(ctx, chainID)
+}
+
+func (s *SpaceChainService) Delete(ctx context.Context, chainID, deletedByUserID string) error {
+	chainID = strings.TrimSpace(chainID)
+	if chainID == "" {
+		return &domain.ValidationError{Field: "id", Message: "required"}
+	}
+	return s.chains.SoftDelete(ctx, chainID, strings.TrimSpace(deletedByUserID))
+}
+
+func (s *SpaceChainService) CreateBinding(ctx context.Context, chainID string, req CreateSpaceChainBindingRequest) (*domain.SpaceChainBinding, error) {
+	chainID = strings.TrimSpace(chainID)
+	if chainID == "" {
+		return nil, &domain.ValidationError{Field: "chain_id", Message: "required"}
+	}
+	chainAPIKey := strings.TrimSpace(req.ChainAPIKey)
+	if chainAPIKey == "" {
+		chainAPIKey = generateChainKey()
+	} else if !strings.HasPrefix(chainAPIKey, domain.ChainKeyPrefix) {
+		return nil, &domain.ValidationError{Field: "chain_api_key", Message: "must start with " + domain.ChainKeyPrefix}
+	}
+	binding := &domain.SpaceChainBinding{
+		ID:              uuid.New().String(),
+		ChainID:         chainID,
+		ChainAPIKey:     chainAPIKey,
+		CreatedByUserID: strings.TrimSpace(req.CreatedByUserID),
+	}
+	if err := s.chains.CreateBinding(ctx, binding); err != nil {
+		return nil, err
+	}
+	return binding, nil
+}
+
+func (s *SpaceChainService) ListBindings(ctx context.Context, chainID string) ([]domain.SpaceChainBinding, error) {
+	return s.chains.ListBindings(ctx, strings.TrimSpace(chainID))
+}
+
+func (s *SpaceChainService) DisableBinding(ctx context.Context, chainID, bindingID, disabledByUserID string) error {
+	chainID = strings.TrimSpace(chainID)
+	bindingID = strings.TrimSpace(bindingID)
+	if chainID == "" {
+		return &domain.ValidationError{Field: "chain_id", Message: "required"}
+	}
+	if bindingID == "" {
+		return &domain.ValidationError{Field: "binding_id", Message: "required"}
+	}
+	bindings, err := s.chains.ListBindings(ctx, chainID)
+	if err != nil {
+		return err
+	}
+	active := 0
+	foundActive := false
+	for _, binding := range bindings {
+		if binding.Disabled {
+			continue
+		}
+		active++
+		if binding.ID == bindingID {
+			foundActive = true
+		}
+	}
+	if !foundActive {
+		return domain.ErrNotFound
+	}
+	if active <= 1 {
+		return &domain.ValidationError{Field: "binding_id", Message: "cannot disable the last active chain key"}
+	}
+	return s.chains.DisableBinding(ctx, chainID, bindingID, strings.TrimSpace(disabledByUserID))
+}
+
+func (s *SpaceChainService) ReplaceNodes(ctx context.Context, chainID string, req ReplaceSpaceChainNodesRequest) ([]domain.SpaceChainNode, error) {
+	chainID = strings.TrimSpace(chainID)
+	if chainID == "" {
+		return nil, &domain.ValidationError{Field: "chain_id", Message: "required"}
+	}
+	nodes := make([]domain.SpaceChainNode, 0, len(req.Nodes))
+	seenTenant := make(map[string]struct{}, len(req.Nodes))
+	seenExternal := make(map[string]struct{}, len(req.Nodes))
+	for i, in := range req.Nodes {
+		tenantID := strings.TrimSpace(in.TenantID)
+		if tenantID == "" {
+			return nil, &domain.ValidationError{Field: "nodes", Message: "tenant_id required"}
+		}
+		if strings.HasPrefix(tenantID, domain.ChainKeyPrefix) {
+			return nil, &domain.ValidationError{Field: "nodes", Message: "chain nodes must be spaces, not Space Chains"}
+		}
+		if _, ok := seenTenant[tenantID]; ok {
+			return nil, &domain.ValidationError{Field: "nodes", Message: "duplicate tenant_id"}
+		}
+		seenTenant[tenantID] = struct{}{}
+
+		externalSpaceID := strings.TrimSpace(in.ExternalSpaceID)
+		if externalSpaceID != "" {
+			if _, ok := seenExternal[externalSpaceID]; ok {
+				return nil, &domain.ValidationError{Field: "nodes", Message: "duplicate external_space_id"}
+			}
+			seenExternal[externalSpaceID] = struct{}{}
+		}
+		nodes = append(nodes, domain.SpaceChainNode{
+			ID:              uuid.New().String(),
+			ChainID:         chainID,
+			TenantID:        tenantID,
+			ExternalSpaceID: externalSpaceID,
+			DisplayName:     strings.TrimSpace(in.DisplayName),
+			Position:        i,
+		})
+	}
+	if err := s.chains.ReplaceNodes(ctx, chainID, nodes); err != nil {
+		return nil, err
+	}
+	return s.chains.ListNodes(ctx, chainID)
+}
+
+func (s *SpaceChainService) ListNodes(ctx context.Context, chainID string) ([]domain.SpaceChainNode, error) {
+	return s.chains.ListNodes(ctx, strings.TrimSpace(chainID))
+}
+
+func (s *SpaceChainService) RemoveNodeByExternalSpaceID(ctx context.Context, externalSpaceID string) error {
+	return s.chains.RemoveNodeByExternalSpaceID(ctx, strings.TrimSpace(externalSpaceID))
+}
+
+func (s *SpaceChainService) KeyStatus(ctx context.Context, apiKey string) (domain.KeyStatus, error) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
+	}
+	if !strings.HasPrefix(apiKey, domain.ChainKeyPrefix) {
+		return "", domain.ErrNotFound
+	}
+	status, err := s.chains.KeyStatus(ctx, apiKey)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return "", domain.ErrNotFound
+		}
+		return "", fmt.Errorf("space chain key status: %w", err)
+	}
+	return status, nil
+}
+
+func generateChainKey() string {
+	var b [24]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return domain.ChainKeyPrefix + strings.ReplaceAll(uuid.New().String(), "-", "")
+	}
+	return domain.ChainKeyPrefix + base64.RawURLEncoding.EncodeToString(b[:])
+}
+
+func keyPreview(key string) string {
+	if len(key) <= len(domain.ChainKeyPrefix)+6 {
+		return key
+	}
+	return key[:len(domain.ChainKeyPrefix)+6] + "..."
+}

--- a/server/internal/service/space_chain.go
+++ b/server/internal/service/space_chain.go
@@ -126,6 +126,24 @@ func (s *SpaceChainService) Authorize(ctx context.Context, chainID, key string) 
 	return chain, nil
 }
 
+func (s *SpaceChainService) AuthorizeManagement(ctx context.Context, chainID, key string) (*domain.SpaceChain, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
+	}
+	if !strings.HasPrefix(key, domain.ChainKeyPrefix) {
+		return nil, &domain.ValidationError{Field: "X-API-Key", Message: "not a chain key"}
+	}
+	chain, err := s.chains.GetByKeyIncludingDisabled(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if chain.ID != chainID {
+		return nil, domain.ErrNotFound
+	}
+	return chain, nil
+}
+
 func (s *SpaceChainService) Update(ctx context.Context, chainID string, req UpdateSpaceChainRequest) (*domain.SpaceChain, error) {
 	chainID = strings.TrimSpace(chainID)
 	name := strings.TrimSpace(req.Name)
@@ -189,12 +207,12 @@ func (s *SpaceChainService) DisableBinding(ctx context.Context, chainID, binding
 	if bindingID == "" {
 		return &domain.ValidationError{Field: "binding_id", Message: "required"}
 	}
+	foundActive := false
+	active := 0
 	bindings, err := s.chains.ListBindings(ctx, chainID)
 	if err != nil {
 		return err
 	}
-	active := 0
-	foundActive := false
 	for _, binding := range bindings {
 		if binding.Disabled {
 			continue
@@ -208,7 +226,7 @@ func (s *SpaceChainService) DisableBinding(ctx context.Context, chainID, binding
 		return domain.ErrNotFound
 	}
 	if active <= 1 {
-		return &domain.ValidationError{Field: "binding_id", Message: "cannot disable the last active chain key"}
+		return &domain.ValidationError{Field: "binding_id", Message: "at least one Space Chain key must remain active"}
 	}
 	return s.chains.DisableBinding(ctx, chainID, bindingID, strings.TrimSpace(disabledByUserID))
 }

--- a/server/internal/service/space_chain_test.go
+++ b/server/internal/service/space_chain_test.go
@@ -85,9 +85,31 @@ func TestSpaceChainReplaceNodesRejectsChainKeyNode(t *testing.T) {
 	}
 }
 
+func TestSpaceChainDisableBindingRejectsLastActiveKey(t *testing.T) {
+	repo := &fakeSpaceChainRepo{
+		chain: &domain.SpaceChain{
+			ID: "chain-1",
+			Bindings: []domain.SpaceChainBinding{
+				{ID: "binding-1", ChainID: "chain-1", ChainAPIKey: "chain_key"},
+			},
+		},
+	}
+	svc := NewSpaceChainService(repo)
+
+	err := svc.DisableBinding(context.Background(), "chain-1", "binding-1", "user-1")
+	var validation *domain.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("expected validation error, got %T: %v", err, err)
+	}
+	if !strings.Contains(validation.Message, "at least one Space Chain key must remain active") {
+		t.Fatalf("validation message = %q", validation.Message)
+	}
+}
+
 type fakeSpaceChainRepo struct {
-	chain *domain.SpaceChain
-	nodes []domain.SpaceChainNode
+	chain             *domain.SpaceChain
+	nodes             []domain.SpaceChainNode
+	disabledBindingID string
 }
 
 func (r *fakeSpaceChainRepo) Create(_ context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error {
@@ -115,6 +137,13 @@ func (r *fakeSpaceChainRepo) GetByKey(_ context.Context, _ string) (*domain.Spac
 	return r.chain, nil
 }
 
+func (r *fakeSpaceChainRepo) GetByKeyIncludingDisabled(_ context.Context, _ string) (*domain.SpaceChain, error) {
+	if r.chain == nil {
+		return nil, domain.ErrNotFound
+	}
+	return r.chain, nil
+}
+
 func (r *fakeSpaceChainRepo) Update(_ context.Context, chain *domain.SpaceChain) error {
 	r.chain = chain
 	return nil
@@ -136,7 +165,10 @@ func (r *fakeSpaceChainRepo) ListBindings(_ context.Context, _ string) ([]domain
 	return r.chain.Bindings, nil
 }
 
-func (r *fakeSpaceChainRepo) DisableBinding(_ context.Context, _, _, _ string) error { return nil }
+func (r *fakeSpaceChainRepo) DisableBinding(_ context.Context, _, bindingID, _ string) error {
+	r.disabledBindingID = bindingID
+	return nil
+}
 
 func (r *fakeSpaceChainRepo) ListNodes(_ context.Context, _ string) ([]domain.SpaceChainNode, error) {
 	return r.nodes, nil

--- a/server/internal/service/space_chain_test.go
+++ b/server/internal/service/space_chain_test.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestSpaceChainCreateGeneratesChainKeyPrefix(t *testing.T) {
+	repo := &fakeSpaceChainRepo{}
+	svc := NewSpaceChainService(repo)
+
+	result, err := svc.Create(context.Background(), CreateSpaceChainRequest{Name: "My Chain"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if result.Chain == nil || result.Chain.ID == "" {
+		t.Fatalf("expected created chain with id, got %#v", result.Chain)
+	}
+	if !strings.HasPrefix(result.ChainKey, domain.ChainKeyPrefix) {
+		t.Fatalf("expected chain key prefix %q, got %q", domain.ChainKeyPrefix, result.ChainKey)
+	}
+}
+
+func TestSpaceChainReplaceNodesUsesZeroBasedPositions(t *testing.T) {
+	repo := &fakeSpaceChainRepo{}
+	svc := NewSpaceChainService(repo)
+
+	nodes, err := svc.ReplaceNodes(context.Background(), "chain-1", ReplaceSpaceChainNodesRequest{
+		Nodes: []SpaceChainNodeInput{
+			{TenantID: "space-1", ExternalSpaceID: "console-space-1"},
+			{TenantID: "space-2", ExternalSpaceID: "console-space-2"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceNodes returned error: %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+	if nodes[0].Position != 0 || nodes[1].Position != 1 {
+		t.Fatalf("expected 0-based positions, got %d and %d", nodes[0].Position, nodes[1].Position)
+	}
+}
+
+func TestSpaceChainReplaceNodesRejectsDuplicates(t *testing.T) {
+	repo := &fakeSpaceChainRepo{}
+	svc := NewSpaceChainService(repo)
+
+	_, err := svc.ReplaceNodes(context.Background(), "chain-1", ReplaceSpaceChainNodesRequest{
+		Nodes: []SpaceChainNodeInput{
+			{TenantID: "space-1", ExternalSpaceID: "console-space-1"},
+			{TenantID: "space-1", ExternalSpaceID: "console-space-2"},
+		},
+	})
+	var validation *domain.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("expected duplicate tenant validation error, got %T: %v", err, err)
+	}
+
+	_, err = svc.ReplaceNodes(context.Background(), "chain-1", ReplaceSpaceChainNodesRequest{
+		Nodes: []SpaceChainNodeInput{
+			{TenantID: "space-1", ExternalSpaceID: "console-space-1"},
+			{TenantID: "space-2", ExternalSpaceID: "console-space-1"},
+		},
+	})
+	if !errors.As(err, &validation) {
+		t.Fatalf("expected duplicate external space validation error, got %T: %v", err, err)
+	}
+}
+
+func TestSpaceChainReplaceNodesRejectsChainKeyNode(t *testing.T) {
+	repo := &fakeSpaceChainRepo{}
+	svc := NewSpaceChainService(repo)
+
+	_, err := svc.ReplaceNodes(context.Background(), "chain-1", ReplaceSpaceChainNodesRequest{
+		Nodes: []SpaceChainNodeInput{{TenantID: "chain_abc"}},
+	})
+	var validation *domain.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("expected chain node validation error, got %T: %v", err, err)
+	}
+}
+
+type fakeSpaceChainRepo struct {
+	chain *domain.SpaceChain
+	nodes []domain.SpaceChainNode
+}
+
+func (r *fakeSpaceChainRepo) Create(_ context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error {
+	copied := *chain
+	if binding != nil {
+		copied.Bindings = []domain.SpaceChainBinding{*binding}
+	}
+	r.chain = &copied
+	return nil
+}
+
+func (r *fakeSpaceChainRepo) GetByID(_ context.Context, id string) (*domain.SpaceChain, error) {
+	if r.chain == nil {
+		return &domain.SpaceChain{ID: id, Name: "fake", Bindings: nil, Nodes: r.nodes}, nil
+	}
+	copied := *r.chain
+	copied.Nodes = r.nodes
+	return &copied, nil
+}
+
+func (r *fakeSpaceChainRepo) GetByKey(_ context.Context, _ string) (*domain.SpaceChain, error) {
+	if r.chain == nil {
+		return nil, domain.ErrNotFound
+	}
+	return r.chain, nil
+}
+
+func (r *fakeSpaceChainRepo) Update(_ context.Context, chain *domain.SpaceChain) error {
+	r.chain = chain
+	return nil
+}
+
+func (r *fakeSpaceChainRepo) SoftDelete(_ context.Context, _, _ string) error { return nil }
+
+func (r *fakeSpaceChainRepo) CreateBinding(_ context.Context, binding *domain.SpaceChainBinding) error {
+	if r.chain != nil {
+		r.chain.Bindings = append(r.chain.Bindings, *binding)
+	}
+	return nil
+}
+
+func (r *fakeSpaceChainRepo) ListBindings(_ context.Context, _ string) ([]domain.SpaceChainBinding, error) {
+	if r.chain == nil {
+		return nil, nil
+	}
+	return r.chain.Bindings, nil
+}
+
+func (r *fakeSpaceChainRepo) DisableBinding(_ context.Context, _, _, _ string) error { return nil }
+
+func (r *fakeSpaceChainRepo) ListNodes(_ context.Context, _ string) ([]domain.SpaceChainNode, error) {
+	return r.nodes, nil
+}
+
+func (r *fakeSpaceChainRepo) ReplaceNodes(_ context.Context, _ string, nodes []domain.SpaceChainNode) error {
+	r.nodes = append([]domain.SpaceChainNode(nil), nodes...)
+	return nil
+}
+
+func (r *fakeSpaceChainRepo) RemoveNodeByExternalSpaceID(_ context.Context, _ string) error {
+	return nil
+}
+
+func (r *fakeSpaceChainRepo) KeyStatus(_ context.Context, _ string) (domain.KeyStatus, error) {
+	return domain.KeyStatusActive, nil
+}

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -34,6 +34,51 @@ CREATE TABLE IF NOT EXISTS tenant_activity (
   INDEX idx_tenant_activity_last_activity (last_activity_at)
 );
 
+CREATE TABLE IF NOT EXISTS space_chains (
+  id                  VARCHAR(36)   PRIMARY KEY,
+  project_id          VARCHAR(255)  NULL,
+  name                VARCHAR(255)  NOT NULL,
+  description         TEXT          NULL,
+  created_by_user_id  VARCHAR(255)  NULL,
+  deleted_at          TIMESTAMP     NULL,
+  deleted_by_user_id  VARCHAR(255)  NULL,
+  created_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  updated_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_space_chains_project (project_id),
+  INDEX idx_space_chains_deleted (deleted_at)
+);
+
+CREATE TABLE IF NOT EXISTS space_chain_bindings (
+  id                  VARCHAR(36)   PRIMARY KEY,
+  chain_id            VARCHAR(36)   NOT NULL,
+  chain_api_key       VARCHAR(255)  NOT NULL,
+  created_by_user_id  VARCHAR(255)  NULL,
+  disabled            TINYINT(1)    NOT NULL DEFAULT 0,
+  disabled_at         TIMESTAMP     NULL,
+  disabled_by_user_id VARCHAR(255)  NULL,
+  created_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE INDEX idx_space_chain_bindings_key (chain_api_key),
+  INDEX idx_space_chain_bindings_chain (chain_id),
+  CONSTRAINT fk_space_chain_bindings_chain FOREIGN KEY (chain_id) REFERENCES space_chains(id)
+);
+
+CREATE TABLE IF NOT EXISTS space_chain_nodes (
+  id                  VARCHAR(36)   PRIMARY KEY,
+  chain_id            VARCHAR(36)   NOT NULL,
+  tenant_id           VARCHAR(36)   NOT NULL,
+  external_space_id   VARCHAR(255)  NULL,
+  display_name        VARCHAR(255)  NULL,
+  position            INT           NOT NULL,
+  created_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+  updated_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE INDEX idx_space_chain_nodes_tenant (chain_id, tenant_id),
+  UNIQUE INDEX idx_space_chain_nodes_external_space (chain_id, external_space_id),
+  UNIQUE INDEX idx_space_chain_nodes_position (chain_id, position),
+  INDEX idx_space_chain_nodes_external_lookup (external_space_id),
+  CONSTRAINT fk_space_chain_nodes_chain FOREIGN KEY (chain_id) REFERENCES space_chains(id),
+  CONSTRAINT fk_space_chain_nodes_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
 -- Tenant data plane schema (per-tenant TiDB Serverless).
 CREATE TABLE IF NOT EXISTS memories (
   id              VARCHAR(36)     PRIMARY KEY,

--- a/server/schema_db9.sql
+++ b/server/schema_db9.sql
@@ -54,6 +54,49 @@ CREATE TABLE IF NOT EXISTS tenant_activity (
 );
 CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);
 
+CREATE TABLE IF NOT EXISTS space_chains (
+    id                  VARCHAR(36)   PRIMARY KEY,
+    project_id          VARCHAR(255)  NULL,
+    name                VARCHAR(255)  NOT NULL,
+    description         TEXT          NULL,
+    created_by_user_id  VARCHAR(255)  NULL,
+    deleted_at          TIMESTAMPTZ   NULL,
+    deleted_by_user_id  VARCHAR(255)  NULL,
+    created_at          TIMESTAMPTZ   DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ   DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_space_chains_project ON space_chains(project_id);
+CREATE INDEX IF NOT EXISTS idx_space_chains_deleted ON space_chains(deleted_at);
+
+CREATE TABLE IF NOT EXISTS space_chain_bindings (
+    id                  VARCHAR(36)   PRIMARY KEY,
+    chain_id            VARCHAR(36)   NOT NULL REFERENCES space_chains(id),
+    chain_api_key       VARCHAR(255)  NOT NULL UNIQUE,
+    created_by_user_id  VARCHAR(255)  NULL,
+    disabled            BOOLEAN       NOT NULL DEFAULT FALSE,
+    disabled_at         TIMESTAMPTZ   NULL,
+    disabled_by_user_id VARCHAR(255)  NULL,
+    created_at          TIMESTAMPTZ   DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_space_chain_bindings_chain ON space_chain_bindings(chain_id);
+
+CREATE TABLE IF NOT EXISTS space_chain_nodes (
+    id                  VARCHAR(36)   PRIMARY KEY,
+    chain_id            VARCHAR(36)   NOT NULL REFERENCES space_chains(id),
+    tenant_id           VARCHAR(36)   NOT NULL REFERENCES tenants(id),
+    external_space_id   VARCHAR(255)  NULL,
+    display_name        VARCHAR(255)  NULL,
+    position            INT           NOT NULL,
+    created_at          TIMESTAMPTZ   DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ   DEFAULT NOW(),
+    CONSTRAINT uniq_space_chain_nodes_tenant UNIQUE (chain_id, tenant_id),
+    CONSTRAINT uniq_space_chain_nodes_position UNIQUE (chain_id, position)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_space_chain_nodes_external_space
+    ON space_chain_nodes(chain_id, external_space_id)
+    WHERE external_space_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_space_chain_nodes_external_lookup ON space_chain_nodes(external_space_id);
+
 -- memories table with auto-embedding column.
 -- Note: The embedding column definition depends on whether auto-embedding is enabled.
 -- When using schema_db9.sql directly (manual setup), use this version with GENERATED ALWAYS.
@@ -120,3 +163,9 @@ CREATE TRIGGER trg_memories_updated BEFORE UPDATE ON memories FOR EACH ROW EXECU
 
 DROP TRIGGER IF EXISTS trg_upload_tasks_updated ON upload_tasks;
 CREATE TRIGGER trg_upload_tasks_updated BEFORE UPDATE ON upload_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_space_chains_updated ON space_chains;
+CREATE TRIGGER trg_space_chains_updated BEFORE UPDATE ON space_chains FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_space_chain_nodes_updated ON space_chain_nodes;
+CREATE TRIGGER trg_space_chain_nodes_updated BEFORE UPDATE ON space_chain_nodes FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/server/schema_pg.sql
+++ b/server/schema_pg.sql
@@ -36,6 +36,49 @@ CREATE TABLE IF NOT EXISTS tenant_activity (
 );
 CREATE INDEX IF NOT EXISTS idx_tenant_activity_last_activity ON tenant_activity(last_activity_at);
 
+CREATE TABLE IF NOT EXISTS space_chains (
+    id                  VARCHAR(36)   PRIMARY KEY,
+    project_id          VARCHAR(255)  NULL,
+    name                VARCHAR(255)  NOT NULL,
+    description         TEXT          NULL,
+    created_by_user_id  VARCHAR(255)  NULL,
+    deleted_at          TIMESTAMPTZ   NULL,
+    deleted_by_user_id  VARCHAR(255)  NULL,
+    created_at          TIMESTAMPTZ   DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ   DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_space_chains_project ON space_chains(project_id);
+CREATE INDEX IF NOT EXISTS idx_space_chains_deleted ON space_chains(deleted_at);
+
+CREATE TABLE IF NOT EXISTS space_chain_bindings (
+    id                  VARCHAR(36)   PRIMARY KEY,
+    chain_id            VARCHAR(36)   NOT NULL REFERENCES space_chains(id),
+    chain_api_key       VARCHAR(255)  NOT NULL UNIQUE,
+    created_by_user_id  VARCHAR(255)  NULL,
+    disabled            BOOLEAN       NOT NULL DEFAULT FALSE,
+    disabled_at         TIMESTAMPTZ   NULL,
+    disabled_by_user_id VARCHAR(255)  NULL,
+    created_at          TIMESTAMPTZ   DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_space_chain_bindings_chain ON space_chain_bindings(chain_id);
+
+CREATE TABLE IF NOT EXISTS space_chain_nodes (
+    id                  VARCHAR(36)   PRIMARY KEY,
+    chain_id            VARCHAR(36)   NOT NULL REFERENCES space_chains(id),
+    tenant_id           VARCHAR(36)   NOT NULL REFERENCES tenants(id),
+    external_space_id   VARCHAR(255)  NULL,
+    display_name        VARCHAR(255)  NULL,
+    position            INT           NOT NULL,
+    created_at          TIMESTAMPTZ   DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ   DEFAULT NOW(),
+    CONSTRAINT uniq_space_chain_nodes_tenant UNIQUE (chain_id, tenant_id),
+    CONSTRAINT uniq_space_chain_nodes_position UNIQUE (chain_id, position)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_space_chain_nodes_external_space
+    ON space_chain_nodes(chain_id, external_space_id)
+    WHERE external_space_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_space_chain_nodes_external_lookup ON space_chain_nodes(external_space_id);
+
 CREATE TABLE IF NOT EXISTS memories (
     id              VARCHAR(36)     PRIMARY KEY,
     content         TEXT            NOT NULL,
@@ -94,3 +137,9 @@ CREATE TRIGGER trg_memories_updated BEFORE UPDATE ON memories FOR EACH ROW EXECU
 
 DROP TRIGGER IF EXISTS trg_upload_tasks_updated ON upload_tasks;
 CREATE TRIGGER trg_upload_tasks_updated BEFORE UPDATE ON upload_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_space_chains_updated ON space_chains;
+CREATE TRIGGER trg_space_chains_updated BEFORE UPDATE ON space_chains FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_space_chain_nodes_updated ON space_chain_nodes;
+CREATE TRIGGER trg_space_chain_nodes_updated BEFORE UPDATE ON space_chain_nodes FOR EACH ROW EXECUTE FUNCTION update_updated_at();


### PR DESCRIPTION
## Summary

- Adds Space Chain runtime support to mem9/server, including source-of-truth schema, repositories, services, handlers, and chain key auth.
- Implements ordered chain recall/write semantics and chain response provenance.
- Uses disabled chain key bindings instead of deletion or revoke semantics; disabled `chain_` keys remain visible but are rejected by runtime and management paths.
- Adds the Space Chain PRD and web console companion plan in `docs/design`.

assistant dev: codex gpt5.5 xhigh

## Validation

- `go test ./...` from `/Users/bosn/git/mem9/server`
- `git diff --check`