### PR TITLE
Add runtime usage quota gate and console metering outbox

### DIFF
--- a/docs/design/mem9-runtime-usage-client-proposal.md
+++ b/docs/design/mem9-runtime-usage-client-proposal.md
@@ -813,8 +813,12 @@ Worker behavior:
 
 Crash and primary-writer-unavailable handling:
 
-1. `BeforeRecall` and known-unit `BeforeMemoryCreate` insert `reserved_active`
-   after console returns `reserved` and before mem9 work starts.
+1. Known-unit `BeforeMemoryCreate` inserts `reserved_active` after console
+   returns `reserved` and before mem9 write work starts. `BeforeRecall` does not
+   insert this local row in A1 so high-QPS recall does not depend on the
+   control-plane outbox table before doing read work; console reservation
+   `expiresAt` remains the crash fallback for that pre-finalization recall
+   window.
 2. On mem9 success, the manager updates the row to `commit_pending` with the
    metering payload before attempting the synchronous commit.
 3. On mem9 failure, the manager updates the row to `release_pending` before
@@ -850,9 +854,9 @@ Reservation leak prevention uses three layers:
 
 1. Handler-level `defer` release for normal failure paths after a reservation is
    acquired but before success finalization.
-2. Local outbox rows for active reservations before executing mem9 work. Startup
-   resumes pending `release_reservation`, `commit_reservation`,
-   `apply_adjustment`, and `submit_metering_event` rows.
+2. Local outbox rows for active memory-slot write reservations before executing
+   mem9 write work. Startup resumes pending `release_reservation`,
+   `commit_reservation`, `apply_adjustment`, and `submit_metering_event` rows.
 3. Console-server `expiresAt` auto-expiry as the final authority for process
    crashes before mem9-server can persist a local outbox row.
 
@@ -862,11 +866,15 @@ console omits `expiresAt`, use `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` as the loca
 deadline. The default is `30m`; production should set it to match console's quota
 reservation TTL.
 
-`BeforeRecall` and `BeforeMemoryCreate` must durably insert the active
-reservation outbox row after console returns `reserved` and before executing the
-mem9 operation. If this insert fails before execution, release the console
-reservation best-effort and return `503`; this is a true fail-closed path because
-the mem9 operation has not started.
+`BeforeMemoryCreate` must durably insert the active reservation outbox row after
+console returns `reserved` and before executing the mem9 write operation. If
+this insert fails before execution, release the console reservation best-effort
+and return `503`; this is a true fail-closed path because the mem9 operation has
+not started. `BeforeRecall` intentionally skips the local active row in A1 to
+avoid putting the control-plane outbox table on the normal recall read path; if
+the process crashes before recall commit or release can be persisted, console
+reservation expiry is the source of truth and the recall may require
+coarse-grained audit from logs rather than row-level local reconciliation.
 
 The outbox worker should mark unresolved `reserved_active` work
 `unknown_after_crash` after `expiresAt + 2m` and emit
@@ -1002,7 +1010,8 @@ promotes them into the internal API contract:
 15. Handler tests cover delete adjustment after success.
 16. Handler tests cover batch delete skipping adjustment for `deleted == 0`.
 17. Handler tests cover runtime usage forcing or rejecting async smart ingest.
-18. Outbox tests cover active reservation row creation before mem9 work starts.
+18. Outbox tests cover active memory-create reservation row creation before
+    mem9 write work starts, and recall skipping the active row.
 19. Outbox tests cover retryable commit failure enqueueing work.
 20. Outbox tests cover pre-execution outbox failure returning `503`.
 21. Outbox tests cover post-execution outbox failure returning operation success

--- a/docs/design/mem9-runtime-usage-client-proposal.md
+++ b/docs/design/mem9-runtime-usage-client-proposal.md
@@ -1,0 +1,1098 @@
+---
+title: mem9-server Runtime Usage Client Proposal
+status: draft
+created: 2026-05-13
+last_updated: 2026-05-13
+sources:
+  - https://github.com/mem9-ai/mem9-console-server/issues/13
+  - https://github.com/mem9-ai/mem9-console-server/issues/16
+---
+
+## Summary
+
+Add a billing-grade runtime quota client plus console-shaped async metering
+writer support to mem9-server so commercial SaaS mode can call the
+console-server internal runtime APIs defined in issues #13 and #16.
+
+The client should:
+
+1. Reserve quota before recall and memory create operations.
+2. Commit or release reservations after operation completion.
+3. Apply quota adjustments after successful delete, merge, or cleanup operations.
+4. Hand metering events to the existing `server/internal/metering.Writer` after
+   quota commit or adjustment.
+5. Retry quota finalization with the same `operationId` until console accepts the
+   operation or the work is durably queued locally.
+
+This must stay generic. mem9-server should know only runtime facts, operation
+types, meters, units, and API endpoints. Console-server continues to own org,
+plan, quota bucket, billing period, S3, Stripe, and rollup logic.
+
+## Background
+
+Issue #13 defines the synchronous quota gate:
+
+1. `PUT /api/internal/quota/reservations/{operationId}`
+2. `PATCH /api/internal/quota/reservations/{operationId}`
+3. `PUT /api/internal/quota/adjustments/{operationId}`
+
+Issue #16 defines the service boundary and metering ledger:
+
+1. `PUT /api/internal/metering/events/{operationId}`
+2. `Authorization: Bearer <internalSecret>` identifies mem9-server.
+3. `X-API-Key: <apiKey>` identifies the quota subject.
+4. `operationId` links quota and metering for one billable or quota-affecting
+   operation.
+
+This proposal includes an inline contract appendix because the console-server
+issues are private to some reviewers. The appendix is copied from issues #13 and
+#16 as read on 2026-05-13 and should be treated as the implementation contract
+until `docs/api/openapi-internal-v1.yaml` is available in console-server.
+
+Contract precedence for A1:
+
+1. If `docs/api/openapi-internal-v1.yaml` exists in console-server, implement the
+   OpenAPI contract.
+2. Until OpenAPI exists, use issue #16's explicit runtime flow for successful
+   usage: mem9-server calls `PATCH /api/internal/quota/reservations/{operationId}`
+   with `status: "committed"` after the mem9 operation succeeds, then submits
+   `PUT /api/internal/metering/events/{operationId}`.
+3. Treat issue #13's state-machine sentence that says metering acceptance
+   performs `reserved -> committed` as stale relative to issue #16. Console
+   should resolve this in OpenAPI before implementation begins.
+4. Use issue #13's quota error name `reservation_conflict`. Do not introduce
+   `operation_conflict` unless OpenAPI explicitly adds it.
+
+Current mem9-server already has an optional metering writer. The `Writer`
+interface is the right async sidecar shape for metering, but the HTTP/webhook
+implementation is not the right API shape or reliability level for
+console-server yet. It currently posts a generic webhook event with a generated
+event ID, while console-server requires
+`PUT /api/internal/metering/events/{operationId}` using the same `operationId`
+as quota. For commercial runtime usage, the HTTP writer must become
+outbox-backed so successful usage is retried until console accepts or the work
+is in a manual-reconciliation terminal state.
+
+Relevant current code:
+
+1. `server/internal/handler/memory.go:297` runs recall/search in
+   `listMemories`, and records recall metering only after success at
+   `server/internal/handler/memory.go:360`.
+2. `server/internal/handler/memory.go:43` handles memory creation. Sync creates
+   return after writes at `server/internal/handler/memory.go:150` and
+   `server/internal/handler/memory.go:163`; async creates run in goroutines at
+   `server/internal/handler/memory.go:106` and
+   `server/internal/handler/memory.go:173`.
+3. `server/internal/handler/memory.go:496` handles single delete, and
+   `server/internal/handler/memory.go:514` handles batch delete.
+4. `server/internal/handler/metering.go:26` and
+   `server/internal/handler/metering.go:41` send the current optional metering
+   events.
+5. `server/internal/metering/writer.go:31` defines `Writer.Record` as
+   non-blocking, and `server/internal/metering/transport_writer.go:289` drops a
+   failed S3 batch after logging.
+6. `server/internal/metering/webhook_writer.go:241` builds a generic webhook
+   event with a generated `evt_...` ID instead of using the console
+   `operationId`.
+
+## Goals
+
+1. Add a generic runtime usage quota client for console-server internal quota
+   APIs.
+2. Reuse the existing `server/internal/metering.Writer` interface for async
+   console metering.
+3. Gate recall and memory create before execution in commercial mode.
+4. Use quota adjustments after successful memory deletion and reconciliation
+   cleanup.
+5. Durably enqueue metering events only after quota commit or adjustment
+   succeeds, then deliver them through the existing metering writer surface.
+6. Keep raw API keys out of logs and public responses.
+7. Support disabled mode for OSS and self-hosted deployments.
+
+## Non-Goals
+
+1. Do not implement console billing, plan, bucket, S3, Stripe, or rollup logic in
+   mem9-server.
+2. Do not replace public mem9 API authentication.
+3. Do not make console-server a hard dependency for OSS mode.
+4. Do not add a second metering-specific interface when the existing
+   `metering.Writer` interface can carry console events.
+5. Do not use the async metering writer for quota reservations, quota commits,
+   releases, or adjustments.
+6. Do not solve public request idempotency from agents to mem9-server in this
+   proposal.
+
+## Proposed Architecture
+
+Add a new package:
+
+```text
+server/internal/runtimeusage/
+```
+
+Core interfaces:
+
+```go
+type QuotaClient interface {
+    Reserve(ctx context.Context, subject Subject, op Operation) (*Reservation, error)
+    FinalizeReservation(ctx context.Context, subject Subject, operationID string, status ReservationFinalStatus, reason string) error
+    ApplyAdjustment(ctx context.Context, subject Subject, op Adjustment) error
+}
+
+type Manager interface {
+    BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error)
+    AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error
+    AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error)
+    BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error)
+    AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error
+    AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error)
+    BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error)
+    AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error
+    AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error)
+}
+```
+
+`QuotaClient` is a thin HTTP API client for quota reservations, reservation
+finalization, and adjustments. `Manager` owns operation generation, reservation
+sequencing, durable quota retry handoff, disabled-mode no-op behavior, durable
+metering enqueue after quota finalization, and the handoff to `metering.Writer`.
+For deletes, `BeforeMemoryDelete` creates `adjustment_intent` before the mem9
+delete executes so a crash cannot erase the operation boundary. Handlers should
+depend on `Manager`, not raw HTTP calls.
+
+`operationId` uses `github.com/google/uuid.NewV7`. The server already pins
+`github.com/google/uuid v1.6.0`, which includes UUIDv7 support.
+
+Console metering stays in the existing package:
+
+```text
+server/internal/metering/
+```
+
+Do not add a new metering interface. Keep the current interface:
+
+```go
+type Writer interface {
+    Record(evt Event)
+    Close(ctx context.Context) error
+}
+```
+
+Extend `metering.Event` with console fields:
+
+```go
+type Event struct {
+    Category string
+    TenantID string
+    ClusterID string
+    AgentID string
+    Data map[string]any
+
+    OperationID string
+    APIKeySubject string
+    EventType string
+    Meter string
+    Units int64
+    OccurredAt time.Time
+    MemoryIDs []string
+}
+```
+
+The quota manager generates `OperationID` and passes it into
+`metering.Event`. The writer must not generate console operation IDs because
+issues #13 and #16 require the same `operationId` across quota and metering for
+the same operation.
+
+## Configuration
+
+Add config fields:
+
+| Env var | Meaning |
+| --- | --- |
+| `MNEMO_RUNTIME_USAGE_ENABLED` | Enables commercial runtime usage integration: synchronous quota gate plus console billing metering. Default `false`. |
+| `MNEMO_RUNTIME_USAGE_BASE_URL` | Console-server base URL for internal quota and metering APIs. Required when enabled. |
+| `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Bearer secret for internal APIs. Required when enabled. |
+| `MNEMO_RUNTIME_USAGE_TIMEOUT` | Per-request timeout for synchronous quota APIs. Default `3s`. |
+| `MNEMO_RUNTIME_USAGE_METERING_TIMEOUT` | Per-request timeout for async console metering API delivery. Default `5s`. |
+| `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` | Fallback reservation TTL for local watchdogs when console response does not include `expiresAt`. Default `30m`. |
+| `MNEMO_RUNTIME_USAGE_OPERATION_TTL` | Fallback TTL for adjustment-backed operations that have no console reservation expiry. Default `30m`. |
+| `MNEMO_RUNTIME_USAGE_FAIL_OPEN` | Development-only override. Default `false`. Production should fail closed. |
+| `MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED` | Enables local durable retry outbox. Default follows runtime usage enabled. |
+| `MNEMO_METERING_ENABLED` | Enables optional legacy/export metering writer. Not required for console billing metering. Default `false`. |
+| `MNEMO_METERING_URL` | Optional legacy/export metering destination, such as `s3://`, `http://`, or `https://`. Not used to build console billing metering URLs. |
+| `MNEMO_METERING_FLUSH_INTERVAL` | Existing legacy/export metering flush interval. Not used by console billing metering. |
+
+Validation should redact the base URL and never log the secret.
+
+Commercial runtime usage should be legible from configuration alone:
+`MNEMO_RUNTIME_USAGE_ENABLED=true` means mem9-server will perform quota gating
+and console billing metering against `MNEMO_RUNTIME_USAGE_BASE_URL`.
+`MNEMO_METERING_ENABLED` remains an independent optional export feature and must
+not be required for console billing correctness.
+
+When runtime usage is enabled, console metering sends to
+`{MNEMO_RUNTIME_USAGE_BASE_URL}/api/internal/metering/events/{operationId}` and
+uses `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` for
+`Authorization: Bearer <internalSecret>`. `MNEMO_METERING_URL` must not override
+or shadow this console URL. If legacy/export metering is also enabled, it runs as
+a separate sidecar destination.
+
+## Subject Identity
+
+Console-server requires `X-API-Key` as the quota subject. Current v1alpha2 auth
+resolves this header in `server/internal/middleware/auth.go:215`, but
+`domain.AuthInfo` currently stores only tenant and cluster identity at
+`server/internal/domain/types.go:58`.
+
+Add an in-memory field:
+
+```go
+type AuthInfo struct {
+    AgentName string
+    TenantID string
+    TenantDB *sql.DB
+    ClusterID string
+    APIKeySubject string
+}
+```
+
+Rules:
+
+1. v1alpha2 routes set `APIKeySubject` from the trimmed `X-API-Key`.
+2. v1alpha1 path-token routes set `APIKeySubject` to the tenant ID only if
+   runtime usage is enabled for that route. Otherwise leave it empty.
+3. Do not log `APIKeySubject`.
+4. Durable retry storage should not store raw API keys in A1. Because the current
+   API key subject is the tenant ID, store `tenant_id` plus
+   `subject_version = "tenant_id_v1"` in the outbox. If API keys later diverge
+   from tenant IDs, add an encrypted subject column in that migration.
+5. A1 runtime usage requires the current invariant that API key subject equals
+   tenant ID. If API key semantics change before encrypted subject storage is
+   implemented, operators must drain or migrate `runtime_usage_outbox` before
+   enabling the new key model.
+
+## Internal API Contract
+
+All calls use:
+
+```http
+Authorization: Bearer <internalSecret>
+X-API-Key: <apiKey>
+```
+
+`operationId` is a UUIDv7 generated by mem9-server. Network retries reuse the
+same `operationId` and the same canonical payload.
+
+### Reserve Quota
+
+```http
+PUT /api/internal/quota/reservations/{operationId}
+```
+
+Request:
+
+```json
+{"meter":"recalls","units":1}
+```
+
+For memory-slot creates, use `{"meter":"memory_slots","units":<positive-int>}`.
+
+Success response:
+
+```json
+{
+  "operationId": "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+  "meter": "recalls",
+  "units": 1,
+  "status": "reserved",
+  "expiresAt": "2026-04-28T12:00:00Z",
+  "remainingIncludedUnits": 999,
+  "reservedUnits": 1,
+  "overageAllowed": false
+}
+```
+
+Quota denial uses `402`:
+
+```json
+{
+  "code": "quota_exhausted",
+  "message": "Included recall quota is exhausted.",
+  "meter": "recalls",
+  "limitType": "includedQuota",
+  "retryable": false,
+  "upgradeAction": "upgradePlan"
+}
+```
+
+Known quota error codes from issue #13 are `quota_exhausted`,
+`spending_limit_exceeded`, `api_key_unbound`, `reservation_conflict`, and
+`meter_not_supported`.
+
+### Commit Or Release Reservation
+
+```http
+PATCH /api/internal/quota/reservations/{operationId}
+```
+
+Commit request:
+
+```json
+{"status":"committed","reason":"operationSucceeded"}
+```
+
+Release request:
+
+```json
+{"status":"released","reason":"operationFailed"}
+```
+
+The response echoes `operationId`, `meter`, `units`, final `status`,
+`expiresAt`, `remainingIncludedUnits`, `reservedUnits`, and `overageAllowed`.
+
+### Apply Quota Adjustment
+
+```http
+PUT /api/internal/quota/adjustments/{operationId}
+```
+
+Request:
+
+```json
+{"meter":"memory_slots","delta":-3,"reason":"memoryDeleted"}
+```
+
+Response:
+
+```json
+{
+  "operationId": "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+  "meter": "memory_slots",
+  "delta": -3,
+  "reason": "memoryDeleted",
+  "status": "applied",
+  "remainingIncludedUnits": 4662
+}
+```
+
+### Submit Metering Event
+
+```http
+PUT /api/internal/metering/events/{operationId}
+```
+
+Request:
+
+```json
+{
+  "eventType": "recall",
+  "meter": "recalls",
+  "units": 1,
+  "occurredAt": "2026-04-28T12:00:00Z",
+  "agentName": "Codex",
+  "memoryIds": ["mem_123", "mem_456"]
+}
+```
+
+Response:
+
+```json
+{"operationId":"018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234","status":"accepted","deduped":false}
+```
+
+Metering is accepted only after the matching reservation is committed or the
+matching adjustment is applied. Same `operationId` plus same canonical payload is
+idempotent; same `operationId` with a different payload returns `409`.
+
+## Operation Flows
+
+### Recall
+
+Only query-based search is billable. Plain list requests with no `q` should not
+reserve recall quota. A query recall is billed once it executes, even if it
+returns zero memories, because the server still performs embedding/vector/keyword
+work. This is an explicit product choice for A1 and should be mirrored in console
+usage copy.
+
+Flow:
+
+1. Handler detects `filter.Query != ""`.
+2. Manager generates UUIDv7 `operationId` with `uuid.NewV7`.
+3. Manager calls:
+
+```http
+PUT /api/internal/quota/reservations/{operationId}
+Authorization: Bearer <internalSecret>
+X-API-Key: <apiKey>
+
+{"meter":"recalls","units":1}
+```
+
+4. On `402`, return a stable 402 response to the caller without executing
+   recall.
+5. On transient failure, fail closed with `503` unless development fail-open is
+   explicitly enabled.
+6. Execute existing recall.
+7. On success, persist `commit_pending` with the metering payload, then commit
+   reservation.
+8. Only after console returns committed or idempotent committed, persist
+   `metering_pending` and call `metering.Writer.Record` with a console-shaped
+   metering event:
+
+```json
+{
+  "operationId": "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+  "apiKeySubject": "<apiKey>",
+  "eventType": "recall",
+  "meter": "recalls",
+  "units": 1,
+  "occurredAt": "2026-05-13T00:00:00Z",
+  "agentName": "Codex",
+  "memoryIds": ["..."]
+}
+```
+
+9. If commit has a retryable or ambiguous failure after recall succeeded,
+   persist `commit_pending` and return success. The worker retries the commit
+   first and does not call `Record` until console ACKs the commit.
+10. If post-execution durable enqueue also fails, do not convert the already
+    completed recall into a client-visible `503`. Return the successful recall
+    response, emit an ERROR log with `operationId`, tenant ID, cluster ID, step,
+    and payload hash, and increment a `manual_reconciliation_required` metric.
+    Fail-closed responses apply only before the mem9 operation starts.
+11. If async metering delivery fails after `Record`, the console writer retries
+    `submit_metering_event` with the same `operationId` until console accepts or
+    the row reaches `terminal_failed`.
+
+Handler shape:
+
+```go
+if filter.Query != "" {
+    lease, err := s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
+    if err != nil {
+        s.handleRuntimeUsageError(r.Context(), w, err)
+        return
+    }
+    finalized := false
+    defer func() {
+        if !finalized {
+            s.runtimeUsage.AfterRecallFailure(context.Background(), lease, context.Canceled)
+        }
+    }()
+
+    memories, total, err = executeRecallSearch(r.Context(), auth, svc, filter)
+    if err != nil {
+        s.runtimeUsage.AfterRecallFailure(context.Background(), lease, err)
+        finalized = true
+        s.handleError(r.Context(), w, err)
+        return
+    }
+    if err := s.runtimeUsage.AfterRecallSuccess(r.Context(), lease, runtimeusage.RecallResult{
+        MemoryIDs: memoryIDs(memories),
+        AgentName: auth.AgentName,
+    }); err != nil {
+        s.logger.Error("runtime usage post-recall finalization failed",
+            "operation_id", lease.OperationID,
+            "tenant_id", auth.TenantID,
+            "cluster_id", auth.ClusterID,
+            "err", err)
+    }
+    finalized = true
+}
+```
+
+### Memory Create
+
+Memory create is harder than recall because the current smart ingest path can
+change an unknown number of active memories.
+
+Before handler integration, refactor the known-unit service write methods to
+return an explicit `UsageDelta`. This is required for A1 create/delete quota
+correctness, but the smart-ingest-specific `UsageDelta` plumbing is deferred to
+A2 because A1 blocks those request shapes in runtime-usage mode.
+
+Known-unit paths:
+
+1. Explicit pinned create reserves `memory_slots` units `1`.
+2. Bulk create reserves `memory_slots` units `len(input.memories)`. The current
+   `MemoryService.BulkCreate` returns only `([]domain.Memory, error)`, so A1 must
+   refactor it to return `UsageDelta` before wiring quota.
+3. Batch import of a known memory file can reserve the number of valid memory
+   records before writing.
+
+Unknown-unit paths:
+
+1. Smart content ingest and message ingest can ADD, UPDATE, and DELETE insights.
+2. `service.IngestResult` reports `MemoriesChanged` at
+   `server/internal/service/ingest.go:56`, but the field counts ADD and UPDATE,
+   not net active memory-slot delta.
+3. Reconciliation deletes insights at `server/internal/service/ingest.go:1266`,
+   but deleted IDs are not returned to the handler.
+
+Recommended A1 behavior:
+
+1. Add a production `UsageDelta` result from service operations:
+
+```go
+type UsageDelta struct {
+    MemorySlotsDelta int64
+    CreatedMemoryIDs []string
+    DeletedMemoryIDs []string
+    UpdatedMemoryIDs []string
+}
+```
+
+2. For known-unit creates, reserve before execution using the known positive
+   `MemorySlotsDelta`.
+3. For smart ingest, do not reserve a guessed `1` unit. A1 will block
+   unknown-delta smart ingest in runtime-usage mode and ship recall plus
+   known-unit memory CRUD first. Plan/apply smart ingest is deferred to A2.
+4. Durably enqueue and record the actual usage delta with `metering.Writer` only
+   after commit or adjustment is accepted or idempotently deduped by console.
+
+This keeps quota gating in front of memory creation while avoiding silent
+under-counting for multi-insight ingest. Commercial SaaS returns a deterministic
+`409` for smart ingest paths instead of accepting ungated async writes.
+
+Blocked A1 request shapes when `MNEMO_RUNTIME_USAGE_ENABLED=true`:
+
+1. `POST /memories` with `messages` non-empty, sync or async.
+2. `POST /memories` with `content` and no explicit
+   `memory_type: "pinned"`, sync or async.
+3. Any async content/message create path that would return `202` before quota
+   reservation and metering state are durable.
+
+Response:
+
+```json
+{
+  "code": "runtime_usage_requires_known_memory_delta",
+  "message": "runtime usage mode requires a known memory_slots delta; use pinned memory create or disable runtime usage for smart ingest",
+  "retryable": false
+}
+```
+
+### Memory Delete And Batch Delete
+
+Delete operations create a durable adjustment intent first, execute mem9 work,
+then apply adjustment only if the returned `UsageDelta` shows active memory
+slots decreased.
+
+Single delete flow:
+
+1. Call `BeforeMemoryDelete` to persist `adjustment_intent` with the target
+   memory ID before executing `svc.memory.Delete`.
+2. Execute `svc.memory.Delete`.
+3. Use the returned `UsageDelta.MemorySlotsDelta`.
+4. If `MemorySlotsDelta == 0`, transition `adjustment_intent -> done` and skip
+   quota adjustment and metering. This handles idempotent deletes where the row
+   is already deleted; current repositories can return nil for already-deleted
+   rows.
+5. If `MemorySlotsDelta < 0`, transition `adjustment_intent ->
+   adjustment_pending` and call:
+
+```json
+{"meter":"memory_slots","delta":-1,"reason":"memoryDeleted"}
+```
+
+6. After console accepts or dedupes the adjustment, transition to
+   `metering_pending` and record a metering event with `eventType:
+   "memoryDeleted"`, `meter: "memory_slots"`, `units: -1`, and the memory ID.
+7. If the delete returns an error and the service cannot prove that no active
+   slot changed, mark the operation `unknown_after_crash` and emit
+   `manual_reconciliation_required`; do not infer a quota adjustment.
+
+Batch delete flow:
+
+1. Call the batch equivalent of `BeforeMemoryDelete` to persist
+   `adjustment_intent` with the requested IDs before executing
+   `svc.memory.BulkDelete`.
+2. Execute `svc.memory.BulkDelete`.
+3. Use the returned `deleted` count from `server/internal/handler/memory.go:523`.
+4. If `deleted == 0`, transition `adjustment_intent -> done` and skip quota and
+   metering.
+5. Otherwise transition `adjustment_intent -> adjustment_pending`, adjust
+   `delta = -deleted`, and record one metering event after console ACKs the
+   adjustment with the deleted IDs available from the request.
+6. If batch delete returns an ambiguous error without a trustworthy delta, mark
+   the operation `unknown_after_crash` and require operator reconciliation.
+
+### Merge And Cleanup
+
+Reconciliation currently performs update as archive-and-create and can delete
+insights. These are quota-affecting but not exposed as top-level handler
+results.
+
+A1 should refactor service result types to return `UsageDelta` from the
+known-unit paths that remain enabled in runtime-usage mode:
+
+1. `MemoryService.CreatePinned`
+2. `MemoryService.BulkCreate`
+3. `MemoryService.Delete`
+4. `MemoryService.BulkDelete`
+
+A2 should add `UsageDelta` to the smart ingest internals before unblocking those
+request shapes:
+
+1. `MemoryService.Create`
+2. `IngestService.ReconcileContent`
+3. `IngestService.ReconcilePhase2`
+
+For each enabled path, the handler sends one quota/metering operation for the
+aggregate delta of the public mem9 operation.
+
+`BulkCreate` needs special handling because it currently returns a memory slice
+but no operation metadata. The refactor should return both the created memories
+and `UsageDelta`, with `MemorySlotsDelta = int64(len(created))` and
+`CreatedMemoryIDs` populated from the successful insert set.
+
+## Error Mapping
+
+Runtime usage errors should not leak internal console details.
+
+| Console/runtime result | mem9-server response |
+| --- | --- |
+| Reservation `402 quota_exhausted` | `402` with stable code and upgrade action. |
+| Reservation `402 spending_limit_exceeded` | `402` with stable code and upgrade action. |
+| `api_key_unbound` | Preserve console's returned status and body; issue #13 examples use the quota denial family, so prefer `402` unless OpenAPI says otherwise. |
+| `reservation_conflict` before execution | `502`, because generated operation IDs should not conflict. |
+| Runtime API network or 5xx before execution | `503 runtime usage unavailable` in fail-closed mode. |
+| Commit retryable failure after execution | Enqueue durable quota retry, then return operation success. |
+| Commit non-retryable conflict after execution | Return operation success if the mem9 response is otherwise valid; log `manual_reconciliation_required` with request ID plus operation ID. |
+| Async metering delivery failure | Keep the mem9 response successful only if the metering event is already durably queued; otherwise log `manual_reconciliation_required`. |
+| Post-execution outbox enqueue failure | Return operation success; log `manual_reconciliation_required` with operation ID, step, tenant ID, cluster ID, and payload hash. |
+| Release failure after execution failure | Enqueue release retry; otherwise rely on console reservation expiry and local watchdog metrics. |
+
+For quota-denied `402` responses, preserve the console response body rather than
+collapsing it to `{"error":"..."}`. If the body is valid JSON, pass it through
+and add `mem9_code: "runtime_quota_denied"` only when that field is absent. This
+keeps `code`, `limitType`, `retryable`, and `upgradeAction` available to clients.
+
+## Metering Writer Refactoring
+
+Refactor `server/internal/metering` instead of adding a new metering package or
+interface.
+
+Required changes:
+
+1. Keep `metering.Writer` unchanged:
+
+```go
+type Writer interface {
+    Record(evt Event)
+    Close(ctx context.Context) error
+}
+```
+
+2. Extend `metering.Event` with optional console fields:
+   `OperationID`, `APIKeySubject`, `EventType`, `Meter`, `Units`, `OccurredAt`,
+   and `MemoryIDs`.
+3. Keep legacy/export writer behavior unchanged for `MNEMO_METERING_URL`
+   destinations.
+4. Add an outbox-aware console HTTP writer in `server/internal/metering`, but do
+   not select it from `MNEMO_METERING_URL`. Runtime usage constructs this writer
+   from `MNEMO_RUNTIME_USAGE_BASE_URL` and
+   `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET`.
+5. The console HTTP writer validates required console fields before delivery.
+   Invalid console events are marked terminal failed with a
+   `manual_reconciliation_required` log and metric; they are not silently
+   dropped.
+6. Make the console HTTP writer outbox-aware by injecting the runtime usage
+   outbox repository and logger when runtime usage is enabled. This keeps
+   `metering.Writer` unchanged while giving the writer ownership of console
+   metering ACK handling.
+7. `Record(evt)` validates required console fields, upserts the
+   `submit_metering_event` payload only when the existing row is absent or has
+   the same canonical payload hash, queues the operation in memory, and returns
+   without waiting for console.
+8. The writer background worker sends:
+
+```http
+PUT {MNEMO_RUNTIME_USAGE_BASE_URL}/api/internal/metering/events/{operationId}
+Authorization: Bearer <internalSecret>
+X-API-Key: <apiKeySubject>
+Content-Type: application/json
+```
+
+Request body:
+
+```json
+{
+  "eventType": "recall",
+  "meter": "recalls",
+  "units": 1,
+  "occurredAt": "2026-04-28T12:00:00Z",
+  "agentName": "Codex",
+  "memoryIds": ["mem_123", "mem_456"]
+}
+```
+
+The console writer uses `Event.OperationID` in the URL. It must not generate a
+new operation ID because issue #13 and issue #16 require quota and metering to
+share one `operationId`.
+
+For A1, console metering follows the existing writer's async sidecar call-site
+semantics: `Record` does not wait for console to accept the event. Unlike the
+legacy/export writer, console delivery must be durable and is part of runtime
+usage even when `MNEMO_METERING_ENABLED=false`. Runtime usage code transitions
+the outbox row to `metering_pending` only after quota commit or adjustment is
+accepted or deduped by console. The console HTTP writer owns the ACK path for
+`submit_metering_event`: accepted or same-payload deduped responses move
+`metering_pending -> done`, different-payload `409` or invalid payloads move
+`metering_pending -> terminal_failed`, and retryable failures keep the row
+pending with backoff. The runtime usage worker must not call `Record` while an
+operation is still `commit_pending` or `adjustment_pending`.
+
+## Durable Retry Outbox
+
+Issue #16 requires quota commit and metering retry until acked or durably
+queued. Add a local runtime usage outbox in the control-plane DB:
+
+```sql
+CREATE TABLE IF NOT EXISTS runtime_usage_outbox (
+  operation_id      VARCHAR(36) PRIMARY KEY,
+  tenant_id         VARCHAR(36) NOT NULL,
+  subject_version   VARCHAR(32) NOT NULL DEFAULT 'tenant_id_v1',
+  step              VARCHAR(32) NOT NULL,
+  phase             VARCHAR(32) NOT NULL,
+  payload_json      JSON        NOT NULL,
+  payload_hash      VARCHAR(64) NOT NULL,
+  expires_at        TIMESTAMP   NULL,
+  status            VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempt_count     INT         NOT NULL DEFAULT 0,
+  next_attempt_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_error        TEXT        NULL,
+  created_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_runtime_usage_outbox_poll (status, next_attempt_at)
+);
+```
+
+Outbox steps:
+
+1. `commit_reservation`
+2. `release_reservation`
+3. `apply_adjustment`
+4. `submit_metering_event`
+
+Operation phases:
+
+1. `reserved_active`: reservation exists and mem9 work may be running.
+2. `commit_pending`: mem9 work succeeded and reservation commit must be retried.
+3. `release_pending`: mem9 work failed or was abandoned and reservation release
+   must be retried.
+4. `adjustment_intent`: adjustment-backed operation has started and has an
+   `expires_at` based on `MNEMO_RUNTIME_USAGE_OPERATION_TTL`, but mem9 work has
+   not been confirmed successful yet.
+5. `adjustment_pending`: mem9 work succeeded and quota adjustment must be
+   retried.
+6. `metering_pending`: quota commit or adjustment is accepted and console
+   metering must be retried.
+7. `done`: all required quota and metering work is accepted or deduped.
+8. `unknown_after_crash`: watchdog cannot infer whether the mem9 write succeeded;
+   operators must reconcile using mem9 data and console operation state.
+9. `terminal_failed`: non-retryable conflict or invalid payload requires
+   operator repair.
+
+Worker behavior:
+
+1. Poll pending rows with exponential backoff.
+2. Use the same `operationId`.
+3. Treat console idempotent quota and metering success as done.
+4. Treat same-payload duplicates as done.
+5. Treat different-payload `409` as terminal failed and log for operator repair.
+6. Limit each poll batch per tenant so one tenant with many pending rows cannot
+   starve others.
+7. Never log raw API key values.
+8. If the outbox row includes a post-success metering event payload, call
+   `metering.Writer.Record` only after the queued quota commit or adjustment is
+   accepted or deduped by console.
+9. For `submit_metering_event`, the console HTTP writer observes the console
+   response and updates the outbox row. The generic runtime usage worker only
+   requeues stale `metering_pending` rows back into `metering.Writer.Record`.
+
+Crash and primary-writer-unavailable handling:
+
+1. `BeforeRecall` and known-unit `BeforeMemoryCreate` insert `reserved_active`
+   after console returns `reserved` and before mem9 work starts.
+2. On mem9 success, the manager updates the row to `commit_pending` with the
+   metering payload before attempting the synchronous commit.
+3. On mem9 failure, the manager updates the row to `release_pending` before
+   attempting release.
+4. If the process crashes while a row is still `reserved_active`, the watchdog
+   waits until `expiresAt + 2m`, marks the row `unknown_after_crash`, and emits
+   `manual_reconciliation_required`. The worker must not guess commit or release
+   without a persisted operation result.
+5. For adjustment-backed deletes and cleanup, the manager writes
+   `adjustment_intent` before execution with the target operation metadata and
+   `expires_at = now() + MNEMO_RUNTIME_USAGE_OPERATION_TTL`. After success with
+   `UsageDelta.MemorySlotsDelta == 0`, it moves the row directly to `done`.
+   After success with a negative delta, it updates the row to
+   `adjustment_pending` with the actual `UsageDelta`. If the process crashes
+   before either transition, the watchdog marks the row `unknown_after_crash`
+   after `expires_at` instead of applying an inferred delta.
+6. If an adjustment-backed mem9 operation fails before changing data, the
+   manager moves `adjustment_intent -> done` with a failure reason and does not
+   call console adjustment or metering. If the failure is ambiguous and no
+   trustworthy `UsageDelta` exists, the manager marks the row
+   `unknown_after_crash` and emits `manual_reconciliation_required`.
+7. After quota commit or adjustment is accepted, the row moves to
+   `metering_pending`. Only after console metering returns accepted or deduped
+   does the row move to `done`.
+
+The worker reconstructs `X-API-Key` from `tenant_id` only for
+`subject_version = "tenant_id_v1"`. A future API-key model where subject differs
+from tenant ID must add an encrypted subject column and a new subject version.
+
+## Reservation Cleanup
+
+Reservation leak prevention uses three layers:
+
+1. Handler-level `defer` release for normal failure paths after a reservation is
+   acquired but before success finalization.
+2. Local outbox rows for active reservations before executing mem9 work. Startup
+   resumes pending `release_reservation`, `commit_reservation`,
+   `apply_adjustment`, and `submit_metering_event` rows.
+3. Console-server `expiresAt` auto-expiry as the final authority for process
+   crashes before mem9-server can persist a local outbox row.
+
+The reservation response includes `expiresAt`. mem9-server stores it in the
+outbox payload and uses it as the retry deadline for release and commit work. If
+console omits `expiresAt`, use `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` as the local
+deadline. The default is `30m`; production should set it to match console's quota
+reservation TTL.
+
+`BeforeRecall` and `BeforeMemoryCreate` must durably insert the active
+reservation outbox row after console returns `reserved` and before executing the
+mem9 operation. If this insert fails before execution, release the console
+reservation best-effort and return `503`; this is a true fail-closed path because
+the mem9 operation has not started.
+
+The outbox worker should mark unresolved `reserved_active` work
+`unknown_after_crash` after `expiresAt + 2m` and emit
+`runtime_usage_reservation_unknown_total`. Retrying a commit after expiry without
+a persisted success result is noise; at that point operators should reconcile
+from the console quota operation state and mem9 logs.
+
+## Finalization Ordering
+
+Metering must never be recorded before quota is finalized.
+
+1. Reservation-backed operations use this strict order:
+   `reserve -> execute mem9 work -> persist commit_pending + metering payload ->
+   commit reservation accepted/deduped -> persist metering_pending -> record
+   metering`.
+2. Adjustment-backed operations use this strict order:
+   `persist adjustment_intent -> execute mem9 work -> persist adjustment_pending
+   + metering payload -> apply adjustment accepted/deduped -> persist
+   metering_pending -> record metering`.
+3. If commit succeeds, durably move the row to `metering_pending`, then call
+   `metering.Writer.Record` with the same `operationId`. Delivery and ACK
+   observation happen asynchronously inside the console writer, but retry state
+   is durable.
+4. If commit response is ambiguous because of timeout or network partition,
+   enqueue `commit_reservation`; the worker retries commit first, then records
+   metering only after console returns committed or idempotent committed.
+5. If adjustment response is ambiguous, enqueue `apply_adjustment`; the worker
+   records metering only after console returns applied or idempotent applied.
+6. If post-execution enqueue fails after mem9 work has already succeeded, return
+   the successful mem9 response and log `manual_reconciliation_required`.
+
+## Handler Integration
+
+Add `runtimeUsage runtimeusage.Manager` to `handler.Server`.
+
+Candidate call sites:
+
+1. Recall: wrap the `filter.Query != ""` branches in `listMemories`.
+2. Explicit pinned create: reserve before `svc.memory.CreatePinned`.
+3. Smart content and message ingest: when runtime usage is enabled, return
+   `409 runtime_usage_requires_known_memory_delta` for the blocked A1 request
+   shapes listed in `Memory Create`.
+4. Async content/message ingest: when runtime usage is enabled, do not accept
+   unknown-delta async creates or return `202` before quota reservation and
+   outbox state are durable.
+5. Single delete and batch delete: persist `adjustment_intent` before delete,
+   then apply quota adjustment and metering only after the returned delta proves
+   active memory slots decreased.
+
+Async create decision for A1: block content/message creates that cannot be fully
+reserved before returning. Returning `202` before quota reservation is not
+allowed in commercial runtime usage because a later quota denial cannot be
+surfaced cleanly to the caller.
+
+## Existing Metering Writer Compatibility
+
+Keep `MNEMO_METERING_ENABLED` and `MNEMO_METERING_URL` as the optional
+legacy/export metering surface. They are no longer the console billing metering
+gate.
+
+Compatibility rules:
+
+1. Keep `metering.Writer` unchanged.
+2. Runtime usage may reuse `metering.Writer` internally for console billing
+   metering, but it is enabled by `MNEMO_RUNTIME_USAGE_ENABLED`, not by
+   `MNEMO_METERING_ENABLED`.
+3. Keep `s3://`, `http://`, and `https://` `MNEMO_METERING_URL` destinations as
+   optional legacy/export infrastructure.
+4. Do not derive the console metering endpoint from `MNEMO_METERING_URL`; derive
+   it from `MNEMO_RUNTIME_USAGE_BASE_URL`.
+5. Do not use `metering.Writer` for quota reservations, commits, releases, or
+   adjustments; those remain synchronous runtime usage quota operations.
+6. Do not add a second metering interface unless future strict durability
+   requirements cannot be met behind the existing `Writer` interface.
+
+## Local Contract Additions
+
+These values are mem9-server local additions unless future console OpenAPI
+promotes them into the internal API contract:
+
+| Value | Kind | Scope |
+| --- | --- | --- |
+| `runtime_usage_requires_known_memory_delta` | HTTP response code | Returned by mem9-server with `409` when runtime usage is enabled and a create path cannot compute memory-slot delta before writes. |
+| `mem9_code = "runtime_quota_denied"` | Optional response field value | Added by mem9-server to pass-through quota-denied JSON only when console did not already include `mem9_code`. |
+| `manual_reconciliation_required` | Log/metric reason | Emitted when post-success quota or metering state cannot be durably persisted or replayed safely. |
+| `runtime_usage_reservation_unknown_total` | Metric | Counts reservations whose success/failure cannot be inferred after `expiresAt + 2m`. |
+| `runtime_usage_metering_delivery_failed_total` | Metric | Counts console metering events that reach terminal failed state after retry or invalid payload. |
+
+## Rollout Plan
+
+1. A1a: Add config, no-op runtime usage manager, quota HTTP client, and
+   `AuthInfo.APIKeySubject` without changing public API behavior.
+2. A1a: Add durable runtime usage outbox schema, repository, watchdog, and
+   worker in no-op mode.
+3. A1b: Extend `metering.Event` and add an outbox-aware console writer that is
+   constructed from runtime usage config and calls
+   `PUT /api/internal/metering/events/{operationId}`.
+4. A1b: Add recall reservation, release, commit, durable metering handoff, and
+   post-execution manual reconciliation logging.
+5. A1c: Refactor known-unit memory CRUD services to return `UsageDelta`.
+6. A1c: Add explicit create reservation, delete adjustment, and batch-delete
+   adjustment.
+7. A1c: Block smart ingest in runtime-usage mode with
+   `409 runtime_usage_requires_known_memory_delta`.
+8. A2: Refactor smart ingest internals to return net `UsageDelta`, then unblock
+   runtime-usage smart ingest with correct quota and metering semantics.
+9. Enable in staging with fail-closed disabled only for pre-execution burn-in.
+10. Switch production commercial SaaS to fail-closed for pre-execution quota
+    failures.
+
+## Test Plan
+
+1. Config validation tests for enabled/disabled runtime usage.
+2. Config tests cover console metering being enabled by
+   `MNEMO_RUNTIME_USAGE_ENABLED` without requiring `MNEMO_METERING_ENABLED`.
+3. Config tests cover `MNEMO_METERING_URL` not overriding the console metering
+   endpoint derived from `MNEMO_RUNTIME_USAGE_BASE_URL`.
+4. Quota HTTP client tests for auth headers, `X-API-Key`, request bodies, idempotent
+   retries, and error parsing.
+5. Metering HTTP writer tests cover console URL shape, bearer auth,
+   `X-API-Key`, body fields, and use of caller-provided `operationId`.
+6. Metering HTTP writer tests cover invalid console events being marked terminal
+   failed with `manual_reconciliation_required`.
+7. Existing legacy/export metering writer tests remain unchanged.
+8. Handler tests cover recall reservation before search.
+9. Handler tests cover `402` quota denial without executing search.
+10. Handler tests cover recall commit before metering handoff.
+11. Handler tests cover reservation release after search failure.
+12. Handler tests cover zero-result recall still committing quota and recording
+    metering.
+13. Handler tests cover explicit create reserving `memory_slots`.
+14. Handler tests cover reservation release after create failure.
+15. Handler tests cover delete adjustment after success.
+16. Handler tests cover batch delete skipping adjustment for `deleted == 0`.
+17. Handler tests cover runtime usage forcing or rejecting async smart ingest.
+18. Outbox tests cover active reservation row creation before mem9 work starts.
+19. Outbox tests cover retryable commit failure enqueueing work.
+20. Outbox tests cover pre-execution outbox failure returning `503`.
+21. Outbox tests cover post-execution outbox failure returning operation success
+    and logging `manual_reconciliation_required`.
+22. Outbox tests cover same-payload duplicates being marked done.
+23. Outbox tests cover different-payload conflict as terminal failed.
+24. Outbox tests cover `reserved_active` expiry at `expiresAt + 2m` becoming
+    `unknown_after_crash`.
+25. Outbox tests cover `adjustment_intent -> done` for zero-delta delete.
+26. Outbox tests cover `adjustment_intent -> unknown_after_crash` after
+    `MNEMO_RUNTIME_USAGE_OPERATION_TTL`.
+27. Outbox tests cover `metering_pending -> done` after console accepted or
+    same-payload deduped response.
+28. Outbox tests cover no metering call while an operation remains
+    `commit_pending` or `adjustment_pending`.
+29. Restart tests cover crash after reserve before mem9 work result is
+    persisted.
+30. Restart tests cover crash after mem9 write before commit transition.
+31. Restart tests cover crash after delete before adjustment transition.
+32. Restart tests cover crash after quota commit before metering is accepted.
+
+Run:
+
+```bash
+make test
+make vet
+```
+
+## Effort Estimate
+
+950-1350 LoC production code:
+
+1. A1a runtime usage quota types, HTTP client, config, startup wiring, and
+   subject identity: ~280 LoC
+2. A1a durable runtime usage outbox schema, repository, watchdog, and generic
+   worker: ~350 LoC
+3. A1b metering event fields and outbox-aware console HTTP writer refactor:
+   ~190 LoC
+4. A1b recall handler integration, reservation finalization, and manual
+   reconciliation logging: ~230 LoC
+5. A1c known-unit `UsageDelta` plumbing through memory services: ~180 LoC
+6. A1c explicit create reservation, delete adjustment, and batch-delete
+   adjustment handler integration: ~180 LoC
+7. Error mapping, passthrough 402 responses, and logging helpers: ~100 LoC
+8. Smart-ingest blocking path: ~60 LoC
+
+A2 smart-ingest `UsageDelta` support is excluded from A1 and should be estimated
+separately after the reconcile result contract is designed.
+
+## Open Questions
+
+1. Should console-server expose a reservation lookup or reconciliation endpoint
+   for operator repair, or is `operationId` plus console DB access enough for A1?
+2. What metric names should production dashboards use for
+   `manual_reconciliation_required`, `runtime_usage_reservation_unknown_total`,
+   and terminal metering failures?
+3. Should `operation_id` remain `VARCHAR(36)` because issue #13 requires UUIDv7,
+   or use `VARCHAR(255)` defensively for future non-UUID operation IDs?
+
+## Acceptance Criteria
+
+1. Runtime usage integration is disabled by default.
+2. Enabled mode requires base URL and internal bearer secret.
+3. Recall calls console quota reservation before executing search.
+4. Recall commits quota and records metering with the same `operationId`.
+5. Zero-result query recalls are explicitly billed.
+6. Memory create reserves `memory_slots` before known-unit writes.
+7. Smart ingest is blocked in runtime-usage mode with
+   `409 runtime_usage_requires_known_memory_delta`.
+8. Memory delete and batch delete apply `memory_slots` adjustments only when
+   `UsageDelta.MemorySlotsDelta < 0`.
+9. Memory delete and batch delete persist `adjustment_intent` before executing
+   mem9 deletes and close zero-delta intents as `done`.
+10. Metering events are durably queued and handed to `metering.Writer` only after
+    quota commit or adjustment is accepted or idempotently deduped.
+11. Quota retries reuse the same UUIDv7 `operationId`.
+12. Active reservation outbox rows are created before mem9 work starts.
+13. Retryable post-success quota finalization and metering delivery failures are
+    durably queued before returning success when possible.
+14. Post-success quota or metering enqueue failures return operation success and emit
+    manual reconciliation logs and metrics.
+15. Raw API keys are not logged or stored raw in the outbox.
+16. mem9-server does not embed org, plan, bucket, Stripe, S3, or rollup logic.
+17. Existing legacy/export metering remains available through
+    `MNEMO_METERING_ENABLED` and `MNEMO_METERING_URL`.
+18. Console metering sends API requests to `MNEMO_RUNTIME_USAGE_BASE_URL` using
+    the caller-provided `OperationID`, not a writer-generated event ID.
+19. Console billing metering does not require `MNEMO_METERING_ENABLED` and is
+    not routed by `MNEMO_METERING_URL`.
+20. The console HTTP writer owns `metering_pending -> done|terminal_failed`
+    transitions after observing console responses.
+21. `reserved_active`, `adjustment_intent`, and `metering_pending` states have
+    restart/watchdog behavior for process crash and network partition cases.

--- a/docs/design/mem9-runtime-usage-client-proposal.md
+++ b/docs/design/mem9-runtime-usage-client-proposal.md
@@ -2,1106 +2,149 @@
 title: mem9-server Runtime Usage Client Proposal
 status: draft
 created: 2026-05-13
-last_updated: 2026-05-13
+last_updated: 2026-05-19
 sources:
-  - https://github.com/mem9-ai/mem9-console-server/issues/13
-  - https://github.com/mem9-ai/mem9-console-server/issues/16
+  - https://github.com/mem9-ai/mem9-console-server/pull/36
 ---
 
 ## Summary
 
-Add a billing-grade runtime quota client plus console-shaped async metering
-writer support to mem9-server so commercial SaaS mode can call the
-console-server internal runtime APIs defined in issues #13 and #16.
+Add a billing-grade runtime usage client to mem9-server so commercial SaaS mode
+can enforce console-owned runtime quotas and submit reliable metering events.
+The current implementation follows console-server PR #36 and the
+`docs/api/openapi-internal-v1.yaml` contract at merge commit
+`a9b7be673bd0f9d78373c04c9b1a66669308b939`.
 
-The client should:
+Runtime usage is request-count based:
 
-1. Reserve quota before recall and memory create operations.
-2. Commit or release reservations after operation completion.
-3. Apply quota adjustments after successful delete, merge, or cleanup operations.
-4. Hand metering events to the existing `server/internal/metering.Writer` after
-   quota commit or adjustment.
-5. Retry quota finalization with the same `operationId` until console accepts the
-   operation or the work is durably queued locally.
+1. Recall operations reserve and meter `memory_recall_requests` with `units: 1`.
+2. Memory write operations reserve and meter `memory_write_requests` with
+   `units: 1`.
+3. Affected object count is diagnostic metadata, not quota units.
+4. The caller's `X-API-Key` remains the console runtime quota subject.
 
-This must stay generic. mem9-server should know only runtime facts, operation
-types, meters, units, and API endpoints. Console-server continues to own org,
-plan, quota bucket, billing period, S3, Stripe, and rollup logic.
+## Console Contract
 
-## Background
-
-Issue #13 defines the synchronous quota gate:
+mem9-server uses these console internal endpoints:
 
 1. `PUT /api/internal/quota/reservations/{operationId}`
 2. `PATCH /api/internal/quota/reservations/{operationId}`
-3. `PUT /api/internal/quota/adjustments/{operationId}`
+3. `PUT /api/internal/metering/events/{operationId}`
 
-Issue #16 defines the service boundary and metering ledger:
+There is no quota adjustment endpoint in the current contract. Deletes and
+batch deletes are treated as normal write requests and emit `memoryDeleted`
+metering events after successful deletion.
 
-1. `PUT /api/internal/metering/events/{operationId}`
-2. `Authorization: Bearer <internalSecret>` identifies mem9-server.
-3. `X-API-Key: <apiKey>` identifies the quota subject.
-4. `operationId` links quota and metering for one billable or quota-affecting
-   operation.
-
-This proposal includes an inline contract appendix because the console-server
-issues are private to some reviewers. The appendix is copied from issues #13 and
-#16 as read on 2026-05-13 and should be treated as the implementation contract
-until `docs/api/openapi-internal-v1.yaml` is available in console-server.
-
-Contract precedence for A1:
-
-1. If `docs/api/openapi-internal-v1.yaml` exists in console-server, implement the
-   OpenAPI contract.
-2. Until OpenAPI exists, use issue #16's explicit runtime flow for successful
-   usage: mem9-server calls `PATCH /api/internal/quota/reservations/{operationId}`
-   with `status: "committed"` after the mem9 operation succeeds, then submits
-   `PUT /api/internal/metering/events/{operationId}`.
-3. Treat issue #13's state-machine sentence that says metering acceptance
-   performs `reserved -> committed` as stale relative to issue #16. Console
-   should resolve this in OpenAPI before implementation begins.
-4. Use issue #13's quota error name `reservation_conflict`. Do not introduce
-   `operation_conflict` unless OpenAPI explicitly adds it.
-
-Current mem9-server already has an optional metering writer. The `Writer`
-interface is the right async sidecar shape for metering, but the HTTP/webhook
-implementation is not the right API shape or reliability level for
-console-server yet. It currently posts a generic webhook event with a generated
-event ID, while console-server requires
-`PUT /api/internal/metering/events/{operationId}` using the same `operationId`
-as quota. For commercial runtime usage, the HTTP writer must become
-outbox-backed so successful usage is retried until console accepts or the work
-is in a manual-reconciliation terminal state.
-
-Relevant current code:
-
-1. `server/internal/handler/memory.go:297` runs recall/search in
-   `listMemories`, and records recall metering only after success at
-   `server/internal/handler/memory.go:360`.
-2. `server/internal/handler/memory.go:43` handles memory creation. Sync creates
-   return after writes at `server/internal/handler/memory.go:150` and
-   `server/internal/handler/memory.go:163`; async creates run in goroutines at
-   `server/internal/handler/memory.go:106` and
-   `server/internal/handler/memory.go:173`.
-3. `server/internal/handler/memory.go:496` handles single delete, and
-   `server/internal/handler/memory.go:514` handles batch delete.
-4. `server/internal/handler/metering.go:26` and
-   `server/internal/handler/metering.go:41` send the current optional metering
-   events.
-5. `server/internal/metering/writer.go:31` defines `Writer.Record` as
-   non-blocking, and `server/internal/metering/transport_writer.go:289` drops a
-   failed S3 batch after logging.
-6. `server/internal/metering/webhook_writer.go:241` builds a generic webhook
-   event with a generated `evt_...` ID instead of using the console
-   `operationId`.
-
-## Goals
-
-1. Add a generic runtime usage quota client for console-server internal quota
-   APIs.
-2. Reuse the existing `server/internal/metering.Writer` interface for async
-   console metering.
-3. Gate recall and memory create before execution in commercial mode.
-4. Use quota adjustments after successful memory deletion and reconciliation
-   cleanup.
-5. Durably enqueue metering events only after quota commit or adjustment
-   succeeds, then deliver them through the existing metering writer surface.
-6. Keep raw API keys out of logs and public responses.
-7. Support disabled mode for OSS and self-hosted deployments.
-
-## Non-Goals
-
-1. Do not implement console billing, plan, bucket, S3, Stripe, or rollup logic in
-   mem9-server.
-2. Do not replace public mem9 API authentication.
-3. Do not make console-server a hard dependency for OSS mode.
-4. Do not add a second metering-specific interface when the existing
-   `metering.Writer` interface can carry console events.
-5. Do not use the async metering writer for quota reservations, quota commits,
-   releases, or adjustments.
-6. Do not solve public request idempotency from agents to mem9-server in this
-   proposal.
-
-## Proposed Architecture
-
-Add a new package:
-
-```text
-server/internal/runtimeusage/
-```
-
-Core interfaces:
-
-```go
-type QuotaClient interface {
-    Reserve(ctx context.Context, subject Subject, op Operation) (*Reservation, error)
-    FinalizeReservation(ctx context.Context, subject Subject, operationID string, status ReservationFinalStatus, reason string) error
-    ApplyAdjustment(ctx context.Context, subject Subject, op Adjustment) error
-}
-
-type Manager interface {
-    BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error)
-    AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error
-    AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error)
-    BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error)
-    AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error
-    AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error)
-    BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error)
-    AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error
-    AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error)
-}
-```
-
-`QuotaClient` is a thin HTTP API client for quota reservations, reservation
-finalization, and adjustments. `Manager` owns operation generation, reservation
-sequencing, durable quota retry handoff, disabled-mode no-op behavior, durable
-metering enqueue after quota finalization, and the handoff to `metering.Writer`.
-For deletes, `BeforeMemoryDelete` creates `adjustment_intent` before the mem9
-delete executes so a crash cannot erase the operation boundary. Handlers should
-depend on `Manager`, not raw HTTP calls.
-
-`operationId` uses `github.com/google/uuid.NewV7`. The server already pins
-`github.com/google/uuid v1.6.0`, which includes UUIDv7 support.
-
-Console metering stays in the existing package:
-
-```text
-server/internal/metering/
-```
-
-Do not add a new metering interface. Keep the current interface:
-
-```go
-type Writer interface {
-    Record(evt Event)
-    Close(ctx context.Context) error
-}
-```
-
-Extend `metering.Event` with console fields:
-
-```go
-type Event struct {
-    Category string
-    TenantID string
-    ClusterID string
-    AgentID string
-    Data map[string]any
-
-    OperationID string
-    APIKeySubject string
-    EventType string
-    Meter string
-    Units int64
-    OccurredAt time.Time
-    MemoryIDs []string
-}
-```
-
-The quota manager generates `OperationID` and passes it into
-`metering.Event`. The writer must not generate console operation IDs because
-issues #13 and #16 require the same `operationId` across quota and metering for
-the same operation.
-
-## Configuration
-
-Add config fields:
-
-| Env var | Meaning |
-| --- | --- |
-| `MNEMO_RUNTIME_USAGE_ENABLED` | Enables commercial runtime usage integration: synchronous quota gate plus console billing metering. Default `false`. |
-| `MNEMO_RUNTIME_USAGE_BASE_URL` | Console-server base URL for internal quota and metering APIs. Required when enabled. |
-| `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Bearer secret for internal APIs. Required when enabled. |
-| `MNEMO_RUNTIME_USAGE_TIMEOUT` | Per-request timeout for synchronous quota APIs. Default `3s`. |
-| `MNEMO_RUNTIME_USAGE_METERING_TIMEOUT` | Per-request timeout for async console metering API delivery. Default `5s`. |
-| `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` | Fallback reservation TTL for local watchdogs when console response does not include `expiresAt`. Default `30m`. |
-| `MNEMO_RUNTIME_USAGE_OPERATION_TTL` | Fallback TTL for adjustment-backed operations that have no console reservation expiry. Default `30m`. |
-| `MNEMO_RUNTIME_USAGE_FAIL_OPEN` | Development-only override. Default `false`. Production should fail closed. |
-| `MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED` | Enables local durable retry outbox. Default follows runtime usage enabled. |
-| `MNEMO_METERING_ENABLED` | Enables optional legacy/export metering writer. Not required for console billing metering. Default `false`. |
-| `MNEMO_METERING_URL` | Optional legacy/export metering destination, such as `s3://`, `http://`, or `https://`. Not used to build console billing metering URLs. |
-| `MNEMO_METERING_FLUSH_INTERVAL` | Existing legacy/export metering flush interval. Not used by console billing metering. |
-
-Validation should redact the base URL and never log the secret.
-
-Commercial runtime usage should be legible from configuration alone:
-`MNEMO_RUNTIME_USAGE_ENABLED=true` means mem9-server will perform quota gating
-and console billing metering against `MNEMO_RUNTIME_USAGE_BASE_URL`.
-`MNEMO_METERING_ENABLED` remains an independent optional export feature and must
-not be required for console billing correctness.
-
-When runtime usage is enabled, console metering sends to
-`{MNEMO_RUNTIME_USAGE_BASE_URL}/api/internal/metering/events/{operationId}` and
-uses `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` for
-`Authorization: Bearer <internalSecret>`. `MNEMO_METERING_URL` must not override
-or shadow this console URL. If legacy/export metering is also enabled, it runs as
-a separate sidecar destination.
-
-## Subject Identity
-
-Console-server requires `X-API-Key` as the quota subject. Current v1alpha2 auth
-resolves this header in `server/internal/middleware/auth.go:215`, but
-`domain.AuthInfo` currently stores only tenant and cluster identity at
-`server/internal/domain/types.go:58`.
-
-Add an in-memory field:
-
-```go
-type AuthInfo struct {
-    AgentName string
-    TenantID string
-    TenantDB *sql.DB
-    ClusterID string
-    APIKeySubject string
-}
-```
-
-Rules:
-
-1. v1alpha2 routes set `APIKeySubject` from the trimmed `X-API-Key`.
-2. v1alpha1 path-token routes set `APIKeySubject` to the tenant ID only if
-   runtime usage is enabled for that route. Otherwise leave it empty.
-3. Do not log `APIKeySubject`.
-4. Durable retry storage should not store raw API keys in A1. Because the current
-   API key subject is the tenant ID, store `tenant_id` plus
-   `subject_version = "tenant_id_v1"` in the outbox. If API keys later diverge
-   from tenant IDs, add an encrypted subject column in that migration.
-5. A1 runtime usage requires the current invariant that API key subject equals
-   tenant ID. If API key semantics change before encrypted subject storage is
-   implemented, operators must drain or migrate `runtime_usage_outbox` before
-   enabling the new key model.
-
-## Internal API Contract
-
-All calls use:
-
-```http
-Authorization: Bearer <internalSecret>
-X-API-Key: <apiKey>
-```
-
-`operationId` is a UUIDv7 generated by mem9-server. Network retries reuse the
-same `operationId` and the same canonical payload.
-
-### Reserve Quota
-
-```http
-PUT /api/internal/quota/reservations/{operationId}
-```
-
-Request:
+Reservation requests use one of two meters:
 
 ```json
-{"meter":"recalls","units":1}
+{"meter":"memory_recall_requests","units":1}
 ```
 
-For memory-slot creates, use `{"meter":"memory_slots","units":<positive-int>}`.
+```json
+{"meter":"memory_write_requests","units":1}
+```
 
-Success response:
+Reservation finalization uses only console-supported reasons:
+
+1. Commit success: `operationSucceeded`
+2. Release failure: `operationFailed`
+3. Release abandoned work: `operationAbandoned`
+4. Release caller cancellation: `clientCancelled`
+5. Release timeout: `timeout`
+
+## Metering Events
+
+Recall events use:
 
 ```json
 {
-  "operationId": "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
-  "meter": "recalls",
+  "eventType": "memoryRecall",
+  "meter": "memory_recall_requests",
   "units": 1,
-  "status": "reserved",
-  "expiresAt": "2026-04-28T12:00:00Z",
-  "remainingIncludedUnits": 999,
-  "reservedUnits": 1,
-  "overageAllowed": false
+  "occurredAt": "2026-05-11T12:00:00Z"
 }
 ```
 
-Quota denial uses `402`:
+Write events use:
 
 ```json
 {
-  "code": "quota_exhausted",
-  "message": "Included recall quota is exhausted.",
-  "meter": "recalls",
-  "limitType": "includedQuota",
-  "retryable": false,
-  "upgradeAction": "upgradePlan"
-}
-```
-
-Known quota error codes from issue #13 are `quota_exhausted`,
-`spending_limit_exceeded`, `api_key_unbound`, `reservation_conflict`, and
-`meter_not_supported`.
-
-### Commit Or Release Reservation
-
-```http
-PATCH /api/internal/quota/reservations/{operationId}
-```
-
-Commit request:
-
-```json
-{"status":"committed","reason":"operationSucceeded"}
-```
-
-Release request:
-
-```json
-{"status":"released","reason":"operationFailed"}
-```
-
-The response echoes `operationId`, `meter`, `units`, final `status`,
-`expiresAt`, `remainingIncludedUnits`, `reservedUnits`, and `overageAllowed`.
-
-### Apply Quota Adjustment
-
-```http
-PUT /api/internal/quota/adjustments/{operationId}
-```
-
-Request:
-
-```json
-{"meter":"memory_slots","delta":-3,"reason":"memoryDeleted"}
-```
-
-Response:
-
-```json
-{
-  "operationId": "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
-  "meter": "memory_slots",
-  "delta": -3,
-  "reason": "memoryDeleted",
-  "status": "applied",
-  "remainingIncludedUnits": 4662
-}
-```
-
-### Submit Metering Event
-
-```http
-PUT /api/internal/metering/events/{operationId}
-```
-
-Request:
-
-```json
-{
-  "eventType": "recall",
-  "meter": "recalls",
+  "eventType": "memoryCreated",
+  "meter": "memory_write_requests",
   "units": 1,
-  "occurredAt": "2026-04-28T12:00:00Z",
-  "agentName": "Codex",
-  "memoryIds": ["mem_123", "mem_456"]
+  "occurredAt": "2026-05-11T12:01:00Z",
+  "metadata": {
+    "objectsAffected": 3
+  }
 }
 ```
 
-Response:
-
-```json
-{"operationId":"018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234","status":"accepted","deduped":false}
-```
-
-Metering is accepted only after the matching reservation is committed or the
-matching adjustment is applied. Same `operationId` plus same canonical payload is
-idempotent; same `operationId` with a different payload returns `409`.
-
-## Operation Flows
-
-### Recall
-
-Only query-based search is billable. Plain list requests with no `q` should not
-reserve recall quota. A query recall is billed once it executes, even if it
-returns zero memories, because the server still performs embedding/vector/keyword
-work. This is an explicit product choice for A1 and should be mirrored in console
-usage copy.
-
-Flow:
-
-1. Handler detects `filter.Query != ""`.
-2. Manager generates UUIDv7 `operationId` with `uuid.NewV7`.
-3. Manager calls:
-
-```http
-PUT /api/internal/quota/reservations/{operationId}
-Authorization: Bearer <internalSecret>
-X-API-Key: <apiKey>
-
-{"meter":"recalls","units":1}
-```
-
-4. On `402`, return a stable 402 response to the caller without executing
-   recall.
-5. On transient failure, fail closed with `503` unless development fail-open is
-   explicitly enabled.
-6. Execute existing recall.
-7. On success, persist `commit_pending` with the metering payload, then commit
-   reservation.
-8. Only after console returns committed or idempotent committed, persist
-   `metering_pending` and call `metering.Writer.Record` with a console-shaped
-   metering event:
-
-```json
-{
-  "operationId": "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
-  "apiKeySubject": "<apiKey>",
-  "eventType": "recall",
-  "meter": "recalls",
-  "units": 1,
-  "occurredAt": "2026-05-13T00:00:00Z",
-  "agentName": "Codex",
-  "memoryIds": ["..."]
-}
-```
-
-9. If commit has a retryable or ambiguous failure after recall succeeded,
-   persist `commit_pending` and return success. The worker retries the commit
-   first and does not call `Record` until console ACKs the commit.
-10. If post-execution durable enqueue also fails, do not convert the already
-    completed recall into a client-visible `503`. Return the successful recall
-    response, emit an ERROR log with `operationId`, tenant ID, cluster ID, step,
-    and payload hash, and increment a `manual_reconciliation_required` metric.
-    Fail-closed responses apply only before the mem9 operation starts.
-11. If async metering delivery fails after `Record`, the console writer retries
-    `submit_metering_event` with the same `operationId` until console accepts or
-    the row reaches `terminal_failed`.
-
-Handler shape:
-
-```go
-if filter.Query != "" {
-    lease, err := s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
-    if err != nil {
-        s.handleRuntimeUsageError(r.Context(), w, err)
-        return
-    }
-    finalized := false
-    defer func() {
-        if !finalized {
-            s.runtimeUsage.AfterRecallFailure(context.Background(), lease, context.Canceled)
-        }
-    }()
-
-    memories, total, err = executeRecallSearch(r.Context(), auth, svc, filter)
-    if err != nil {
-        s.runtimeUsage.AfterRecallFailure(context.Background(), lease, err)
-        finalized = true
-        s.handleError(r.Context(), w, err)
-        return
-    }
-    if err := s.runtimeUsage.AfterRecallSuccess(r.Context(), lease, runtimeusage.RecallResult{
-        MemoryIDs: memoryIDs(memories),
-        AgentName: auth.AgentName,
-    }); err != nil {
-        s.logger.Error("runtime usage post-recall finalization failed",
-            "operation_id", lease.OperationID,
-            "tenant_id", auth.TenantID,
-            "cluster_id", auth.ClusterID,
-            "err", err)
-    }
-    finalized = true
-}
-```
-
-### Memory Create
-
-Memory create is harder than recall because the current smart ingest path can
-change an unknown number of active memories.
-
-Before handler integration, refactor the known-unit service write methods to
-return an explicit `UsageDelta`. This is required for A1 create/delete quota
-correctness, but the smart-ingest-specific `UsageDelta` plumbing is deferred to
-A2 because A1 blocks those request shapes in runtime-usage mode.
-
-Known-unit paths:
-
-1. Explicit pinned create reserves `memory_slots` units `1`.
-2. Bulk create reserves `memory_slots` units `len(input.memories)`. The current
-   `MemoryService.BulkCreate` returns only `([]domain.Memory, error)`, so A1 must
-   refactor it to return `UsageDelta` before wiring quota.
-3. Batch import of a known memory file can reserve the number of valid memory
-   records before writing.
-
-Unknown-unit paths:
-
-1. Smart content ingest and message ingest can ADD, UPDATE, and DELETE insights.
-2. `service.IngestResult` reports `MemoriesChanged` at
-   `server/internal/service/ingest.go:56`, but the field counts ADD and UPDATE,
-   not net active memory-slot delta.
-3. Reconciliation deletes insights at `server/internal/service/ingest.go:1266`,
-   but deleted IDs are not returned to the handler.
-
-Recommended A1 behavior:
-
-1. Add a production `UsageDelta` result from service operations:
-
-```go
-type UsageDelta struct {
-    MemorySlotsDelta int64
-    CreatedMemoryIDs []string
-    DeletedMemoryIDs []string
-    UpdatedMemoryIDs []string
-}
-```
-
-2. For known-unit creates, reserve before execution using the known positive
-   `MemorySlotsDelta`.
-3. For smart ingest, do not reserve a guessed `1` unit. A1 will block
-   unknown-delta smart ingest in runtime-usage mode and ship recall plus
-   known-unit memory CRUD first. Plan/apply smart ingest is deferred to A2.
-4. Durably enqueue and record the actual usage delta with `metering.Writer` only
-   after commit or adjustment is accepted or idempotently deduped by console.
-
-This keeps quota gating in front of memory creation while avoiding silent
-under-counting for multi-insight ingest. Commercial SaaS returns a deterministic
-`409` for smart ingest paths instead of accepting ungated async writes.
-
-Blocked A1 request shapes when `MNEMO_RUNTIME_USAGE_ENABLED=true`:
-
-1. `POST /memories` with `messages` non-empty, sync or async.
-2. `POST /memories` with `content` and no explicit
-   `memory_type: "pinned"`, sync or async.
-3. Any async content/message create path that would return `202` before quota
-   reservation and metering state are durable.
-
-Response:
-
-```json
-{
-  "code": "runtime_usage_requires_known_memory_delta",
-  "message": "runtime usage mode requires a known memory_slots delta; use pinned memory create or disable runtime usage for smart ingest",
-  "retryable": false
-}
-```
-
-### Memory Delete And Batch Delete
-
-Delete operations create a durable adjustment intent first, execute mem9 work,
-then apply adjustment only if the returned `UsageDelta` shows active memory
-slots decreased.
-
-Single delete flow:
-
-1. Call `BeforeMemoryDelete` to persist `adjustment_intent` with the target
-   memory ID before executing `svc.memory.Delete`.
-2. Execute `svc.memory.Delete`.
-3. Use the returned `UsageDelta.MemorySlotsDelta`.
-4. If `MemorySlotsDelta == 0`, transition `adjustment_intent -> done` and skip
-   quota adjustment and metering. This handles idempotent deletes where the row
-   is already deleted; current repositories can return nil for already-deleted
-   rows.
-5. If `MemorySlotsDelta < 0`, transition `adjustment_intent ->
-   adjustment_pending` and call:
-
-```json
-{"meter":"memory_slots","delta":-1,"reason":"memoryDeleted"}
-```
-
-6. After console accepts or dedupes the adjustment, transition to
-   `metering_pending` and record a metering event with `eventType:
-   "memoryDeleted"`, `meter: "memory_slots"`, `units: -1`, and the memory ID.
-7. If the delete returns an error and the service cannot prove that no active
-   slot changed, mark the operation `unknown_after_crash` and emit
-   `manual_reconciliation_required`; do not infer a quota adjustment.
-
-Batch delete flow:
-
-1. Call the batch equivalent of `BeforeMemoryDelete` to persist
-   `adjustment_intent` with the requested IDs before executing
-   `svc.memory.BulkDelete`.
-2. Execute `svc.memory.BulkDelete`.
-3. Use the returned `deleted` count from `server/internal/handler/memory.go:523`.
-4. If `deleted == 0`, transition `adjustment_intent -> done` and skip quota and
-   metering.
-5. Otherwise transition `adjustment_intent -> adjustment_pending`, adjust
-   `delta = -deleted`, and record one metering event after console ACKs the
-   adjustment with the deleted IDs available from the request.
-6. If batch delete returns an ambiguous error without a trustworthy delta, mark
-   the operation `unknown_after_crash` and require operator reconciliation.
-
-### Merge And Cleanup
-
-Reconciliation currently performs update as archive-and-create and can delete
-insights. These are quota-affecting but not exposed as top-level handler
-results.
-
-A1 should refactor service result types to return `UsageDelta` from the
-known-unit paths that remain enabled in runtime-usage mode:
-
-1. `MemoryService.CreatePinned`
-2. `MemoryService.BulkCreate`
-3. `MemoryService.Delete`
-4. `MemoryService.BulkDelete`
-
-A2 should add `UsageDelta` to the smart ingest internals before unblocking those
-request shapes:
-
-1. `MemoryService.Create`
-2. `IngestService.ReconcileContent`
-3. `IngestService.ReconcilePhase2`
-
-For each enabled path, the handler sends one quota/metering operation for the
-aggregate delta of the public mem9 operation.
-
-`BulkCreate` needs special handling because it currently returns a memory slice
-but no operation metadata. The refactor should return both the created memories
-and `UsageDelta`, with `MemorySlotsDelta = int64(len(created))` and
-`CreatedMemoryIDs` populated from the successful insert set.
-
-## Error Mapping
-
-Runtime usage errors should not leak internal console details.
-
-| Console/runtime result | mem9-server response |
-| --- | --- |
-| Reservation `402 quota_exhausted` | `402` with stable code and upgrade action. |
-| Reservation `402 spending_limit_exceeded` | `402` with stable code and upgrade action. |
-| `api_key_unbound` | Preserve console's returned status and body; issue #13 examples use the quota denial family, so prefer `402` unless OpenAPI says otherwise. |
-| `reservation_conflict` before execution | `502`, because generated operation IDs should not conflict. |
-| Runtime API network or 5xx before execution | `503 runtime usage unavailable` in fail-closed mode. |
-| Commit retryable failure after execution | Enqueue durable quota retry, then return operation success. |
-| Commit non-retryable conflict after execution | Return operation success if the mem9 response is otherwise valid; log `manual_reconciliation_required` with request ID plus operation ID. |
-| Async metering delivery failure | Keep the mem9 response successful only if the metering event is already durably queued; otherwise log `manual_reconciliation_required`. |
-| Post-execution outbox enqueue failure | Return operation success; log `manual_reconciliation_required` with operation ID, step, tenant ID, cluster ID, and payload hash. |
-| Release failure after execution failure | Enqueue release retry; otherwise rely on console reservation expiry and local watchdog metrics. |
-
-For quota-denied `402` responses, preserve the console response body rather than
-collapsing it to `{"error":"..."}`. If the body is valid JSON, pass it through
-and add `mem9_code: "runtime_quota_denied"` only when that field is absent. This
-keeps `code`, `limitType`, `retryable`, and `upgradeAction` available to clients.
-
-## Metering Writer Refactoring
-
-Refactor `server/internal/metering` instead of adding a new metering package or
-interface.
-
-Required changes:
-
-1. Keep `metering.Writer` unchanged:
-
-```go
-type Writer interface {
-    Record(evt Event)
-    Close(ctx context.Context) error
-}
-```
-
-2. Extend `metering.Event` with optional console fields:
-   `OperationID`, `APIKeySubject`, `EventType`, `Meter`, `Units`, `OccurredAt`,
-   and `MemoryIDs`.
-3. Keep legacy/export writer behavior unchanged for `MNEMO_METERING_URL`
-   destinations.
-4. Add an outbox-aware console HTTP writer in `server/internal/metering`, but do
-   not select it from `MNEMO_METERING_URL`. Runtime usage constructs this writer
-   from `MNEMO_RUNTIME_USAGE_BASE_URL` and
-   `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET`.
-5. The console HTTP writer validates required console fields before delivery.
-   Invalid console events are marked terminal failed with a
-   `manual_reconciliation_required` log and metric; they are not silently
-   dropped.
-6. Make the console HTTP writer outbox-aware by injecting the runtime usage
-   outbox repository and logger when runtime usage is enabled. This keeps
-   `metering.Writer` unchanged while giving the writer ownership of console
-   metering ACK handling.
-7. `Record(evt)` validates required console fields, upserts the
-   `submit_metering_event` payload only when the existing row is absent or has
-   the same canonical payload hash, queues the operation in memory, and returns
-   without waiting for console.
-8. The writer background worker sends:
-
-```http
-PUT {MNEMO_RUNTIME_USAGE_BASE_URL}/api/internal/metering/events/{operationId}
-Authorization: Bearer <internalSecret>
-X-API-Key: <apiKeySubject>
-Content-Type: application/json
-```
-
-Request body:
-
-```json
-{
-  "eventType": "recall",
-  "meter": "recalls",
-  "units": 1,
-  "occurredAt": "2026-04-28T12:00:00Z",
-  "agentName": "Codex",
-  "memoryIds": ["mem_123", "mem_456"]
-}
-```
-
-The console writer uses `Event.OperationID` in the URL. It must not generate a
-new operation ID because issue #13 and issue #16 require quota and metering to
-share one `operationId`.
-
-For A1, console metering follows the existing writer's async sidecar call-site
-semantics: `Record` does not wait for console to accept the event. Unlike the
-legacy/export writer, console delivery must be durable and is part of runtime
-usage even when `MNEMO_METERING_ENABLED=false`. Runtime usage code transitions
-the outbox row to `metering_pending` only after quota commit or adjustment is
-accepted or deduped by console. The console HTTP writer owns the ACK path for
-`submit_metering_event`: accepted or same-payload deduped responses move
-`metering_pending -> done`, different-payload `409` or invalid payloads move
-`metering_pending -> terminal_failed`, and retryable failures keep the row
-pending with backoff. The runtime usage worker must not call `Record` while an
-operation is still `commit_pending` or `adjustment_pending`.
-
-## Durable Retry Outbox
-
-Issue #16 requires quota commit and metering retry until acked or durably
-queued. Add a local runtime usage outbox in the control-plane DB:
-
-```sql
-CREATE TABLE IF NOT EXISTS runtime_usage_outbox (
-  operation_id      VARCHAR(36) PRIMARY KEY,
-  tenant_id         VARCHAR(36) NOT NULL,
-  subject_version   VARCHAR(32) NOT NULL DEFAULT 'tenant_id_v1',
-  step              VARCHAR(32) NOT NULL,
-  phase             VARCHAR(32) NOT NULL,
-  payload_json      JSON        NOT NULL,
-  payload_hash      VARCHAR(64) NOT NULL,
-  expires_at        TIMESTAMP   NULL,
-  status            VARCHAR(20) NOT NULL DEFAULT 'pending',
-  attempt_count     INT         NOT NULL DEFAULT 0,
-  next_attempt_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  last_error        TEXT        NULL,
-  created_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
-  updated_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-  INDEX idx_runtime_usage_outbox_poll (status, next_attempt_at)
-);
-```
-
-Outbox steps:
-
-1. `commit_reservation`
-2. `release_reservation`
-3. `apply_adjustment`
-4. `submit_metering_event`
-
-Operation phases:
-
-1. `reserved_active`: reservation exists and mem9 work may be running.
-2. `commit_pending`: mem9 work succeeded and reservation commit must be retried.
-3. `release_pending`: mem9 work failed or was abandoned and reservation release
-   must be retried.
-4. `adjustment_intent`: adjustment-backed operation has started and has an
-   `expires_at` based on `MNEMO_RUNTIME_USAGE_OPERATION_TTL`, but mem9 work has
-   not been confirmed successful yet.
-5. `adjustment_pending`: mem9 work succeeded and quota adjustment must be
-   retried.
-6. `metering_pending`: quota commit or adjustment is accepted and console
-   metering must be retried.
-7. `done`: all required quota and metering work is accepted or deduped.
-8. `unknown_after_crash`: watchdog cannot infer whether the mem9 write succeeded;
-   operators must reconcile using mem9 data and console operation state.
-9. `terminal_failed`: non-retryable conflict or invalid payload requires
-   operator repair.
-
-Worker behavior:
-
-1. Poll pending rows with exponential backoff.
-2. Use the same `operationId`.
-3. Treat console idempotent quota and metering success as done.
-4. Treat same-payload duplicates as done.
-5. Treat different-payload `409` as terminal failed and log for operator repair.
-6. Limit each poll batch per tenant so one tenant with many pending rows cannot
-   starve others.
-7. Never log raw API key values.
-8. If the outbox row includes a post-success metering event payload, call
-   `metering.Writer.Record` only after the queued quota commit or adjustment is
-   accepted or deduped by console.
-9. For `submit_metering_event`, the console HTTP writer observes the console
-   response and updates the outbox row. The generic runtime usage worker only
-   requeues stale `metering_pending` rows back into `metering.Writer.Record`.
-
-Crash and primary-writer-unavailable handling:
-
-1. Known-unit `BeforeMemoryCreate` inserts `reserved_active` after console
-   returns `reserved` and before mem9 write work starts. `BeforeRecall` does not
-   insert this local row in A1 so high-QPS recall does not depend on the
-   control-plane outbox table before doing read work; console reservation
-   `expiresAt` remains the crash fallback for that pre-finalization recall
-   window.
-2. On mem9 success, the manager updates the row to `commit_pending` with the
-   metering payload before attempting the synchronous commit.
-3. On mem9 failure, the manager updates the row to `release_pending` before
-   attempting release.
-4. If the process crashes while a row is still `reserved_active`, the watchdog
-   waits until `expiresAt + 2m`, marks the row `unknown_after_crash`, and emits
-   `manual_reconciliation_required`. The worker must not guess commit or release
-   without a persisted operation result.
-5. For adjustment-backed deletes and cleanup, the manager writes
-   `adjustment_intent` before execution with the target operation metadata and
-   `expires_at = now() + MNEMO_RUNTIME_USAGE_OPERATION_TTL`. After success with
-   `UsageDelta.MemorySlotsDelta == 0`, it moves the row directly to `done`.
-   After success with a negative delta, it updates the row to
-   `adjustment_pending` with the actual `UsageDelta`. If the process crashes
-   before either transition, the watchdog marks the row `unknown_after_crash`
-   after `expires_at` instead of applying an inferred delta.
-6. If an adjustment-backed mem9 operation fails before changing data, the
-   manager moves `adjustment_intent -> done` with a failure reason and does not
-   call console adjustment or metering. If the failure is ambiguous and no
-   trustworthy `UsageDelta` exists, the manager marks the row
-   `unknown_after_crash` and emits `manual_reconciliation_required`.
-7. After quota commit or adjustment is accepted, the row moves to
-   `metering_pending`. Only after console metering returns accepted or deduped
-   does the row move to `done`.
-
-The worker reconstructs `X-API-Key` from `tenant_id` only for
-`subject_version = "tenant_id_v1"`. A future API-key model where subject differs
-from tenant ID must add an encrypted subject column and a new subject version.
-
-## Reservation Cleanup
-
-Reservation leak prevention uses three layers:
-
-1. Handler-level `defer` release for normal failure paths after a reservation is
-   acquired but before success finalization.
-2. Local outbox rows for active memory-slot write reservations before executing
-   mem9 write work. Startup resumes pending `release_reservation`,
-   `commit_reservation`, `apply_adjustment`, and `submit_metering_event` rows.
-3. Console-server `expiresAt` auto-expiry as the final authority for process
-   crashes before mem9-server can persist a local outbox row.
-
-The reservation response includes `expiresAt`. mem9-server stores it in the
-outbox payload and uses it as the retry deadline for release and commit work. If
-console omits `expiresAt`, use `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` as the local
-deadline. The default is `30m`; production should set it to match console's quota
-reservation TTL.
-
-`BeforeMemoryCreate` must durably insert the active reservation outbox row after
-console returns `reserved` and before executing the mem9 write operation. If
-this insert fails before execution, release the console reservation best-effort
-and return `503`; this is a true fail-closed path because the mem9 operation has
-not started. `BeforeRecall` intentionally skips the local active row in A1 to
-avoid putting the control-plane outbox table on the normal recall read path; if
-the process crashes before recall commit or release can be persisted, console
-reservation expiry is the source of truth and the recall may require
-coarse-grained audit from logs rather than row-level local reconciliation.
-
-The outbox worker should mark unresolved `reserved_active` work
-`unknown_after_crash` after `expiresAt + 2m` and emit
-`runtime_usage_reservation_unknown_total`. Retrying a commit after expiry without
-a persisted success result is noise; at that point operators should reconcile
-from the console quota operation state and mem9 logs.
-
-## Finalization Ordering
-
-Metering must never be recorded before quota is finalized.
-
-1. Reservation-backed operations use this strict order:
-   `reserve -> execute mem9 work -> persist commit_pending + metering payload ->
-   commit reservation accepted/deduped -> persist metering_pending -> record
-   metering`.
-2. Adjustment-backed operations use this strict order:
-   `persist adjustment_intent -> execute mem9 work -> persist adjustment_pending
-   + metering payload -> apply adjustment accepted/deduped -> persist
-   metering_pending -> record metering`.
-3. If commit succeeds, durably move the row to `metering_pending`, then call
-   `metering.Writer.Record` with the same `operationId`. Delivery and ACK
-   observation happen asynchronously inside the console writer, but retry state
-   is durable.
-4. If commit response is ambiguous because of timeout or network partition,
-   enqueue `commit_reservation`; the worker retries commit first, then records
-   metering only after console returns committed or idempotent committed.
-5. If adjustment response is ambiguous, enqueue `apply_adjustment`; the worker
-   records metering only after console returns applied or idempotent applied.
-6. If post-execution enqueue fails after mem9 work has already succeeded, return
-   the successful mem9 response and log `manual_reconciliation_required`.
-
-## Handler Integration
-
-Add `runtimeUsage runtimeusage.Manager` to `handler.Server`.
-
-Candidate call sites:
-
-1. Recall: wrap the `filter.Query != ""` branches in `listMemories`.
-2. Explicit pinned create: reserve before `svc.memory.CreatePinned`.
-3. Smart content and message ingest: when runtime usage is enabled, return
-   `409 runtime_usage_requires_known_memory_delta` for the blocked A1 request
-   shapes listed in `Memory Create`.
-4. Async content/message ingest: when runtime usage is enabled, do not accept
-   unknown-delta async creates or return `202` before quota reservation and
-   outbox state are durable.
-5. Single delete and batch delete: persist `adjustment_intent` before delete,
-   then apply quota adjustment and metering only after the returned delta proves
-   active memory slots decreased.
-
-Async create decision for A1: block content/message creates that cannot be fully
-reserved before returning. Returning `202` before quota reservation is not
-allowed in commercial runtime usage because a later quota denial cannot be
-surfaced cleanly to the caller.
-
-## Existing Metering Writer Compatibility
-
-Keep `MNEMO_METERING_ENABLED` and `MNEMO_METERING_URL` as the optional
-legacy/export metering surface. They are no longer the console billing metering
-gate.
-
-Compatibility rules:
-
-1. Keep `metering.Writer` unchanged.
-2. Runtime usage may reuse `metering.Writer` internally for console billing
-   metering, but it is enabled by `MNEMO_RUNTIME_USAGE_ENABLED`, not by
-   `MNEMO_METERING_ENABLED`.
-3. Keep `s3://`, `http://`, and `https://` `MNEMO_METERING_URL` destinations as
-   optional legacy/export infrastructure.
-4. Do not derive the console metering endpoint from `MNEMO_METERING_URL`; derive
-   it from `MNEMO_RUNTIME_USAGE_BASE_URL`.
-5. Do not use `metering.Writer` for quota reservations, commits, releases, or
-   adjustments; those remain synchronous runtime usage quota operations.
-6. Do not add a second metering interface unless future strict durability
-   requirements cannot be met behind the existing `Writer` interface.
-
-## Local Contract Additions
-
-These values are mem9-server local additions unless future console OpenAPI
-promotes them into the internal API contract:
-
-| Value | Kind | Scope |
-| --- | --- | --- |
-| `runtime_usage_requires_known_memory_delta` | HTTP response code | Returned by mem9-server with `409` when runtime usage is enabled and a create path cannot compute memory-slot delta before writes. |
-| `mem9_code = "runtime_quota_denied"` | Optional response field value | Added by mem9-server to pass-through quota-denied JSON only when console did not already include `mem9_code`. |
-| `manual_reconciliation_required` | Log/metric reason | Emitted when post-success quota or metering state cannot be durably persisted or replayed safely. |
-| `runtime_usage_reservation_unknown_total` | Metric | Counts reservations whose success/failure cannot be inferred after `expiresAt + 2m`. |
-| `runtime_usage_metering_delivery_failed_total` | Metric | Counts console metering events that reach terminal failed state after retry or invalid payload. |
-
-## Rollout Plan
-
-1. A1a: Add config, no-op runtime usage manager, quota HTTP client, and
-   `AuthInfo.APIKeySubject` without changing public API behavior.
-2. A1a: Add durable runtime usage outbox schema, repository, watchdog, and
-   worker in no-op mode.
-3. A1b: Extend `metering.Event` and add an outbox-aware console writer that is
-   constructed from runtime usage config and calls
-   `PUT /api/internal/metering/events/{operationId}`.
-4. A1b: Add recall reservation, release, commit, durable metering handoff, and
-   post-execution manual reconciliation logging.
-5. A1c: Refactor known-unit memory CRUD services to return `UsageDelta`.
-6. A1c: Add explicit create reservation, delete adjustment, and batch-delete
-   adjustment.
-7. A1c: Block smart ingest in runtime-usage mode with
-   `409 runtime_usage_requires_known_memory_delta`.
-8. A2: Refactor smart ingest internals to return net `UsageDelta`, then unblock
-   runtime-usage smart ingest with correct quota and metering semantics.
-9. Enable in staging with fail-closed disabled only for pre-execution burn-in.
-10. Switch production commercial SaaS to fail-closed for pre-execution quota
-    failures.
-
-## Test Plan
-
-1. Config validation tests for enabled/disabled runtime usage.
-2. Config tests cover console metering being enabled by
-   `MNEMO_RUNTIME_USAGE_ENABLED` without requiring `MNEMO_METERING_ENABLED`.
-3. Config tests cover `MNEMO_METERING_URL` not overriding the console metering
-   endpoint derived from `MNEMO_RUNTIME_USAGE_BASE_URL`.
-4. Quota HTTP client tests for auth headers, `X-API-Key`, request bodies, idempotent
-   retries, and error parsing.
-5. Metering HTTP writer tests cover console URL shape, bearer auth,
-   `X-API-Key`, body fields, and use of caller-provided `operationId`.
-6. Metering HTTP writer tests cover invalid console events being marked terminal
-   failed with `manual_reconciliation_required`.
-7. Existing legacy/export metering writer tests remain unchanged.
-8. Handler tests cover recall reservation before search.
-9. Handler tests cover `402` quota denial without executing search.
-10. Handler tests cover recall commit before metering handoff.
-11. Handler tests cover reservation release after search failure.
-12. Handler tests cover zero-result recall still committing quota and recording
-    metering.
-13. Handler tests cover explicit create reserving `memory_slots`.
-14. Handler tests cover reservation release after create failure.
-15. Handler tests cover delete adjustment after success.
-16. Handler tests cover batch delete skipping adjustment for `deleted == 0`.
-17. Handler tests cover runtime usage forcing or rejecting async smart ingest.
-18. Outbox tests cover active memory-create reservation row creation before
-    mem9 write work starts, and recall skipping the active row.
-19. Outbox tests cover retryable commit failure enqueueing work.
-20. Outbox tests cover pre-execution outbox failure returning `503`.
-21. Outbox tests cover post-execution outbox failure returning operation success
-    and logging `manual_reconciliation_required`.
-22. Outbox tests cover same-payload duplicates being marked done.
-23. Outbox tests cover different-payload conflict as terminal failed.
-24. Outbox tests cover `reserved_active` expiry at `expiresAt + 2m` becoming
-    `unknown_after_crash`.
-25. Outbox tests cover `adjustment_intent -> done` for zero-delta delete.
-26. Outbox tests cover `adjustment_intent -> unknown_after_crash` after
-    `MNEMO_RUNTIME_USAGE_OPERATION_TTL`.
-27. Outbox tests cover `metering_pending -> done` after console accepted or
-    same-payload deduped response.
-28. Outbox tests cover no metering call while an operation remains
-    `commit_pending` or `adjustment_pending`.
-29. Restart tests cover crash after reserve before mem9 work result is
-    persisted.
-30. Restart tests cover crash after mem9 write before commit transition.
-31. Restart tests cover crash after delete before adjustment transition.
-32. Restart tests cover crash after quota commit before metering is accepted.
-
-Run:
-
-```bash
-make test
-make vet
-```
-
-## Effort Estimate
-
-950-1350 LoC production code:
-
-1. A1a runtime usage quota types, HTTP client, config, startup wiring, and
-   subject identity: ~280 LoC
-2. A1a durable runtime usage outbox schema, repository, watchdog, and generic
-   worker: ~350 LoC
-3. A1b metering event fields and outbox-aware console HTTP writer refactor:
-   ~190 LoC
-4. A1b recall handler integration, reservation finalization, and manual
-   reconciliation logging: ~230 LoC
-5. A1c known-unit `UsageDelta` plumbing through memory services: ~180 LoC
-6. A1c explicit create reservation, delete adjustment, and batch-delete
-   adjustment handler integration: ~180 LoC
-7. Error mapping, passthrough 402 responses, and logging helpers: ~100 LoC
-8. Smart-ingest blocking path: ~60 LoC
-
-A2 smart-ingest `UsageDelta` support is excluded from A1 and should be estimated
-separately after the reconcile result contract is designed.
-
-## Open Questions
-
-1. Should console-server expose a reservation lookup or reconciliation endpoint
-   for operator repair, or is `operationId` plus console DB access enough for A1?
-2. What metric names should production dashboards use for
-   `manual_reconciliation_required`, `runtime_usage_reservation_unknown_total`,
-   and terminal metering failures?
-3. Should `operation_id` remain `VARCHAR(36)` because issue #13 requires UUIDv7,
-   or use `VARCHAR(255)` defensively for future non-UUID operation IDs?
-
-## Acceptance Criteria
-
-1. Runtime usage integration is disabled by default.
-2. Enabled mode requires base URL and internal bearer secret.
-3. Recall calls console quota reservation before executing search.
-4. Recall commits quota and records metering with the same `operationId`.
-5. Zero-result query recalls are explicitly billed.
-6. Memory create reserves `memory_slots` before known-unit writes.
-7. Smart ingest is blocked in runtime-usage mode with
-   `409 runtime_usage_requires_known_memory_delta`.
-8. Memory delete and batch delete apply `memory_slots` adjustments only when
-   `UsageDelta.MemorySlotsDelta < 0`.
-9. Memory delete and batch delete persist `adjustment_intent` before executing
-   mem9 deletes and close zero-delta intents as `done`.
-10. Metering events are durably queued and handed to `metering.Writer` only after
-    quota commit or adjustment is accepted or idempotently deduped.
-11. Quota retries reuse the same UUIDv7 `operationId`.
-12. Active reservation outbox rows are created before mem9 work starts.
-13. Retryable post-success quota finalization and metering delivery failures are
-    durably queued before returning success when possible.
-14. Post-success quota or metering enqueue failures return operation success and emit
-    manual reconciliation logs and metrics.
-15. Raw API keys are not logged or stored raw in the outbox.
-16. mem9-server does not embed org, plan, bucket, Stripe, S3, or rollup logic.
-17. Existing legacy/export metering remains available through
-    `MNEMO_METERING_ENABLED` and `MNEMO_METERING_URL`.
-18. Console metering sends API requests to `MNEMO_RUNTIME_USAGE_BASE_URL` using
-    the caller-provided `OperationID`, not a writer-generated event ID.
-19. Console billing metering does not require `MNEMO_METERING_ENABLED` and is
-    not routed by `MNEMO_METERING_URL`.
-20. The console HTTP writer owns `metering_pending -> done|terminal_failed`
-    transitions after observing console responses.
-21. `reserved_active`, `adjustment_intent`, and `metering_pending` states have
-    restart/watchdog behavior for process crash and network partition cases.
+Supported write event types are `memoryCreated`, `memoryUpdated`,
+`memoryDeleted`, `memoryMerged`, and `memoryCleanup`. This PR emits
+`memoryCreated` for create, bulk-create, content ingest, and message ingest
+paths, and `memoryDeleted` for delete and batch-delete paths.
+
+`occurredAt` is truncated to whole-second RFC3339 before payload construction
+because it is part of the canonical metering payload. Optional `agentName` is
+omitted unless it matches console validation:
+`^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$`.
+
+Metering metadata is intentionally narrow. It should contain only stable,
+non-sensitive diagnostic fields such as `objectsAffected`. It must not contain
+prompts, memory content, raw API keys, bearer tokens, cookies, DSNs, or auth
+material. `memoryIds` are capped at 200 IDs to stay inside console validation.
+
+## Request Flow
+
+For recall:
+
+1. Reserve one `memory_recall_requests` unit before running search.
+2. On recall success, persist `commit_pending` if an outbox is configured.
+3. Commit the reservation.
+4. Submit a `memoryRecall` metering event.
+5. On recall failure, release the reservation with a mapped console reason.
+
+For memory writes:
+
+1. Reserve one `memory_write_requests` unit before executing the write.
+2. Execute the mem9 write path.
+3. On success, persist `commit_pending` if an outbox is configured.
+4. Commit the reservation.
+5. Submit a write metering event with safe metadata.
+6. On failure before the write succeeds, release the reservation.
+
+The SQL outbox is intentionally not used for pre-success reservation state in
+the normal path. It is limited to post-success commit and metering retry state,
+because console now owns reliable metering ingress behind
+`PUT /api/internal/metering/events/{operationId}`.
+
+## Covered Operations
+
+Runtime usage currently covers:
+
+1. Recall queries.
+2. Explicit pinned create.
+3. Smart content create.
+4. Message ingest.
+5. Bulk create.
+6. Delete.
+7. Batch delete.
+
+Async create and ingest paths reserve before returning `202 Accepted`; the
+background worker commits or releases the reservation after the operation
+finishes.
+
+## Failure Semantics
+
+Quota denial returns `402`. Transient console failures return `503` unless
+fail-open mode is configured for reservation failures.
+
+After a mem9 operation succeeds, mem9-server must not release the reservation.
+It either commits synchronously, durably queues commit/metering retry, or marks
+the operation for manual reconciliation. If no durable retry path exists and the
+commit cannot be acknowledged, the handler fails closed for synchronous paths.
+
+Metering retries are idempotent by `operationId` and canonical payload hash.
+`200` with `deduped: true` is success. `409 operation_conflict` is terminal and
+requires reconciliation.

--- a/docs/design/mem9-runtime-usage-client-proposal.md
+++ b/docs/design/mem9-runtime-usage-client-proposal.md
@@ -8,10 +8,10 @@ last_updated: 2026-05-19
 ## Summary
 
 Add a billing-grade runtime usage client to mem9-server so commercial SaaS mode
-can enforce console-owned runtime quotas and submit reliable metering events.
-The current implementation follows the inline console contract snapshot below so
-public readers can audit the endpoint, meter, event, retry, and conflict
-semantics from this repository.
+can enforce runtime usage service quotas and submit reliable metering events.
+The current implementation follows the inline runtime usage service contract
+snapshot below so public readers can audit the endpoint, meter, event, retry,
+and conflict semantics from this repository.
 
 Runtime usage is request-count based:
 
@@ -19,11 +19,11 @@ Runtime usage is request-count based:
 2. Memory write operations reserve and meter `memory_write_requests` with
    `units: 1`.
 3. Affected object count is diagnostic metadata, not quota units.
-4. The caller's `X-API-Key` remains the console runtime quota subject.
+4. The caller's `X-API-Key` remains the runtime usage quota subject.
 
-## Console Contract
+## Runtime Usage Service Contract
 
-mem9-server uses these console internal endpoints:
+mem9-server uses these runtime usage service internal endpoints:
 
 1. `PUT /api/internal/quota/reservations/{operationId}`
 2. `PATCH /api/internal/quota/reservations/{operationId}`
@@ -43,7 +43,7 @@ Reservation requests use one of two meters:
 {"meter":"memory_write_requests","units":1}
 ```
 
-Reservation finalization uses only console-supported reasons:
+Reservation finalization uses only runtime usage service supported reasons:
 
 1. Commit success: `operationSucceeded`
 2. Release failure: `operationFailed`
@@ -86,13 +86,14 @@ batch-delete paths.
 
 `occurredAt` is truncated to whole-second RFC3339 before payload construction
 because it is part of the canonical metering payload. Optional `agentName` is
-omitted unless it matches console validation:
+omitted unless it matches runtime usage service validation:
 `^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$`.
 
 Metering metadata is intentionally narrow. It should contain only stable,
 non-sensitive diagnostic fields such as `objectsAffected`. It must not contain
 prompts, memory content, raw API keys, bearer tokens, cookies, DSNs, or auth
-material. `memoryIds` are capped at 200 IDs to stay inside console validation.
+material. `memoryIds` are capped at 200 IDs to stay inside runtime usage
+service validation.
 
 ## Request Flow
 
@@ -102,7 +103,8 @@ For recall:
 2. On recall success, persist `commit_pending` if an outbox is configured.
 3. Commit the reservation.
 4. Submit a `memoryRecall` metering event.
-5. On recall failure, release the reservation with a mapped console reason.
+5. On recall failure, release the reservation with a mapped runtime usage
+   service reason.
 
 For memory writes:
 
@@ -115,7 +117,7 @@ For memory writes:
 
 The SQL outbox is intentionally not used for pre-success reservation state in
 the normal path. It is limited to post-success commit and metering retry state,
-because console now owns reliable metering ingress behind
+because the runtime usage service owns reliable metering ingress behind
 `PUT /api/internal/metering/events/{operationId}`.
 
 ## Covered Operations
@@ -138,8 +140,8 @@ finishes.
 
 ## Failure Semantics
 
-Quota denial returns `402`. Transient console failures return `503` unless
-fail-open mode is configured for reservation failures.
+Quota denial returns `402`. Transient runtime usage service failures return
+`503` unless fail-open mode is configured for reservation failures.
 
 After a mem9 operation succeeds, mem9-server must not release the reservation.
 It either commits synchronously, durably queues commit/metering retry, or marks

--- a/docs/design/mem9-runtime-usage-client-proposal.md
+++ b/docs/design/mem9-runtime-usage-client-proposal.md
@@ -3,17 +3,15 @@ title: mem9-server Runtime Usage Client Proposal
 status: draft
 created: 2026-05-13
 last_updated: 2026-05-19
-sources:
-  - https://github.com/mem9-ai/mem9-console-server/pull/36
 ---
 
 ## Summary
 
 Add a billing-grade runtime usage client to mem9-server so commercial SaaS mode
 can enforce console-owned runtime quotas and submit reliable metering events.
-The current implementation follows console-server PR #36 and the
-`docs/api/openapi-internal-v1.yaml` contract at merge commit
-`a9b7be673bd0f9d78373c04c9b1a66669308b939`.
+The current implementation follows the inline console contract snapshot below so
+public readers can audit the endpoint, meter, event, retry, and conflict
+semantics from this repository.
 
 Runtime usage is request-count based:
 
@@ -83,7 +81,8 @@ Write events use:
 Supported write event types are `memoryCreated`, `memoryUpdated`,
 `memoryDeleted`, `memoryMerged`, and `memoryCleanup`. This PR emits
 `memoryCreated` for create, bulk-create, content ingest, and message ingest
-paths, and `memoryDeleted` for delete and batch-delete paths.
+paths, `memoryUpdated` for update paths, and `memoryDeleted` for delete and
+batch-delete paths.
 
 `occurredAt` is truncated to whole-second RFC3339 before payload construction
 because it is part of the canonical metering payload. Optional `agentName` is
@@ -128,8 +127,10 @@ Runtime usage currently covers:
 3. Smart content create.
 4. Message ingest.
 5. Bulk create.
-6. Delete.
-7. Batch delete.
+6. Update.
+7. Delete.
+8. Batch delete.
+9. Chain update, delete, and batch-delete against the resolved node subject.
 
 Async create and ingest paths reserve before returning `202 Accepted`; the
 background worker commits or releases the reservation after the operation

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/repository"
 	"github.com/qiffang/mnemos/server/internal/reqid"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
 	"github.com/qiffang/mnemos/server/internal/tenant"
 )
@@ -140,6 +141,62 @@ func main() {
 	}
 	logger.Info("metering writer initialized", "enabled", cfg.MeteringEnabled, "destination", redactMeteringURLForLog(cfg.MeteringURL))
 
+	var runtimeUsageMetering metering.Writer
+	var runtimeUsageStore *runtimeusage.SQLStore
+	if cfg.RuntimeUsageEnabled {
+		if cfg.RuntimeUsageOutboxEnabled {
+			runtimeUsageStore = runtimeusage.NewSQLStore(db, cfg.DBBackend)
+			if err := runtimeUsageStore.EnsureSchema(context.Background()); err != nil {
+				logger.Error("failed to initialize runtime usage outbox", "err", err)
+				os.Exit(1)
+			}
+		}
+		runtimeUsageMetering, err = metering.NewConsoleRuntime(metering.ConsoleRuntimeConfig{
+			BaseURL:        cfg.RuntimeUsageBaseURL,
+			InternalSecret: cfg.RuntimeUsageInternalSecret,
+			Timeout:        cfg.RuntimeUsageMeteringTimeout,
+			Store:          runtimeUsageStore,
+		}, logger)
+		if err != nil {
+			logger.Error("failed to initialize runtime usage metering writer", "err", err)
+			os.Exit(1)
+		}
+		defer func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := runtimeUsageMetering.Close(ctx); err != nil {
+				logger.Error("runtime usage metering close error", "err", err)
+			}
+		}()
+		logger.Info("runtime usage metering writer initialized", "enabled", true)
+	}
+	runtimeUsageClient := runtimeusage.NewHTTPClient(cfg.RuntimeUsageBaseURL, cfg.RuntimeUsageInternalSecret, cfg.RuntimeUsageTimeout)
+	runtimeUsageManager := runtimeusage.NewManager(runtimeusage.Config{
+		Enabled:         cfg.RuntimeUsageEnabled,
+		BaseURL:         cfg.RuntimeUsageBaseURL,
+		InternalSecret:  cfg.RuntimeUsageInternalSecret,
+		Timeout:         cfg.RuntimeUsageTimeout,
+		MeteringTimeout: cfg.RuntimeUsageMeteringTimeout,
+		ReservationTTL:  cfg.RuntimeUsageReservationTTL,
+		OperationTTL:    cfg.RuntimeUsageOperationTTL,
+		FailOpen:        cfg.RuntimeUsageFailOpen,
+		OutboxEnabled:   cfg.RuntimeUsageOutboxEnabled,
+		Outbox:          runtimeUsageStore,
+	}, runtimeUsageClient, runtimeUsageMetering, logger)
+	var runtimeUsageWorkerCancel context.CancelFunc
+	if cfg.RuntimeUsageEnabled && runtimeUsageStore != nil {
+		var runtimeUsageWorkerCtx context.Context
+		runtimeUsageWorkerCtx, runtimeUsageWorkerCancel = context.WithCancel(context.Background())
+		defer runtimeUsageWorkerCancel()
+		go func() {
+			err := runtimeusage.NewWorker(runtimeUsageStore, runtimeUsageClient, runtimeUsageMetering, logger).Run(runtimeUsageWorkerCtx)
+			if err != nil && err != context.Canceled {
+				logger.Error("runtime usage outbox worker stopped", "err", err)
+			}
+		}()
+	}
+	logger.Info("runtime usage initialized", "enabled", cfg.RuntimeUsageEnabled)
+
 	// Services.
 	// Select provisioner based on configuration
 	var provisioner tenant.Provisioner
@@ -204,6 +261,7 @@ func main() {
 	srv := handler.NewServer(tenantSvc, uploadTaskRepo, cfg.UploadDir, embedder, llmClient, cfg.EmbedAutoModel, cfg.FTSEnabled, service.IngestMode(cfg.IngestMode), cfg.DBBackend, logger).
 		WithSpaceChainService(spaceChainSvc, cfg.ChainRecallStopScore).
 		WithMetering(meteringWriter).
+		WithRuntimeUsage(runtimeUsageManager).
 		WithActivityTracker(activityTracker)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW)
 
@@ -245,6 +303,9 @@ func main() {
 		sig := <-sigCh
 		logger.Info("received signal, shutting down", "signal", sig)
 
+		if runtimeUsageWorkerCancel != nil {
+			runtimeUsageWorkerCancel()
+		}
 		workerCancel() // Stop upload worker first.
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -65,8 +65,8 @@ type Config struct {
 	MeteringURL           string
 	MeteringFlushInterval time.Duration
 
-	// RuntimeUsage enables commercial SaaS quota gating plus console billing
-	// metering. Console metering uses RuntimeUsageBaseURL, not MeteringURL.
+	// RuntimeUsage enables commercial SaaS quota gating plus runtime usage
+	// service metering. Runtime usage metering uses RuntimeUsageBaseURL, not MeteringURL.
 	RuntimeUsageEnabled         bool
 	RuntimeUsageBaseURL         string
 	RuntimeUsageInternalSecret  string `json:"-"`

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -65,6 +65,18 @@ type Config struct {
 	MeteringURL           string
 	MeteringFlushInterval time.Duration
 
+	// RuntimeUsage enables commercial SaaS quota gating plus console billing
+	// metering. Console metering uses RuntimeUsageBaseURL, not MeteringURL.
+	RuntimeUsageEnabled         bool
+	RuntimeUsageBaseURL         string
+	RuntimeUsageInternalSecret  string `json:"-"`
+	RuntimeUsageTimeout         time.Duration
+	RuntimeUsageMeteringTimeout time.Duration
+	RuntimeUsageReservationTTL  time.Duration
+	RuntimeUsageOperationTTL    time.Duration
+	RuntimeUsageFailOpen        bool
+	RuntimeUsageOutboxEnabled   bool
+
 	// DebugLLM enables logging of raw LLM response content, which may contain
 	// user data. Disabled by default. Enable only in dev/test environments via
 	// MNEMO_DEBUG_LLM=true.
@@ -122,49 +134,75 @@ func Load() (*Config, error) {
 			return nil, err
 		}
 	}
+	runtimeUsageEnabled := envBool("MNEMO_RUNTIME_USAGE_ENABLED", false)
+	runtimeUsageFailOpen := envBool("MNEMO_RUNTIME_USAGE_FAIL_OPEN", false)
+	runtimeUsageOutboxEnabled, runtimeUsageOutboxSet := envBoolWithSet("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED", runtimeUsageEnabled)
+	runtimeUsageBaseURL := ""
+	if runtimeUsageEnabled {
+		var err error
+		runtimeUsageBaseURL, err = parseRuntimeUsageBaseURL(os.Getenv("MNEMO_RUNTIME_USAGE_BASE_URL"))
+		if err != nil {
+			return nil, err
+		}
+		if strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")) == "" {
+			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET is required when MNEMO_RUNTIME_USAGE_ENABLED=true")
+		}
+		if runtimeUsageOutboxSet && !runtimeUsageOutboxEnabled && !runtimeUsageFailOpen {
+			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED=false requires MNEMO_RUNTIME_USAGE_FAIL_OPEN=true when runtime usage is enabled")
+		}
+	}
 
 	cfg := &Config{
-		Port:                     envOr("MNEMO_PORT", "8080"),
-		DSN:                      dsn,
-		DBBackend:                envOr("MNEMO_DB_BACKEND", "tidb"),
-		RateLimit:                envFloat("MNEMO_RATE_LIMIT", 100),
-		RateBurst:                envInt("MNEMO_RATE_BURST", 200),
-		EmbedAutoModel:           os.Getenv("MNEMO_EMBED_AUTO_MODEL"),
-		EmbedAutoDims:            envInt("MNEMO_EMBED_AUTO_DIMS", 1024),
-		EmbedAPIKey:              os.Getenv("MNEMO_EMBED_API_KEY"),
-		EmbedBaseURL:             os.Getenv("MNEMO_EMBED_BASE_URL"),
-		EmbedModel:               os.Getenv("MNEMO_EMBED_MODEL"),
-		EmbedDims:                envInt("MNEMO_EMBED_DIMS", 1536),
-		LLMAPIKey:                os.Getenv("MNEMO_LLM_API_KEY"),
-		LLMBaseURL:               os.Getenv("MNEMO_LLM_BASE_URL"),
-		LLMModel:                 envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
-		LLMTemperature:           envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
-		IngestMode:               envOr("MNEMO_INGEST_MODE", "smart"),
-		TiDBZeroEnabled:          envBool("MNEMO_TIDB_ZERO_ENABLED", true),
-		TiDBZeroAPIURL:           envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
-		TiDBCloudAPIURL:          envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),
-		TiDBCloudPoolID:          envOr("MNEMO_TIDBCLOUD_POOL_ID", "2"),
-		TenantPoolMaxIdle:        envInt("MNEMO_TENANT_POOL_MAX_IDLE", 5),
-		TenantPoolMaxOpen:        envInt("MNEMO_TENANT_POOL_MAX_OPEN", 10),
-		TenantPoolConnectTimeout: envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
-		TenantPoolIdleTimeout:    envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
-		TenantPoolTotalLimit:     envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
-		ChainRecallStopScore:     envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.5),
-		UploadDir:                envOr("MNEMO_UPLOAD_DIR", "./uploads"),
-		FTSEnabled:               envBool("MNEMO_FTS_ENABLED", false),
-		WorkerConcurrency:        envInt("MNEMO_WORKER_CONCURRENCY", 5),
-		MeteringEnabled:          meteringEnabled,
-		MeteringURL:              meteringURL,
-		MeteringFlushInterval:    envDuration("MNEMO_METERING_FLUSH_INTERVAL", 10*time.Second),
-		EncryptType:              envOr("MNEMO_ENCRYPT_TYPE", "plain"),
-		EncryptKey:               os.Getenv("MNEMO_ENCRYPT_KEY"),
-		DebugLLM:                 envBool("MNEMO_DEBUG_LLM", false),
-		ClusterBlacklist:         parseClusterBlacklist(os.Getenv("MNEMO_CLUSTER_BLACKLIST")),
-		AutoSpendLimitEnabled:    envBool("MNEMO_AUTO_SPEND_LIMIT_ENABLED", false),
-		AutoSpendLimitIncrement:  envInt("MNEMO_AUTO_SPEND_LIMIT_INCREMENT", 500),
-		AutoSpendLimitMax:        envInt("MNEMO_AUTO_SPEND_LIMIT_MAX", 10000),
-		AutoSpendLimitCooldown:   envDuration("MNEMO_AUTO_SPEND_LIMIT_COOLDOWN", 1*time.Hour),
-		UTMEnabled:               envBool("MNEMO_UTM_ENABLED", false),
+		Port:                        envOr("MNEMO_PORT", "8080"),
+		DSN:                         dsn,
+		DBBackend:                   envOr("MNEMO_DB_BACKEND", "tidb"),
+		RateLimit:                   envFloat("MNEMO_RATE_LIMIT", 100),
+		RateBurst:                   envInt("MNEMO_RATE_BURST", 200),
+		EmbedAutoModel:              os.Getenv("MNEMO_EMBED_AUTO_MODEL"),
+		EmbedAutoDims:               envInt("MNEMO_EMBED_AUTO_DIMS", 1024),
+		EmbedAPIKey:                 os.Getenv("MNEMO_EMBED_API_KEY"),
+		EmbedBaseURL:                os.Getenv("MNEMO_EMBED_BASE_URL"),
+		EmbedModel:                  os.Getenv("MNEMO_EMBED_MODEL"),
+		EmbedDims:                   envInt("MNEMO_EMBED_DIMS", 1536),
+		LLMAPIKey:                   os.Getenv("MNEMO_LLM_API_KEY"),
+		LLMBaseURL:                  os.Getenv("MNEMO_LLM_BASE_URL"),
+		LLMModel:                    envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
+		LLMTemperature:              envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
+		IngestMode:                  envOr("MNEMO_INGEST_MODE", "smart"),
+		TiDBZeroEnabled:             envBool("MNEMO_TIDB_ZERO_ENABLED", true),
+		TiDBZeroAPIURL:              envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
+		TiDBCloudAPIURL:             envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),
+		TiDBCloudPoolID:             envOr("MNEMO_TIDBCLOUD_POOL_ID", "2"),
+		TenantPoolMaxIdle:           envInt("MNEMO_TENANT_POOL_MAX_IDLE", 5),
+		TenantPoolMaxOpen:           envInt("MNEMO_TENANT_POOL_MAX_OPEN", 10),
+		TenantPoolConnectTimeout:    envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
+		TenantPoolIdleTimeout:       envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
+		TenantPoolTotalLimit:        envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
+		ChainRecallStopScore:        envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.5),
+		UploadDir:                   envOr("MNEMO_UPLOAD_DIR", "./uploads"),
+		FTSEnabled:                  envBool("MNEMO_FTS_ENABLED", false),
+		WorkerConcurrency:           envInt("MNEMO_WORKER_CONCURRENCY", 5),
+		MeteringEnabled:             meteringEnabled,
+		MeteringURL:                 meteringURL,
+		MeteringFlushInterval:       envDuration("MNEMO_METERING_FLUSH_INTERVAL", 10*time.Second),
+		RuntimeUsageEnabled:         runtimeUsageEnabled,
+		RuntimeUsageBaseURL:         runtimeUsageBaseURL,
+		RuntimeUsageInternalSecret:  strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")),
+		RuntimeUsageTimeout:         envDuration("MNEMO_RUNTIME_USAGE_TIMEOUT", 3*time.Second),
+		RuntimeUsageMeteringTimeout: envDuration("MNEMO_RUNTIME_USAGE_METERING_TIMEOUT", 5*time.Second),
+		RuntimeUsageReservationTTL:  envDuration("MNEMO_RUNTIME_USAGE_RESERVATION_TTL", 30*time.Minute),
+		RuntimeUsageOperationTTL:    envDuration("MNEMO_RUNTIME_USAGE_OPERATION_TTL", 30*time.Minute),
+		RuntimeUsageFailOpen:        runtimeUsageFailOpen,
+		RuntimeUsageOutboxEnabled:   runtimeUsageOutboxEnabled,
+		EncryptType:                 envOr("MNEMO_ENCRYPT_TYPE", "plain"),
+		EncryptKey:                  os.Getenv("MNEMO_ENCRYPT_KEY"),
+		DebugLLM:                    envBool("MNEMO_DEBUG_LLM", false),
+		ClusterBlacklist:            parseClusterBlacklist(os.Getenv("MNEMO_CLUSTER_BLACKLIST")),
+		AutoSpendLimitEnabled:       envBool("MNEMO_AUTO_SPEND_LIMIT_ENABLED", false),
+		AutoSpendLimitIncrement:     envInt("MNEMO_AUTO_SPEND_LIMIT_INCREMENT", 500),
+		AutoSpendLimitMax:           envInt("MNEMO_AUTO_SPEND_LIMIT_MAX", 10000),
+		AutoSpendLimitCooldown:      envDuration("MNEMO_AUTO_SPEND_LIMIT_COOLDOWN", 1*time.Hour),
+		UTMEnabled:                  envBool("MNEMO_UTM_ENABLED", false),
 	}
 	// Validate ingest mode.
 	switch cfg.IngestMode {
@@ -232,6 +270,15 @@ func envBool(key string, fallback bool) bool {
 	return fallback
 }
 
+func envBoolWithSet(key string, fallback bool) (bool, bool) {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b, true
+		}
+	}
+	return fallback, false
+}
+
 func envDuration(key string, fallback time.Duration) time.Duration {
 	if v := os.Getenv(key); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
@@ -273,6 +320,33 @@ func parseMeteringURL(raw string) (string, error) {
 	return raw, nil
 }
 
+func parseRuntimeUsageBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("MNEMO_RUNTIME_USAGE_BASE_URL is required when MNEMO_RUNTIME_USAGE_ENABLED=true")
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid MNEMO_RUNTIME_USAGE_BASE_URL")
+	}
+	switch u.Scheme {
+	case "http", "https":
+		// ok
+	default:
+		return "", fmt.Errorf("invalid MNEMO_RUNTIME_USAGE_BASE_URL: unsupported scheme")
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("invalid MNEMO_RUNTIME_USAGE_BASE_URL: host is required")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("invalid MNEMO_RUNTIME_USAGE_BASE_URL: query and fragment are not allowed")
+	}
+
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
 // LogValue returns a slog.Value with sensitive fields masked.
 // Use this when logging the config to avoid leaking secrets.
 func (c *Config) LogValue() slog.Value {
@@ -281,6 +355,8 @@ func (c *Config) LogValue() slog.Value {
 		slog.String("DBBackend", c.DBBackend),
 		slog.String("EncryptType", c.EncryptType),
 		slog.Bool("EncryptKeyConfigured", c.EncryptKey != ""),
+		slog.Bool("RuntimeUsageEnabled", c.RuntimeUsageEnabled),
+		slog.Bool("RuntimeUsageInternalSecretConfigured", c.RuntimeUsageInternalSecret != ""),
 		// Add other non-sensitive fields as needed
 	)
 }

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -113,19 +113,132 @@ func TestLoad_MeteringURLValidationErrorRedactsRawURL(t *testing.T) {
 	}
 }
 
+func TestLoad_RuntimeUsageConfig(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://console.example.com/internal/")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+	t.Setenv("MNEMO_RUNTIME_USAGE_TIMEOUT", "4s")
+	t.Setenv("MNEMO_RUNTIME_USAGE_METERING_TIMEOUT", "6s")
+	t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_TTL", "20m")
+	t.Setenv("MNEMO_RUNTIME_USAGE_OPERATION_TTL", "25m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.RuntimeUsageEnabled {
+		t.Fatal("RuntimeUsageEnabled = false, want true")
+	}
+	if cfg.RuntimeUsageBaseURL != "https://console.example.com/internal" {
+		t.Fatalf("RuntimeUsageBaseURL = %q", cfg.RuntimeUsageBaseURL)
+	}
+	if cfg.RuntimeUsageInternalSecret != "secret-value" {
+		t.Fatal("RuntimeUsageInternalSecret not loaded")
+	}
+	if cfg.RuntimeUsageTimeout != 4*time.Second {
+		t.Fatalf("RuntimeUsageTimeout = %v, want 4s", cfg.RuntimeUsageTimeout)
+	}
+	if cfg.RuntimeUsageMeteringTimeout != 6*time.Second {
+		t.Fatalf("RuntimeUsageMeteringTimeout = %v, want 6s", cfg.RuntimeUsageMeteringTimeout)
+	}
+	if cfg.RuntimeUsageReservationTTL != 20*time.Minute {
+		t.Fatalf("RuntimeUsageReservationTTL = %v, want 20m", cfg.RuntimeUsageReservationTTL)
+	}
+	if cfg.RuntimeUsageOperationTTL != 25*time.Minute {
+		t.Fatalf("RuntimeUsageOperationTTL = %v, want 25m", cfg.RuntimeUsageOperationTTL)
+	}
+	if !cfg.RuntimeUsageOutboxEnabled {
+		t.Fatal("RuntimeUsageOutboxEnabled = false, want default true when runtime usage is enabled")
+	}
+	if cfg.MeteringEnabled {
+		t.Fatal("MeteringEnabled = true, want false; console billing metering must not require MNEMO_METERING_ENABLED")
+	}
+}
+
+func TestLoad_RuntimeUsageRequiresBaseURLAndSecret(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseURL    string
+		secret     string
+		wantSubstr string
+	}{
+		{name: "missing base URL", secret: "secret", wantSubstr: "MNEMO_RUNTIME_USAGE_BASE_URL is required"},
+		{name: "invalid base URL", baseURL: "ftp://token:secret@example.com/path?api_key=secret", secret: "secret", wantSubstr: "invalid MNEMO_RUNTIME_USAGE_BASE_URL"},
+		{name: "missing secret", baseURL: "https://console.example.com", wantSubstr: "MNEMO_RUNTIME_USAGE_INTERNAL_SECRET is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MNEMO_DSN", "test-dsn")
+			t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+			if tt.baseURL != "" {
+				t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", tt.baseURL)
+			}
+			if tt.secret != "" {
+				t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", tt.secret)
+			}
+
+			_, err := Load()
+			if err == nil {
+				t.Fatal("Load error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("Load error = %q, want substring %q", err.Error(), tt.wantSubstr)
+			}
+			if strings.Contains(err.Error(), "token:secret") || strings.Contains(err.Error(), "api_key=secret") {
+				t.Fatalf("runtime usage validation error leaked secret content: %q", err.Error())
+			}
+		})
+	}
+}
+
+func TestLoad_RuntimeUsageOutboxCannotBeDisabledWithoutFailOpen(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://console.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+	t.Setenv("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED", "false")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load error = nil, want outbox disabled error")
+	}
+}
+
+func TestLoad_RuntimeUsageBaseURLDrivesConsoleMeteringWhenLegacyMeteringEnabled(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://console.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+	t.Setenv("MNEMO_METERING_ENABLED", "true")
+	t.Setenv("MNEMO_METERING_URL", "s3://legacy-export/mem9/")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RuntimeUsageBaseURL != "https://console.example.com" {
+		t.Fatalf("RuntimeUsageBaseURL = %q", cfg.RuntimeUsageBaseURL)
+	}
+	if cfg.MeteringURL != "s3://legacy-export/mem9/" {
+		t.Fatalf("MeteringURL = %q", cfg.MeteringURL)
+	}
+}
+
 func TestLoad_AutoSpendLimitDefaultsAndCustom(t *testing.T) {
 	tests := []struct {
-		name              string
-		envs              map[string]string
-		wantEnabled       bool
-		wantIncrement     int
-		wantMax           int
-		wantCooldown      time.Duration
+		name          string
+		envs          map[string]string
+		wantEnabled   bool
+		wantIncrement int
+		wantMax       int
+		wantCooldown  time.Duration
 	}{
 		{
-			name: "defaults",
-			envs: map[string]string{},
-			wantEnabled:  false,
+			name:          "defaults",
+			envs:          map[string]string{},
+			wantEnabled:   false,
 			wantIncrement: 500,
 			wantMax:       10000,
 			wantCooldown:  time.Hour,
@@ -138,7 +251,7 @@ func TestLoad_AutoSpendLimitDefaultsAndCustom(t *testing.T) {
 				"MNEMO_AUTO_SPEND_LIMIT_MAX":       "20000",
 				"MNEMO_AUTO_SPEND_LIMIT_COOLDOWN":  "2h",
 			},
-			wantEnabled:  true,
+			wantEnabled:   true,
 			wantIncrement: 750,
 			wantMax:       20000,
 			wantCooldown:  2 * time.Hour,
@@ -174,9 +287,9 @@ func TestLoad_AutoSpendLimitDefaultsAndCustom(t *testing.T) {
 
 func TestLoad_AutoSpendLimitValidation(t *testing.T) {
 	tests := []struct {
-		name        string
-		envs        map[string]string
-		wantSubstr  string
+		name       string
+		envs       map[string]string
+		wantSubstr string
 	}{
 		{
 			name: "increment zero",

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -116,7 +116,7 @@ func TestLoad_MeteringURLValidationErrorRedactsRawURL(t *testing.T) {
 func TestLoad_RuntimeUsageConfig(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
-	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://console.example.com/internal/")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com/internal/")
 	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
 	t.Setenv("MNEMO_RUNTIME_USAGE_TIMEOUT", "4s")
 	t.Setenv("MNEMO_RUNTIME_USAGE_METERING_TIMEOUT", "6s")
@@ -130,7 +130,7 @@ func TestLoad_RuntimeUsageConfig(t *testing.T) {
 	if !cfg.RuntimeUsageEnabled {
 		t.Fatal("RuntimeUsageEnabled = false, want true")
 	}
-	if cfg.RuntimeUsageBaseURL != "https://console.example.com/internal" {
+	if cfg.RuntimeUsageBaseURL != "https://runtime-usage.example.com/internal" {
 		t.Fatalf("RuntimeUsageBaseURL = %q", cfg.RuntimeUsageBaseURL)
 	}
 	if cfg.RuntimeUsageInternalSecret != "secret-value" {
@@ -152,7 +152,7 @@ func TestLoad_RuntimeUsageConfig(t *testing.T) {
 		t.Fatal("RuntimeUsageOutboxEnabled = false, want default true when runtime usage is enabled")
 	}
 	if cfg.MeteringEnabled {
-		t.Fatal("MeteringEnabled = true, want false; console billing metering must not require MNEMO_METERING_ENABLED")
+		t.Fatal("MeteringEnabled = true, want false; runtime usage metering must not require MNEMO_METERING_ENABLED")
 	}
 }
 
@@ -165,7 +165,7 @@ func TestLoad_RuntimeUsageRequiresBaseURLAndSecret(t *testing.T) {
 	}{
 		{name: "missing base URL", secret: "secret", wantSubstr: "MNEMO_RUNTIME_USAGE_BASE_URL is required"},
 		{name: "invalid base URL", baseURL: "ftp://token:secret@example.com/path?api_key=secret", secret: "secret", wantSubstr: "invalid MNEMO_RUNTIME_USAGE_BASE_URL"},
-		{name: "missing secret", baseURL: "https://console.example.com", wantSubstr: "MNEMO_RUNTIME_USAGE_INTERNAL_SECRET is required"},
+		{name: "missing secret", baseURL: "https://runtime-usage.example.com", wantSubstr: "MNEMO_RUNTIME_USAGE_INTERNAL_SECRET is required"},
 	}
 
 	for _, tt := range tests {
@@ -196,7 +196,7 @@ func TestLoad_RuntimeUsageRequiresBaseURLAndSecret(t *testing.T) {
 func TestLoad_RuntimeUsageOutboxCannotBeDisabledWithoutFailOpen(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
-	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://console.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
 	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
 	t.Setenv("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED", "false")
 
@@ -206,10 +206,10 @@ func TestLoad_RuntimeUsageOutboxCannotBeDisabledWithoutFailOpen(t *testing.T) {
 	}
 }
 
-func TestLoad_RuntimeUsageBaseURLDrivesConsoleMeteringWhenLegacyMeteringEnabled(t *testing.T) {
+func TestLoad_RuntimeUsageBaseURLDrivesRuntimeUsageMeteringWhenLegacyMeteringEnabled(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
-	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://console.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
 	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
 	t.Setenv("MNEMO_METERING_ENABLED", "true")
 	t.Setenv("MNEMO_METERING_URL", "s3://legacy-export/mem9/")
@@ -218,7 +218,7 @@ func TestLoad_RuntimeUsageBaseURLDrivesConsoleMeteringWhenLegacyMeteringEnabled(
 	if err != nil {
 		t.Fatalf("Load: %v", err)
 	}
-	if cfg.RuntimeUsageBaseURL != "https://console.example.com" {
+	if cfg.RuntimeUsageBaseURL != "https://runtime-usage.example.com" {
 		t.Fatalf("RuntimeUsageBaseURL = %q", cfg.RuntimeUsageBaseURL)
 	}
 	if cfg.MeteringURL != "s3://legacy-export/mem9/" {

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -76,8 +76,8 @@ type AuthInfo struct {
 	TenantDB  *sql.DB
 	ClusterID string
 
-	// APIKeySubject is the billing/quota subject passed to console internal
-	// runtime usage APIs. It must not be logged raw.
+	// APIKeySubject is the billing/quota subject passed to runtime usage
+	// service APIs. It must not be logged raw.
 	APIKeySubject string
 
 	// Chain is non-nil when X-API-Key resolved to a Space Chain key.

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -76,6 +76,10 @@ type AuthInfo struct {
 	TenantDB  *sql.DB
 	ClusterID string
 
+	// APIKeySubject is the billing/quota subject passed to console internal
+	// runtime usage APIs. It must not be logged raw.
+	APIKeySubject string
+
 	// Chain is non-nil when X-API-Key resolved to a Space Chain key.
 	Chain *ChainAuth
 }

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/service"
 )
 
 func (s *Server) firstChainNodeAuth(auth *domain.AuthInfo) (*domain.AuthInfo, error) {
@@ -38,6 +39,66 @@ func applyChainSource(memories []domain.Memory, source *domain.ChainSource) {
 	for i := range memories {
 		memories[i].ChainSource = source
 	}
+}
+
+type chainMemoryTarget struct {
+	nodeAuth *domain.AuthInfo
+	svc      resolvedSvc
+	source   *domain.ChainSource
+}
+
+type chainDeleteGroup struct {
+	target chainMemoryTarget
+	ids    []string
+}
+
+func (s *Server) findChainMemoryTarget(ctx context.Context, auth *domain.AuthInfo, id string) (chainMemoryTarget, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return chainMemoryTarget{}, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	for _, node := range auth.Chain.Nodes {
+		nodeAuth := chainNodeAuth(auth, node)
+		svc := s.resolveServices(nodeAuth)
+		if _, err := svc.memory.Get(ctx, id); err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				continue
+			}
+			return chainMemoryTarget{}, err
+		}
+		return chainMemoryTarget{
+			nodeAuth: nodeAuth,
+			svc:      svc,
+			source:   chainSource(auth, node),
+		}, nil
+	}
+	return chainMemoryTarget{}, domain.ErrNotFound
+}
+
+func (s *Server) chainDeleteGroups(ctx context.Context, auth *domain.AuthInfo, ids []string) ([]chainDeleteGroup, error) {
+	deleteIDs, err := service.ValidateBulkDeleteIDs(ids)
+	if err != nil {
+		return nil, err
+	}
+	groups := make([]chainDeleteGroup, 0)
+	groupIndexes := make(map[string]int)
+	for _, id := range deleteIDs {
+		target, err := s.findChainMemoryTarget(ctx, auth, id)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				continue
+			}
+			return nil, err
+		}
+		key := target.nodeAuth.TenantID + "\x00" + target.nodeAuth.ClusterID
+		index, ok := groupIndexes[key]
+		if !ok {
+			index = len(groups)
+			groupIndexes[key] = index
+			groups = append(groups, chainDeleteGroup{target: target})
+		}
+		groups[index].ids = append(groups[index].ids, id)
+	}
+	return groups, nil
 }
 
 func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
@@ -131,98 +192,6 @@ func (s *Server) getChainMemory(ctx context.Context, auth *domain.AuthInfo, id s
 		return mem, nil
 	}
 	return nil, domain.ErrNotFound
-}
-
-func (s *Server) updateChainMemory(ctx context.Context, auth *domain.AuthInfo, id string, req updateMemoryRequest, ifMatch int) (*domain.Memory, *domain.AuthInfo, resolvedSvc, error) {
-	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
-		return nil, nil, resolvedSvc{}, &domain.ValidationError{Message: "Space Chain has no nodes."}
-	}
-	for _, node := range auth.Chain.Nodes {
-		nodeAuth := chainNodeAuth(auth, node)
-		svc := s.resolveServices(nodeAuth)
-		if _, err := svc.memory.Get(ctx, id); err != nil {
-			if errors.Is(err, domain.ErrNotFound) {
-				continue
-			}
-			return nil, nil, resolvedSvc{}, err
-		}
-		mem, err := svc.memory.Update(ctx, auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
-		if err != nil {
-			return nil, nil, resolvedSvc{}, err
-		}
-		mem.ChainSource = chainSource(auth, node)
-		return mem, nodeAuth, svc, nil
-	}
-	return nil, nil, resolvedSvc{}, domain.ErrNotFound
-}
-
-func (s *Server) deleteChainMemory(ctx context.Context, auth *domain.AuthInfo, id string) (*domain.AuthInfo, resolvedSvc, error) {
-	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
-		return nil, resolvedSvc{}, &domain.ValidationError{Message: "Space Chain has no nodes."}
-	}
-	for _, node := range auth.Chain.Nodes {
-		nodeAuth := chainNodeAuth(auth, node)
-		svc := s.resolveServices(nodeAuth)
-		if _, err := svc.memory.Get(ctx, id); err != nil {
-			if errors.Is(err, domain.ErrNotFound) {
-				continue
-			}
-			return nil, resolvedSvc{}, err
-		}
-		if _, err := svc.memory.Delete(ctx, id, auth.AgentName); err != nil {
-			return nil, resolvedSvc{}, err
-		}
-		return nodeAuth, svc, nil
-	}
-	return nil, resolvedSvc{}, domain.ErrNotFound
-}
-
-func (s *Server) batchDeleteChainMemories(ctx context.Context, auth *domain.AuthInfo, ids []string) (int64, error) {
-	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
-		return 0, &domain.ValidationError{Message: "Space Chain has no nodes."}
-	}
-	if len(ids) == 0 {
-		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
-	}
-	if len(ids) > 1000 {
-		return 0, &domain.ValidationError{Field: "ids", Message: "too many (max 1000)"}
-	}
-	seen := make(map[string]struct{}, len(ids))
-	unique := make([]string, 0, len(ids))
-	for _, id := range ids {
-		if id == "" {
-			continue
-		}
-		if _, ok := seen[id]; ok {
-			continue
-		}
-		seen[id] = struct{}{}
-		unique = append(unique, id)
-	}
-	if len(unique) == 0 {
-		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
-	}
-	var deleted int64
-	for _, id := range unique {
-		for _, node := range auth.Chain.Nodes {
-			nodeAuth := chainNodeAuth(auth, node)
-			svc := s.resolveServices(nodeAuth)
-			if _, err := svc.memory.Get(ctx, id); err != nil {
-				if errors.Is(err, domain.ErrNotFound) {
-					continue
-				}
-				return deleted, err
-			}
-			removed, err := svc.memory.Delete(ctx, id, auth.AgentName)
-			if err != nil {
-				return deleted, err
-			}
-			go s.afterSuccessfulWrite(nodeAuth, svc, 0)
-			deleted += removed
-			break
-		}
-	}
-	return deleted, nil
 }
 
 func topChainScore(memories []domain.Memory) float64 {

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -169,7 +169,7 @@ func (s *Server) deleteChainMemory(ctx context.Context, auth *domain.AuthInfo, i
 			}
 			return nil, resolvedSvc{}, err
 		}
-		if err := svc.memory.Delete(ctx, id, auth.AgentName); err != nil {
+		if _, err := svc.memory.Delete(ctx, id, auth.AgentName); err != nil {
 			return nil, resolvedSvc{}, err
 		}
 		return nodeAuth, svc, nil
@@ -213,11 +213,12 @@ func (s *Server) batchDeleteChainMemories(ctx context.Context, auth *domain.Auth
 				}
 				return deleted, err
 			}
-			if err := svc.memory.Delete(ctx, id, auth.AgentName); err != nil {
+			removed, err := svc.memory.Delete(ctx, id, auth.AgentName)
+			if err != nil {
 				return deleted, err
 			}
 			go s.afterSuccessfulWrite(nodeAuth, svc, 0)
-			deleted++
+			deleted += removed
 			break
 		}
 	}

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -18,11 +18,16 @@ func (s *Server) firstChainNodeAuth(auth *domain.AuthInfo) (*domain.AuthInfo, er
 }
 
 func chainNodeAuth(auth *domain.AuthInfo, node domain.ChainAuthNode) *domain.AuthInfo {
+	apiKeySubject := auth.APIKeySubject
+	if apiKeySubject == "" && auth.Chain != nil {
+		apiKeySubject = auth.Chain.APIKey
+	}
 	return &domain.AuthInfo{
-		AgentName: auth.AgentName,
-		TenantID:  node.TenantID,
-		TenantDB:  node.TenantDB,
-		ClusterID: node.ClusterID,
+		AgentName:     auth.AgentName,
+		TenantID:      node.TenantID,
+		TenantDB:      node.TenantDB,
+		ClusterID:     node.ClusterID,
+		APIKeySubject: apiKeySubject,
 	}
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/repository"
 	"github.com/qiffang/mnemos/server/internal/reqid"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
 
@@ -40,6 +41,7 @@ type Server struct {
 	dbBackend            string
 	logger               *slog.Logger
 	metering             metering.Writer
+	runtimeUsage         runtimeusage.Manager
 	activity             *service.ActivityTracker
 	startedAt            time.Time
 	svcCache             sync.Map
@@ -85,6 +87,11 @@ func (s *Server) WithSpaceChainService(chains *service.SpaceChainService, stopSc
 
 func (s *Server) WithMetering(writer metering.Writer) *Server {
 	s.metering = writer
+	return s
+}
+
+func (s *Server) WithRuntimeUsage(manager runtimeusage.Manager) *Server {
+	s.runtimeUsage = manager
 	return s
 }
 

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -739,22 +739,99 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if auth.IsChain() {
-		mem, nodeAuth, nodeSvc, err := s.updateChainMemory(r.Context(), auth, id, req, ifMatch)
+		target, err := s.findChainMemoryTarget(r.Context(), auth, id)
 		if err != nil {
 			s.handleError(r.Context(), w, err)
 			return
 		}
-		go s.afterSuccessfulWrite(nodeAuth, nodeSvc, 1)
+		var lease *runtimeusage.OperationLease
+		finalized := false
+		if s.runtimeUsageEnabled() {
+			lease, err = s.runtimeUsage.BeforeMemoryUpdate(r.Context(), subjectFromAuth(target.nodeAuth))
+			if err != nil {
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			defer func() {
+				if !finalized {
+					s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, context.Canceled)
+				}
+			}()
+		}
+		mem, err := target.svc.memory.Update(r.Context(), auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
+		if err != nil {
+			if s.runtimeUsageEnabled() {
+				s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, err)
+				finalized = true
+			}
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		mem.ChainSource = target.source
+		if s.runtimeUsageEnabled() {
+			if err := s.runtimeUsage.AfterMemoryUpdateSuccess(r.Context(), lease, runtimeusage.MemoryUpdateResult{
+				MemoryIDs:       []string{mem.ID},
+				AgentName:       target.nodeAuth.AgentName,
+				ObjectsAffected: 1,
+			}); err != nil {
+				s.logger.Error("runtime usage chain memory update finalization failed",
+					"operation_id", lease.OperationID,
+					"tenant_id", target.nodeAuth.TenantID,
+					"cluster_id", target.nodeAuth.ClusterID,
+					"err", err)
+				finalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			finalized = true
+		}
+		go s.afterSuccessfulWrite(target.nodeAuth, target.svc, 1)
 		w.Header().Set("ETag", strconv.Itoa(mem.Version))
 		respond(w, http.StatusOK, mem)
 		return
 	}
 
 	svc := s.resolveServices(auth)
+	var lease *runtimeusage.OperationLease
+	finalized := false
+	if s.runtimeUsageEnabled() {
+		var err error
+		lease, err = s.runtimeUsage.BeforeMemoryUpdate(r.Context(), subjectFromAuth(auth))
+		if err != nil {
+			s.handleRuntimeUsageError(w, err)
+			return
+		}
+		defer func() {
+			if !finalized {
+				s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, context.Canceled)
+			}
+		}()
+	}
 	mem, err := svc.memory.Update(r.Context(), auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
 	if err != nil {
+		if s.runtimeUsageEnabled() {
+			s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, err)
+			finalized = true
+		}
 		s.handleError(r.Context(), w, err)
 		return
+	}
+	if s.runtimeUsageEnabled() {
+		if err := s.runtimeUsage.AfterMemoryUpdateSuccess(r.Context(), lease, runtimeusage.MemoryUpdateResult{
+			MemoryIDs:       []string{mem.ID},
+			AgentName:       auth.AgentName,
+			ObjectsAffected: 1,
+		}); err != nil {
+			s.logger.Error("runtime usage memory update finalization failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", auth.TenantID,
+				"cluster_id", auth.ClusterID,
+				"err", err)
+			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
+		}
+		finalized = true
 	}
 
 	go s.afterSuccessfulWrite(auth, svc, 1)
@@ -767,12 +844,52 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
 	if auth.IsChain() {
-		nodeAuth, nodeSvc, err := s.deleteChainMemory(r.Context(), auth, id)
+		target, err := s.findChainMemoryTarget(r.Context(), auth, id)
 		if err != nil {
 			s.handleError(r.Context(), w, err)
 			return
 		}
-		go s.afterSuccessfulWrite(nodeAuth, nodeSvc, 0)
+		var lease *runtimeusage.OperationLease
+		finalized := false
+		if s.runtimeUsageEnabled() {
+			lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(target.nodeAuth))
+			if err != nil {
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			defer func() {
+				if !finalized {
+					s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+				}
+			}()
+		}
+		deleted, err := target.svc.memory.Delete(r.Context(), id, auth.AgentName)
+		if err != nil {
+			if s.runtimeUsageEnabled() {
+				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+				finalized = true
+			}
+			s.handleError(r.Context(), w, err)
+			return
+		}
+		if s.runtimeUsageEnabled() {
+			if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+				MemoryIDs:       []string{id},
+				AgentName:       target.nodeAuth.AgentName,
+				ObjectsAffected: deleted,
+			}); err != nil {
+				s.logger.Error("runtime usage chain memory delete finalization failed",
+					"operation_id", lease.OperationID,
+					"tenant_id", target.nodeAuth.TenantID,
+					"cluster_id", target.nodeAuth.ClusterID,
+					"err", err)
+				finalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			finalized = true
+		}
+		go s.afterSuccessfulWrite(target.nodeAuth, target.svc, 0)
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -838,10 +955,59 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 
 	auth := authInfo(r)
 	if auth.IsChain() {
-		deleted, err := s.batchDeleteChainMemories(r.Context(), auth, req.IDs)
+		groups, err := s.chainDeleteGroups(r.Context(), auth, req.IDs)
 		if err != nil {
-			s.handleError(r.Context(), w, err)
+			if isRuntimeUsageError(err) {
+				s.handleRuntimeUsageError(w, err)
+			} else {
+				s.handleError(r.Context(), w, err)
+			}
 			return
+		}
+		var deleted int64
+		for _, group := range groups {
+			var lease *runtimeusage.OperationLease
+			finalized := false
+			if s.runtimeUsageEnabled() {
+				lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(group.target.nodeAuth))
+				if err != nil {
+					s.handleRuntimeUsageError(w, err)
+					return
+				}
+			}
+			groupDeleted, err := group.target.svc.memory.BulkDelete(r.Context(), group.ids, auth.AgentName)
+			if err != nil {
+				if s.runtimeUsageEnabled() {
+					s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+					finalized = true
+				}
+				s.handleError(r.Context(), w, err)
+				return
+			}
+			if s.runtimeUsageEnabled() {
+				if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+					MemoryIDs:       append([]string(nil), group.ids...),
+					AgentName:       group.target.nodeAuth.AgentName,
+					ObjectsAffected: groupDeleted,
+				}); err != nil {
+					s.logger.Error("runtime usage chain batch delete finalization failed",
+						"operation_id", lease.OperationID,
+						"tenant_id", group.target.nodeAuth.TenantID,
+						"cluster_id", group.target.nodeAuth.ClusterID,
+						"err", err)
+					finalized = true
+					s.handleRuntimeUsageError(w, err)
+					return
+				}
+				finalized = true
+			}
+			if s.runtimeUsageEnabled() && !finalized {
+				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+			}
+			if groupDeleted > 0 {
+				go s.afterSuccessfulWrite(group.target.nodeAuth, group.target.svc, 0)
+			}
+			deleted += groupDeleted
 		}
 		respond(w, http.StatusOK, map[string]any{
 			"deleted": deleted,

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -720,11 +720,16 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	svc := s.resolveServices(auth)
+	deleteIDs, err := service.ValidateBulkDeleteIDs(req.IDs)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
 	var lease *runtimeusage.OperationLease
 	finalized := false
 	if s.runtimeUsageEnabled() {
 		var err error
-		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth), runtimeusage.MemoryDeleteTarget{MemoryIDs: append([]string(nil), req.IDs...)})
+		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth), runtimeusage.MemoryDeleteTarget{MemoryIDs: append([]string(nil), deleteIDs...)})
 		if err != nil {
 			s.handleRuntimeUsageError(w, err)
 			return
@@ -735,7 +740,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 	}
-	deleted, err := svc.memory.BulkDelete(r.Context(), req.IDs, auth.AgentName)
+	deleted, err := svc.memory.BulkDelete(r.Context(), deleteIDs, auth.AgentName)
 	if err != nil {
 		if s.runtimeUsageEnabled() {
 			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
@@ -746,7 +751,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.runtimeUsageEnabled() {
 		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
-			MemoryIDs:        append([]string(nil), req.IDs...),
+			MemoryIDs:        append([]string(nil), deleteIDs...),
 			MemorySlotsDelta: -deleted,
 			AgentName:        auth.AgentName,
 		}); err != nil {
@@ -793,8 +798,8 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	svc := s.resolveServices(auth)
-	if len(req.Memories) == 0 {
-		s.handleError(r.Context(), w, &domain.ValidationError{Field: "memories", Message: "required"})
+	if err := service.ValidateBulkMemoryInputs(req.Memories); err != nil {
+		s.handleError(r.Context(), w, err)
 		return
 	}
 	var lease *runtimeusage.OperationLease

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -142,7 +142,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				if result != nil {
 					ids = result.InsightIDs
 				}
-				if err := s.runtimeUsage.AfterMemoryCreateSuccess(syncCtx, lease, runtimeusage.MemoryCreateResult{
+				if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
 					MemoryIDs:       ids,
 					AgentName:       auth.AgentName,
 					ObjectsAffected: written,
@@ -277,7 +277,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if memoryID != "" {
 				ids = []string{memoryID}
 			}
-			if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
+			if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
 				MemoryIDs:       ids,
 				AgentName:       auth.AgentName,
 				ObjectsAffected: int64(written),
@@ -330,7 +330,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if mem != nil && mem.ID != "" {
 				ids = []string{mem.ID}
 			}
-			if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
+			if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
 				MemoryIDs:       ids,
 				AgentName:       auth.AgentName,
 				ObjectsAffected: int64(written),
@@ -769,7 +769,7 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		mem.ChainSource = target.source
 		if s.runtimeUsageEnabled() {
-			if err := s.runtimeUsage.AfterMemoryUpdateSuccess(r.Context(), lease, runtimeusage.MemoryUpdateResult{
+			if err := s.runtimeUsage.AfterMemoryUpdateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryUpdateResult{
 				MemoryIDs:       []string{mem.ID},
 				AgentName:       target.nodeAuth.AgentName,
 				ObjectsAffected: 1,
@@ -817,7 +817,7 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryUpdateSuccess(r.Context(), lease, runtimeusage.MemoryUpdateResult{
+		if err := s.runtimeUsage.AfterMemoryUpdateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryUpdateResult{
 			MemoryIDs:       []string{mem.ID},
 			AgentName:       auth.AgentName,
 			ObjectsAffected: 1,
@@ -873,7 +873,7 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if s.runtimeUsageEnabled() {
-			if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+			if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
 				MemoryIDs:       []string{id},
 				AgentName:       target.nodeAuth.AgentName,
 				ObjectsAffected: deleted,
@@ -921,7 +921,7 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
 			MemoryIDs:       []string{id},
 			AgentName:       auth.AgentName,
 			ObjectsAffected: deleted,
@@ -985,7 +985,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if s.runtimeUsageEnabled() {
-				if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+				if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
 					MemoryIDs:       append([]string(nil), group.ids...),
 					AgentName:       group.target.nodeAuth.AgentName,
 					ObjectsAffected: groupDeleted,
@@ -1046,7 +1046,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
 			MemoryIDs:       append([]string(nil), deleteIDs...),
 			AgentName:       auth.AgentName,
 			ObjectsAffected: deleted,
@@ -1124,7 +1124,7 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	applyChainSource(memories, writeChainSource)
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
+		if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
 			MemoryIDs:       memoryIDs(memories),
 			AgentName:       auth.AgentName,
 			ObjectsAffected: int64(len(memories)),

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -81,15 +81,6 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.runtimeUsageEnabled() && hasMessages {
-		respond(w, http.StatusConflict, map[string]any{
-			"code":      "runtime_usage_requires_known_memory_delta",
-			"message":   "runtime usage mode requires a known memory_slots delta; use pinned memory create or disable runtime usage for smart ingest",
-			"retryable": false,
-		})
-		return
-	}
-
 	if hasMessages {
 		messages := append([]service.IngestMessage(nil), req.Messages...)
 		ingestReq := service.IngestRequest{
@@ -103,8 +94,28 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			syncCtx, cancel := context.WithTimeout(r.Context(), syncIngestTimeout)
 			defer cancel()
 
+			var lease *runtimeusage.OperationLease
+			finalized := false
+			if s.runtimeUsageEnabled() {
+				var err error
+				lease, err = s.runtimeUsage.BeforeMemoryCreate(syncCtx, subjectFromAuth(auth), 1)
+				if err != nil {
+					s.handleRuntimeUsageError(w, err)
+					return
+				}
+				defer func() {
+					if !finalized {
+						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+					}
+				}()
+			}
+
 			result, err := s.ingestMessages(syncCtx, auth, svc, ingestReq)
 			if err != nil {
+				if s.runtimeUsageEnabled() {
+					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					finalized = true
+				}
 				if isSyncIngestTimeout(syncCtx, err) {
 					s.logger.Warn("sync ingest timed out", "session", ingestReq.SessionID, "timeout", syncIngestTimeout)
 					respondError(w, http.StatusGatewayTimeout, fmt.Sprintf("sync ingest timed out after %s", syncIngestTimeout))
@@ -114,6 +125,11 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if result != nil && result.Status == "failed" {
+				if s.runtimeUsageEnabled() {
+					err := errors.New("ingest reconciliation failed")
+					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					finalized = true
+				}
 				respondError(w, http.StatusInternalServerError, "ingest reconciliation failed")
 				return
 			}
@@ -121,17 +137,53 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if result != nil {
 				written = int64(result.MemoriesChanged)
 			}
+			if s.runtimeUsageEnabled() {
+				var ids []string
+				if result != nil {
+					ids = result.InsightIDs
+				}
+				if err := s.runtimeUsage.AfterMemoryCreateSuccess(syncCtx, lease, runtimeusage.MemoryCreateResult{
+					MemoryIDs:       ids,
+					AgentName:       auth.AgentName,
+					ObjectsAffected: written,
+				}); err != nil {
+					s.logger.Error("runtime usage sync ingest finalization failed",
+						"operation_id", lease.OperationID,
+						"tenant_id", auth.TenantID,
+						"cluster_id", auth.ClusterID,
+						"err", err)
+					finalized = true
+					s.handleRuntimeUsageError(w, err)
+					return
+				}
+				finalized = true
+			}
 			s.recordIngestMetering(auth, svc)
 			go s.afterSuccessfulWrite(auth, svc, written)
 			respond(w, http.StatusOK, map[string]string{"status": "ok"})
 		} else {
-			go func() {
+			var lease *runtimeusage.OperationLease
+			if s.runtimeUsageEnabled() {
+				var err error
+				lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
+				if err != nil {
+					s.handleRuntimeUsageError(w, err)
+					return
+				}
+			}
+			go func(lease *runtimeusage.OperationLease) {
 				result, err := s.ingestMessages(context.Background(), auth, svc, ingestReq)
 				if err != nil {
+					if s.runtimeUsageEnabled() {
+						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					}
 					slog.Error("async ingest failed", "session", ingestReq.SessionID, "err", err)
 					return
 				}
 				if result != nil && result.Status == "failed" {
+					if s.runtimeUsageEnabled() {
+						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, errors.New("ingest reconciliation failed"))
+					}
 					slog.Error("async ingest reconcile failed", "session", ingestReq.SessionID)
 					return
 				}
@@ -139,8 +191,26 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				if result != nil {
 					written = int64(result.MemoriesChanged)
 				}
+				if s.runtimeUsageEnabled() {
+					var ids []string
+					if result != nil {
+						ids = result.InsightIDs
+					}
+					if err := s.runtimeUsage.AfterMemoryCreateSuccess(context.Background(), lease, runtimeusage.MemoryCreateResult{
+						MemoryIDs:       ids,
+						AgentName:       auth.AgentName,
+						ObjectsAffected: written,
+					}); err != nil {
+						s.logger.Error("runtime usage async ingest finalization failed",
+							"operation_id", lease.OperationID,
+							"tenant_id", auth.TenantID,
+							"cluster_id", auth.ClusterID,
+							"err", err)
+						return
+					}
+				}
 				s.afterSuccessfulIngest(auth, svc, written)
-			}()
+			}(lease)
 			respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 		}
 		return
@@ -159,15 +229,6 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	metadata := append(json.RawMessage(nil), req.Metadata...)
 	content := req.Content
 	explicitMemoryType := strings.TrimSpace(req.MemoryType)
-
-	if s.runtimeUsageEnabled() && explicitMemoryType == "" {
-		respond(w, http.StatusConflict, map[string]any{
-			"code":      "runtime_usage_requires_known_memory_delta",
-			"message":   "runtime usage mode requires a known memory_slots delta; use pinned memory create or disable runtime usage for smart ingest",
-			"retryable": false,
-		})
-		return
-	}
 
 	if explicitMemoryType != "" {
 		if explicitMemoryType != string(domain.TypePinned) {
@@ -217,8 +278,9 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				ids = []string{memoryID}
 			}
 			if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
-				MemoryIDs: ids,
-				AgentName: auth.AgentName,
+				MemoryIDs:       ids,
+				AgentName:       auth.AgentName,
+				ObjectsAffected: int64(written),
 			}); err != nil {
 				s.logger.Error("runtime usage memory create finalization failed",
 					"operation_id", lease.OperationID,
@@ -237,21 +299,72 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if req.Sync {
+		var lease *runtimeusage.OperationLease
+		finalized := false
+		if s.runtimeUsageEnabled() {
+			var err error
+			lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
+			if err != nil {
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			defer func() {
+				if !finalized {
+					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+				}
+			}()
+		}
 		// s.persistContentSession(r.Context(), auth, svc, req.SessionID, agentID, content, metadata)
 		mem, written, err := svc.memory.Create(r.Context(), agentID, content, tags, metadata)
 		if err != nil {
+			if s.runtimeUsageEnabled() {
+				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+				finalized = true
+			}
 			slog.Error("sync memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
 			s.handleError(r.Context(), w, err)
 			return
 		}
-		_ = mem
+		if s.runtimeUsageEnabled() {
+			var ids []string
+			if mem != nil && mem.ID != "" {
+				ids = []string{mem.ID}
+			}
+			if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
+				MemoryIDs:       ids,
+				AgentName:       auth.AgentName,
+				ObjectsAffected: int64(written),
+			}); err != nil {
+				s.logger.Error("runtime usage sync memory create finalization failed",
+					"operation_id", lease.OperationID,
+					"tenant_id", auth.TenantID,
+					"cluster_id", auth.ClusterID,
+					"err", err)
+				finalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			finalized = true
+		}
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusOK, map[string]string{"status": "ok"})
 	} else {
-		go func(auth *domain.AuthInfo, agentName, actorAgentID, sessionID, content string, tags []string, metadata json.RawMessage) {
+		var lease *runtimeusage.OperationLease
+		if s.runtimeUsageEnabled() {
+			var err error
+			lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
+			if err != nil {
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+		}
+		go func(auth *domain.AuthInfo, lease *runtimeusage.OperationLease, agentName, actorAgentID, sessionID, content string, tags []string, metadata json.RawMessage) {
 			// s.persistContentSession(context.Background(), auth, svc, sessionID, actorAgentID, content, metadata)
 			mem, written, err := svc.memory.Create(context.Background(), actorAgentID, content, tags, metadata)
 			if err != nil {
+				if s.runtimeUsageEnabled() {
+					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+				}
 				slog.Error("async memory create failed", "agent", actorAgentID, "actor", agentName, "err", err)
 				return
 			}
@@ -260,8 +373,26 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			} else {
 				slog.Info("async memory create complete", "agent", actorAgentID, "actor", agentName, "memory_id", "")
 			}
+			if s.runtimeUsageEnabled() {
+				var ids []string
+				if mem != nil && mem.ID != "" {
+					ids = []string{mem.ID}
+				}
+				if err := s.runtimeUsage.AfterMemoryCreateSuccess(context.Background(), lease, runtimeusage.MemoryCreateResult{
+					MemoryIDs:       ids,
+					AgentName:       auth.AgentName,
+					ObjectsAffected: int64(written),
+				}); err != nil {
+					s.logger.Error("runtime usage async memory create finalization failed",
+						"operation_id", lease.OperationID,
+						"tenant_id", auth.TenantID,
+						"cluster_id", auth.ClusterID,
+						"err", err)
+					return
+				}
+			}
 			s.afterSuccessfulWrite(auth, svc, int64(written))
-		}(auth, auth.AgentName, agentID, req.SessionID, content, tags, metadata)
+		}(auth, lease, auth.AgentName, agentID, req.SessionID, content, tags, metadata)
 
 		respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 	}
@@ -651,7 +782,7 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	finalized := false
 	if s.runtimeUsageEnabled() {
 		var err error
-		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth), runtimeusage.MemoryDeleteTarget{MemoryIDs: []string{id}})
+		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth))
 		if err != nil {
 			s.handleRuntimeUsageError(w, err)
 			return
@@ -673,11 +804,10 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		delta := -deleted
 		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
-			MemoryIDs:        []string{id},
-			MemorySlotsDelta: delta,
-			AgentName:        auth.AgentName,
+			MemoryIDs:       []string{id},
+			AgentName:       auth.AgentName,
+			ObjectsAffected: deleted,
 		}); err != nil {
 			s.logger.Error("runtime usage memory delete finalization failed",
 				"operation_id", lease.OperationID,
@@ -729,7 +859,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	finalized := false
 	if s.runtimeUsageEnabled() {
 		var err error
-		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth), runtimeusage.MemoryDeleteTarget{MemoryIDs: append([]string(nil), deleteIDs...)})
+		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth))
 		if err != nil {
 			s.handleRuntimeUsageError(w, err)
 			return
@@ -751,9 +881,9 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.runtimeUsageEnabled() {
 		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
-			MemoryIDs:        append([]string(nil), deleteIDs...),
-			MemorySlotsDelta: -deleted,
-			AgentName:        auth.AgentName,
+			MemoryIDs:       append([]string(nil), deleteIDs...),
+			AgentName:       auth.AgentName,
+			ObjectsAffected: deleted,
 		}); err != nil {
 			s.logger.Error("runtime usage batch delete finalization failed",
 				"operation_id", lease.OperationID,
@@ -806,7 +936,7 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	finalized := false
 	if s.runtimeUsageEnabled() {
 		var err error
-		lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), int64(len(req.Memories)))
+		lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
 		if err != nil {
 			s.handleRuntimeUsageError(w, err)
 			return
@@ -829,8 +959,9 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	applyChainSource(memories, writeChainSource)
 	if s.runtimeUsageEnabled() {
 		if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
-			MemoryIDs: memoryIDs(memories),
-			AgentName: auth.AgentName,
+			MemoryIDs:       memoryIDs(memories),
+			AgentName:       auth.AgentName,
+			ObjectsAffected: int64(len(memories)),
 		}); err != nil {
 			s.logger.Error("runtime usage bulk create finalization failed",
 				"operation_id", lease.OperationID,

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -226,8 +226,6 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					"cluster_id", auth.ClusterID,
 					"err", err)
 				finalized = true
-				s.handleRuntimeUsageError(w, err)
-				return
 			}
 			finalized = true
 		}
@@ -469,8 +467,6 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 					"cluster_id", auth.ClusterID,
 					"err", err)
 				recallFinalized = true
-				s.handleRuntimeUsageError(w, err)
-				return
 			}
 			recallFinalized = true
 		}
@@ -685,8 +681,6 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 				"cluster_id", auth.ClusterID,
 				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
-			return
 		}
 		finalized = true
 	}
@@ -761,8 +755,6 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				"cluster_id", auth.ClusterID,
 				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
-			return
 		}
 		finalized = true
 	}
@@ -838,8 +830,6 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 				"cluster_id", auth.ClusterID,
 				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
-			return
 		}
 		finalized = true
 	}

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -226,6 +226,8 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					"cluster_id", auth.ClusterID,
 					"err", err)
 				finalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
 			}
 			finalized = true
 		}
@@ -467,6 +469,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 					"cluster_id", auth.ClusterID,
 					"err", err)
 				recallFinalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
 			}
 			recallFinalized = true
 		}
@@ -681,6 +685,8 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 				"cluster_id", auth.ClusterID,
 				"err", err)
 			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
 		}
 		finalized = true
 	}
@@ -755,6 +761,8 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				"cluster_id", auth.ClusterID,
 				"err", err)
 			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
 		}
 		finalized = true
 	}
@@ -830,6 +838,8 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 				"cluster_id", auth.ClusterID,
 				"err", err)
 			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
 		}
 		finalized = true
 	}

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
 
@@ -77,6 +78,15 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 
 	if hasMessages && strings.TrimSpace(req.MemoryType) != "" {
 		s.handleError(r.Context(), w, &domain.ValidationError{Field: "memory_type", Message: "memory_type is only allowed with content, not messages"})
+		return
+	}
+
+	if s.runtimeUsageEnabled() && hasMessages {
+		respond(w, http.StatusConflict, map[string]any{
+			"code":      "runtime_usage_requires_known_memory_delta",
+			"message":   "runtime usage mode requires a known memory_slots delta; use pinned memory create or disable runtime usage for smart ingest",
+			"retryable": false,
+		})
 		return
 	}
 
@@ -150,6 +160,15 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	content := req.Content
 	explicitMemoryType := strings.TrimSpace(req.MemoryType)
 
+	if s.runtimeUsageEnabled() && explicitMemoryType == "" {
+		respond(w, http.StatusConflict, map[string]any{
+			"code":      "runtime_usage_requires_known_memory_delta",
+			"message":   "runtime usage mode requires a known memory_slots delta; use pinned memory create or disable runtime usage for smart ingest",
+			"retryable": false,
+		})
+		return
+	}
+
 	if explicitMemoryType != "" {
 		if explicitMemoryType != string(domain.TypePinned) {
 			s.handleError(r.Context(), w, &domain.ValidationError{
@@ -159,13 +178,56 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		var lease *runtimeusage.OperationLease
+		finalized := false
+		if s.runtimeUsageEnabled() {
+			var err error
+			lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
+			if err != nil {
+				s.handleRuntimeUsageError(w, err)
+				return
+			}
+			defer func() {
+				if !finalized {
+					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+				}
+			}()
+		}
+
 		mem, written, err := svc.memory.CreatePinned(r.Context(), agentID, content, tags, metadata)
 		if err != nil {
+			if s.runtimeUsageEnabled() {
+				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+				finalized = true
+			}
 			slog.Error("pinned memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
 			s.handleError(r.Context(), w, err)
 			return
 		}
-		mem.ChainSource = writeChainSource
+		if mem != nil {
+			mem.ChainSource = writeChainSource
+		}
+		if s.runtimeUsageEnabled() {
+			memoryID := ""
+			if mem != nil {
+				memoryID = mem.ID
+			}
+			var ids []string
+			if memoryID != "" {
+				ids = []string{memoryID}
+			}
+			if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
+				MemoryIDs: ids,
+				AgentName: auth.AgentName,
+			}); err != nil {
+				s.logger.Error("runtime usage memory create finalization failed",
+					"operation_id", lease.OperationID,
+					"tenant_id", auth.TenantID,
+					"cluster_id", auth.ClusterID,
+					"err", err)
+			}
+			finalized = true
+		}
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusCreated, mem)
 		return
@@ -343,6 +405,21 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	var memories []domain.Memory
 	var total int
 	var err error
+	var recallLease *runtimeusage.OperationLease
+	recallFinalized := false
+
+	if s.runtimeUsageEnabled() && filter.Query != "" {
+		recallLease, err = s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
+		if err != nil {
+			s.handleRuntimeUsageError(w, err)
+			return
+		}
+		defer func() {
+			if !recallFinalized {
+				s.runtimeUsage.AfterRecallFailure(context.Background(), recallLease, context.Canceled)
+			}
+		}()
+	}
 
 	if auth.IsChain() {
 		memories, total, err = s.listChainMemories(r.Context(), auth, filter)
@@ -361,6 +438,10 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err != nil {
+		if s.runtimeUsageEnabled() && recallLease != nil {
+			s.runtimeUsage.AfterRecallFailure(context.Background(), recallLease, err)
+			recallFinalized = true
+		}
 		s.handleError(r.Context(), w, err)
 		return
 	}
@@ -374,6 +455,19 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if filter.Query != "" {
+		if s.runtimeUsageEnabled() && recallLease != nil {
+			if err := s.runtimeUsage.AfterRecallSuccess(r.Context(), recallLease, runtimeusage.RecallResult{
+				MemoryIDs: memoryIDs(memories),
+				AgentName: auth.AgentName,
+			}); err != nil {
+				s.logger.Error("runtime usage recall finalization failed",
+					"operation_id", recallLease.OperationID,
+					"tenant_id", auth.TenantID,
+					"cluster_id", auth.ClusterID,
+					"err", err)
+			}
+			recallFinalized = true
+		}
 		s.recordRecallMetering(auth)
 	}
 
@@ -547,9 +641,45 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	svc := s.resolveServices(auth)
-	if err := svc.memory.Delete(r.Context(), id, auth.AgentName); err != nil {
+	var lease *runtimeusage.OperationLease
+	finalized := false
+	if s.runtimeUsageEnabled() {
+		var err error
+		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth), runtimeusage.MemoryDeleteTarget{MemoryIDs: []string{id}})
+		if err != nil {
+			s.handleRuntimeUsageError(w, err)
+			return
+		}
+		defer func() {
+			if !finalized {
+				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+			}
+		}()
+	}
+
+	deleted, err := svc.memory.Delete(r.Context(), id, auth.AgentName)
+	if err != nil {
+		if s.runtimeUsageEnabled() {
+			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+			finalized = true
+		}
 		s.handleError(r.Context(), w, err)
 		return
+	}
+	if s.runtimeUsageEnabled() {
+		delta := -deleted
+		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+			MemoryIDs:        []string{id},
+			MemorySlotsDelta: delta,
+			AgentName:        auth.AgentName,
+		}); err != nil {
+			s.logger.Error("runtime usage memory delete finalization failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", auth.TenantID,
+				"cluster_id", auth.ClusterID,
+				"err", err)
+		}
+		finalized = true
 	}
 
 	go s.afterSuccessfulWrite(auth, svc, 0)
@@ -581,10 +711,43 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	svc := s.resolveServices(auth)
+	var lease *runtimeusage.OperationLease
+	finalized := false
+	if s.runtimeUsageEnabled() {
+		var err error
+		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth), runtimeusage.MemoryDeleteTarget{MemoryIDs: append([]string(nil), req.IDs...)})
+		if err != nil {
+			s.handleRuntimeUsageError(w, err)
+			return
+		}
+		defer func() {
+			if !finalized {
+				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+			}
+		}()
+	}
 	deleted, err := svc.memory.BulkDelete(r.Context(), req.IDs, auth.AgentName)
 	if err != nil {
+		if s.runtimeUsageEnabled() {
+			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+			finalized = true
+		}
 		s.handleError(r.Context(), w, err)
 		return
+	}
+	if s.runtimeUsageEnabled() {
+		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(r.Context(), lease, runtimeusage.MemoryDeleteResult{
+			MemoryIDs:        append([]string(nil), req.IDs...),
+			MemorySlotsDelta: -deleted,
+			AgentName:        auth.AgentName,
+		}); err != nil {
+			s.logger.Error("runtime usage batch delete finalization failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", auth.TenantID,
+				"cluster_id", auth.ClusterID,
+				"err", err)
+		}
+		finalized = true
 	}
 
 	go s.afterSuccessfulWrite(auth, svc, 0)
@@ -618,12 +781,48 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	svc := s.resolveServices(auth)
+	if len(req.Memories) == 0 {
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "memories", Message: "required"})
+		return
+	}
+	var lease *runtimeusage.OperationLease
+	finalized := false
+	if s.runtimeUsageEnabled() {
+		var err error
+		lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), int64(len(req.Memories)))
+		if err != nil {
+			s.handleRuntimeUsageError(w, err)
+			return
+		}
+		defer func() {
+			if !finalized {
+				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+			}
+		}()
+	}
 	memories, err := svc.memory.BulkCreate(r.Context(), auth.AgentName, req.Memories)
 	if err != nil {
+		if s.runtimeUsageEnabled() {
+			s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+			finalized = true
+		}
 		s.handleError(r.Context(), w, err)
 		return
 	}
 	applyChainSource(memories, writeChainSource)
+	if s.runtimeUsageEnabled() {
+		if err := s.runtimeUsage.AfterMemoryCreateSuccess(r.Context(), lease, runtimeusage.MemoryCreateResult{
+			MemoryIDs: memoryIDs(memories),
+			AgentName: auth.AgentName,
+		}); err != nil {
+			s.logger.Error("runtime usage bulk create finalization failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", auth.TenantID,
+				"cluster_id", auth.ClusterID,
+				"err", err)
+		}
+		finalized = true
+	}
 
 	go s.afterSuccessfulIngest(auth, svc, int64(len(memories)))
 	respond(w, http.StatusCreated, map[string]any{

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -142,10 +142,12 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				if result != nil {
 					ids = result.InsightIDs
 				}
-				if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
-					MemoryIDs:       ids,
-					AgentName:       auth.AgentName,
-					ObjectsAffected: written,
+				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+					return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+						MemoryIDs:       ids,
+						AgentName:       auth.AgentName,
+						ObjectsAffected: written,
+					})
 				}); err != nil {
 					s.logger.Error("runtime usage sync ingest finalization failed",
 						"operation_id", lease.OperationID,
@@ -277,10 +279,12 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if memoryID != "" {
 				ids = []string{memoryID}
 			}
-			if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
-				MemoryIDs:       ids,
-				AgentName:       auth.AgentName,
-				ObjectsAffected: int64(written),
+			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+					MemoryIDs:       ids,
+					AgentName:       auth.AgentName,
+					ObjectsAffected: int64(written),
+				})
 			}); err != nil {
 				s.logger.Error("runtime usage memory create finalization failed",
 					"operation_id", lease.OperationID,
@@ -330,10 +334,12 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if mem != nil && mem.ID != "" {
 				ids = []string{mem.ID}
 			}
-			if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
-				MemoryIDs:       ids,
-				AgentName:       auth.AgentName,
-				ObjectsAffected: int64(written),
+			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+					MemoryIDs:       ids,
+					AgentName:       auth.AgentName,
+					ObjectsAffected: int64(written),
+				})
 			}); err != nil {
 				s.logger.Error("runtime usage sync memory create finalization failed",
 					"operation_id", lease.OperationID,
@@ -590,9 +596,11 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if filter.Query != "" {
 		if s.runtimeUsageEnabled() && recallLease != nil {
-			if err := s.runtimeUsage.AfterRecallSuccess(r.Context(), recallLease, runtimeusage.RecallResult{
-				MemoryIDs: memoryIDs(memories),
-				AgentName: auth.AgentName,
+			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				return s.runtimeUsage.AfterRecallSuccess(ctx, recallLease, runtimeusage.RecallResult{
+					MemoryIDs: memoryIDs(memories),
+					AgentName: auth.AgentName,
+				})
 			}); err != nil {
 				s.logger.Error("runtime usage recall finalization failed",
 					"operation_id", recallLease.OperationID,
@@ -769,10 +777,12 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		mem.ChainSource = target.source
 		if s.runtimeUsageEnabled() {
-			if err := s.runtimeUsage.AfterMemoryUpdateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryUpdateResult{
-				MemoryIDs:       []string{mem.ID},
-				AgentName:       target.nodeAuth.AgentName,
-				ObjectsAffected: 1,
+			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				return s.runtimeUsage.AfterMemoryUpdateSuccess(ctx, lease, runtimeusage.MemoryUpdateResult{
+					MemoryIDs:       []string{mem.ID},
+					AgentName:       target.nodeAuth.AgentName,
+					ObjectsAffected: 1,
+				})
 			}); err != nil {
 				s.logger.Error("runtime usage chain memory update finalization failed",
 					"operation_id", lease.OperationID,
@@ -817,10 +827,12 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryUpdateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryUpdateResult{
-			MemoryIDs:       []string{mem.ID},
-			AgentName:       auth.AgentName,
-			ObjectsAffected: 1,
+		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			return s.runtimeUsage.AfterMemoryUpdateSuccess(ctx, lease, runtimeusage.MemoryUpdateResult{
+				MemoryIDs:       []string{mem.ID},
+				AgentName:       auth.AgentName,
+				ObjectsAffected: 1,
+			})
 		}); err != nil {
 			s.logger.Error("runtime usage memory update finalization failed",
 				"operation_id", lease.OperationID,
@@ -873,10 +885,12 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if s.runtimeUsageEnabled() {
-			if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
-				MemoryIDs:       []string{id},
-				AgentName:       target.nodeAuth.AgentName,
-				ObjectsAffected: deleted,
+			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
+					MemoryIDs:       []string{id},
+					AgentName:       target.nodeAuth.AgentName,
+					ObjectsAffected: deleted,
+				})
 			}); err != nil {
 				s.logger.Error("runtime usage chain memory delete finalization failed",
 					"operation_id", lease.OperationID,
@@ -921,10 +935,12 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
-			MemoryIDs:       []string{id},
-			AgentName:       auth.AgentName,
-			ObjectsAffected: deleted,
+		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
+				MemoryIDs:       []string{id},
+				AgentName:       auth.AgentName,
+				ObjectsAffected: deleted,
+			})
 		}); err != nil {
 			s.logger.Error("runtime usage memory delete finalization failed",
 				"operation_id", lease.OperationID,
@@ -985,10 +1001,12 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if s.runtimeUsageEnabled() {
-				if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
-					MemoryIDs:       append([]string(nil), group.ids...),
-					AgentName:       group.target.nodeAuth.AgentName,
-					ObjectsAffected: groupDeleted,
+				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+					return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
+						MemoryIDs:       append([]string(nil), group.ids...),
+						AgentName:       group.target.nodeAuth.AgentName,
+						ObjectsAffected: groupDeleted,
+					})
 				}); err != nil {
 					s.logger.Error("runtime usage chain batch delete finalization failed",
 						"operation_id", lease.OperationID,
@@ -1046,10 +1064,12 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryDeleteSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryDeleteResult{
-			MemoryIDs:       append([]string(nil), deleteIDs...),
-			AgentName:       auth.AgentName,
-			ObjectsAffected: deleted,
+		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
+				MemoryIDs:       append([]string(nil), deleteIDs...),
+				AgentName:       auth.AgentName,
+				ObjectsAffected: deleted,
+			})
 		}); err != nil {
 			s.logger.Error("runtime usage batch delete finalization failed",
 				"operation_id", lease.OperationID,
@@ -1124,10 +1144,12 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	applyChainSource(memories, writeChainSource)
 	if s.runtimeUsageEnabled() {
-		if err := s.runtimeUsage.AfterMemoryCreateSuccess(runtimeUsagePostSuccessContext(), lease, runtimeusage.MemoryCreateResult{
-			MemoryIDs:       memoryIDs(memories),
-			AgentName:       auth.AgentName,
-			ObjectsAffected: int64(len(memories)),
+		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+				MemoryIDs:       memoryIDs(memories),
+				AgentName:       auth.AgentName,
+				ObjectsAffected: int64(len(memories)),
+			})
 		}); err != nil {
 			s.logger.Error("runtime usage bulk create finalization failed",
 				"operation_id", lease.OperationID,

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -225,6 +225,9 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					"tenant_id", auth.TenantID,
 					"cluster_id", auth.ClusterID,
 					"err", err)
+				finalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
 			}
 			finalized = true
 		}
@@ -465,6 +468,9 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 					"tenant_id", auth.TenantID,
 					"cluster_id", auth.ClusterID,
 					"err", err)
+				recallFinalized = true
+				s.handleRuntimeUsageError(w, err)
+				return
 			}
 			recallFinalized = true
 		}
@@ -678,6 +684,9 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 				"tenant_id", auth.TenantID,
 				"cluster_id", auth.ClusterID,
 				"err", err)
+			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
 		}
 		finalized = true
 	}
@@ -746,6 +755,9 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				"tenant_id", auth.TenantID,
 				"cluster_id", auth.ClusterID,
 				"err", err)
+			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
 		}
 		finalized = true
 	}
@@ -820,6 +832,9 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 				"tenant_id", auth.TenantID,
 				"cluster_id", auth.ClusterID,
 				"err", err)
+			finalized = true
+			s.handleRuntimeUsageError(w, err)
+			return
 		}
 		finalized = true
 	}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/llm"
 	"github.com/qiffang/mnemos/server/internal/metering"
@@ -31,6 +32,8 @@ type testMemoryRepo struct {
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordFilter    domain.MemoryFilter
+	softDeleteCalls      []string
+	softDeleteResult     int64
 	bulkSoftDeleteCalls  [][]string
 	bulkSoftDeleteResult int64
 	countStatsTotal      int64
@@ -57,8 +60,28 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 	}
 	return nil, domain.ErrNotFound
 }
-func (m *testMemoryRepo) UpdateOptimistic(context.Context, *domain.Memory, int) error { return nil }
-func (m *testMemoryRepo) SoftDelete(context.Context, string, string) (int64, error)   { return 1, nil }
+func (m *testMemoryRepo) UpdateOptimistic(_ context.Context, mem *domain.Memory, _ int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i := range m.createCalls {
+		if m.createCalls[i].ID == mem.ID {
+			cp := *mem
+			cp.Version++
+			m.createCalls[i] = &cp
+			return nil
+		}
+	}
+	return domain.ErrNotFound
+}
+func (m *testMemoryRepo) SoftDelete(_ context.Context, id string, _ string) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.softDeleteCalls = append(m.softDeleteCalls, id)
+	if m.softDeleteResult != 0 {
+		return m.softDeleteResult, nil
+	}
+	return 1, nil
+}
 func (m *testMemoryRepo) BulkSoftDelete(_ context.Context, ids []string, _ string) (int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -230,9 +253,17 @@ type captureRuntimeUsageManager struct {
 	afterRecallSuccessCalls int
 	beforeCreateCalls       int
 	afterCreateFailureCalls int
+	beforeUpdateCalls       int
+	afterUpdateSuccessCalls int
+	afterUpdateFailureCalls int
 	beforeDeleteCalls       int
+	afterDeleteSuccessCalls int
 	enabled                 bool
 	afterCreateSuccessErr   error
+	beforeUpdateSubjects    []runtimeusage.Subject
+	beforeDeleteSubjects    []runtimeusage.Subject
+	updateResults           []runtimeusage.MemoryUpdateResult
+	deleteResults           []runtimeusage.MemoryDeleteResult
 }
 
 func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
@@ -256,11 +287,27 @@ func (m *captureRuntimeUsageManager) AfterMemoryCreateSuccess(context.Context, *
 func (m *captureRuntimeUsageManager) AfterMemoryCreateFailure(context.Context, *runtimeusage.OperationLease, error) {
 	m.afterCreateFailureCalls++
 }
-func (m *captureRuntimeUsageManager) BeforeMemoryDelete(context.Context, runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
+func (m *captureRuntimeUsageManager) BeforeMemoryUpdate(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
+	m.beforeUpdateCalls++
+	m.beforeUpdateSubjects = append(m.beforeUpdateSubjects, subject)
+	return &runtimeusage.OperationLease{OperationID: "op-update", Reserved: true}, nil
+}
+func (m *captureRuntimeUsageManager) AfterMemoryUpdateSuccess(_ context.Context, _ *runtimeusage.OperationLease, result runtimeusage.MemoryUpdateResult) error {
+	m.afterUpdateSuccessCalls++
+	m.updateResults = append(m.updateResults, result)
+	return nil
+}
+func (m *captureRuntimeUsageManager) AfterMemoryUpdateFailure(context.Context, *runtimeusage.OperationLease, error) {
+	m.afterUpdateFailureCalls++
+}
+func (m *captureRuntimeUsageManager) BeforeMemoryDelete(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeDeleteCalls++
+	m.beforeDeleteSubjects = append(m.beforeDeleteSubjects, subject)
 	return &runtimeusage.OperationLease{OperationID: "op-delete", Reserved: true}, nil
 }
-func (m *captureRuntimeUsageManager) AfterMemoryDeleteSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.MemoryDeleteResult) error {
+func (m *captureRuntimeUsageManager) AfterMemoryDeleteSuccess(_ context.Context, _ *runtimeusage.OperationLease, result runtimeusage.MemoryDeleteResult) error {
+	m.afterDeleteSuccessCalls++
+	m.deleteResults = append(m.deleteResults, result)
 	return nil
 }
 func (m *captureRuntimeUsageManager) AfterMemoryDeleteFailure(context.Context, *runtimeusage.OperationLease, error) {
@@ -418,6 +465,35 @@ func makeTenantRequest(t *testing.T, method, path string, body any) *http.Reques
 	}
 	ctx := middleware.WithAuthContext(req.Context(), auth)
 	return req.WithContext(ctx)
+}
+
+func makeChainRequest(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+	req := makeRequest(t, method, path, body)
+	auth := &domain.AuthInfo{
+		AgentName: "test-agent",
+		Chain: &domain.ChainAuth{
+			ChainID: "chain-a",
+			APIKey:  "chain-key-a",
+			Nodes: []domain.ChainAuthNode{
+				{
+					SpaceChainNode: domain.SpaceChainNode{
+						TenantID: "tenant-a",
+						Position: 1,
+					},
+					ClusterID: "10006636",
+				},
+			},
+		},
+	}
+	ctx := middleware.WithAuthContext(req.Context(), auth)
+	return req.WithContext(ctx)
+}
+
+func withURLParam(req *http.Request, key string, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
 func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
@@ -1111,6 +1187,117 @@ func TestBatchDeleteMemories_RuntimeUsageValidatesBeforeQuota(t *testing.T) {
 	}
 	if len(memRepo.bulkSoftDeleteCalls) != 0 {
 		t.Fatalf("bulk soft delete calls = %d, want 0", len(memRepo.bulkSoftDeleteCalls))
+	}
+}
+
+func TestUpdateMemory_RuntimeUsageRecordsUpdate(t *testing.T) {
+	memRepo := &testMemoryRepo{
+		createCalls: []*domain.Memory{
+			{ID: "mem-1", Content: "old", Version: 1},
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{"content": "new"}
+	req := withURLParam(makeTenantRequest(t, http.MethodPatch, "/memories/mem-1", body), "id", "mem-1")
+	rr := httptest.NewRecorder()
+
+	srv.updateMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeUpdateCalls != 1 || runtimeUsage.afterUpdateSuccessCalls != 1 {
+		t.Fatalf("runtime update calls = before:%d success:%d, want 1/1", runtimeUsage.beforeUpdateCalls, runtimeUsage.afterUpdateSuccessCalls)
+	}
+	if len(runtimeUsage.updateResults) != 1 || len(runtimeUsage.updateResults[0].MemoryIDs) != 1 || runtimeUsage.updateResults[0].MemoryIDs[0] != "mem-1" {
+		t.Fatalf("update results = %+v, want mem-1", runtimeUsage.updateResults)
+	}
+	if runtimeUsage.updateResults[0].ObjectsAffected != 1 {
+		t.Fatalf("objects affected = %d, want 1", runtimeUsage.updateResults[0].ObjectsAffected)
+	}
+}
+
+func TestUpdateMemory_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.T) {
+	memRepo := &testMemoryRepo{
+		createCalls: []*domain.Memory{
+			{ID: "mem-1", Content: "old", Version: 1},
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{"content": "new"}
+	req := withURLParam(makeChainRequest(t, http.MethodPatch, "/memories/mem-1", body), "id", "mem-1")
+	rr := httptest.NewRecorder()
+
+	srv.updateMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeUpdateCalls != 1 || runtimeUsage.afterUpdateSuccessCalls != 1 {
+		t.Fatalf("runtime update calls = before:%d success:%d, want 1/1", runtimeUsage.beforeUpdateCalls, runtimeUsage.afterUpdateSuccessCalls)
+	}
+	if len(runtimeUsage.beforeUpdateSubjects) != 1 || runtimeUsage.beforeUpdateSubjects[0].TenantID != "tenant-a" || runtimeUsage.beforeUpdateSubjects[0].ClusterID != "10006636" {
+		t.Fatalf("update subject = %+v, want tenant-a/10006636", runtimeUsage.beforeUpdateSubjects)
+	}
+}
+
+func TestDeleteMemory_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.T) {
+	memRepo := &testMemoryRepo{
+		createCalls: []*domain.Memory{
+			{ID: "mem-1", Content: "old", Version: 1},
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	req := withURLParam(makeChainRequest(t, http.MethodDelete, "/memories/mem-1", nil), "id", "mem-1")
+	rr := httptest.NewRecorder()
+
+	srv.deleteMemory(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeDeleteCalls != 1 || runtimeUsage.afterDeleteSuccessCalls != 1 {
+		t.Fatalf("runtime delete calls = before:%d success:%d, want 1/1", runtimeUsage.beforeDeleteCalls, runtimeUsage.afterDeleteSuccessCalls)
+	}
+	if len(runtimeUsage.beforeDeleteSubjects) != 1 || runtimeUsage.beforeDeleteSubjects[0].TenantID != "tenant-a" || runtimeUsage.beforeDeleteSubjects[0].ClusterID != "10006636" {
+		t.Fatalf("delete subject = %+v, want tenant-a/10006636", runtimeUsage.beforeDeleteSubjects)
+	}
+}
+
+func TestBatchDeleteMemories_ChainRuntimeUsageGroupsByResolvedNode(t *testing.T) {
+	memRepo := &testMemoryRepo{
+		createCalls: []*domain.Memory{
+			{ID: "mem-1", Content: "one", Version: 1},
+			{ID: "mem-2", Content: "two", Version: 1},
+		},
+		bulkSoftDeleteResult: 2,
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{"ids": []string{"mem-1", "mem-2"}}
+	req := makeChainRequest(t, http.MethodPost, "/memories/delete", body)
+	rr := httptest.NewRecorder()
+
+	srv.batchDeleteMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeDeleteCalls != 1 || runtimeUsage.afterDeleteSuccessCalls != 1 {
+		t.Fatalf("runtime batch delete calls = before:%d success:%d, want 1/1", runtimeUsage.beforeDeleteCalls, runtimeUsage.afterDeleteSuccessCalls)
+	}
+	if len(runtimeUsage.deleteResults) != 1 || runtimeUsage.deleteResults[0].ObjectsAffected != 2 {
+		t.Fatalf("delete results = %+v, want objectsAffected=2", runtimeUsage.deleteResults)
+	}
+	if len(memRepo.bulkSoftDeleteCalls) != 1 || len(memRepo.bulkSoftDeleteCalls[0]) != 2 {
+		t.Fatalf("bulk delete calls = %+v, want one grouped call with two IDs", memRepo.bulkSoftDeleteCalls)
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -29,6 +29,7 @@ type testMemoryRepo struct {
 	mu                   sync.Mutex
 	createCalls          []*domain.Memory
 	bulkCreateCalls      int
+	bulkCreateHook       func(context.Context)
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordFilter    domain.MemoryFilter
@@ -100,10 +101,14 @@ func (m *testMemoryRepo) List(context.Context, domain.MemoryFilter) ([]domain.Me
 	return nil, 0, nil
 }
 func (m *testMemoryRepo) Count(context.Context) (int, error) { return 0, nil }
-func (m *testMemoryRepo) BulkCreate(context.Context, []*domain.Memory) error {
+func (m *testMemoryRepo) BulkCreate(ctx context.Context, _ []*domain.Memory) error {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	m.bulkCreateCalls++
+	hook := m.bulkCreateHook
+	m.mu.Unlock()
+	if hook != nil {
+		hook(ctx)
+	}
 	return nil
 }
 func (m *testMemoryRepo) VectorSearch(context.Context, []float32, domain.MemoryFilter, int) ([]domain.Memory, error) {
@@ -249,21 +254,25 @@ func (w *blockingMeteringWriter) Record(evt metering.Event) {
 func (w *blockingMeteringWriter) Close(context.Context) error { return nil }
 
 type captureRuntimeUsageManager struct {
-	beforeRecallCalls       int
-	afterRecallSuccessCalls int
-	beforeCreateCalls       int
-	afterCreateFailureCalls int
-	beforeUpdateCalls       int
-	afterUpdateSuccessCalls int
-	afterUpdateFailureCalls int
-	beforeDeleteCalls       int
-	afterDeleteSuccessCalls int
-	enabled                 bool
-	afterCreateSuccessErr   error
-	beforeUpdateSubjects    []runtimeusage.Subject
-	beforeDeleteSubjects    []runtimeusage.Subject
-	updateResults           []runtimeusage.MemoryUpdateResult
-	deleteResults           []runtimeusage.MemoryDeleteResult
+	beforeRecallCalls        int
+	afterRecallSuccessCalls  int
+	beforeCreateCalls        int
+	afterCreateSuccessCalls  int
+	afterCreateFailureCalls  int
+	beforeUpdateCalls        int
+	afterUpdateSuccessCalls  int
+	afterUpdateFailureCalls  int
+	beforeDeleteCalls        int
+	afterDeleteSuccessCalls  int
+	enabled                  bool
+	afterCreateSuccessErr    error
+	beforeCreateSubjects     []runtimeusage.Subject
+	createResults            []runtimeusage.MemoryCreateResult
+	createSuccessContextErrs []error
+	beforeUpdateSubjects     []runtimeusage.Subject
+	beforeDeleteSubjects     []runtimeusage.Subject
+	updateResults            []runtimeusage.MemoryUpdateResult
+	deleteResults            []runtimeusage.MemoryDeleteResult
 }
 
 func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
@@ -277,11 +286,15 @@ func (m *captureRuntimeUsageManager) AfterRecallSuccess(context.Context, *runtim
 }
 func (m *captureRuntimeUsageManager) AfterRecallFailure(context.Context, *runtimeusage.OperationLease, error) {
 }
-func (m *captureRuntimeUsageManager) BeforeMemoryCreate(context.Context, runtimeusage.Subject, int64) (*runtimeusage.OperationLease, error) {
+func (m *captureRuntimeUsageManager) BeforeMemoryCreate(_ context.Context, subject runtimeusage.Subject, _ int64) (*runtimeusage.OperationLease, error) {
 	m.beforeCreateCalls++
+	m.beforeCreateSubjects = append(m.beforeCreateSubjects, subject)
 	return &runtimeusage.OperationLease{OperationID: "op-create", Reserved: true}, nil
 }
-func (m *captureRuntimeUsageManager) AfterMemoryCreateSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.MemoryCreateResult) error {
+func (m *captureRuntimeUsageManager) AfterMemoryCreateSuccess(ctx context.Context, _ *runtimeusage.OperationLease, result runtimeusage.MemoryCreateResult) error {
+	m.afterCreateSuccessCalls++
+	m.createResults = append(m.createResults, result)
+	m.createSuccessContextErrs = append(m.createSuccessContextErrs, ctx.Err())
 	return m.afterCreateSuccessErr
 }
 func (m *captureRuntimeUsageManager) AfterMemoryCreateFailure(context.Context, *runtimeusage.OperationLease, error) {
@@ -1140,6 +1153,72 @@ func TestBulkCreateMemories_RuntimeUsageFinalizationFailureFailsClosed(t *testin
 	}
 }
 
+func TestBulkCreateMemories_RuntimeUsageFinalizationIgnoresRequestCancellation(t *testing.T) {
+	var cancel context.CancelFunc
+	memRepo := &testMemoryRepo{
+		bulkCreateHook: func(context.Context) {
+			cancel()
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"memories": []map[string]any{
+			{"content": "bulk memory"},
+		},
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories/bulk", body)
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	srv.bulkCreateMemories(rr, req)
+
+	if ctx.Err() != context.Canceled {
+		t.Fatal("request context was not canceled during bulk create")
+	}
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.afterCreateSuccessCalls != 1 {
+		t.Fatalf("AfterMemoryCreateSuccess calls = %d, want 1", runtimeUsage.afterCreateSuccessCalls)
+	}
+	if len(runtimeUsage.createSuccessContextErrs) != 1 || runtimeUsage.createSuccessContextErrs[0] != nil {
+		t.Fatalf("finalization context errors = %+v, want [<nil>]", runtimeUsage.createSuccessContextErrs)
+	}
+}
+
+func TestBulkCreateMemories_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"memories": []map[string]any{
+			{"content": "bulk memory"},
+		},
+	}
+	req := makeChainRequest(t, http.MethodPost, "/memories/bulk", body)
+	rr := httptest.NewRecorder()
+
+	srv.bulkCreateMemories(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeCreateCalls != 1 || runtimeUsage.afterCreateSuccessCalls != 1 {
+		t.Fatalf("runtime create calls = before:%d success:%d, want 1/1", runtimeUsage.beforeCreateCalls, runtimeUsage.afterCreateSuccessCalls)
+	}
+	if len(runtimeUsage.beforeCreateSubjects) != 1 ||
+		runtimeUsage.beforeCreateSubjects[0].TenantID != "tenant-a" ||
+		runtimeUsage.beforeCreateSubjects[0].ClusterID != "10006636" ||
+		runtimeUsage.beforeCreateSubjects[0].APIKeySubject != "chain-key-a" {
+		t.Fatalf("create subject = %+v, want tenant-a/10006636 with chain-key-a subject", runtimeUsage.beforeCreateSubjects)
+	}
+}
+
 func TestBulkCreateMemories_RuntimeUsageValidatesBeforeQuota(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
@@ -1240,8 +1319,11 @@ func TestUpdateMemory_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.T) {
 	if runtimeUsage.beforeUpdateCalls != 1 || runtimeUsage.afterUpdateSuccessCalls != 1 {
 		t.Fatalf("runtime update calls = before:%d success:%d, want 1/1", runtimeUsage.beforeUpdateCalls, runtimeUsage.afterUpdateSuccessCalls)
 	}
-	if len(runtimeUsage.beforeUpdateSubjects) != 1 || runtimeUsage.beforeUpdateSubjects[0].TenantID != "tenant-a" || runtimeUsage.beforeUpdateSubjects[0].ClusterID != "10006636" {
-		t.Fatalf("update subject = %+v, want tenant-a/10006636", runtimeUsage.beforeUpdateSubjects)
+	if len(runtimeUsage.beforeUpdateSubjects) != 1 ||
+		runtimeUsage.beforeUpdateSubjects[0].TenantID != "tenant-a" ||
+		runtimeUsage.beforeUpdateSubjects[0].ClusterID != "10006636" ||
+		runtimeUsage.beforeUpdateSubjects[0].APIKeySubject != "chain-key-a" {
+		t.Fatalf("update subject = %+v, want tenant-a/10006636 with chain-key-a subject", runtimeUsage.beforeUpdateSubjects)
 	}
 }
 
@@ -1265,8 +1347,11 @@ func TestDeleteMemory_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.T) {
 	if runtimeUsage.beforeDeleteCalls != 1 || runtimeUsage.afterDeleteSuccessCalls != 1 {
 		t.Fatalf("runtime delete calls = before:%d success:%d, want 1/1", runtimeUsage.beforeDeleteCalls, runtimeUsage.afterDeleteSuccessCalls)
 	}
-	if len(runtimeUsage.beforeDeleteSubjects) != 1 || runtimeUsage.beforeDeleteSubjects[0].TenantID != "tenant-a" || runtimeUsage.beforeDeleteSubjects[0].ClusterID != "10006636" {
-		t.Fatalf("delete subject = %+v, want tenant-a/10006636", runtimeUsage.beforeDeleteSubjects)
+	if len(runtimeUsage.beforeDeleteSubjects) != 1 ||
+		runtimeUsage.beforeDeleteSubjects[0].TenantID != "tenant-a" ||
+		runtimeUsage.beforeDeleteSubjects[0].ClusterID != "10006636" ||
+		runtimeUsage.beforeDeleteSubjects[0].APIKeySubject != "chain-key-a" {
+		t.Fatalf("delete subject = %+v, want tenant-a/10006636 with chain-key-a subject", runtimeUsage.beforeDeleteSubjects)
 	}
 }
 
@@ -1298,6 +1383,12 @@ func TestBatchDeleteMemories_ChainRuntimeUsageGroupsByResolvedNode(t *testing.T)
 	}
 	if len(memRepo.bulkSoftDeleteCalls) != 1 || len(memRepo.bulkSoftDeleteCalls[0]) != 2 {
 		t.Fatalf("bulk delete calls = %+v, want one grouped call with two IDs", memRepo.bulkSoftDeleteCalls)
+	}
+	if len(runtimeUsage.beforeDeleteSubjects) != 1 ||
+		runtimeUsage.beforeDeleteSubjects[0].TenantID != "tenant-a" ||
+		runtimeUsage.beforeDeleteSubjects[0].ClusterID != "10006636" ||
+		runtimeUsage.beforeDeleteSubjects[0].APIKeySubject != "chain-key-a" {
+		t.Fatalf("batch delete subject = %+v, want tenant-a/10006636 with chain-key-a subject", runtimeUsage.beforeDeleteSubjects)
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/llm"
 	"github.com/qiffang/mnemos/server/internal/metering"
 	"github.com/qiffang/mnemos/server/internal/middleware"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
 
@@ -57,7 +58,7 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 	return nil, domain.ErrNotFound
 }
 func (m *testMemoryRepo) UpdateOptimistic(context.Context, *domain.Memory, int) error { return nil }
-func (m *testMemoryRepo) SoftDelete(context.Context, string, string) error            { return nil }
+func (m *testMemoryRepo) SoftDelete(context.Context, string, string) (int64, error)   { return 1, nil }
 func (m *testMemoryRepo) BulkSoftDelete(_ context.Context, ids []string, _ string) (int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -223,6 +224,44 @@ func (w *blockingMeteringWriter) Record(evt metering.Event) {
 }
 
 func (w *blockingMeteringWriter) Close(context.Context) error { return nil }
+
+type captureRuntimeUsageManager struct {
+	beforeRecallCalls       int
+	afterRecallSuccessCalls int
+	beforeCreateCalls       int
+	beforeDeleteCalls       int
+	enabled                 bool
+}
+
+func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
+func (m *captureRuntimeUsageManager) BeforeRecall(context.Context, runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
+	m.beforeRecallCalls++
+	return &runtimeusage.OperationLease{OperationID: "op-recall", Reserved: true}, nil
+}
+func (m *captureRuntimeUsageManager) AfterRecallSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.RecallResult) error {
+	m.afterRecallSuccessCalls++
+	return nil
+}
+func (m *captureRuntimeUsageManager) AfterRecallFailure(context.Context, *runtimeusage.OperationLease, error) {
+}
+func (m *captureRuntimeUsageManager) BeforeMemoryCreate(context.Context, runtimeusage.Subject, int64) (*runtimeusage.OperationLease, error) {
+	m.beforeCreateCalls++
+	return &runtimeusage.OperationLease{OperationID: "op-create", Reserved: true}, nil
+}
+func (m *captureRuntimeUsageManager) AfterMemoryCreateSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.MemoryCreateResult) error {
+	return nil
+}
+func (m *captureRuntimeUsageManager) AfterMemoryCreateFailure(context.Context, *runtimeusage.OperationLease, error) {
+}
+func (m *captureRuntimeUsageManager) BeforeMemoryDelete(context.Context, runtimeusage.Subject, runtimeusage.MemoryDeleteTarget) (*runtimeusage.OperationLease, error) {
+	m.beforeDeleteCalls++
+	return &runtimeusage.OperationLease{OperationID: "op-delete"}, nil
+}
+func (m *captureRuntimeUsageManager) AfterMemoryDeleteSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.MemoryDeleteResult) error {
+	return nil
+}
+func (m *captureRuntimeUsageManager) AfterMemoryDeleteFailure(context.Context, *runtimeusage.OperationLease, error) {
+}
 
 type handlerActivityTenantRepo struct {
 	mu              sync.Mutex
@@ -407,6 +446,56 @@ func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
 	}
 	if memRepo.bulkCreateCalls != 0 {
 		t.Fatalf("expected legacy create path to skip bulk create, got %d", memRepo.bulkCreateCalls)
+	}
+}
+
+func TestCreateMemory_RuntimeUsageBlocksUnknownDeltaContent(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"content": "test memory content",
+		"sync":    true,
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeCreateCalls != 0 {
+		t.Fatalf("BeforeMemoryCreate calls = %d, want 0", runtimeUsage.beforeCreateCalls)
+	}
+	if len(memRepo.createCalls) != 0 {
+		t.Fatalf("create calls = %d, want 0", len(memRepo.createCalls))
+	}
+}
+
+func TestCreateMemory_RuntimeUsageAllowsPinnedKnownDelta(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"content":     "test memory content",
+		"memory_type": "pinned",
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeCreateCalls != 1 {
+		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
+	}
+	if memRepo.bulkCreateCalls != 1 {
+		t.Fatalf("bulk create calls = %d, want 1", memRepo.bulkCreateCalls)
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -256,9 +256,9 @@ func (m *captureRuntimeUsageManager) AfterMemoryCreateSuccess(context.Context, *
 func (m *captureRuntimeUsageManager) AfterMemoryCreateFailure(context.Context, *runtimeusage.OperationLease, error) {
 	m.afterCreateFailureCalls++
 }
-func (m *captureRuntimeUsageManager) BeforeMemoryDelete(context.Context, runtimeusage.Subject, runtimeusage.MemoryDeleteTarget) (*runtimeusage.OperationLease, error) {
+func (m *captureRuntimeUsageManager) BeforeMemoryDelete(context.Context, runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeDeleteCalls++
-	return &runtimeusage.OperationLease{OperationID: "op-delete"}, nil
+	return &runtimeusage.OperationLease{OperationID: "op-delete", Reserved: true}, nil
 }
 func (m *captureRuntimeUsageManager) AfterMemoryDeleteSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.MemoryDeleteResult) error {
 	return nil
@@ -452,7 +452,7 @@ func TestCreateMemory_SyncContent_Returns200(t *testing.T) {
 	}
 }
 
-func TestCreateMemory_RuntimeUsageBlocksUnknownDeltaContent(t *testing.T) {
+func TestCreateMemory_RuntimeUsageAllowsSmartContentWrite(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
 	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
@@ -466,14 +466,14 @@ func TestCreateMemory_RuntimeUsageBlocksUnknownDeltaContent(t *testing.T) {
 
 	srv.createMemory(rr, req)
 
-	if rr.Code != http.StatusConflict {
-		t.Fatalf("status = %d, want 409: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
 	}
-	if runtimeUsage.beforeCreateCalls != 0 {
-		t.Fatalf("BeforeMemoryCreate calls = %d, want 0", runtimeUsage.beforeCreateCalls)
+	if runtimeUsage.beforeCreateCalls != 1 {
+		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
 	}
-	if len(memRepo.createCalls) != 0 {
-		t.Fatalf("create calls = %d, want 0", len(memRepo.createCalls))
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("create calls = %d, want 1", len(memRepo.createCalls))
 	}
 }
 
@@ -1090,7 +1090,7 @@ func TestBulkCreateMemories_RuntimeUsageValidatesBeforeQuota(t *testing.T) {
 	}
 }
 
-func TestBatchDeleteMemories_RuntimeUsageValidatesBeforeAdjustmentIntent(t *testing.T) {
+func TestBatchDeleteMemories_RuntimeUsageValidatesBeforeQuota(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
 	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -502,7 +502,7 @@ func TestCreateMemory_RuntimeUsageAllowsPinnedKnownDelta(t *testing.T) {
 	}
 }
 
-func TestCreateMemory_RuntimeUsageFinalizationFailureKeepsSuccess(t *testing.T) {
+func TestCreateMemory_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{
 		enabled:               true,
@@ -519,8 +519,8 @@ func TestCreateMemory_RuntimeUsageFinalizationFailureKeepsSuccess(t *testing.T) 
 
 	srv.createMemory(rr, req)
 
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
 	}
 	if runtimeUsage.beforeCreateCalls != 1 {
 		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
@@ -1032,7 +1032,7 @@ func TestBulkCreateMemoriesTriggersPostWriteHooks(t *testing.T) {
 	}
 }
 
-func TestBulkCreateMemories_RuntimeUsageFinalizationFailureKeepsSuccess(t *testing.T) {
+func TestBulkCreateMemories_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{
 		enabled:               true,
@@ -1050,8 +1050,8 @@ func TestBulkCreateMemories_RuntimeUsageFinalizationFailureKeepsSuccess(t *testi
 
 	srv.bulkCreateMemories(rr, req)
 
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
 	}
 	if runtimeUsage.beforeCreateCalls != 1 {
 		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -229,8 +229,10 @@ type captureRuntimeUsageManager struct {
 	beforeRecallCalls       int
 	afterRecallSuccessCalls int
 	beforeCreateCalls       int
+	afterCreateFailureCalls int
 	beforeDeleteCalls       int
 	enabled                 bool
+	afterCreateSuccessErr   error
 }
 
 func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
@@ -249,9 +251,10 @@ func (m *captureRuntimeUsageManager) BeforeMemoryCreate(context.Context, runtime
 	return &runtimeusage.OperationLease{OperationID: "op-create", Reserved: true}, nil
 }
 func (m *captureRuntimeUsageManager) AfterMemoryCreateSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.MemoryCreateResult) error {
-	return nil
+	return m.afterCreateSuccessErr
 }
 func (m *captureRuntimeUsageManager) AfterMemoryCreateFailure(context.Context, *runtimeusage.OperationLease, error) {
+	m.afterCreateFailureCalls++
 }
 func (m *captureRuntimeUsageManager) BeforeMemoryDelete(context.Context, runtimeusage.Subject, runtimeusage.MemoryDeleteTarget) (*runtimeusage.OperationLease, error) {
 	m.beforeDeleteCalls++
@@ -493,6 +496,37 @@ func TestCreateMemory_RuntimeUsageAllowsPinnedKnownDelta(t *testing.T) {
 	}
 	if runtimeUsage.beforeCreateCalls != 1 {
 		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
+	}
+	if memRepo.bulkCreateCalls != 1 {
+		t.Fatalf("bulk create calls = %d, want 1", memRepo.bulkCreateCalls)
+	}
+}
+
+func TestCreateMemory_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled:               true,
+		afterCreateSuccessErr: &runtimeusage.UnavailableError{Err: errors.New("console unavailable")},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"content":     "test memory content",
+		"memory_type": "pinned",
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeCreateCalls != 1 {
+		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
+	}
+	if runtimeUsage.afterCreateFailureCalls != 0 {
+		t.Fatalf("AfterMemoryCreateFailure calls = %d, want 0", runtimeUsage.afterCreateFailureCalls)
 	}
 	if memRepo.bulkCreateCalls != 1 {
 		t.Fatalf("bulk create calls = %d, want 1", memRepo.bulkCreateCalls)
@@ -995,6 +1029,38 @@ func TestBulkCreateMemoriesTriggersPostWriteHooks(t *testing.T) {
 	events := waitForMeteringEvents(t, meteringWriter, 1, time.Second)
 	if got := events[0].Data["event_type"]; got != "ingest" {
 		t.Fatalf("event_type = %v, want ingest", got)
+	}
+}
+
+func TestBulkCreateMemories_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled:               true,
+		afterCreateSuccessErr: &runtimeusage.UnavailableError{Err: errors.New("console unavailable")},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"memories": []map[string]any{
+			{"content": "bulk memory"},
+		},
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories/bulk", body)
+	rr := httptest.NewRecorder()
+
+	srv.bulkCreateMemories(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeCreateCalls != 1 {
+		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
+	}
+	if runtimeUsage.afterCreateFailureCalls != 0 {
+		t.Fatalf("AfterMemoryCreateFailure calls = %d, want 0", runtimeUsage.afterCreateFailureCalls)
+	}
+	if memRepo.bulkCreateCalls != 1 {
+		t.Fatalf("bulk create calls = %d, want 1", memRepo.bulkCreateCalls)
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -266,6 +266,9 @@ type captureRuntimeUsageManager struct {
 	afterDeleteSuccessCalls  int
 	enabled                  bool
 	afterCreateSuccessErr    error
+	beforeRecallSubjects     []runtimeusage.Subject
+	recallResults            []runtimeusage.RecallResult
+	recallSuccessContextErrs []error
 	beforeCreateSubjects     []runtimeusage.Subject
 	createResults            []runtimeusage.MemoryCreateResult
 	createSuccessContextErrs []error
@@ -276,12 +279,15 @@ type captureRuntimeUsageManager struct {
 }
 
 func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
-func (m *captureRuntimeUsageManager) BeforeRecall(context.Context, runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
+func (m *captureRuntimeUsageManager) BeforeRecall(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeRecallCalls++
+	m.beforeRecallSubjects = append(m.beforeRecallSubjects, subject)
 	return &runtimeusage.OperationLease{OperationID: "op-recall", Reserved: true}, nil
 }
-func (m *captureRuntimeUsageManager) AfterRecallSuccess(context.Context, *runtimeusage.OperationLease, runtimeusage.RecallResult) error {
+func (m *captureRuntimeUsageManager) AfterRecallSuccess(ctx context.Context, _ *runtimeusage.OperationLease, result runtimeusage.RecallResult) error {
 	m.afterRecallSuccessCalls++
+	m.recallResults = append(m.recallResults, result)
+	m.recallSuccessContextErrs = append(m.recallSuccessContextErrs, ctx.Err())
 	return nil
 }
 func (m *captureRuntimeUsageManager) AfterRecallFailure(context.Context, *runtimeusage.OperationLease, error) {
@@ -1216,6 +1222,71 @@ func TestBulkCreateMemories_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.
 		runtimeUsage.beforeCreateSubjects[0].ClusterID != "10006636" ||
 		runtimeUsage.beforeCreateSubjects[0].APIKeySubject != "chain-key-a" {
 		t.Fatalf("create subject = %+v, want tenant-a/10006636 with chain-key-a subject", runtimeUsage.beforeCreateSubjects)
+	}
+}
+
+func TestListMemories_RuntimeUsageRecallFinalizationIgnoresRequestCancellation(t *testing.T) {
+	now := time.Now()
+	var cancelRequest context.CancelFunc
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			cancelRequest()
+			return []domain.Memory{
+				{ID: "m1", Content: `"Under Armour"`, MemoryType: domain.TypePinned, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	req := makeTenantRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&memory_type=pinned&limit=10", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancelRequest = cancel
+	defer cancel()
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if ctx.Err() != context.Canceled {
+		t.Fatal("request context was not canceled during recall")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.afterRecallSuccessCalls != 1 {
+		t.Fatalf("AfterRecallSuccess calls = %d, want 1", runtimeUsage.afterRecallSuccessCalls)
+	}
+	if len(runtimeUsage.recallSuccessContextErrs) != 1 || runtimeUsage.recallSuccessContextErrs[0] != nil {
+		t.Fatalf("recall finalization context errors = %+v, want [<nil>]", runtimeUsage.recallSuccessContextErrs)
+	}
+}
+
+func TestListMemories_ChainRuntimeUsageRecallUsesChainAPIKeySubject(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{ID: "m1", Content: `"Under Armour"`, MemoryType: domain.TypePinned, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	req := makeChainRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&memory_type=pinned&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeRecallCalls != 1 || runtimeUsage.afterRecallSuccessCalls != 1 {
+		t.Fatalf("runtime recall calls = before:%d success:%d, want 1/1", runtimeUsage.beforeRecallCalls, runtimeUsage.afterRecallSuccessCalls)
+	}
+	if len(runtimeUsage.beforeRecallSubjects) != 1 || runtimeUsage.beforeRecallSubjects[0].APIKeySubject != "chain-key-a" {
+		t.Fatalf("recall subject = %+v, want chain-key-a API key subject", runtimeUsage.beforeRecallSubjects)
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1064,6 +1064,56 @@ func TestBulkCreateMemories_RuntimeUsageFinalizationFailureFailsClosed(t *testin
 	}
 }
 
+func TestBulkCreateMemories_RuntimeUsageValidatesBeforeQuota(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"memories": []map[string]any{
+			{"content": ""},
+		},
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories/bulk", body)
+	rr := httptest.NewRecorder()
+
+	srv.bulkCreateMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeCreateCalls != 0 {
+		t.Fatalf("BeforeMemoryCreate calls = %d, want 0", runtimeUsage.beforeCreateCalls)
+	}
+	if memRepo.bulkCreateCalls != 0 {
+		t.Fatalf("bulk create calls = %d, want 0", memRepo.bulkCreateCalls)
+	}
+}
+
+func TestBatchDeleteMemories_RuntimeUsageValidatesBeforeAdjustmentIntent(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"ids": []string{"", ""},
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories/delete", body)
+	rr := httptest.NewRecorder()
+
+	srv.batchDeleteMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if runtimeUsage.beforeDeleteCalls != 0 {
+		t.Fatalf("BeforeMemoryDelete calls = %d, want 0", runtimeUsage.beforeDeleteCalls)
+	}
+	if len(memRepo.bulkSoftDeleteCalls) != 0 {
+		t.Fatalf("bulk soft delete calls = %d, want 0", len(memRepo.bulkSoftDeleteCalls))
+	}
+}
+
 // failSearchMemoryRepo embeds testMemoryRepo but makes KeywordSearch fail,
 // triggering gatherExistingMemories → reconcile → ReconcilePhase2 Status:"failed".
 type failSearchMemoryRepo struct {

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -502,7 +502,7 @@ func TestCreateMemory_RuntimeUsageAllowsPinnedKnownDelta(t *testing.T) {
 	}
 }
 
-func TestCreateMemory_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
+func TestCreateMemory_RuntimeUsageFinalizationFailureKeepsSuccess(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{
 		enabled:               true,
@@ -519,8 +519,8 @@ func TestCreateMemory_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
 
 	srv.createMemory(rr, req)
 
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
 	}
 	if runtimeUsage.beforeCreateCalls != 1 {
 		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)
@@ -1032,7 +1032,7 @@ func TestBulkCreateMemoriesTriggersPostWriteHooks(t *testing.T) {
 	}
 }
 
-func TestBulkCreateMemories_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
+func TestBulkCreateMemories_RuntimeUsageFinalizationFailureKeepsSuccess(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{
 		enabled:               true,
@@ -1050,8 +1050,8 @@ func TestBulkCreateMemories_RuntimeUsageFinalizationFailureFailsClosed(t *testin
 
 	srv.bulkCreateMemories(rr, req)
 
-	if rr.Code != http.StatusServiceUnavailable {
-		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
 	}
 	if runtimeUsage.beforeCreateCalls != 1 {
 		t.Fatalf("BeforeMemoryCreate calls = %d, want 1", runtimeUsage.beforeCreateCalls)

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
+)
+
+func (s *Server) runtimeUsageEnabled() bool {
+	return s != nil && s.runtimeUsage != nil && s.runtimeUsage.Enabled()
+}
+
+func memoryIDs(memories []domain.Memory) []string {
+	ids := make([]string, 0, len(memories))
+	for _, mem := range memories {
+		if mem.ID != "" {
+			ids = append(ids, mem.ID)
+		}
+	}
+	return ids
+}
+
+func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
+	if auth == nil {
+		return runtimeusage.Subject{}
+	}
+	subject := auth.APIKeySubject
+	if subject == "" {
+		subject = auth.TenantID
+	}
+	return runtimeusage.Subject{
+		TenantID:      auth.TenantID,
+		ClusterID:     auth.ClusterID,
+		APIKeySubject: subject,
+		AgentName:     auth.AgentName,
+	}
+}
+
+func (s *Server) handleRuntimeUsageError(w http.ResponseWriter, err error) {
+	var denied *runtimeusage.QuotaDeniedError
+	if errors.As(err, &denied) {
+		body := denied.ResponseBody()
+		if body = ensureMem9QuotaDeniedCode(body); len(body) > 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusPaymentRequired)
+			_, _ = w.Write(body)
+			return
+		}
+		respondError(w, http.StatusPaymentRequired, "runtime usage quota denied")
+		return
+	}
+	status := runtimeusage.HTTPStatus(err)
+	if status == http.StatusBadGateway {
+		respondError(w, status, "runtime usage conflict")
+		return
+	}
+	respondError(w, status, "runtime usage unavailable")
+}
+
+func ensureMem9QuotaDeniedCode(body []byte) []byte {
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 {
+		return nil
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return body
+	}
+	if _, ok := parsed["mem9_code"]; !ok {
+		parsed["mem9_code"] = "runtime_quota_denied"
+	}
+	out, err := json.Marshal(parsed)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -22,6 +23,11 @@ func memoryIDs(memories []domain.Memory) []string {
 		}
 	}
 	return ids
+}
+
+func runtimeUsagePostSuccessContext() context.Context {
+	// Post-success finalization must survive request cancellation after tenant writes commit.
+	return context.Background()
 }
 
 func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -61,6 +61,13 @@ func (s *Server) handleRuntimeUsageError(w http.ResponseWriter, err error) {
 	respondError(w, status, "runtime usage unavailable")
 }
 
+func isRuntimeUsageError(err error) bool {
+	var denied *runtimeusage.QuotaDeniedError
+	var unavailable *runtimeusage.UnavailableError
+	var conflict *runtimeusage.ConflictError
+	return errors.As(err, &denied) || errors.As(err, &unavailable) || errors.As(err, &conflict)
+}
+
 func ensureMem9QuotaDeniedCode(body []byte) []byte {
 	body = bytes.TrimSpace(body)
 	if len(body) == 0 {

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -6,10 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
+
+const runtimeUsagePostSuccessTimeout = 10 * time.Second
 
 func (s *Server) runtimeUsageEnabled() bool {
 	return s != nil && s.runtimeUsage != nil && s.runtimeUsage.Enabled()
@@ -25,9 +28,11 @@ func memoryIDs(memories []domain.Memory) []string {
 	return ids
 }
 
-func runtimeUsagePostSuccessContext() context.Context {
+func withRuntimeUsagePostSuccessContext(run func(context.Context) error) error {
 	// Post-success finalization must survive request cancellation after tenant writes commit.
-	return context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), runtimeUsagePostSuccessTimeout)
+	defer cancel()
+	return run(ctx)
 }
 
 func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
@@ -35,6 +40,9 @@ func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
 		return runtimeusage.Subject{}
 	}
 	subject := auth.APIKeySubject
+	if subject == "" && auth.Chain != nil {
+		subject = auth.Chain.APIKey
+	}
 	if subject == "" {
 		subject = auth.TenantID
 	}

--- a/server/internal/metering/console_writer.go
+++ b/server/internal/metering/console_writer.go
@@ -44,6 +44,11 @@ type consoleMeteringPayload struct {
 	MemoryIDs  []string `json:"memoryIds,omitempty"`
 }
 
+type consoleMeteringHashPayload struct {
+	APIKeySubject string `json:"apiKeySubject"`
+	consoleMeteringPayload
+}
+
 type consoleQueuedEvent struct {
 	evt         Event
 	payloadJSON []byte
@@ -198,7 +203,14 @@ func (w *consoleRuntimeWriter) makeQueuedEvent(evt Event) (consoleQueuedEvent, e
 	if err != nil {
 		return consoleQueuedEvent{}, err
 	}
-	sum := sha256.Sum256(payloadJSON)
+	hashJSON, err := json.Marshal(consoleMeteringHashPayload{
+		APIKeySubject:          evt.APIKeySubject,
+		consoleMeteringPayload: payload,
+	})
+	if err != nil {
+		return consoleQueuedEvent{}, err
+	}
+	sum := sha256.Sum256(hashJSON)
 	return consoleQueuedEvent{
 		evt:         evt,
 		payloadJSON: payloadJSON,

--- a/server/internal/metering/console_writer.go
+++ b/server/internal/metering/console_writer.go
@@ -1,0 +1,390 @@
+package metering
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/metrics"
+)
+
+type ConsoleRuntimeConfig struct {
+	BaseURL        string
+	InternalSecret string
+	Timeout        time.Duration
+	ChannelSize    int
+	Store          ConsoleEventStore
+}
+
+type ConsoleEventStore interface {
+	UpsertMeteringPending(ctx context.Context, evt Event, payloadJSON []byte, payloadHash string) error
+	MarkMeteringDone(ctx context.Context, operationID string) error
+	MarkMeteringTerminalFailed(ctx context.Context, operationID, reason string) error
+	MarkMeteringRetryableFailure(ctx context.Context, operationID, reason string) error
+}
+
+const consoleOutboxTimeout = 2 * time.Second
+
+type consoleMeteringPayload struct {
+	EventType  string   `json:"eventType"`
+	Meter      string   `json:"meter"`
+	Units      int64    `json:"units"`
+	OccurredAt string   `json:"occurredAt"`
+	AgentName  string   `json:"agentName,omitempty"`
+	MemoryIDs  []string `json:"memoryIds,omitempty"`
+}
+
+type consoleQueuedEvent struct {
+	evt         Event
+	payloadJSON []byte
+	payloadHash string
+}
+
+type consoleRuntimeWriter struct {
+	cfg    ConsoleRuntimeConfig
+	client httpDoer
+	logger *slog.Logger
+
+	ch   chan consoleQueuedEvent
+	done chan struct{}
+	wg   sync.WaitGroup
+
+	closeOnce sync.Once
+
+	lastFullWarn int64
+	now          func() time.Time
+
+	closeCtxMu sync.Mutex
+	closeCtx   context.Context
+
+	runtimeCtx    context.Context
+	runtimeCancel context.CancelFunc
+}
+
+func NewConsoleRuntime(cfg ConsoleRuntimeConfig, logger *slog.Logger) (Writer, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return nil, fmt.Errorf("metering: console runtime base URL is required")
+	}
+	if strings.TrimSpace(cfg.InternalSecret) == "" {
+		return nil, fmt.Errorf("metering: console runtime internal secret is required")
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 5 * time.Second
+	}
+	if cfg.ChannelSize <= 0 {
+		cfg.ChannelSize = defaultChannelSize
+	}
+	baseURL := strings.TrimRight(cfg.BaseURL, "/")
+	cfg.BaseURL = baseURL
+	return newConsoleRuntimeWriter(cfg, &http.Client{Timeout: cfg.Timeout}, logger), nil
+}
+
+func newConsoleRuntimeWriter(cfg ConsoleRuntimeConfig, client httpDoer, logger *slog.Logger) *consoleRuntimeWriter {
+	runtimeCtx, runtimeCancel := context.WithCancel(context.Background())
+	w := &consoleRuntimeWriter{
+		cfg:           cfg,
+		client:        client,
+		logger:        logger,
+		ch:            make(chan consoleQueuedEvent, cfg.ChannelSize),
+		done:          make(chan struct{}),
+		now:           time.Now,
+		runtimeCtx:    runtimeCtx,
+		runtimeCancel: runtimeCancel,
+	}
+	w.wg.Add(1)
+	go w.run()
+	return w
+}
+
+func (w *consoleRuntimeWriter) Record(evt Event) {
+	if evt.OccurredAt.IsZero() {
+		evt.OccurredAt = w.now().UTC()
+	}
+	item, err := w.makeQueuedEvent(evt)
+	if err != nil {
+		w.logInvalidEvent(evt, err)
+		return
+	}
+	if w.cfg.Store != nil {
+		ctx, cancel := consoleOutboxContext()
+		defer cancel()
+		if err := w.cfg.Store.UpsertMeteringPending(ctx, evt, item.payloadJSON, item.payloadHash); err != nil {
+			w.logger.Error("metering: console event outbox upsert failed",
+				"operation_id", evt.OperationID,
+				"tenant_id", evt.TenantID,
+				"cluster_id", evt.ClusterID,
+				"payload_hash", item.payloadHash,
+				"err", err,
+			)
+			return
+		}
+	}
+	select {
+	case w.ch <- item:
+	default:
+		w.maybeWarnFull()
+	}
+}
+
+func (w *consoleRuntimeWriter) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	w.closeOnce.Do(func() {
+		w.closeCtxMu.Lock()
+		w.closeCtx = ctx
+		w.closeCtxMu.Unlock()
+		if w.runtimeCancel != nil {
+			w.runtimeCancel()
+		}
+		if w.done != nil {
+			close(w.done)
+		}
+	})
+
+	waitCh := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(waitCh)
+	}()
+
+	select {
+	case <-waitCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *consoleRuntimeWriter) makeQueuedEvent(evt Event) (consoleQueuedEvent, error) {
+	if evt.OperationID == "" {
+		return consoleQueuedEvent{}, fmt.Errorf("operation ID is required")
+	}
+	if evt.APIKeySubject == "" {
+		return consoleQueuedEvent{}, fmt.Errorf("API key subject is required")
+	}
+	if evt.EventType == "" {
+		return consoleQueuedEvent{}, fmt.Errorf("event type is required")
+	}
+	if evt.Meter == "" {
+		return consoleQueuedEvent{}, fmt.Errorf("meter is required")
+	}
+	if evt.Units == 0 {
+		return consoleQueuedEvent{}, fmt.Errorf("units must be non-zero")
+	}
+	payload := consoleMeteringPayload{
+		EventType:  evt.EventType,
+		Meter:      evt.Meter,
+		Units:      evt.Units,
+		OccurredAt: evt.OccurredAt.UTC().Format(time.RFC3339),
+		AgentName:  evt.AgentID,
+		MemoryIDs:  append([]string(nil), evt.MemoryIDs...),
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return consoleQueuedEvent{}, err
+	}
+	sum := sha256.Sum256(payloadJSON)
+	return consoleQueuedEvent{
+		evt:         evt,
+		payloadJSON: payloadJSON,
+		payloadHash: hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+func (w *consoleRuntimeWriter) run() {
+	defer w.wg.Done()
+
+	for {
+		select {
+		case item := <-w.ch:
+			w.deliver(item)
+		case <-w.done:
+			w.drainAndDeliver(w.shutdownContext())
+			return
+		}
+	}
+}
+
+func (w *consoleRuntimeWriter) deliver(item consoleQueuedEvent) {
+	if err := w.putEvent(w.runtimeCtx, item); err != nil {
+		if w.runtimeCtx.Err() != nil {
+			shutdownCtx := w.shutdownContext()
+			if shutdownCtx.Err() == nil {
+				if retryErr := w.putEvent(shutdownCtx, item); retryErr == nil {
+					return
+				} else {
+					err = retryErr
+				}
+			}
+		}
+		w.markRetryableFailure(item, err)
+	}
+}
+
+func (w *consoleRuntimeWriter) drainAndDeliver(ctx context.Context) {
+	for {
+		select {
+		case item := <-w.ch:
+			if err := w.putEvent(ctx, item); err != nil {
+				w.markRetryableFailure(item, err)
+				if ctx.Err() != nil {
+					return
+				}
+			}
+		default:
+			return
+		}
+	}
+}
+
+func (w *consoleRuntimeWriter) shutdownContext() context.Context {
+	w.closeCtxMu.Lock()
+	defer w.closeCtxMu.Unlock()
+	if w.closeCtx == nil {
+		return context.Background()
+	}
+	return w.closeCtx
+}
+
+func (w *consoleRuntimeWriter) putEvent(ctx context.Context, item consoleQueuedEvent) error {
+	endpoint := w.cfg.BaseURL + "/api/internal/metering/events/" + item.evt.OperationID
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(item.payloadJSON))
+	if err != nil {
+		return fmt.Errorf("metering: build console request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+w.cfg.InternalSecret)
+	req.Header.Set("X-API-Key", item.evt.APIKeySubject)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("metering: put console event: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
+		w.markDone(item)
+		return nil
+	}
+	if resp.StatusCode == http.StatusConflict && consoleBodyIsDeduped(body) {
+		w.markDone(item)
+		return nil
+	}
+	if resp.StatusCode == http.StatusConflict || resp.StatusCode == http.StatusBadRequest {
+		w.markTerminalFailed(item, fmt.Sprintf("console metering returned status %d", resp.StatusCode))
+		return nil
+	}
+	return fmt.Errorf("metering: console returned status %d", resp.StatusCode)
+}
+
+func consoleBodyIsDeduped(body []byte) bool {
+	var parsed struct {
+		Status  string `json:"status"`
+		Code    string `json:"code"`
+		Deduped bool   `json:"deduped"`
+	}
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		status := strings.ToLower(parsed.Status)
+		code := strings.ToLower(parsed.Code)
+		return parsed.Deduped || status == "deduped" || status == "accepted" || code == "deduped"
+	}
+	return false
+}
+
+func (w *consoleRuntimeWriter) markDone(item consoleQueuedEvent) {
+	if w.cfg.Store != nil {
+		ctx, cancel := consoleOutboxContext()
+		defer cancel()
+		if err := w.cfg.Store.MarkMeteringDone(ctx, item.evt.OperationID); err != nil {
+			w.logger.Error("metering: mark console event done failed",
+				"operation_id", item.evt.OperationID,
+				"payload_hash", item.payloadHash,
+				"err", err,
+			)
+		}
+	}
+}
+
+func (w *consoleRuntimeWriter) markTerminalFailed(item consoleQueuedEvent, reason string) {
+	metrics.RuntimeUsageMeteringDeliveryFailedTotal.WithLabelValues("terminal_response").Inc()
+	if w.cfg.Store != nil {
+		ctx, cancel := consoleOutboxContext()
+		defer cancel()
+		if err := w.cfg.Store.MarkMeteringTerminalFailed(ctx, item.evt.OperationID, reason); err != nil {
+			w.logger.Error("metering: mark console event terminal failed failed",
+				"operation_id", item.evt.OperationID,
+				"payload_hash", item.payloadHash,
+				"err", err,
+			)
+		}
+	}
+	w.logger.Error("metering: console event terminal failed",
+		"operation_id", item.evt.OperationID,
+		"tenant_id", item.evt.TenantID,
+		"cluster_id", item.evt.ClusterID,
+		"payload_hash", item.payloadHash,
+		"reason", reason,
+	)
+}
+
+func (w *consoleRuntimeWriter) markRetryableFailure(item consoleQueuedEvent, err error) {
+	if w.cfg.Store != nil {
+		ctx, cancel := consoleOutboxContext()
+		defer cancel()
+		_ = w.cfg.Store.MarkMeteringRetryableFailure(ctx, item.evt.OperationID, err.Error())
+	}
+	w.logger.Warn("metering: console delivery failed, will retry from outbox",
+		"operation_id", item.evt.OperationID,
+		"tenant_id", item.evt.TenantID,
+		"cluster_id", item.evt.ClusterID,
+		"payload_hash", item.payloadHash,
+		"err", err,
+	)
+}
+
+func (w *consoleRuntimeWriter) logInvalidEvent(evt Event, err error) {
+	metrics.RuntimeUsageMeteringDeliveryFailedTotal.WithLabelValues("invalid_event").Inc()
+	if evt.OperationID != "" && w.cfg.Store != nil {
+		ctx, cancel := consoleOutboxContext()
+		defer cancel()
+		_ = w.cfg.Store.MarkMeteringTerminalFailed(ctx, evt.OperationID, err.Error())
+	}
+	w.logger.Error("metering: invalid console event",
+		"operation_id", evt.OperationID,
+		"tenant_id", evt.TenantID,
+		"cluster_id", evt.ClusterID,
+		"err", err,
+	)
+}
+
+func consoleOutboxContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), consoleOutboxTimeout)
+}
+
+func (w *consoleRuntimeWriter) maybeWarnFull() {
+	now := w.now().Unix()
+	last := atomic.LoadInt64(&w.lastFullWarn)
+	if now-last < 10 {
+		return
+	}
+	if !atomic.CompareAndSwapInt64(&w.lastFullWarn, last, now) {
+		return
+	}
+	w.logger.Warn("metering: console event channel full, keeping outbox row for retry", "capacity", cap(w.ch))
+}

--- a/server/internal/metering/console_writer.go
+++ b/server/internal/metering/console_writer.go
@@ -83,10 +83,10 @@ func NewConsoleRuntime(cfg ConsoleRuntimeConfig, logger *slog.Logger) (Writer, e
 		logger = slog.Default()
 	}
 	if strings.TrimSpace(cfg.BaseURL) == "" {
-		return nil, fmt.Errorf("metering: console runtime base URL is required")
+		return nil, fmt.Errorf("metering: runtime usage service base URL is required")
 	}
 	if strings.TrimSpace(cfg.InternalSecret) == "" {
-		return nil, fmt.Errorf("metering: console runtime internal secret is required")
+		return nil, fmt.Errorf("metering: runtime usage service internal secret is required")
 	}
 	if cfg.Timeout <= 0 {
 		cfg.Timeout = 5 * time.Second
@@ -131,7 +131,7 @@ func (w *consoleRuntimeWriter) Record(evt Event) {
 		ctx, cancel := consoleOutboxContext()
 		defer cancel()
 		if err := w.cfg.Store.UpsertMeteringPending(ctx, item.evt, item.payloadJSON, item.payloadHash); err != nil {
-			w.logger.Error("metering: console event outbox upsert failed",
+			w.logger.Error("metering: runtime usage service event outbox upsert failed",
 				"operation_id", evt.OperationID,
 				"tenant_id", evt.TenantID,
 				"cluster_id", evt.ClusterID,
@@ -399,7 +399,7 @@ func (w *consoleRuntimeWriter) putEvent(ctx context.Context, item consoleQueuedE
 	endpoint := w.cfg.BaseURL + "/api/internal/metering/events/" + item.evt.OperationID
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, bytes.NewReader(item.payloadJSON))
 	if err != nil {
-		return fmt.Errorf("metering: build console request: %w", err)
+		return fmt.Errorf("metering: build runtime usage service request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+w.cfg.InternalSecret)
 	req.Header.Set("X-API-Key", item.evt.APIKeySubject)
@@ -407,7 +407,7 @@ func (w *consoleRuntimeWriter) putEvent(ctx context.Context, item consoleQueuedE
 
 	resp, err := w.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("metering: put console event: %w", err)
+		return fmt.Errorf("metering: put runtime usage service event: %w", err)
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
@@ -417,10 +417,10 @@ func (w *consoleRuntimeWriter) putEvent(ctx context.Context, item consoleQueuedE
 		return nil
 	}
 	if resp.StatusCode == http.StatusConflict || resp.StatusCode == http.StatusBadRequest {
-		w.markTerminalFailed(item, fmt.Sprintf("console metering returned status %d", resp.StatusCode))
+		w.markTerminalFailed(item, fmt.Sprintf("runtime usage service metering returned status %d", resp.StatusCode))
 		return nil
 	}
-	return fmt.Errorf("metering: console returned status %d", resp.StatusCode)
+	return fmt.Errorf("metering: runtime usage service returned status %d", resp.StatusCode)
 }
 
 func (w *consoleRuntimeWriter) markDone(item consoleQueuedEvent) {
@@ -428,7 +428,7 @@ func (w *consoleRuntimeWriter) markDone(item consoleQueuedEvent) {
 		ctx, cancel := consoleOutboxContext()
 		defer cancel()
 		if err := w.cfg.Store.MarkMeteringDone(ctx, item.evt.OperationID); err != nil {
-			w.logger.Error("metering: mark console event done failed",
+			w.logger.Error("metering: mark runtime usage service event done failed",
 				"operation_id", item.evt.OperationID,
 				"payload_hash", item.payloadHash,
 				"err", err,
@@ -443,14 +443,14 @@ func (w *consoleRuntimeWriter) markTerminalFailed(item consoleQueuedEvent, reaso
 		ctx, cancel := consoleOutboxContext()
 		defer cancel()
 		if err := w.cfg.Store.MarkMeteringTerminalFailed(ctx, item.evt.OperationID, reason); err != nil {
-			w.logger.Error("metering: mark console event terminal failed failed",
+			w.logger.Error("metering: mark runtime usage service event terminal failed failed",
 				"operation_id", item.evt.OperationID,
 				"payload_hash", item.payloadHash,
 				"err", err,
 			)
 		}
 	}
-	w.logger.Error("metering: console event terminal failed",
+	w.logger.Error("metering: runtime usage service event terminal failed",
 		"operation_id", item.evt.OperationID,
 		"tenant_id", item.evt.TenantID,
 		"cluster_id", item.evt.ClusterID,
@@ -465,7 +465,7 @@ func (w *consoleRuntimeWriter) markRetryableFailure(item consoleQueuedEvent, err
 		defer cancel()
 		_ = w.cfg.Store.MarkMeteringRetryableFailure(ctx, item.evt.OperationID, err.Error())
 	}
-	w.logger.Warn("metering: console delivery failed, will retry from outbox",
+	w.logger.Warn("metering: runtime usage service delivery failed, will retry from outbox",
 		"operation_id", item.evt.OperationID,
 		"tenant_id", item.evt.TenantID,
 		"cluster_id", item.evt.ClusterID,
@@ -481,7 +481,7 @@ func (w *consoleRuntimeWriter) logInvalidEvent(evt Event, err error) {
 		defer cancel()
 		_ = w.cfg.Store.MarkMeteringTerminalFailed(ctx, evt.OperationID, err.Error())
 	}
-	w.logger.Error("metering: invalid console event",
+	w.logger.Error("metering: invalid runtime usage service event",
 		"operation_id", evt.OperationID,
 		"tenant_id", evt.TenantID,
 		"cluster_id", evt.ClusterID,
@@ -502,5 +502,5 @@ func (w *consoleRuntimeWriter) maybeWarnFull() {
 	if !atomic.CompareAndSwapInt64(&w.lastFullWarn, last, now) {
 		return
 	}
-	w.logger.Warn("metering: console event channel full, keeping outbox row for retry", "capacity", cap(w.ch))
+	w.logger.Warn("metering: runtime usage service event channel full, keeping outbox row for retry", "capacity", cap(w.ch))
 }

--- a/server/internal/metering/console_writer.go
+++ b/server/internal/metering/console_writer.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -36,12 +37,13 @@ type ConsoleEventStore interface {
 const consoleOutboxTimeout = 2 * time.Second
 
 type consoleMeteringPayload struct {
-	EventType  string   `json:"eventType"`
-	Meter      string   `json:"meter"`
-	Units      int64    `json:"units"`
-	OccurredAt string   `json:"occurredAt"`
-	AgentName  string   `json:"agentName,omitempty"`
-	MemoryIDs  []string `json:"memoryIds,omitempty"`
+	EventType  string         `json:"eventType"`
+	Meter      string         `json:"meter"`
+	Units      int64          `json:"units"`
+	OccurredAt string         `json:"occurredAt"`
+	AgentName  string         `json:"agentName,omitempty"`
+	MemoryIDs  []string       `json:"memoryIds,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
 }
 
 type consoleMeteringHashPayload struct {
@@ -116,7 +118,9 @@ func newConsoleRuntimeWriter(cfg ConsoleRuntimeConfig, client httpDoer, logger *
 
 func (w *consoleRuntimeWriter) Record(evt Event) {
 	if evt.OccurredAt.IsZero() {
-		evt.OccurredAt = w.now().UTC()
+		evt.OccurredAt = w.now().UTC().Truncate(time.Second)
+	} else {
+		evt.OccurredAt = evt.OccurredAt.UTC().Truncate(time.Second)
 	}
 	item, err := w.makeQueuedEvent(evt)
 	if err != nil {
@@ -126,7 +130,7 @@ func (w *consoleRuntimeWriter) Record(evt Event) {
 	if w.cfg.Store != nil {
 		ctx, cancel := consoleOutboxContext()
 		defer cancel()
-		if err := w.cfg.Store.UpsertMeteringPending(ctx, evt, item.payloadJSON, item.payloadHash); err != nil {
+		if err := w.cfg.Store.UpsertMeteringPending(ctx, item.evt, item.payloadJSON, item.payloadHash); err != nil {
 			w.logger.Error("metering: console event outbox upsert failed",
 				"operation_id", evt.OperationID,
 				"tenant_id", evt.TenantID,
@@ -191,13 +195,15 @@ func (w *consoleRuntimeWriter) makeQueuedEvent(evt Event) (consoleQueuedEvent, e
 	if evt.Units == 0 {
 		return consoleQueuedEvent{}, fmt.Errorf("units must be non-zero")
 	}
+	occurredAt := evt.OccurredAt.UTC().Truncate(time.Second)
 	payload := consoleMeteringPayload{
 		EventType:  evt.EventType,
 		Meter:      evt.Meter,
 		Units:      evt.Units,
-		OccurredAt: evt.OccurredAt.UTC().Format(time.RFC3339),
-		AgentName:  evt.AgentID,
-		MemoryIDs:  append([]string(nil), evt.MemoryIDs...),
+		OccurredAt: occurredAt.Format(time.RFC3339),
+		AgentName:  consoleAgentName(evt.AgentID),
+		MemoryIDs:  consoleMemoryIDs(evt.MemoryIDs),
+		Metadata:   consoleMetadata(evt.Metadata),
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -211,11 +217,127 @@ func (w *consoleRuntimeWriter) makeQueuedEvent(evt Event) (consoleQueuedEvent, e
 		return consoleQueuedEvent{}, err
 	}
 	sum := sha256.Sum256(hashJSON)
+	evt.OccurredAt = occurredAt
+	evt.AgentID = payload.AgentName
+	evt.MemoryIDs = append([]string(nil), payload.MemoryIDs...)
+	evt.Metadata = consoleMetadata(payload.Metadata)
 	return consoleQueuedEvent{
 		evt:         evt,
 		payloadJSON: payloadJSON,
 		payloadHash: hex.EncodeToString(sum[:]),
 	}, nil
+}
+
+var (
+	consoleAgentNamePattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9 ._-]{0,63}$`)
+	consoleMemoryIDPattern    = regexp.MustCompile(`^[A-Za-z0-9_.:-]{1,128}$`)
+	consoleMetadataKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]{1,64}$`)
+)
+
+func consoleAgentName(agentName string) string {
+	if consoleAgentNamePattern.MatchString(agentName) && !looksSensitive(agentName) {
+		return agentName
+	}
+	return ""
+}
+
+func consoleMemoryIDs(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := make([]string, 0, min(len(ids), 200))
+	seen := make(map[string]struct{}, min(len(ids), 200))
+	for _, id := range ids {
+		if len(out) >= 200 {
+			break
+		}
+		if !consoleMemoryIDPattern.MatchString(id) || looksSensitive(id) {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func consoleMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]any, min(len(metadata), 20))
+	for key, value := range metadata {
+		if len(out) >= 20 {
+			break
+		}
+		if !consoleMetadataKeyPattern.MatchString(key) || sensitiveMetadataKey(key) {
+			continue
+		}
+		switch v := value.(type) {
+		case string:
+			if len(v) > 512 || looksSensitive(v) {
+				continue
+			}
+			out[key] = v
+		case int:
+			out[key] = v
+		case int8:
+			out[key] = int64(v)
+		case int16:
+			out[key] = int64(v)
+		case int32:
+			out[key] = int64(v)
+		case int64:
+			out[key] = v
+		case uint:
+			out[key] = uint64(v)
+		case uint8:
+			out[key] = uint64(v)
+		case uint16:
+			out[key] = uint64(v)
+		case uint32:
+			out[key] = uint64(v)
+		case uint64:
+			out[key] = v
+		case float32:
+			out[key] = float64(v)
+		case float64:
+			out[key] = v
+		case bool:
+			out[key] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func sensitiveMetadataKey(key string) bool {
+	key = strings.ToLower(key)
+	sensitive := []string{"authorization", "cookie", "token", "secret", "password", "api_key", "apikey", "dsn", "prompt", "content"}
+	for _, marker := range sensitive {
+		if strings.Contains(key, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksSensitive(value string) bool {
+	value = strings.TrimSpace(value)
+	lower := strings.ToLower(value)
+	return strings.HasPrefix(lower, "bearer ") ||
+		strings.Contains(lower, "authorization:") ||
+		strings.Contains(lower, "password=") ||
+		strings.Contains(lower, "x-api-key") ||
+		strings.Contains(lower, "mnemo_") ||
+		strings.Contains(lower, "mem9_")
 }
 
 func (w *consoleRuntimeWriter) run() {

--- a/server/internal/metering/console_writer.go
+++ b/server/internal/metering/console_writer.go
@@ -288,13 +288,9 @@ func (w *consoleRuntimeWriter) putEvent(ctx context.Context, item consoleQueuedE
 		return fmt.Errorf("metering: put console event: %w", err)
 	}
 	defer resp.Body.Close()
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
-		w.markDone(item)
-		return nil
-	}
-	if resp.StatusCode == http.StatusConflict && consoleBodyIsDeduped(body) {
 		w.markDone(item)
 		return nil
 	}
@@ -303,20 +299,6 @@ func (w *consoleRuntimeWriter) putEvent(ctx context.Context, item consoleQueuedE
 		return nil
 	}
 	return fmt.Errorf("metering: console returned status %d", resp.StatusCode)
-}
-
-func consoleBodyIsDeduped(body []byte) bool {
-	var parsed struct {
-		Status  string `json:"status"`
-		Code    string `json:"code"`
-		Deduped bool   `json:"deduped"`
-	}
-	if err := json.Unmarshal(body, &parsed); err == nil {
-		status := strings.ToLower(parsed.Status)
-		code := strings.ToLower(parsed.Code)
-		return parsed.Deduped || status == "deduped" || status == "accepted" || code == "deduped"
-	}
-	return false
 }
 
 func (w *consoleRuntimeWriter) markDone(item consoleQueuedEvent) {

--- a/server/internal/metering/writer.go
+++ b/server/internal/metering/writer.go
@@ -26,6 +26,14 @@ type Event struct {
 	ClusterID string
 	AgentID   string
 	Data      map[string]any
+
+	OperationID   string
+	APIKeySubject string
+	EventType     string
+	Meter         string
+	Units         int64
+	OccurredAt    time.Time
+	MemoryIDs     []string
 }
 
 // Writer records metering events asynchronously and delivers them through the

--- a/server/internal/metering/writer.go
+++ b/server/internal/metering/writer.go
@@ -34,6 +34,7 @@ type Event struct {
 	Units         int64
 	OccurredAt    time.Time
 	MemoryIDs     []string
+	Metadata      map[string]any
 }
 
 // Writer records metering events asynchronously and delivers them through the

--- a/server/internal/metering/writer_test.go
+++ b/server/internal/metering/writer_test.go
@@ -1083,7 +1083,7 @@ func TestConsoleRuntimeWriter_PayloadHashIncludesAPIKeySubject(t *testing.T) {
 		t.Fatalf("payload hash did not change when APIKeySubject changed: %s", first.payloadHash)
 	}
 	if !bytes.Equal(first.payloadJSON, second.payloadJSON) {
-		t.Fatalf("console payload JSON changed with APIKeySubject: first=%s second=%s", first.payloadJSON, second.payloadJSON)
+		t.Fatalf("runtime usage payload JSON changed with APIKeySubject: first=%s second=%s", first.payloadJSON, second.payloadJSON)
 	}
 }
 

--- a/server/internal/metering/writer_test.go
+++ b/server/internal/metering/writer_test.go
@@ -994,6 +994,37 @@ func TestConsoleRuntimeWriter_SendsConsoleShapeAndMarksDone(t *testing.T) {
 	}
 }
 
+func TestConsoleRuntimeWriter_PayloadHashIncludesAPIKeySubject(t *testing.T) {
+	w := &consoleRuntimeWriter{}
+	evt := Event{
+		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		APIKeySubject: "api-key-a",
+		EventType:     "recall",
+		Meter:         "recalls",
+		Units:         1,
+		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
+		AgentID:       "Codex",
+		MemoryIDs:     []string{"mem-1"},
+	}
+
+	first, err := w.makeQueuedEvent(evt)
+	if err != nil {
+		t.Fatalf("makeQueuedEvent first: %v", err)
+	}
+	evt.APIKeySubject = "api-key-b"
+	second, err := w.makeQueuedEvent(evt)
+	if err != nil {
+		t.Fatalf("makeQueuedEvent second: %v", err)
+	}
+
+	if first.payloadHash == second.payloadHash {
+		t.Fatalf("payload hash did not change when APIKeySubject changed: %s", first.payloadHash)
+	}
+	if !bytes.Equal(first.payloadJSON, second.payloadJSON) {
+		t.Fatalf("console payload JSON changed with APIKeySubject: first=%s second=%s", first.payloadJSON, second.payloadJSON)
+	}
+}
+
 func TestGzipRoundTrip(t *testing.T) {
 	p := newGzipPool()
 	input := []byte(`{"category":"mem9-api","tenant_id":"tenant-a","cluster_id":"10006636"}`)

--- a/server/internal/metering/writer_test.go
+++ b/server/internal/metering/writer_test.go
@@ -164,6 +164,20 @@ func waitForConsoleStore(t *testing.T, store *fakeConsoleStore, wantDone int, ti
 	t.Fatalf("timed out waiting for done=%d; got upserted=%d done=%d terminal=%d retry=%d", wantDone, upserted, done, terminal, retry)
 }
 
+func waitForConsoleTerminal(t *testing.T, store *fakeConsoleStore, wantTerminal int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, _, terminal, _ := store.counts()
+		if terminal == wantTerminal {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	upserted, done, terminal, retry := store.counts()
+	t.Fatalf("timed out waiting for terminal=%d; got upserted=%d done=%d terminal=%d retry=%d", wantTerminal, upserted, done, terminal, retry)
+}
+
 func decodePayload(t *testing.T, body []byte) s3Payload {
 	t.Helper()
 	r, err := gzip.NewReader(bytes.NewReader(body))
@@ -991,6 +1005,45 @@ func TestConsoleRuntimeWriter_SendsConsoleShapeAndMarksDone(t *testing.T) {
 	}
 	if gotBody["units"] != float64(1) {
 		t.Fatalf("units = %#v, want 1", gotBody["units"])
+	}
+}
+
+func TestConsoleRuntimeWriter_ConflictMarksTerminalEvenWithDedupedBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"status":"accepted","deduped":true}`))
+	}))
+	defer server.Close()
+
+	store := &fakeConsoleStore{}
+	logger, _ := newTestLogger()
+	writer, err := NewConsoleRuntime(ConsoleRuntimeConfig{
+		BaseURL:        server.URL,
+		InternalSecret: "internal-secret",
+		Timeout:        time.Second,
+		Store:          store,
+	}, logger)
+	if err != nil {
+		t.Fatalf("NewConsoleRuntime: %v", err)
+	}
+	defer writer.Close(context.Background())
+
+	writer.Record(Event{
+		TenantID:      "tenant-a",
+		ClusterID:     "cluster-a",
+		AgentID:       "Codex",
+		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		APIKeySubject: "tenant-a",
+		EventType:     "recall",
+		Meter:         "recalls",
+		Units:         1,
+		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
+	})
+
+	waitForConsoleTerminal(t, store, 1, time.Second)
+	upserted, done, terminal, retry := store.counts()
+	if upserted != 1 || done != 0 || terminal != 1 || retry != 0 {
+		t.Fatalf("store counts = upserted=%d done=%d terminal=%d retry=%d", upserted, done, terminal, retry)
 	}
 }
 

--- a/server/internal/metering/writer_test.go
+++ b/server/internal/metering/writer_test.go
@@ -85,10 +85,83 @@ type webhookPayload struct {
 	Metadata  map[string]interface{} `json:"metadata"`
 }
 
+type fakeConsoleStore struct {
+	mu            sync.Mutex
+	upserted      []string
+	done          []string
+	terminal      []string
+	retryFailures []string
+	noDeadline    int
+}
+
+func (s *fakeConsoleStore) UpsertMeteringPending(ctx context.Context, evt Event, _ []byte, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recordDeadlineLocked(ctx)
+	s.upserted = append(s.upserted, evt.OperationID)
+	return nil
+}
+
+func (s *fakeConsoleStore) MarkMeteringDone(ctx context.Context, operationID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recordDeadlineLocked(ctx)
+	s.done = append(s.done, operationID)
+	return nil
+}
+
+func (s *fakeConsoleStore) MarkMeteringTerminalFailed(ctx context.Context, operationID, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recordDeadlineLocked(ctx)
+	s.terminal = append(s.terminal, operationID)
+	return nil
+}
+
+func (s *fakeConsoleStore) MarkMeteringRetryableFailure(ctx context.Context, operationID, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recordDeadlineLocked(ctx)
+	s.retryFailures = append(s.retryFailures, operationID)
+	return nil
+}
+
+func (s *fakeConsoleStore) recordDeadlineLocked(ctx context.Context) {
+	if _, ok := ctx.Deadline(); !ok {
+		s.noDeadline++
+	}
+}
+
+func (s *fakeConsoleStore) counts() (upserted, done, terminal, retry int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.upserted), len(s.done), len(s.terminal), len(s.retryFailures)
+}
+
+func (s *fakeConsoleStore) noDeadlineCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.noDeadline
+}
+
 func newTestLogger() (*slog.Logger, *bytes.Buffer) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	return logger, buf
+}
+
+func waitForConsoleStore(t *testing.T, store *fakeConsoleStore, wantDone int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		_, done, _, _ := store.counts()
+		if done == wantDone {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	upserted, done, terminal, retry := store.counts()
+	t.Fatalf("timed out waiting for done=%d; got upserted=%d done=%d terminal=%d retry=%d", wantDone, upserted, done, terminal, retry)
 }
 
 func decodePayload(t *testing.T, body []byte) s3Payload {
@@ -843,6 +916,81 @@ func TestRecord_MalformedEvent_DroppedSilently(t *testing.T) {
 	}
 	if strings.Contains(buf.String(), "channel full") || strings.Contains(buf.String(), "flush failed") {
 		t.Fatalf("unexpected logs for malformed events: %q", buf.String())
+	}
+}
+
+func TestConsoleRuntimeWriter_SendsConsoleShapeAndMarksDone(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+		gotAPIKey string
+		gotBody   map[string]any
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotAPIKey = r.Header.Get("X-API-Key")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"accepted"}`))
+	}))
+	defer server.Close()
+
+	store := &fakeConsoleStore{}
+	logger, _ := newTestLogger()
+	writer, err := NewConsoleRuntime(ConsoleRuntimeConfig{
+		BaseURL:        server.URL + "/",
+		InternalSecret: "internal-secret",
+		Timeout:        time.Second,
+		Store:          store,
+	}, logger)
+	if err != nil {
+		t.Fatalf("NewConsoleRuntime: %v", err)
+	}
+	defer writer.Close(context.Background())
+
+	writer.Record(Event{
+		TenantID:      "tenant-a",
+		ClusterID:     "cluster-a",
+		AgentID:       "Codex",
+		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		APIKeySubject: "tenant-a",
+		EventType:     "recall",
+		Meter:         "recalls",
+		Units:         1,
+		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
+		MemoryIDs:     []string{"mem-1", "mem-2"},
+	})
+
+	waitForConsoleStore(t, store, 1, time.Second)
+	upserted, done, terminal, retry := store.counts()
+	if upserted != 1 || done != 1 || terminal != 0 || retry != 0 {
+		t.Fatalf("store counts = upserted=%d done=%d terminal=%d retry=%d", upserted, done, terminal, retry)
+	}
+	if store.noDeadlineCount() != 0 {
+		t.Fatalf("store calls without deadline = %d, want 0", store.noDeadlineCount())
+	}
+	if gotMethod != http.MethodPut {
+		t.Fatalf("method = %s, want PUT", gotMethod)
+	}
+	if gotPath != "/api/internal/metering/events/018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234" {
+		t.Fatalf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer internal-secret" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotAPIKey != "tenant-a" {
+		t.Fatalf("X-API-Key = %q", gotAPIKey)
+	}
+	if gotBody["eventType"] != "recall" || gotBody["meter"] != "recalls" || gotBody["agentName"] != "Codex" {
+		t.Fatalf("unexpected body: %+v", gotBody)
+	}
+	if gotBody["units"] != float64(1) {
+		t.Fatalf("units = %#v, want 1", gotBody["units"])
 	}
 }
 

--- a/server/internal/metering/writer_test.go
+++ b/server/internal/metering/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -973,11 +974,12 @@ func TestConsoleRuntimeWriter_SendsConsoleShapeAndMarksDone(t *testing.T) {
 		AgentID:       "Codex",
 		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
 		APIKeySubject: "tenant-a",
-		EventType:     "recall",
-		Meter:         "recalls",
+		EventType:     "memoryRecall",
+		Meter:         "memory_recall_requests",
 		Units:         1,
-		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
+		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 123, time.UTC),
 		MemoryIDs:     []string{"mem-1", "mem-2"},
+		Metadata:      map[string]any{"objectsAffected": int64(2)},
 	})
 
 	waitForConsoleStore(t, store, 1, time.Second)
@@ -1000,11 +1002,18 @@ func TestConsoleRuntimeWriter_SendsConsoleShapeAndMarksDone(t *testing.T) {
 	if gotAPIKey != "tenant-a" {
 		t.Fatalf("X-API-Key = %q", gotAPIKey)
 	}
-	if gotBody["eventType"] != "recall" || gotBody["meter"] != "recalls" || gotBody["agentName"] != "Codex" {
+	if gotBody["eventType"] != "memoryRecall" || gotBody["meter"] != "memory_recall_requests" || gotBody["agentName"] != "Codex" {
 		t.Fatalf("unexpected body: %+v", gotBody)
 	}
 	if gotBody["units"] != float64(1) {
 		t.Fatalf("units = %#v, want 1", gotBody["units"])
+	}
+	if gotBody["occurredAt"] != "2026-05-13T01:02:03Z" {
+		t.Fatalf("occurredAt = %#v, want whole-second RFC3339", gotBody["occurredAt"])
+	}
+	metadata, ok := gotBody["metadata"].(map[string]any)
+	if !ok || metadata["objectsAffected"] != float64(2) {
+		t.Fatalf("metadata = %#v, want objectsAffected=2", gotBody["metadata"])
 	}
 }
 
@@ -1034,8 +1043,8 @@ func TestConsoleRuntimeWriter_ConflictMarksTerminalEvenWithDedupedBody(t *testin
 		AgentID:       "Codex",
 		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
 		APIKeySubject: "tenant-a",
-		EventType:     "recall",
-		Meter:         "recalls",
+		EventType:     "memoryRecall",
+		Meter:         "memory_recall_requests",
 		Units:         1,
 		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
 	})
@@ -1052,8 +1061,8 @@ func TestConsoleRuntimeWriter_PayloadHashIncludesAPIKeySubject(t *testing.T) {
 	evt := Event{
 		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
 		APIKeySubject: "api-key-a",
-		EventType:     "recall",
-		Meter:         "recalls",
+		EventType:     "memoryRecall",
+		Meter:         "memory_recall_requests",
 		Units:         1,
 		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
 		AgentID:       "Codex",
@@ -1075,6 +1084,51 @@ func TestConsoleRuntimeWriter_PayloadHashIncludesAPIKeySubject(t *testing.T) {
 	}
 	if !bytes.Equal(first.payloadJSON, second.payloadJSON) {
 		t.Fatalf("console payload JSON changed with APIKeySubject: first=%s second=%s", first.payloadJSON, second.payloadJSON)
+	}
+}
+
+func TestConsoleRuntimeWriter_OmitsInvalidAgentNameAndCapsMemoryIDs(t *testing.T) {
+	w := &consoleRuntimeWriter{}
+	ids := make([]string, 0, 205)
+	for i := 0; i < 205; i++ {
+		ids = append(ids, fmt.Sprintf("mem-%d", i))
+	}
+	evt := Event{
+		OperationID:   "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		APIKeySubject: "api-key-a",
+		EventType:     "memoryCreated",
+		Meter:         "memory_write_requests",
+		Units:         1,
+		OccurredAt:    time.Date(2026, 5, 13, 1, 2, 3, 0, time.UTC),
+		AgentID:       "@codex",
+		MemoryIDs:     ids,
+		Metadata: map[string]any{
+			"objectsAffected": 205,
+			"authorization":   "Bearer secret",
+		},
+	}
+
+	item, err := w.makeQueuedEvent(evt)
+	if err != nil {
+		t.Fatalf("makeQueuedEvent: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(item.payloadJSON, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if _, ok := payload["agentName"]; ok {
+		t.Fatalf("agentName present in payload: %+v", payload)
+	}
+	memoryIDs, ok := payload["memoryIds"].([]any)
+	if !ok || len(memoryIDs) != 200 {
+		t.Fatalf("memoryIds len = %d, want 200", len(memoryIDs))
+	}
+	metadata, ok := payload["metadata"].(map[string]any)
+	if !ok || metadata["objectsAffected"] != float64(205) {
+		t.Fatalf("metadata = %#v, want objectsAffected=205", payload["metadata"])
+	}
+	if _, ok := metadata["authorization"]; ok {
+		t.Fatalf("sensitive metadata was retained: %+v", metadata)
 	}
 }
 

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -202,13 +202,13 @@ var (
 		[]string{"phase"},
 	)
 
-	// RuntimeUsageMeteringDeliveryFailedTotal counts console metering events
-	// that reached a terminal failed state.
+	// RuntimeUsageMeteringDeliveryFailedTotal counts runtime usage service
+	// metering events that reached a terminal failed state.
 	RuntimeUsageMeteringDeliveryFailedTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "mnemo",
 			Name:      "runtime_usage_metering_delivery_failed_total",
-			Help:      "Console runtime usage metering events that reached terminal failed state.",
+			Help:      "Runtime usage service metering events that reached terminal failed state.",
 		},
 		[]string{"reason"},
 	)

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -177,6 +177,41 @@ var (
 		},
 		[]string{"op", "status"},
 	)
+
+	// RuntimeUsageManualReconciliationTotal counts runtime usage operations that
+	// require operator reconciliation because local state cannot safely infer the
+	// final quota or metering outcome.
+	RuntimeUsageManualReconciliationTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "runtime_usage_manual_reconciliation_total",
+			Help:      "Runtime usage operations requiring manual reconciliation.",
+		},
+		[]string{"reason"},
+	)
+
+	// RuntimeUsageReservationUnknownTotal counts reservations or adjustment
+	// intents whose mem9 operation outcome was not durably persisted before the
+	// local watchdog deadline.
+	RuntimeUsageReservationUnknownTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "runtime_usage_reservation_unknown_total",
+			Help:      "Runtime usage reservations or adjustment intents with unknown operation outcome after local deadline.",
+		},
+		[]string{"phase"},
+	)
+
+	// RuntimeUsageMeteringDeliveryFailedTotal counts console metering events
+	// that reached a terminal failed state.
+	RuntimeUsageMeteringDeliveryFailedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "runtime_usage_metering_delivery_failed_total",
+			Help:      "Console runtime usage metering events that reached terminal failed state.",
+		},
+		[]string{"reason"},
+	)
 )
 
 // Middleware records HTTP request count and duration for each request.

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -189,9 +189,10 @@ func ResolveTenant(
 			)
 
 			info := &domain.AuthInfo{
-				TenantID:  t.ID,
-				TenantDB:  db,
-				ClusterID: t.ClusterID,
+				TenantID:      t.ID,
+				TenantDB:      db,
+				ClusterID:     t.ClusterID,
+				APIKeySubject: t.ID,
 			}
 			if agentID := r.Header.Get(AgentIDHeader); agentID != "" {
 				info.AgentName = agentID
@@ -410,9 +411,10 @@ func ResolveApiKey(
 			)
 
 			info := &domain.AuthInfo{
-				TenantID:  t.ID,
-				TenantDB:  db,
-				ClusterID: t.ClusterID,
+				TenantID:      t.ID,
+				TenantDB:      db,
+				ClusterID:     t.ClusterID,
+				APIKeySubject: t.ID,
 			}
 			if agentID := r.Header.Get(AgentIDHeader); agentID != "" {
 				info.AgentName = agentID

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -414,7 +414,7 @@ func ResolveApiKey(
 				TenantID:      t.ID,
 				TenantDB:      db,
 				ClusterID:     t.ClusterID,
-				APIKeySubject: t.ID,
+				APIKeySubject: apiKey,
 			}
 			if agentID := r.Header.Get(AgentIDHeader); agentID != "" {
 				info.AgentName = agentID

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -331,6 +331,54 @@ func TestResolveApiKey_PopulatesAuthInfo(t *testing.T) {
 	}
 }
 
+func TestResolveApiKey_PreservesAPIKeySubject(t *testing.T) {
+	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
+	defer pool.Close()
+
+	db := sql.OpenDB(pingOKConnector{})
+	defer db.Close()
+	cacheTenantDB(t, pool, "tenant-1", db)
+
+	repo := stubTenantRepo{
+		tenants: map[string]*domain.Tenant{
+			"api-key-a": {
+				ID:       "tenant-1",
+				Status:   domain.TenantActive,
+				DBHost:   "127.0.0.1",
+				DBPort:   4000,
+				DBUser:   "user",
+				DBName:   "db",
+				Provider: "tidb",
+			},
+		},
+	}
+
+	enc := encrypt.NewPlainEncryptor()
+	mw := ResolveApiKey(repo, pool, enc, nil)
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := AuthFromContext(r.Context())
+		if info == nil {
+			t.Fatal("auth info missing from context")
+		}
+		if info.TenantID != "tenant-1" {
+			t.Fatalf("tenant ID = %q, want %q", info.TenantID, "tenant-1")
+		}
+		if info.APIKeySubject != "api-key-a" {
+			t.Fatalf("APIKeySubject = %q, want api-key-a", info.APIKeySubject)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set(APIKeyHeader, " api-key-a ")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+}
+
 func TestResolveApiKey_MD5Encryptor_DecryptsPassword(t *testing.T) {
 	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
 	defer pool.Close()

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -82,10 +82,10 @@ func (r *MemoryRepo) UpdateOptimistic(ctx context.Context, m *domain.Memory, exp
 	return nil
 }
 
-func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) error {
+func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("soft delete begin tx: %w", err)
+		return 0, fmt.Errorf("soft delete begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -95,24 +95,27 @@ func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) error
 		id,
 	).Scan(&state)
 	if err == sql.ErrNoRows {
-		return domain.ErrNotFound
+		return 0, domain.ErrNotFound
 	}
 	if err != nil {
-		return fmt.Errorf("soft delete lock row: %w", err)
+		return 0, fmt.Errorf("soft delete lock row: %w", err)
 	}
 
 	if state.String == string(domain.StateDeleted) {
-		return nil
+		return 0, tx.Commit()
 	}
 	_, err = tx.ExecContext(ctx,
 		`UPDATE memories SET state = 'deleted', updated_at = NOW() WHERE id = $1`,
 		id,
 	)
 	if err != nil {
-		return fmt.Errorf("soft delete update: %w", err)
+		return 0, fmt.Errorf("soft delete update: %w", err)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return 1, nil
 }
 
 func (r *MemoryRepo) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -12,7 +12,7 @@ type MemoryRepo interface {
 	Create(ctx context.Context, m *domain.Memory) error
 	GetByID(ctx context.Context, id string) (*domain.Memory, error)
 	UpdateOptimistic(ctx context.Context, m *domain.Memory, expectedVersion int) error
-	SoftDelete(ctx context.Context, id, agentName string) error
+	SoftDelete(ctx context.Context, id, agentName string) (int64, error)
 	BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error)
 	ArchiveMemory(ctx context.Context, id, supersededBy string) error
 	ArchiveAndCreate(ctx context.Context, archiveID, supersededBy string, newMem *domain.Memory) error

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -105,10 +105,10 @@ func (r *MemoryRepo) UpdateOptimistic(ctx context.Context, m *domain.Memory, exp
 	return nil
 }
 
-func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) error {
+func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("soft delete begin tx: %w", err)
+		return 0, fmt.Errorf("soft delete begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -118,24 +118,31 @@ func (r *MemoryRepo) SoftDelete(ctx context.Context, id, agentName string) error
 		id,
 	).Scan(&state)
 	if err == sql.ErrNoRows {
-		return domain.ErrNotFound
+		return 0, domain.ErrNotFound
 	}
 	if err != nil {
-		return fmt.Errorf("soft delete lock row: %w", err)
+		return 0, fmt.Errorf("soft delete lock row: %w", err)
 	}
 
 	if state.String == string(domain.StateDeleted) {
-		return nil
+		return 0, tx.Commit()
 	}
-	_, err = tx.ExecContext(ctx,
+	result, err := tx.ExecContext(ctx,
 		`UPDATE memories SET state = 'deleted', updated_at = NOW() WHERE id = ?`,
 		id,
 	)
 	if err != nil {
-		return fmt.Errorf("soft delete update: %w", err)
+		return 0, fmt.Errorf("soft delete update: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("soft delete rows affected: %w", err)
 	}
 
-	return tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return deleted, nil
 }
 
 func (r *MemoryRepo) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {

--- a/server/internal/repository/tidb/memory_integration_test.go
+++ b/server/internal/repository/tidb/memory_integration_test.go
@@ -94,7 +94,7 @@ func TestGetByIDDeletedState(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	// Soft delete.
-	if err := repo.SoftDelete(ctx, m.ID, "test-agent"); err != nil {
+	if _, err := repo.SoftDelete(ctx, m.ID, "test-agent"); err != nil {
 		t.Fatalf("SoftDelete: %v", err)
 	}
 	// GetByID filters state='active', so deleted should return ErrNotFound.
@@ -150,7 +150,7 @@ func TestSoftDelete(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := repo.SoftDelete(ctx, m.ID, "deleter"); err != nil {
+	if _, err := repo.SoftDelete(ctx, m.ID, "deleter"); err != nil {
 		t.Fatalf("SoftDelete: %v", err)
 	}
 
@@ -165,12 +165,12 @@ func TestSoftDelete(t *testing.T) {
 	}
 
 	// Idempotent — deleting again should not error.
-	if err := repo.SoftDelete(ctx, m.ID, "deleter"); err != nil {
+	if _, err := repo.SoftDelete(ctx, m.ID, "deleter"); err != nil {
 		t.Fatalf("idempotent SoftDelete: %v", err)
 	}
 
 	// Non-existent.
-	err = repo.SoftDelete(ctx, "nonexistent-id", "agent")
+	_, err = repo.SoftDelete(ctx, "nonexistent-id", "agent")
 	if !errors.Is(err, domain.ErrNotFound) {
 		t.Fatalf("expected ErrNotFound for nonexistent delete, got %v", err)
 	}
@@ -436,7 +436,7 @@ func TestCount(t *testing.T) {
 			t.Fatalf("Create: %v", err)
 		}
 		if i == 0 {
-			if err := repo.SoftDelete(ctx, m.ID, "agent"); err != nil {
+			if _, err := repo.SoftDelete(ctx, m.ID, "agent"); err != nil {
 				t.Fatalf("SoftDelete: %v", err)
 			}
 		}

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -77,7 +77,7 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		return &ConflictError{StatusCode: resp.StatusCode, Body: respBody}
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return &UnavailableError{Err: fmt.Errorf("console returned status %d", resp.StatusCode)}
+		return &UnavailableError{Err: fmt.Errorf("runtime usage service returned status %d", resp.StatusCode)}
 	}
 	if out != nil && len(respBody) > 0 {
 		if err := json.Unmarshal(respBody, out); err != nil {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -1,0 +1,97 @@
+package runtimeusage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type HTTPClient struct {
+	baseURL        string
+	internalSecret string
+	client         *http.Client
+}
+
+func NewHTTPClient(baseURL, internalSecret string, timeout time.Duration) *HTTPClient {
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	return &HTTPClient{
+		baseURL:        strings.TrimRight(baseURL, "/"),
+		internalSecret: internalSecret,
+		client:         &http.Client{Timeout: timeout},
+	}
+}
+
+func (c *HTTPClient) Reserve(ctx context.Context, subject Subject, operationID string, op Operation) (*Reservation, error) {
+	body := map[string]any{
+		"meter": op.Meter,
+		"units": op.Units,
+	}
+	var reservation Reservation
+	if err := c.doJSON(ctx, http.MethodPut, "/api/internal/quota/reservations/"+operationID, subject, body, &reservation); err != nil {
+		return nil, err
+	}
+	return &reservation, nil
+}
+
+func (c *HTTPClient) FinalizeReservation(ctx context.Context, subject Subject, operationID string, status string, reason string) error {
+	body := map[string]any{
+		"status": status,
+	}
+	if reason != "" {
+		body["reason"] = reason
+	}
+	return c.doJSON(ctx, http.MethodPatch, "/api/internal/quota/reservations/"+operationID, subject, body, nil)
+}
+
+func (c *HTTPClient) ApplyAdjustment(ctx context.Context, subject Subject, adj Adjustment) error {
+	body := map[string]any{
+		"meter":  adj.Meter,
+		"delta":  adj.Delta,
+		"reason": adj.Reason,
+	}
+	return c.doJSON(ctx, http.MethodPut, "/api/internal/quota/adjustments/"+adj.OperationID, subject, body, nil)
+}
+
+func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Subject, body any, out any) error {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("runtime usage marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("runtime usage build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.internalSecret)
+	req.Header.Set("X-API-Key", subject.APIKeySubject)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return &UnavailableError{Err: err}
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+
+	if resp.StatusCode == http.StatusPaymentRequired {
+		return &QuotaDeniedError{StatusCode: resp.StatusCode, Body: respBody}
+	}
+	if resp.StatusCode == http.StatusConflict {
+		return &ConflictError{StatusCode: resp.StatusCode, Body: respBody}
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return &UnavailableError{Err: fmt.Errorf("console returned status %d", resp.StatusCode)}
+	}
+	if out != nil && len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, out); err != nil {
+			return fmt.Errorf("runtime usage decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -50,15 +50,6 @@ func (c *HTTPClient) FinalizeReservation(ctx context.Context, subject Subject, o
 	return c.doJSON(ctx, http.MethodPatch, "/api/internal/quota/reservations/"+operationID, subject, body, nil)
 }
 
-func (c *HTTPClient) ApplyAdjustment(ctx context.Context, subject Subject, adj Adjustment) error {
-	body := map[string]any{
-		"meter":  adj.Meter,
-		"delta":  adj.Delta,
-		"reason": adj.Reason,
-	}
-	return c.doJSON(ctx, http.MethodPut, "/api/internal/quota/adjustments/"+adj.OperationID, subject, body, nil)
-}
-
 func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Subject, body any, out any) error {
 	payload, err := json.Marshal(body)
 	if err != nil {

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -1,0 +1,92 @@
+package runtimeusage
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestHTTPClientReserveAllowsNullRemainingIncludedUnits(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", req.Method)
+		}
+		if req.URL.Path != "/api/internal/quota/reservations/op-null" {
+			t.Fatalf("path = %s", req.URL.Path)
+		}
+		if got := req.Header.Get("X-API-Key"); got != "api-key-subject" {
+			t.Fatalf("X-API-Key = %q", got)
+		}
+		return jsonResponse(`{
+			"operationId": "op-null",
+			"meter": "memory_write_requests",
+			"units": 1,
+			"status": "reserved",
+			"expiresAt": "2026-05-19T08:00:00Z",
+			"remainingIncludedUnits": null,
+			"reservedUnits": 1,
+			"overageAllowed": true
+		}`), nil
+	})}
+
+	reservation, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-null", Operation{
+		Meter: MeterMemoryWriteRequests,
+		Units: 1,
+	})
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if reservation.RemainingIncludedUnits != nil {
+		t.Fatalf("RemainingIncludedUnits = %v, want nil", *reservation.RemainingIncludedUnits)
+	}
+}
+
+func TestHTTPClientReserveDecodesRemainingIncludedUnits(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		body, err := json.Marshal(map[string]any{
+			"operationId":            "op-remaining",
+			"meter":                  "memory_recall_requests",
+			"units":                  1,
+			"status":                 "reserved",
+			"expiresAt":              "2026-05-19T08:00:00Z",
+			"remainingIncludedUnits": 42,
+			"reservedUnits":          1,
+			"overageAllowed":         false,
+		})
+		if err != nil {
+			t.Fatalf("Marshal response: %v", err)
+		}
+		return jsonResponse(string(body)), nil
+	})}
+
+	reservation, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-remaining", Operation{
+		Meter: MeterMemoryRecallRequests,
+		Units: 1,
+	})
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if reservation.RemainingIncludedUnits == nil || *reservation.RemainingIncludedUnits != 42 {
+		t.Fatalf("RemainingIncludedUnits = %v, want 42", reservation.RemainingIncludedUnits)
+	}
+}
+
+func jsonResponse(body string) *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metering"
 	"github.com/qiffang/mnemos/server/internal/metrics"
 )
@@ -56,7 +55,7 @@ func (noopManager) AfterMemoryCreateSuccess(context.Context, *OperationLease, Me
 	return nil
 }
 func (noopManager) AfterMemoryCreateFailure(context.Context, *OperationLease, error) {}
-func (noopManager) BeforeMemoryDelete(context.Context, Subject, MemoryDeleteTarget) (*OperationLease, error) {
+func (noopManager) BeforeMemoryDelete(context.Context, Subject) (*OperationLease, error) {
 	return nil, nil
 }
 func (noopManager) AfterMemoryDeleteSuccess(context.Context, *OperationLease, MemoryDeleteResult) error {
@@ -67,14 +66,14 @@ func (noopManager) AfterMemoryDeleteFailure(context.Context, *OperationLease, er
 func (m *manager) Enabled() bool { return true }
 
 func (m *manager) BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error) {
-	return m.reserve(ctx, subject, MeterRecalls, 1, false)
+	return m.reserve(ctx, subject, MeterMemoryRecallRequests, 1)
 }
 
 func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error {
 	if lease == nil || !lease.Reserved {
 		return nil
 	}
-	event := m.consoleMeteringEvent(lease, EventTypeRecall, result.AgentName, result.MemoryIDs, lease.Units)
+	event := m.consoleMeteringEvent(lease, EventTypeMemoryRecall, result.AgentName, result.MemoryIDs, lease.Units, nil)
 	if err := m.storeCommitPending(ctx, lease, event); err != nil {
 		return m.commitReservationWithoutOutbox(ctx, lease, event, err)
 	}
@@ -93,15 +92,15 @@ func (m *manager) AfterRecallFailure(ctx context.Context, lease *OperationLease,
 	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("recallFailed", cause))
 }
 
-func (m *manager) BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error) {
-	return m.reserve(ctx, subject, MeterMemorySlots, units, true)
+func (m *manager) BeforeMemoryCreate(ctx context.Context, subject Subject, _ int64) (*OperationLease, error) {
+	return m.reserve(ctx, subject, MeterMemoryWriteRequests, 1)
 }
 
 func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error {
 	if lease == nil || !lease.Reserved {
 		return nil
 	}
-	event := m.consoleMeteringEvent(lease, EventTypeMemoryCreated, result.AgentName, result.MemoryIDs, lease.Units)
+	event := m.consoleMeteringEvent(lease, EventTypeMemoryCreated, result.AgentName, result.MemoryIDs, lease.Units, objectsAffectedMetadata(result.ObjectsAffected))
 	if err := m.storeCommitPending(ctx, lease, event); err != nil {
 		return m.commitReservationWithoutOutbox(ctx, lease, event, err)
 	}
@@ -120,53 +119,19 @@ func (m *manager) AfterMemoryCreateFailure(ctx context.Context, lease *Operation
 	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("memoryCreateFailed", cause))
 }
 
-func (m *manager) BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error) {
-	operationID, err := newOperationID()
-	if err != nil {
-		return nil, err
-	}
-	lease := &OperationLease{
-		OperationID: operationID,
-		Subject:     subject,
-		Meter:       MeterMemorySlots,
-		Units:       0,
-		Reserved:    false,
-	}
-	if m.outbox != nil {
-		expiresAt := m.now().UTC().Add(m.cfg.OperationTTL)
-		if m.cfg.OperationTTL <= 0 {
-			expiresAt = m.now().UTC().Add(30 * time.Minute)
-		}
-		if err := m.outbox.StoreAdjustmentIntent(ctx, lease, target, expiresAt); err != nil {
-			return nil, err
-		}
-	}
-	return lease, nil
+func (m *manager) BeforeMemoryDelete(ctx context.Context, subject Subject) (*OperationLease, error) {
+	return m.reserve(ctx, subject, MeterMemoryWriteRequests, 1)
 }
 
 func (m *manager) AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error {
-	if lease == nil || result.MemorySlotsDelta == 0 {
-		if lease != nil && m.outbox != nil {
-			if err := m.outbox.StoreAdjustmentDone(ctx, lease.OperationID, "noMemorySlotsDeleted"); err != nil {
-				return err
-			}
-		}
+	if lease == nil || !lease.Reserved {
 		return nil
 	}
-	if result.MemorySlotsDelta > 0 {
-		return m.rejectPositiveDeleteDelta(ctx, lease, result.MemorySlotsDelta)
+	event := m.consoleMeteringEvent(lease, EventTypeMemoryDeleted, result.AgentName, result.MemoryIDs, lease.Units, objectsAffectedMetadata(result.ObjectsAffected))
+	if err := m.storeCommitPending(ctx, lease, event); err != nil {
+		return m.commitReservationWithoutOutbox(ctx, lease, event, err)
 	}
-	adj := Adjustment{
-		OperationID: lease.OperationID,
-		Meter:       MeterMemorySlots,
-		Delta:       result.MemorySlotsDelta,
-		Reason:      "memoryDeleted",
-	}
-	event := m.consoleMeteringEvent(lease, EventTypeMemoryDeleted, result.AgentName, result.MemoryIDs, result.MemorySlotsDelta)
-	if err := m.storeAdjustmentPending(ctx, lease, adj, event); err != nil {
-		return m.applyAdjustmentWithoutOutbox(ctx, lease, adj, event, err)
-	}
-	if err := m.client.ApplyAdjustment(ctx, lease.Subject, adj); err != nil {
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
 		if m.outbox != nil {
 			return nil
@@ -178,71 +143,11 @@ func (m *manager) AfterMemoryDeleteSuccess(ctx context.Context, lease *Operation
 }
 
 func (m *manager) AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error) {
-	if lease == nil || m.outbox == nil {
-		return
-	}
-	if errors.Is(cause, domain.ErrNotFound) {
-		if err := m.outbox.StoreAdjustmentDone(ctx, lease.OperationID, "memoryDeleteNotFound"); err != nil {
-			m.logger.WarnContext(ctx, "runtime usage adjustment intent cleanup failed",
-				"operation_id", lease.OperationID,
-				"tenant_id", lease.Subject.TenantID,
-				"cluster_id", lease.Subject.ClusterID,
-				"err", err,
-			)
-		}
-		return
-	}
-	reason := "memory delete failed before quota delta was known"
-	if cause != nil {
-		reason = cause.Error()
-	}
-	if err := m.outbox.MarkUnknownAfterCrash(ctx, lease.OperationID, reason); err != nil {
-		m.logger.WarnContext(ctx, "runtime usage adjustment intent unknown mark failed",
-			"operation_id", lease.OperationID,
-			"tenant_id", lease.Subject.TenantID,
-			"cluster_id", lease.Subject.ClusterID,
-			"err", err,
-		)
-	}
-	metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("memory_delete_failed_unknown").Inc()
-	metrics.RuntimeUsageReservationUnknownTotal.WithLabelValues(outboxPhaseAdjustmentIntent).Inc()
-	m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage memory delete failed before quota delta was known",
-		"operation_id", lease.OperationID,
-		"tenant_id", lease.Subject.TenantID,
-		"cluster_id", lease.Subject.ClusterID,
-		"err", cause,
-	)
+	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("memoryDeleteFailed", cause))
 }
 
-func (m *manager) rejectPositiveDeleteDelta(ctx context.Context, lease *OperationLease, delta int64) error {
-	err := fmt.Errorf("runtime usage memory delete delta must be non-positive: %d", delta)
-	if lease == nil || m.outbox == nil {
-		return err
-	}
-	if markErr := m.outbox.MarkUnknownAfterCrash(ctx, lease.OperationID, err.Error()); markErr != nil {
-		m.logger.WarnContext(ctx, "runtime usage positive delete delta unknown mark failed",
-			"operation_id", lease.OperationID,
-			"tenant_id", lease.Subject.TenantID,
-			"cluster_id", lease.Subject.ClusterID,
-			"memory_slots_delta", delta,
-			"err", markErr,
-		)
-	}
-	metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("memory_delete_positive_delta").Inc()
-	metrics.RuntimeUsageReservationUnknownTotal.WithLabelValues(outboxPhaseAdjustmentIntent).Inc()
-	m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage memory delete delta was positive",
-		"operation_id", lease.OperationID,
-		"tenant_id", lease.Subject.TenantID,
-		"cluster_id", lease.Subject.ClusterID,
-		"memory_slots_delta", delta,
-	)
-	return err
-}
-
-func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64, storeActive bool) (*OperationLease, error) {
-	if units <= 0 {
-		return nil, errors.New("runtime usage reserve units must be positive")
-	}
+func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64) (*OperationLease, error) {
+	units = 1
 	operationID, err := newOperationID()
 	if err != nil {
 		return nil, err
@@ -254,7 +159,7 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		Units:       units,
 		Reserved:    true,
 	}
-	reservation, err := m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
+	_, err = m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
 	if err != nil {
 		var denied *QuotaDeniedError
 		if errors.As(err, &denied) {
@@ -276,13 +181,6 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 			return lease, nil
 		}
 		return nil, err
-	}
-	if storeActive && m.outbox != nil {
-		expiresAt := reservationExpiresAt(reservation, m.now().UTC(), m.cfg.ReservationTTL)
-		if err := m.outbox.StoreReservedActive(ctx, lease, reservation, expiresAt); err != nil {
-			m.release(ctx, lease, reservationReleaseOperationAbandoned, fmt.Sprintf("reservedActiveOutboxFailed: %v", err))
-			return nil, &UnavailableError{Err: err}
-		}
 	}
 	return lease, nil
 }
@@ -326,8 +224,8 @@ func (m *manager) release(ctx context.Context, lease *OperationLease, reason str
 	}
 }
 
-func (m *manager) consoleMeteringEvent(lease *OperationLease, eventType, agentName string, memoryIDs []string, units int64) MeteringEvent {
-	occurredAt := m.now().UTC()
+func (m *manager) consoleMeteringEvent(lease *OperationLease, eventType, agentName string, memoryIDs []string, units int64, metadata map[string]any) MeteringEvent {
+	occurredAt := m.now().UTC().Truncate(time.Second)
 	return MeteringEvent{
 		EventType:  eventType,
 		Meter:      lease.Meter,
@@ -335,6 +233,7 @@ func (m *manager) consoleMeteringEvent(lease *OperationLease, eventType, agentNa
 		OccurredAt: occurredAt,
 		AgentName:  agentName,
 		MemoryIDs:  append([]string(nil), memoryIDs...),
+		Metadata:   cloneMetadata(metadata),
 	}
 }
 
@@ -354,6 +253,7 @@ func (m *manager) recordConsoleMetering(lease *OperationLease, event MeteringEve
 		Units:         event.Units,
 		OccurredAt:    event.OccurredAt,
 		MemoryIDs:     append([]string(nil), event.MemoryIDs...),
+		Metadata:      cloneMetadata(event.Metadata),
 	})
 }
 
@@ -369,26 +269,7 @@ func (m *manager) commitReservationWithoutOutbox(ctx context.Context, lease *Ope
 		)
 		return fmt.Errorf("runtime usage commit not durable: outbox: %v; finalize: %w", outboxErr, err)
 	}
-	if lease.Meter == MeterMemorySlots {
-		m.markDoneBestEffort(ctx, lease, "quotaFinalizedWithoutOutbox")
-	}
-	m.recordConsoleMetering(lease, event)
-	return nil
-}
-
-func (m *manager) applyAdjustmentWithoutOutbox(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent, outboxErr error) error {
-	if err := m.client.ApplyAdjustment(ctx, lease.Subject, adj); err != nil {
-		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("adjustment_after_outbox_failed").Inc()
-		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage adjustment failed after outbox failure",
-			"operation_id", lease.OperationID,
-			"tenant_id", lease.Subject.TenantID,
-			"cluster_id", lease.Subject.ClusterID,
-			"outbox_err", outboxErr,
-			"err", err,
-		)
-		return fmt.Errorf("runtime usage adjustment not durable: outbox: %v; apply: %w", outboxErr, err)
-	}
-	m.markDoneBestEffort(ctx, lease, "quotaAdjustedWithoutOutbox")
+	m.markDoneBestEffort(ctx, lease, "quotaFinalizedWithoutOutbox")
 	m.recordConsoleMetering(lease, event)
 	return nil
 }
@@ -414,23 +295,6 @@ func (m *manager) storeCommitPending(ctx context.Context, lease *OperationLease,
 	if err := m.outbox.StoreCommitPending(ctx, lease, event); err != nil {
 		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("commit_pending_outbox_failed").Inc()
 		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage commit pending outbox failed",
-			"operation_id", lease.OperationID,
-			"tenant_id", lease.Subject.TenantID,
-			"cluster_id", lease.Subject.ClusterID,
-			"err", err,
-		)
-		return err
-	}
-	return nil
-}
-
-func (m *manager) storeAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error {
-	if m.outbox == nil {
-		return nil
-	}
-	if err := m.outbox.StoreAdjustmentPending(ctx, lease, adj, event); err != nil {
-		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("adjustment_pending_outbox_failed").Inc()
-		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage adjustment pending outbox failed",
 			"operation_id", lease.OperationID,
 			"tenant_id", lease.Subject.TenantID,
 			"cluster_id", lease.Subject.ClusterID,
@@ -473,14 +337,22 @@ func releaseDetail(prefix string, cause error) string {
 	return fmt.Sprintf("%s: %v", prefix, cause)
 }
 
-func reservationExpiresAt(reservation *Reservation, now time.Time, fallback time.Duration) time.Time {
-	if reservation != nil && !reservation.ExpiresAt.IsZero() {
-		return reservation.ExpiresAt.UTC()
+func objectsAffectedMetadata(objectsAffected int64) map[string]any {
+	if objectsAffected <= 0 {
+		return nil
 	}
-	if fallback <= 0 {
-		fallback = 30 * time.Minute
+	return map[string]any{"objectsAffected": objectsAffected}
+}
+
+func cloneMetadata(metadata map[string]any) map[string]any {
+	if len(metadata) == 0 {
+		return nil
 	}
-	return now.Add(fallback)
+	out := make(map[string]any, len(metadata))
+	for k, v := range metadata {
+		out[k] = v
+	}
+	return out
 }
 
 func newOperationID() (string, error) {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -67,7 +67,7 @@ func (noopManager) AfterMemoryDeleteFailure(context.Context, *OperationLease, er
 func (m *manager) Enabled() bool { return true }
 
 func (m *manager) BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error) {
-	return m.reserve(ctx, subject, MeterRecalls, 1)
+	return m.reserve(ctx, subject, MeterRecalls, 1, false)
 }
 
 func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error {
@@ -94,7 +94,7 @@ func (m *manager) AfterRecallFailure(ctx context.Context, lease *OperationLease,
 }
 
 func (m *manager) BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error) {
-	return m.reserve(ctx, subject, MeterMemorySlots, units)
+	return m.reserve(ctx, subject, MeterMemorySlots, units, true)
 }
 
 func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error {
@@ -239,7 +239,7 @@ func (m *manager) rejectPositiveDeleteDelta(ctx context.Context, lease *Operatio
 	return err
 }
 
-func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64) (*OperationLease, error) {
+func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64, storeActive bool) (*OperationLease, error) {
 	if units <= 0 {
 		return nil, errors.New("runtime usage reserve units must be positive")
 	}
@@ -254,7 +254,7 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		Units:       units,
 		Reserved:    true,
 	}
-	_, err = m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
+	reservation, err := m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
 	if err != nil {
 		var denied *QuotaDeniedError
 		if errors.As(err, &denied) {
@@ -276,6 +276,13 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 			return lease, nil
 		}
 		return nil, err
+	}
+	if storeActive && m.outbox != nil {
+		expiresAt := reservationExpiresAt(reservation, m.now().UTC(), m.cfg.ReservationTTL)
+		if err := m.outbox.StoreReservedActive(ctx, lease, reservation, expiresAt); err != nil {
+			m.release(ctx, lease, reservationReleaseOperationAbandoned, fmt.Sprintf("reservedActiveOutboxFailed: %v", err))
+			return nil, &UnavailableError{Err: err}
+		}
 	}
 	return lease, nil
 }
@@ -362,6 +369,9 @@ func (m *manager) commitReservationWithoutOutbox(ctx context.Context, lease *Ope
 		)
 		return fmt.Errorf("runtime usage commit not durable: outbox: %v; finalize: %w", outboxErr, err)
 	}
+	if lease.Meter == MeterMemorySlots {
+		m.markDoneBestEffort(ctx, lease, "quotaFinalizedWithoutOutbox")
+	}
 	m.recordConsoleMetering(lease, event)
 	return nil
 }
@@ -378,8 +388,23 @@ func (m *manager) applyAdjustmentWithoutOutbox(ctx context.Context, lease *Opera
 		)
 		return fmt.Errorf("runtime usage adjustment not durable: outbox: %v; apply: %w", outboxErr, err)
 	}
+	m.markDoneBestEffort(ctx, lease, "quotaAdjustedWithoutOutbox")
 	m.recordConsoleMetering(lease, event)
 	return nil
+}
+
+func (m *manager) markDoneBestEffort(ctx context.Context, lease *OperationLease, reason string) {
+	if m.outbox == nil || lease == nil {
+		return
+	}
+	if err := m.outbox.MarkOperationDone(ctx, lease.OperationID, reason); err != nil {
+		m.logger.WarnContext(ctx, "runtime usage outbox done update failed after direct finalization",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"err", err,
+		)
+	}
 }
 
 func (m *manager) storeCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error {
@@ -446,6 +471,16 @@ func releaseDetail(prefix string, cause error) string {
 		return prefix
 	}
 	return fmt.Sprintf("%s: %v", prefix, cause)
+}
+
+func reservationExpiresAt(reservation *Reservation, now time.Time, fallback time.Duration) time.Time {
+	if reservation != nil && !reservation.ExpiresAt.IsZero() {
+		return reservation.ExpiresAt.UTC()
+	}
+	if fallback <= 0 {
+		fallback = 30 * time.Minute
+	}
+	return now.Add(fallback)
 }
 
 func newOperationID() (string, error) {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -1,0 +1,357 @@
+package runtimeusage
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/qiffang/mnemos/server/internal/metering"
+	"github.com/qiffang/mnemos/server/internal/metrics"
+)
+
+type manager struct {
+	cfg      Config
+	client   QuotaClient
+	metering metering.Writer
+	outbox   OutboxStore
+	logger   *slog.Logger
+	now      func() time.Time
+}
+
+func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *slog.Logger) Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !cfg.Enabled {
+		return noopManager{}
+	}
+	return &manager{
+		cfg:      cfg,
+		client:   client,
+		metering: writer,
+		outbox:   cfg.Outbox,
+		logger:   logger,
+		now:      time.Now,
+	}
+}
+
+type noopManager struct{}
+
+func (noopManager) Enabled() bool { return false }
+func (noopManager) BeforeRecall(context.Context, Subject) (*OperationLease, error) {
+	return nil, nil
+}
+func (noopManager) AfterRecallSuccess(context.Context, *OperationLease, RecallResult) error {
+	return nil
+}
+func (noopManager) AfterRecallFailure(context.Context, *OperationLease, error) {}
+func (noopManager) BeforeMemoryCreate(context.Context, Subject, int64) (*OperationLease, error) {
+	return nil, nil
+}
+func (noopManager) AfterMemoryCreateSuccess(context.Context, *OperationLease, MemoryCreateResult) error {
+	return nil
+}
+func (noopManager) AfterMemoryCreateFailure(context.Context, *OperationLease, error) {}
+func (noopManager) BeforeMemoryDelete(context.Context, Subject, MemoryDeleteTarget) (*OperationLease, error) {
+	return nil, nil
+}
+func (noopManager) AfterMemoryDeleteSuccess(context.Context, *OperationLease, MemoryDeleteResult) error {
+	return nil
+}
+func (noopManager) AfterMemoryDeleteFailure(context.Context, *OperationLease, error) {}
+
+func (m *manager) Enabled() bool { return true }
+
+func (m *manager) BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error) {
+	return m.reserve(ctx, subject, MeterRecalls, 1)
+}
+
+func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error {
+	if lease == nil || !lease.Reserved {
+		return nil
+	}
+	event := m.consoleMeteringEvent(lease, EventTypeRecall, result.AgentName, result.MemoryIDs, lease.Units)
+	if err := m.storeCommitPending(ctx, lease, event); err != nil {
+		return err
+	}
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "recallCompleted"); err != nil {
+		m.markRetryable(ctx, lease.OperationID, err)
+		return err
+	}
+	m.recordConsoleMetering(lease, event)
+	return nil
+}
+
+func (m *manager) AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error) {
+	m.release(ctx, lease, "recallFailed")
+}
+
+func (m *manager) BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error) {
+	return m.reserve(ctx, subject, MeterMemorySlots, units)
+}
+
+func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error {
+	if lease == nil || !lease.Reserved {
+		return nil
+	}
+	event := m.consoleMeteringEvent(lease, EventTypeMemoryCreated, result.AgentName, result.MemoryIDs, lease.Units)
+	if err := m.storeCommitPending(ctx, lease, event); err != nil {
+		return err
+	}
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "memoryCreated"); err != nil {
+		m.markRetryable(ctx, lease.OperationID, err)
+		return err
+	}
+	m.recordConsoleMetering(lease, event)
+	return nil
+}
+
+func (m *manager) AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error) {
+	m.release(ctx, lease, "memoryCreateFailed")
+}
+
+func (m *manager) BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error) {
+	operationID, err := newOperationID()
+	if err != nil {
+		return nil, err
+	}
+	lease := &OperationLease{
+		OperationID: operationID,
+		Subject:     subject,
+		Meter:       MeterMemorySlots,
+		Units:       0,
+		Reserved:    false,
+	}
+	if m.outbox != nil {
+		expiresAt := m.now().UTC().Add(m.cfg.OperationTTL)
+		if m.cfg.OperationTTL <= 0 {
+			expiresAt = m.now().UTC().Add(30 * time.Minute)
+		}
+		if err := m.outbox.StoreAdjustmentIntent(ctx, lease, target, expiresAt); err != nil {
+			return nil, err
+		}
+	}
+	return lease, nil
+}
+
+func (m *manager) AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error {
+	if lease == nil || result.MemorySlotsDelta == 0 {
+		if lease != nil && m.outbox != nil {
+			if err := m.outbox.StoreAdjustmentDone(ctx, lease.OperationID, "noMemorySlotsDeleted"); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	adj := Adjustment{
+		OperationID: lease.OperationID,
+		Meter:       MeterMemorySlots,
+		Delta:       result.MemorySlotsDelta,
+		Reason:      "memoryDeleted",
+	}
+	event := m.consoleMeteringEvent(lease, EventTypeMemoryDeleted, result.AgentName, result.MemoryIDs, result.MemorySlotsDelta)
+	if err := m.storeAdjustmentPending(ctx, lease, adj, event); err != nil {
+		return err
+	}
+	if err := m.client.ApplyAdjustment(ctx, lease.Subject, adj); err != nil {
+		m.markRetryable(ctx, lease.OperationID, err)
+		return err
+	}
+	m.recordConsoleMetering(lease, event)
+	return nil
+}
+
+func (m *manager) AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error) {
+	if lease == nil || m.outbox == nil {
+		return
+	}
+	if err := m.outbox.StoreAdjustmentDone(ctx, lease.OperationID, "memoryDeleteFailed"); err != nil {
+		m.logger.WarnContext(ctx, "runtime usage adjustment intent cleanup failed",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"err", err,
+		)
+	}
+}
+
+func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64) (*OperationLease, error) {
+	if units <= 0 {
+		return nil, errors.New("runtime usage reserve units must be positive")
+	}
+	operationID, err := newOperationID()
+	if err != nil {
+		return nil, err
+	}
+	lease := &OperationLease{
+		OperationID: operationID,
+		Subject:     subject,
+		Meter:       meter,
+		Units:       units,
+		Reserved:    true,
+	}
+	reservation, err := m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
+	if err != nil {
+		var denied *QuotaDeniedError
+		if errors.As(err, &denied) {
+			return nil, err
+		}
+		var conflict *ConflictError
+		if errors.As(err, &conflict) {
+			return nil, err
+		}
+		if m.cfg.FailOpen {
+			m.logger.WarnContext(ctx, "runtime usage reserve failed open",
+				"operation_id", operationID,
+				"tenant_id", subject.TenantID,
+				"cluster_id", subject.ClusterID,
+				"meter", meter,
+				"err", err,
+			)
+			lease.Reserved = false
+			return lease, nil
+		}
+		return nil, err
+	}
+	if m.outbox != nil {
+		expiresAt := reservationExpiresAt(reservation, m.now().UTC(), m.cfg.ReservationTTL)
+		if err := m.outbox.StoreReservedActive(ctx, lease, reservation, expiresAt); err != nil {
+			m.release(ctx, lease, "outboxStoreFailed")
+			return nil, &UnavailableError{Err: err}
+		}
+	}
+	return lease, nil
+}
+
+func (m *manager) release(ctx context.Context, lease *OperationLease, reason string) {
+	if lease == nil || !lease.Reserved {
+		return
+	}
+	if m.outbox != nil {
+		if err := m.outbox.StoreReleasePending(ctx, lease, reason); err != nil {
+			m.logger.WarnContext(ctx, "runtime usage release pending outbox failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", lease.Subject.TenantID,
+				"cluster_id", lease.Subject.ClusterID,
+				"err", err,
+			)
+		}
+	}
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusReleased, reason); err != nil {
+		m.markRetryable(ctx, lease.OperationID, err)
+		m.logger.WarnContext(ctx, "runtime usage release failed",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"err", err,
+		)
+		return
+	}
+	if m.outbox != nil {
+		if err := m.outbox.MarkOperationDone(ctx, lease.OperationID, "reservationReleased"); err != nil {
+			m.logger.WarnContext(ctx, "runtime usage release done outbox failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", lease.Subject.TenantID,
+				"cluster_id", lease.Subject.ClusterID,
+				"err", err,
+			)
+		}
+	}
+}
+
+func (m *manager) consoleMeteringEvent(lease *OperationLease, eventType, agentName string, memoryIDs []string, units int64) MeteringEvent {
+	occurredAt := m.now().UTC()
+	return MeteringEvent{
+		EventType:  eventType,
+		Meter:      lease.Meter,
+		Units:      units,
+		OccurredAt: occurredAt,
+		AgentName:  agentName,
+		MemoryIDs:  append([]string(nil), memoryIDs...),
+	}
+}
+
+func (m *manager) recordConsoleMetering(lease *OperationLease, event MeteringEvent) {
+	if m.metering == nil || lease == nil || event.Units == 0 {
+		return
+	}
+	m.metering.Record(metering.Event{
+		Category:      "runtime-usage",
+		TenantID:      lease.Subject.TenantID,
+		ClusterID:     lease.Subject.ClusterID,
+		AgentID:       event.AgentName,
+		OperationID:   lease.OperationID,
+		APIKeySubject: lease.Subject.APIKeySubject,
+		EventType:     event.EventType,
+		Meter:         event.Meter,
+		Units:         event.Units,
+		OccurredAt:    event.OccurredAt,
+		MemoryIDs:     append([]string(nil), event.MemoryIDs...),
+	})
+}
+
+func (m *manager) storeCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error {
+	if m.outbox == nil {
+		return nil
+	}
+	if err := m.outbox.StoreCommitPending(ctx, lease, event); err != nil {
+		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("commit_pending_outbox_failed").Inc()
+		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage commit pending outbox failed",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"err", err,
+		)
+		return err
+	}
+	return nil
+}
+
+func (m *manager) storeAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error {
+	if m.outbox == nil {
+		return nil
+	}
+	if err := m.outbox.StoreAdjustmentPending(ctx, lease, adj, event); err != nil {
+		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("adjustment_pending_outbox_failed").Inc()
+		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage adjustment pending outbox failed",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"err", err,
+		)
+		return err
+	}
+	return nil
+}
+
+func (m *manager) markRetryable(ctx context.Context, operationID string, err error) {
+	if m.outbox == nil || operationID == "" || err == nil {
+		return
+	}
+	if markErr := m.outbox.MarkOperationRetryableFailure(ctx, operationID, err.Error()); markErr != nil {
+		m.logger.WarnContext(ctx, "runtime usage retryable outbox update failed",
+			"operation_id", operationID,
+			"err", markErr,
+		)
+	}
+}
+
+func reservationExpiresAt(reservation *Reservation, now time.Time, fallback time.Duration) time.Time {
+	if reservation != nil && !reservation.ExpiresAt.IsZero() {
+		return reservation.ExpiresAt.UTC()
+	}
+	if fallback <= 0 {
+		fallback = 30 * time.Minute
+	}
+	return now.Add(fallback)
+}
+
+func newOperationID() (string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
+}

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -79,6 +79,9 @@ func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease,
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "recallCompleted"); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
+		if m.outbox != nil {
+			return nil
+		}
 		return err
 	}
 	m.recordConsoleMetering(lease, event)
@@ -104,6 +107,9 @@ func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *Operation
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "memoryCreated"); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
+		if m.outbox != nil {
+			return nil
+		}
 		return err
 	}
 	m.recordConsoleMetering(lease, event)
@@ -159,6 +165,9 @@ func (m *manager) AfterMemoryDeleteSuccess(ctx context.Context, lease *Operation
 	}
 	if err := m.client.ApplyAdjustment(ctx, lease.Subject, adj); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
+		if m.outbox != nil {
+			return nil
+		}
 		return err
 	}
 	m.recordConsoleMetering(lease, event)

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -74,6 +74,7 @@ func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease,
 	}
 	event := m.consoleMeteringEvent(lease, EventTypeRecall, result.AgentName, result.MemoryIDs, lease.Units)
 	if err := m.storeCommitPending(ctx, lease, event); err != nil {
+		m.release(ctx, lease, "recallCommitPendingFailed")
 		return err
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "recallCompleted"); err != nil {
@@ -98,6 +99,7 @@ func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *Operation
 	}
 	event := m.consoleMeteringEvent(lease, EventTypeMemoryCreated, result.AgentName, result.MemoryIDs, lease.Units)
 	if err := m.storeCommitPending(ctx, lease, event); err != nil {
+		m.release(ctx, lease, "memoryCreateCommitPendingFailed")
 		return err
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "memoryCreated"); err != nil {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -78,7 +78,7 @@ func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease,
 		m.release(ctx, lease, "recallCommitPendingFailed")
 		return err
 	}
-	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "recallCompleted"); err != nil {
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
 		if m.outbox != nil {
 			return nil
@@ -106,7 +106,7 @@ func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *Operation
 		m.release(ctx, lease, "memoryCreateCommitPendingFailed")
 		return err
 	}
-	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, "memoryCreated"); err != nil {
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
 		if m.outbox != nil {
 			return nil

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -55,6 +55,13 @@ func (noopManager) AfterMemoryCreateSuccess(context.Context, *OperationLease, Me
 	return nil
 }
 func (noopManager) AfterMemoryCreateFailure(context.Context, *OperationLease, error) {}
+func (noopManager) BeforeMemoryUpdate(context.Context, Subject) (*OperationLease, error) {
+	return nil, nil
+}
+func (noopManager) AfterMemoryUpdateSuccess(context.Context, *OperationLease, MemoryUpdateResult) error {
+	return nil
+}
+func (noopManager) AfterMemoryUpdateFailure(context.Context, *OperationLease, error) {}
 func (noopManager) BeforeMemoryDelete(context.Context, Subject) (*OperationLease, error) {
 	return nil, nil
 }
@@ -117,6 +124,33 @@ func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *Operation
 
 func (m *manager) AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error) {
 	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("memoryCreateFailed", cause))
+}
+
+func (m *manager) BeforeMemoryUpdate(ctx context.Context, subject Subject) (*OperationLease, error) {
+	return m.reserve(ctx, subject, MeterMemoryWriteRequests, 1)
+}
+
+func (m *manager) AfterMemoryUpdateSuccess(ctx context.Context, lease *OperationLease, result MemoryUpdateResult) error {
+	if lease == nil || !lease.Reserved {
+		return nil
+	}
+	event := m.consoleMeteringEvent(lease, EventTypeMemoryUpdated, result.AgentName, result.MemoryIDs, lease.Units, objectsAffectedMetadata(result.ObjectsAffected))
+	if err := m.storeCommitPending(ctx, lease, event); err != nil {
+		return m.commitReservationWithoutOutbox(ctx, lease, event, err)
+	}
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
+		m.markRetryable(ctx, lease.OperationID, err)
+		if m.outbox != nil {
+			return nil
+		}
+		return err
+	}
+	m.recordConsoleMetering(lease, event)
+	return nil
+}
+
+func (m *manager) AfterMemoryUpdateFailure(ctx context.Context, lease *OperationLease, cause error) {
+	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("memoryUpdateFailed", cause))
 }
 
 func (m *manager) BeforeMemoryDelete(ctx context.Context, subject Subject) (*OperationLease, error) {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -3,6 +3,7 @@ package runtimeusage
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -154,6 +155,9 @@ func (m *manager) AfterMemoryDeleteSuccess(ctx context.Context, lease *Operation
 		}
 		return nil
 	}
+	if result.MemorySlotsDelta > 0 {
+		return m.rejectPositiveDeleteDelta(ctx, lease, result.MemorySlotsDelta)
+	}
 	adj := Adjustment{
 		OperationID: lease.OperationID,
 		Meter:       MeterMemorySlots,
@@ -210,6 +214,31 @@ func (m *manager) AfterMemoryDeleteFailure(ctx context.Context, lease *Operation
 		"cluster_id", lease.Subject.ClusterID,
 		"err", cause,
 	)
+}
+
+func (m *manager) rejectPositiveDeleteDelta(ctx context.Context, lease *OperationLease, delta int64) error {
+	err := fmt.Errorf("runtime usage memory delete delta must be non-positive: %d", delta)
+	if lease == nil || m.outbox == nil {
+		return err
+	}
+	if markErr := m.outbox.MarkUnknownAfterCrash(ctx, lease.OperationID, err.Error()); markErr != nil {
+		m.logger.WarnContext(ctx, "runtime usage positive delete delta unknown mark failed",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"memory_slots_delta", delta,
+			"err", markErr,
+		)
+	}
+	metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("memory_delete_positive_delta").Inc()
+	metrics.RuntimeUsageReservationUnknownTotal.WithLabelValues(outboxPhaseAdjustmentIntent).Inc()
+	m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage memory delete delta was positive",
+		"operation_id", lease.OperationID,
+		"tenant_id", lease.Subject.TenantID,
+		"cluster_id", lease.Subject.ClusterID,
+		"memory_slots_delta", delta,
+	)
+	return err
 }
 
 func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64) (*OperationLease, error) {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metering"
 	"github.com/qiffang/mnemos/server/internal/metrics"
 )
@@ -178,14 +179,37 @@ func (m *manager) AfterMemoryDeleteFailure(ctx context.Context, lease *Operation
 	if lease == nil || m.outbox == nil {
 		return
 	}
-	if err := m.outbox.StoreAdjustmentDone(ctx, lease.OperationID, "memoryDeleteFailed"); err != nil {
-		m.logger.WarnContext(ctx, "runtime usage adjustment intent cleanup failed",
+	if errors.Is(cause, domain.ErrNotFound) {
+		if err := m.outbox.StoreAdjustmentDone(ctx, lease.OperationID, "memoryDeleteNotFound"); err != nil {
+			m.logger.WarnContext(ctx, "runtime usage adjustment intent cleanup failed",
+				"operation_id", lease.OperationID,
+				"tenant_id", lease.Subject.TenantID,
+				"cluster_id", lease.Subject.ClusterID,
+				"err", err,
+			)
+		}
+		return
+	}
+	reason := "memory delete failed before quota delta was known"
+	if cause != nil {
+		reason = cause.Error()
+	}
+	if err := m.outbox.MarkUnknownAfterCrash(ctx, lease.OperationID, reason); err != nil {
+		m.logger.WarnContext(ctx, "runtime usage adjustment intent unknown mark failed",
 			"operation_id", lease.OperationID,
 			"tenant_id", lease.Subject.TenantID,
 			"cluster_id", lease.Subject.ClusterID,
 			"err", err,
 		)
 	}
+	metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("memory_delete_failed_unknown").Inc()
+	metrics.RuntimeUsageReservationUnknownTotal.WithLabelValues(outboxPhaseAdjustmentIntent).Inc()
+	m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage memory delete failed before quota delta was known",
+		"operation_id", lease.OperationID,
+		"tenant_id", lease.Subject.TenantID,
+		"cluster_id", lease.Subject.ClusterID,
+		"err", cause,
+	)
 }
 
 func (m *manager) reserve(ctx context.Context, subject Subject, meter string, units int64) (*OperationLease, error) {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -76,8 +76,7 @@ func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease,
 	}
 	event := m.consoleMeteringEvent(lease, EventTypeRecall, result.AgentName, result.MemoryIDs, lease.Units)
 	if err := m.storeCommitPending(ctx, lease, event); err != nil {
-		m.release(ctx, lease, "recallCommitPendingFailed")
-		return err
+		return m.commitReservationWithoutOutbox(ctx, lease, event, err)
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
@@ -91,7 +90,7 @@ func (m *manager) AfterRecallSuccess(ctx context.Context, lease *OperationLease,
 }
 
 func (m *manager) AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error) {
-	m.release(ctx, lease, "recallFailed")
+	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("recallFailed", cause))
 }
 
 func (m *manager) BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error) {
@@ -104,8 +103,7 @@ func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *Operation
 	}
 	event := m.consoleMeteringEvent(lease, EventTypeMemoryCreated, result.AgentName, result.MemoryIDs, lease.Units)
 	if err := m.storeCommitPending(ctx, lease, event); err != nil {
-		m.release(ctx, lease, "memoryCreateCommitPendingFailed")
-		return err
+		return m.commitReservationWithoutOutbox(ctx, lease, event, err)
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
@@ -119,7 +117,7 @@ func (m *manager) AfterMemoryCreateSuccess(ctx context.Context, lease *Operation
 }
 
 func (m *manager) AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error) {
-	m.release(ctx, lease, "memoryCreateFailed")
+	m.release(ctx, lease, reservationReleaseReason(cause), releaseDetail("memoryCreateFailed", cause))
 }
 
 func (m *manager) BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error) {
@@ -166,7 +164,7 @@ func (m *manager) AfterMemoryDeleteSuccess(ctx context.Context, lease *Operation
 	}
 	event := m.consoleMeteringEvent(lease, EventTypeMemoryDeleted, result.AgentName, result.MemoryIDs, result.MemorySlotsDelta)
 	if err := m.storeAdjustmentPending(ctx, lease, adj, event); err != nil {
-		return err
+		return m.applyAdjustmentWithoutOutbox(ctx, lease, adj, event, err)
 	}
 	if err := m.client.ApplyAdjustment(ctx, lease.Subject, adj); err != nil {
 		m.markRetryable(ctx, lease.OperationID, err)
@@ -256,7 +254,7 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		Units:       units,
 		Reserved:    true,
 	}
-	reservation, err := m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
+	_, err = m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
 	if err != nil {
 		var denied *QuotaDeniedError
 		if errors.As(err, &denied) {
@@ -279,17 +277,10 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		}
 		return nil, err
 	}
-	if m.outbox != nil {
-		expiresAt := reservationExpiresAt(reservation, m.now().UTC(), m.cfg.ReservationTTL)
-		if err := m.outbox.StoreReservedActive(ctx, lease, reservation, expiresAt); err != nil {
-			m.release(ctx, lease, "outboxStoreFailed")
-			return nil, &UnavailableError{Err: err}
-		}
-	}
 	return lease, nil
 }
 
-func (m *manager) release(ctx context.Context, lease *OperationLease, reason string) {
+func (m *manager) release(ctx context.Context, lease *OperationLease, reason string, detail string) {
 	if lease == nil || !lease.Reserved {
 		return
 	}
@@ -301,6 +292,9 @@ func (m *manager) release(ctx context.Context, lease *OperationLease, reason str
 				"cluster_id", lease.Subject.ClusterID,
 				"err", err,
 			)
+		}
+		if detail != "" && detail != reason {
+			m.markRetryable(ctx, lease.OperationID, errors.New(detail))
 		}
 	}
 	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusReleased, reason); err != nil {
@@ -356,6 +350,38 @@ func (m *manager) recordConsoleMetering(lease *OperationLease, event MeteringEve
 	})
 }
 
+func (m *manager) commitReservationWithoutOutbox(ctx context.Context, lease *OperationLease, event MeteringEvent, outboxErr error) error {
+	if err := m.client.FinalizeReservation(ctx, lease.Subject, lease.OperationID, ReservationStatusCommitted, reservationCommitReason); err != nil {
+		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("commit_after_outbox_failed").Inc()
+		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage commit failed after outbox failure",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"outbox_err", outboxErr,
+			"err", err,
+		)
+		return fmt.Errorf("runtime usage commit not durable: outbox: %v; finalize: %w", outboxErr, err)
+	}
+	m.recordConsoleMetering(lease, event)
+	return nil
+}
+
+func (m *manager) applyAdjustmentWithoutOutbox(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent, outboxErr error) error {
+	if err := m.client.ApplyAdjustment(ctx, lease.Subject, adj); err != nil {
+		metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("adjustment_after_outbox_failed").Inc()
+		m.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage adjustment failed after outbox failure",
+			"operation_id", lease.OperationID,
+			"tenant_id", lease.Subject.TenantID,
+			"cluster_id", lease.Subject.ClusterID,
+			"outbox_err", outboxErr,
+			"err", err,
+		)
+		return fmt.Errorf("runtime usage adjustment not durable: outbox: %v; apply: %w", outboxErr, err)
+	}
+	m.recordConsoleMetering(lease, event)
+	return nil
+}
+
 func (m *manager) storeCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error {
 	if m.outbox == nil {
 		return nil
@@ -402,14 +428,24 @@ func (m *manager) markRetryable(ctx context.Context, operationID string, err err
 	}
 }
 
-func reservationExpiresAt(reservation *Reservation, now time.Time, fallback time.Duration) time.Time {
-	if reservation != nil && !reservation.ExpiresAt.IsZero() {
-		return reservation.ExpiresAt.UTC()
+func reservationReleaseReason(cause error) string {
+	switch {
+	case errors.Is(cause, context.Canceled):
+		return reservationReleaseClientCancelled
+	case errors.Is(cause, context.DeadlineExceeded):
+		return reservationReleaseTimeout
+	case cause == nil:
+		return reservationReleaseOperationAbandoned
+	default:
+		return reservationReleaseOperationFailed
 	}
-	if fallback <= 0 {
-		fallback = 30 * time.Minute
+}
+
+func releaseDetail(prefix string, cause error) string {
+	if cause == nil {
+		return prefix
 	}
-	return now.Add(fallback)
+	return fmt.Sprintf("%s: %v", prefix, cause)
 }
 
 func newOperationID() (string, error) {

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -77,6 +77,8 @@ type fakeOutboxStore struct {
 	retryable         int
 	unknown           int
 	commitErr         error
+	releaseReasons    []string
+	retryReasons      []string
 }
 
 func (s *fakeOutboxStore) StoreReservedActive(context.Context, *OperationLease, *Reservation, time.Time) error {
@@ -89,8 +91,9 @@ func (s *fakeOutboxStore) StoreCommitPending(context.Context, *OperationLease, M
 	return s.commitErr
 }
 
-func (s *fakeOutboxStore) StoreReleasePending(context.Context, *OperationLease, string) error {
+func (s *fakeOutboxStore) StoreReleasePending(_ context.Context, _ *OperationLease, reason string) error {
 	s.releasePending++
+	s.releaseReasons = append(s.releaseReasons, reason)
 	return nil
 }
 
@@ -114,8 +117,9 @@ func (s *fakeOutboxStore) MarkOperationDone(context.Context, string, string) err
 	return nil
 }
 
-func (s *fakeOutboxStore) MarkOperationRetryableFailure(context.Context, string, string) error {
+func (s *fakeOutboxStore) MarkOperationRetryableFailure(_ context.Context, _ string, reason string) error {
 	s.retryable++
+	s.retryReasons = append(s.retryReasons, reason)
 	return nil
 }
 
@@ -273,8 +277,8 @@ func TestManagerCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T
 		t.Fatalf("AfterRecallSuccess: %v", err)
 	}
 
-	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
-		t.Fatalf("outbox = %+v, want reserved, commit pending, retryable", outbox)
+	if outbox.reservedActive != 0 || outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want commit pending and retryable without active reservation write", outbox)
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
@@ -297,8 +301,8 @@ func TestManagerMemoryCreateCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(
 		t.Fatalf("AfterMemoryCreateSuccess: %v", err)
 	}
 
-	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
-		t.Fatalf("outbox = %+v, want reserved, commit pending, retryable", outbox)
+	if outbox.reservedActive != 0 || outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want commit pending and retryable without active reservation write", outbox)
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
@@ -375,7 +379,7 @@ func TestManagerAdjustmentFailureWithoutOutboxReturnsError(t *testing.T) {
 	}
 }
 
-func TestManagerRecallCommitPendingFailureReleasesReservation(t *testing.T) {
+func TestManagerRecallCommitPendingFailureCommitsDirectly(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}
 	outbox := &fakeOutboxStore{commitErr: errString("outbox unavailable")}
@@ -387,23 +391,23 @@ func TestManagerRecallCommitPendingFailureReleasesReservation(t *testing.T) {
 		t.Fatalf("BeforeRecall: %v", err)
 	}
 	err = manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
-	if err == nil {
-		t.Fatal("AfterRecallSuccess error = nil, want commit pending error")
+	if err != nil {
+		t.Fatalf("AfterRecallSuccess: %v", err)
 	}
 
-	wantFinalize := lease.OperationID + ":" + ReservationStatusReleased + ":recallCommitPendingFailed"
+	wantFinalize := lease.OperationID + ":" + ReservationStatusCommitted + ":" + reservationCommitReason
 	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
 		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
 	}
-	if outbox.releasePending != 1 || outbox.done != 1 {
-		t.Fatalf("outbox release state = %+v, want release pending and done", outbox)
+	if outbox.releasePending != 0 || outbox.done != 0 {
+		t.Fatalf("outbox release state = %+v, want no release after successful recall", outbox)
 	}
-	if len(writer.events) != 0 {
-		t.Fatalf("metering events = %+v, want none", writer.events)
+	if len(writer.events) != 1 {
+		t.Fatalf("metering events = %+v, want direct metering after commit", writer.events)
 	}
 }
 
-func TestManagerMemoryCreateCommitPendingFailureReleasesReservation(t *testing.T) {
+func TestManagerMemoryCreateCommitPendingFailureCommitsDirectly(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}
 	outbox := &fakeOutboxStore{commitErr: errString("outbox unavailable")}
@@ -415,18 +419,65 @@ func TestManagerMemoryCreateCommitPendingFailureReleasesReservation(t *testing.T
 		t.Fatalf("BeforeMemoryCreate: %v", err)
 	}
 	err = manager.AfterMemoryCreateSuccess(context.Background(), lease, MemoryCreateResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
-	if err == nil {
-		t.Fatal("AfterMemoryCreateSuccess error = nil, want commit pending error")
+	if err != nil {
+		t.Fatalf("AfterMemoryCreateSuccess: %v", err)
 	}
 
-	wantFinalize := lease.OperationID + ":" + ReservationStatusReleased + ":memoryCreateCommitPendingFailed"
+	wantFinalize := lease.OperationID + ":" + ReservationStatusCommitted + ":" + reservationCommitReason
 	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
 		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
 	}
-	if outbox.releasePending != 1 || outbox.done != 1 {
-		t.Fatalf("outbox release state = %+v, want release pending and done", outbox)
+	if outbox.releasePending != 0 || outbox.done != 0 {
+		t.Fatalf("outbox release state = %+v, want no release after successful memory create", outbox)
+	}
+	if len(writer.events) != 1 {
+		t.Fatalf("metering events = %+v, want direct metering after commit", writer.events)
+	}
+}
+
+func TestManagerCommitPendingFailureAndCommitFailureReturnsErrorWithoutRelease(t *testing.T) {
+	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{commitErr: errString("outbox unavailable")}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeRecall(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	err = manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
+	if err == nil {
+		t.Fatal("AfterRecallSuccess error = nil, want non-durable finalization error")
+	}
+	if outbox.releasePending != 0 || outbox.done != 0 {
+		t.Fatalf("outbox release state = %+v, want no release after successful recall", outbox)
 	}
 	if len(writer.events) != 0 {
-		t.Fatalf("metering events = %+v, want none", writer.events)
+		t.Fatalf("metering events = %+v, want none before durable quota commit", writer.events)
+	}
+}
+
+func TestManagerReleaseUsesConsoleSpecReason(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, &captureWriter{}, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeRecall(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	manager.AfterRecallFailure(context.Background(), lease, context.DeadlineExceeded)
+
+	wantFinalize := lease.OperationID + ":" + ReservationStatusReleased + ":" + reservationReleaseTimeout
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
+	}
+	if len(outbox.releaseReasons) != 1 || outbox.releaseReasons[0] != reservationReleaseTimeout {
+		t.Fatalf("release reasons = %+v, want [%s]", outbox.releaseReasons, reservationReleaseTimeout)
+	}
+	if len(outbox.retryReasons) != 1 || outbox.retryReasons[0] != "recallFailed: context deadline exceeded" {
+		t.Fatalf("retry reasons = %+v, want local failure detail", outbox.retryReasons)
 	}
 }

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -137,8 +137,9 @@ func TestManagerRecallCommitsBeforeMetering(t *testing.T) {
 	if len(quota.reserveOps) != 1 || quota.reserveOps[0].Meter != MeterRecalls || quota.reserveOps[0].Units != 1 {
 		t.Fatalf("reserve ops = %+v", quota.reserveOps)
 	}
-	if len(quota.finalized) != 1 {
-		t.Fatalf("finalized = %+v", quota.finalized)
+	wantFinalize := lease.OperationID + ":" + ReservationStatusCommitted + ":" + reservationCommitReason
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
 	}
 	if len(writer.events) != 1 {
 		t.Fatalf("metering events = %+v", writer.events)

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1,0 +1,203 @@
+package runtimeusage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/metering"
+)
+
+type fakeQuotaClient struct {
+	reserveOps  []Operation
+	finalized   []string
+	adjusted    []Adjustment
+	err         error
+	reserveErr  error
+	finalizeErr error
+	adjustErr   error
+}
+
+func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID string, op Operation) (*Reservation, error) {
+	if c.reserveErr != nil {
+		return nil, c.reserveErr
+	}
+	if c.err != nil {
+		return nil, c.err
+	}
+	c.reserveOps = append(c.reserveOps, op)
+	return &Reservation{OperationID: operationID, Meter: op.Meter, Units: op.Units, Status: "reserved"}, nil
+}
+
+func (c *fakeQuotaClient) FinalizeReservation(_ context.Context, _ Subject, operationID string, status string, reason string) error {
+	if c.finalizeErr != nil {
+		return c.finalizeErr
+	}
+	if c.err != nil {
+		return c.err
+	}
+	c.finalized = append(c.finalized, operationID+":"+status+":"+reason)
+	return nil
+}
+
+func (c *fakeQuotaClient) ApplyAdjustment(_ context.Context, _ Subject, adj Adjustment) error {
+	if c.adjustErr != nil {
+		return c.adjustErr
+	}
+	if c.err != nil {
+		return c.err
+	}
+	c.adjusted = append(c.adjusted, adj)
+	return nil
+}
+
+type captureWriter struct {
+	events []metering.Event
+}
+
+func (w *captureWriter) Record(evt metering.Event) {
+	w.events = append(w.events, evt)
+}
+
+func (w *captureWriter) Close(context.Context) error { return nil }
+
+type fakeOutboxStore struct {
+	reservedActive    int
+	commitPending     int
+	releasePending    int
+	adjustmentIntent  int
+	adjustmentDone    int
+	adjustmentPending int
+	done              int
+	retryable         int
+}
+
+func (s *fakeOutboxStore) StoreReservedActive(context.Context, *OperationLease, *Reservation, time.Time) error {
+	s.reservedActive++
+	return nil
+}
+
+func (s *fakeOutboxStore) StoreCommitPending(context.Context, *OperationLease, MeteringEvent) error {
+	s.commitPending++
+	return nil
+}
+
+func (s *fakeOutboxStore) StoreReleasePending(context.Context, *OperationLease, string) error {
+	s.releasePending++
+	return nil
+}
+
+func (s *fakeOutboxStore) StoreAdjustmentIntent(context.Context, *OperationLease, MemoryDeleteTarget, time.Time) error {
+	s.adjustmentIntent++
+	return nil
+}
+
+func (s *fakeOutboxStore) StoreAdjustmentDone(context.Context, string, string) error {
+	s.adjustmentDone++
+	return nil
+}
+
+func (s *fakeOutboxStore) StoreAdjustmentPending(context.Context, *OperationLease, Adjustment, MeteringEvent) error {
+	s.adjustmentPending++
+	return nil
+}
+
+func (s *fakeOutboxStore) MarkOperationDone(context.Context, string, string) error {
+	s.done++
+	return nil
+}
+
+func (s *fakeOutboxStore) MarkOperationRetryableFailure(context.Context, string, string) error {
+	s.retryable++
+	return nil
+}
+
+func TestManagerRecallCommitsBeforeMetering(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeRecall(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	if err := manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"}); err != nil {
+		t.Fatalf("AfterRecallSuccess: %v", err)
+	}
+
+	if len(quota.reserveOps) != 1 || quota.reserveOps[0].Meter != MeterRecalls || quota.reserveOps[0].Units != 1 {
+		t.Fatalf("reserve ops = %+v", quota.reserveOps)
+	}
+	if len(quota.finalized) != 1 {
+		t.Fatalf("finalized = %+v", quota.finalized)
+	}
+	if len(writer.events) != 1 {
+		t.Fatalf("metering events = %+v", writer.events)
+	}
+	evt := writer.events[0]
+	if evt.OperationID != lease.OperationID {
+		t.Fatalf("event OperationID = %q, want %q", evt.OperationID, lease.OperationID)
+	}
+	if evt.APIKeySubject != "tenant-a" || evt.EventType != EventTypeRecall || evt.Meter != MeterRecalls || evt.Units != 1 {
+		t.Fatalf("unexpected event: %+v", evt)
+	}
+}
+
+func TestManagerDeleteZeroDeltaSkipsAdjustmentAndMetering(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	if err != nil {
+		t.Fatalf("BeforeMemoryDelete: %v", err)
+	}
+	if err := manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{MemorySlotsDelta: 0}); err != nil {
+		t.Fatalf("AfterMemoryDeleteSuccess: %v", err)
+	}
+	if len(quota.adjusted) != 0 {
+		t.Fatalf("adjustments = %+v, want none", quota.adjusted)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none", writer.events)
+	}
+}
+
+func TestManagerFailOpenDoesNotBypassQuotaDenied(t *testing.T) {
+	quota := &fakeQuotaClient{reserveErr: &QuotaDeniedError{StatusCode: 402}}
+	manager := NewManager(Config{Enabled: true, FailOpen: true}, quota, &captureWriter{}, nil)
+
+	lease, err := manager.BeforeRecall(context.Background(), Subject{TenantID: "tenant-a", APIKeySubject: "tenant-a"})
+	if err == nil {
+		t.Fatal("BeforeRecall error = nil, want quota denied")
+	}
+	if lease != nil {
+		t.Fatalf("lease = %+v, want nil", lease)
+	}
+}
+
+func TestManagerCommitFailureLeavesOutboxPendingAndSkipsMetering(t *testing.T) {
+	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeRecall(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	err = manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
+	if err == nil {
+		t.Fatal("AfterRecallSuccess error = nil, want finalize error")
+	}
+
+	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want reserved, commit pending, retryable", outbox)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
+	}
+}

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -278,7 +278,7 @@ func TestManagerCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T
 	}
 
 	if outbox.reservedActive != 0 || outbox.commitPending != 1 || outbox.retryable != 1 {
-		t.Fatalf("outbox = %+v, want commit pending and retryable without active reservation write", outbox)
+		t.Fatalf("outbox = %+v, want recall commit pending and retryable without active reservation write", outbox)
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
@@ -301,8 +301,8 @@ func TestManagerMemoryCreateCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(
 		t.Fatalf("AfterMemoryCreateSuccess: %v", err)
 	}
 
-	if outbox.reservedActive != 0 || outbox.commitPending != 1 || outbox.retryable != 1 {
-		t.Fatalf("outbox = %+v, want commit pending and retryable without active reservation write", outbox)
+	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want memory create active reservation, commit pending, retryable", outbox)
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
@@ -427,8 +427,8 @@ func TestManagerMemoryCreateCommitPendingFailureCommitsDirectly(t *testing.T) {
 	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
 		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
 	}
-	if outbox.releasePending != 0 || outbox.done != 0 {
-		t.Fatalf("outbox release state = %+v, want no release after successful memory create", outbox)
+	if outbox.releasePending != 0 || outbox.done != 1 {
+		t.Fatalf("outbox release state = %+v, want no release and done after successful memory create", outbox)
 	}
 	if len(writer.events) != 1 {
 		t.Fatalf("metering events = %+v, want direct metering after commit", writer.events)

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -174,6 +174,36 @@ func TestManagerDeleteZeroDeltaSkipsAdjustmentAndMetering(t *testing.T) {
 	}
 }
 
+func TestManagerDeletePositiveDeltaMarksUnknownAndSkipsAdjustment(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	if err != nil {
+		t.Fatalf("BeforeMemoryDelete: %v", err)
+	}
+	err = manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
+		MemoryIDs:        []string{"mem-1"},
+		MemorySlotsDelta: 1,
+		AgentName:        "Codex",
+	})
+	if err == nil {
+		t.Fatal("AfterMemoryDeleteSuccess error = nil, want positive delta error")
+	}
+	if len(quota.adjusted) != 0 {
+		t.Fatalf("adjustments = %+v, want none", quota.adjusted)
+	}
+	if outbox.adjustmentIntent != 1 || outbox.adjustmentPending != 0 || outbox.unknown != 1 {
+		t.Fatalf("outbox = %+v, want adjustment intent marked unknown without pending adjustment", outbox)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none", writer.events)
+	}
+}
+
 func TestManagerMemoryDeleteFailureNotFoundMarksAdjustmentDone(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -70,6 +70,7 @@ type fakeOutboxStore struct {
 	adjustmentPending int
 	done              int
 	retryable         int
+	commitErr         error
 }
 
 func (s *fakeOutboxStore) StoreReservedActive(context.Context, *OperationLease, *Reservation, time.Time) error {
@@ -79,7 +80,7 @@ func (s *fakeOutboxStore) StoreReservedActive(context.Context, *OperationLease, 
 
 func (s *fakeOutboxStore) StoreCommitPending(context.Context, *OperationLease, MeteringEvent) error {
 	s.commitPending++
-	return nil
+	return s.commitErr
 }
 
 func (s *fakeOutboxStore) StoreReleasePending(context.Context, *OperationLease, string) error {
@@ -199,5 +200,61 @@ func TestManagerCommitFailureLeavesOutboxPendingAndSkipsMetering(t *testing.T) {
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
+	}
+}
+
+func TestManagerRecallCommitPendingFailureReleasesReservation(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{commitErr: errString("outbox unavailable")}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeRecall(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	err = manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
+	if err == nil {
+		t.Fatal("AfterRecallSuccess error = nil, want commit pending error")
+	}
+
+	wantFinalize := lease.OperationID + ":" + ReservationStatusReleased + ":recallCommitPendingFailed"
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
+	}
+	if outbox.releasePending != 1 || outbox.done != 1 {
+		t.Fatalf("outbox release state = %+v, want release pending and done", outbox)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none", writer.events)
+	}
+}
+
+func TestManagerMemoryCreateCommitPendingFailureReleasesReservation(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{commitErr: errString("outbox unavailable")}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryCreate(context.Background(), subject, 1)
+	if err != nil {
+		t.Fatalf("BeforeMemoryCreate: %v", err)
+	}
+	err = manager.AfterMemoryCreateSuccess(context.Background(), lease, MemoryCreateResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
+	if err == nil {
+		t.Fatal("AfterMemoryCreateSuccess error = nil, want commit pending error")
+	}
+
+	wantFinalize := lease.OperationID + ":" + ReservationStatusReleased + ":memoryCreateCommitPendingFailed"
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
+	}
+	if outbox.releasePending != 1 || outbox.done != 1 {
+		t.Fatalf("outbox release state = %+v, want release pending and done", outbox)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none", writer.events)
 	}
 }

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metering"
 )
 
@@ -70,6 +71,7 @@ type fakeOutboxStore struct {
 	adjustmentPending int
 	done              int
 	retryable         int
+	unknown           int
 	commitErr         error
 }
 
@@ -110,6 +112,11 @@ func (s *fakeOutboxStore) MarkOperationDone(context.Context, string, string) err
 
 func (s *fakeOutboxStore) MarkOperationRetryableFailure(context.Context, string, string) error {
 	s.retryable++
+	return nil
+}
+
+func (s *fakeOutboxStore) MarkUnknownAfterCrash(context.Context, string, string) error {
+	s.unknown++
 	return nil
 }
 
@@ -163,6 +170,42 @@ func TestManagerDeleteZeroDeltaSkipsAdjustmentAndMetering(t *testing.T) {
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none", writer.events)
+	}
+}
+
+func TestManagerMemoryDeleteFailureNotFoundMarksAdjustmentDone(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	if err != nil {
+		t.Fatalf("BeforeMemoryDelete: %v", err)
+	}
+	manager.AfterMemoryDeleteFailure(context.Background(), lease, domain.ErrNotFound)
+
+	if outbox.adjustmentIntent != 1 || outbox.adjustmentDone != 1 || outbox.unknown != 0 {
+		t.Fatalf("outbox = %+v, want adjustment intent done without unknown", outbox)
+	}
+}
+
+func TestManagerMemoryDeleteFailureAmbiguousMarksUnknown(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	if err != nil {
+		t.Fatalf("BeforeMemoryDelete: %v", err)
+	}
+	manager.AfterMemoryDeleteFailure(context.Background(), lease, errString("delete commit failed"))
+
+	if outbox.adjustmentIntent != 1 || outbox.unknown != 1 || outbox.adjustmentDone != 0 {
+		t.Fatalf("outbox = %+v, want adjustment intent marked unknown", outbox)
 	}
 }
 

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -179,7 +179,7 @@ func TestManagerFailOpenDoesNotBypassQuotaDenied(t *testing.T) {
 	}
 }
 
-func TestManagerCommitFailureLeavesOutboxPendingAndSkipsMetering(t *testing.T) {
+func TestManagerCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T) {
 	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
 	writer := &captureWriter{}
 	outbox := &fakeOutboxStore{}
@@ -191,8 +191,8 @@ func TestManagerCommitFailureLeavesOutboxPendingAndSkipsMetering(t *testing.T) {
 		t.Fatalf("BeforeRecall: %v", err)
 	}
 	err = manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
-	if err == nil {
-		t.Fatal("AfterRecallSuccess error = nil, want finalize error")
+	if err != nil {
+		t.Fatalf("AfterRecallSuccess: %v", err)
 	}
 
 	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
@@ -200,6 +200,100 @@ func TestManagerCommitFailureLeavesOutboxPendingAndSkipsMetering(t *testing.T) {
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
+	}
+}
+
+func TestManagerMemoryCreateCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T) {
+	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryCreate(context.Background(), subject, 1)
+	if err != nil {
+		t.Fatalf("BeforeMemoryCreate: %v", err)
+	}
+	err = manager.AfterMemoryCreateSuccess(context.Background(), lease, MemoryCreateResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
+	if err != nil {
+		t.Fatalf("AfterMemoryCreateSuccess: %v", err)
+	}
+
+	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want reserved, commit pending, retryable", outbox)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
+	}
+}
+
+func TestManagerCommitFailureWithoutOutboxReturnsError(t *testing.T) {
+	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
+	writer := &captureWriter{}
+	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeRecall(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	err = manager.AfterRecallSuccess(context.Background(), lease, RecallResult{MemoryIDs: []string{"mem-1"}, AgentName: "Codex"})
+	if err == nil {
+		t.Fatal("AfterRecallSuccess error = nil, want finalize error without outbox")
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
+	}
+}
+
+func TestManagerAdjustmentFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T) {
+	quota := &fakeQuotaClient{adjustErr: &UnavailableError{Err: errString("timeout")}}
+	writer := &captureWriter{}
+	outbox := &fakeOutboxStore{}
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	if err != nil {
+		t.Fatalf("BeforeMemoryDelete: %v", err)
+	}
+	err = manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
+		MemoryIDs:        []string{"mem-1"},
+		MemorySlotsDelta: -1,
+		AgentName:        "Codex",
+	})
+	if err != nil {
+		t.Fatalf("AfterMemoryDeleteSuccess: %v", err)
+	}
+
+	if outbox.adjustmentIntent != 1 || outbox.adjustmentPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want adjustment intent, adjustment pending, retryable", outbox)
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none before quota adjustment", writer.events)
+	}
+}
+
+func TestManagerAdjustmentFailureWithoutOutboxReturnsError(t *testing.T) {
+	quota := &fakeQuotaClient{adjustErr: &UnavailableError{Err: errString("timeout")}}
+	writer := &captureWriter{}
+	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	if err != nil {
+		t.Fatalf("BeforeMemoryDelete: %v", err)
+	}
+	err = manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
+		MemoryIDs:        []string{"mem-1"},
+		MemorySlotsDelta: -1,
+		AgentName:        "Codex",
+	})
+	if err == nil {
+		t.Fatal("AfterMemoryDeleteSuccess error = nil, want adjustment error without outbox")
+	}
+	if len(writer.events) != 0 {
+		t.Fatalf("metering events = %+v, want none before quota adjustment", writer.events)
 	}
 }
 

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 type fakeQuotaClient struct {
-	reserveOps  []Operation
-	finalized   []string
-	adjusted    []Adjustment
-	err         error
-	reserveErr  error
-	finalizeErr error
-	adjustErr   error
+	reserveOps       []Operation
+	finalized        []string
+	adjusted         []Adjustment
+	finalizeSubjects []Subject
+	adjustSubjects   []Subject
+	err              error
+	reserveErr       error
+	finalizeErr      error
+	adjustErr        error
 }
 
 func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID string, op Operation) (*Reservation, error) {
@@ -30,7 +32,7 @@ func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID stri
 	return &Reservation{OperationID: operationID, Meter: op.Meter, Units: op.Units, Status: "reserved"}, nil
 }
 
-func (c *fakeQuotaClient) FinalizeReservation(_ context.Context, _ Subject, operationID string, status string, reason string) error {
+func (c *fakeQuotaClient) FinalizeReservation(_ context.Context, subject Subject, operationID string, status string, reason string) error {
 	if c.finalizeErr != nil {
 		return c.finalizeErr
 	}
@@ -38,10 +40,11 @@ func (c *fakeQuotaClient) FinalizeReservation(_ context.Context, _ Subject, oper
 		return c.err
 	}
 	c.finalized = append(c.finalized, operationID+":"+status+":"+reason)
+	c.finalizeSubjects = append(c.finalizeSubjects, subject)
 	return nil
 }
 
-func (c *fakeQuotaClient) ApplyAdjustment(_ context.Context, _ Subject, adj Adjustment) error {
+func (c *fakeQuotaClient) ApplyAdjustment(_ context.Context, subject Subject, adj Adjustment) error {
 	if c.adjustErr != nil {
 		return c.adjustErr
 	}
@@ -49,6 +52,7 @@ func (c *fakeQuotaClient) ApplyAdjustment(_ context.Context, _ Subject, adj Adju
 		return c.err
 	}
 	c.adjusted = append(c.adjusted, adj)
+	c.adjustSubjects = append(c.adjustSubjects, subject)
 	return nil
 }
 

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -3,22 +3,17 @@ package runtimeusage
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metering"
 )
 
 type fakeQuotaClient struct {
 	reserveOps       []Operation
 	finalized        []string
-	adjusted         []Adjustment
 	finalizeSubjects []Subject
-	adjustSubjects   []Subject
 	err              error
 	reserveErr       error
 	finalizeErr      error
-	adjustErr        error
 }
 
 func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID string, op Operation) (*Reservation, error) {
@@ -44,18 +39,6 @@ func (c *fakeQuotaClient) FinalizeReservation(_ context.Context, subject Subject
 	return nil
 }
 
-func (c *fakeQuotaClient) ApplyAdjustment(_ context.Context, subject Subject, adj Adjustment) error {
-	if c.adjustErr != nil {
-		return c.adjustErr
-	}
-	if c.err != nil {
-		return c.err
-	}
-	c.adjusted = append(c.adjusted, adj)
-	c.adjustSubjects = append(c.adjustSubjects, subject)
-	return nil
-}
-
 type captureWriter struct {
 	events []metering.Event
 }
@@ -67,23 +50,14 @@ func (w *captureWriter) Record(evt metering.Event) {
 func (w *captureWriter) Close(context.Context) error { return nil }
 
 type fakeOutboxStore struct {
-	reservedActive    int
-	commitPending     int
-	releasePending    int
-	adjustmentIntent  int
-	adjustmentDone    int
-	adjustmentPending int
-	done              int
-	retryable         int
-	unknown           int
-	commitErr         error
-	releaseReasons    []string
-	retryReasons      []string
-}
-
-func (s *fakeOutboxStore) StoreReservedActive(context.Context, *OperationLease, *Reservation, time.Time) error {
-	s.reservedActive++
-	return nil
+	commitPending  int
+	releasePending int
+	done           int
+	retryable      int
+	unknown        int
+	commitErr      error
+	releaseReasons []string
+	retryReasons   []string
 }
 
 func (s *fakeOutboxStore) StoreCommitPending(context.Context, *OperationLease, MeteringEvent) error {
@@ -94,21 +68,6 @@ func (s *fakeOutboxStore) StoreCommitPending(context.Context, *OperationLease, M
 func (s *fakeOutboxStore) StoreReleasePending(_ context.Context, _ *OperationLease, reason string) error {
 	s.releasePending++
 	s.releaseReasons = append(s.releaseReasons, reason)
-	return nil
-}
-
-func (s *fakeOutboxStore) StoreAdjustmentIntent(context.Context, *OperationLease, MemoryDeleteTarget, time.Time) error {
-	s.adjustmentIntent++
-	return nil
-}
-
-func (s *fakeOutboxStore) StoreAdjustmentDone(context.Context, string, string) error {
-	s.adjustmentDone++
-	return nil
-}
-
-func (s *fakeOutboxStore) StoreAdjustmentPending(context.Context, *OperationLease, Adjustment, MeteringEvent) error {
-	s.adjustmentPending++
 	return nil
 }
 
@@ -142,7 +101,7 @@ func TestManagerRecallCommitsBeforeMetering(t *testing.T) {
 		t.Fatalf("AfterRecallSuccess: %v", err)
 	}
 
-	if len(quota.reserveOps) != 1 || quota.reserveOps[0].Meter != MeterRecalls || quota.reserveOps[0].Units != 1 {
+	if len(quota.reserveOps) != 1 || quota.reserveOps[0].Meter != MeterMemoryRecallRequests || quota.reserveOps[0].Units != 1 {
 		t.Fatalf("reserve ops = %+v", quota.reserveOps)
 	}
 	wantFinalize := lease.OperationID + ":" + ReservationStatusCommitted + ":" + reservationCommitReason
@@ -156,95 +115,65 @@ func TestManagerRecallCommitsBeforeMetering(t *testing.T) {
 	if evt.OperationID != lease.OperationID {
 		t.Fatalf("event OperationID = %q, want %q", evt.OperationID, lease.OperationID)
 	}
-	if evt.APIKeySubject != "tenant-a" || evt.EventType != EventTypeRecall || evt.Meter != MeterRecalls || evt.Units != 1 {
+	if evt.APIKeySubject != "tenant-a" || evt.EventType != EventTypeMemoryRecall || evt.Meter != MeterMemoryRecallRequests || evt.Units != 1 {
 		t.Fatalf("unexpected event: %+v", evt)
 	}
 }
 
-func TestManagerDeleteZeroDeltaSkipsAdjustmentAndMetering(t *testing.T) {
+func TestManagerMemoryDeleteUsesWriteRequestMeter(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}
 	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
 	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
 
-	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject)
 	if err != nil {
 		t.Fatalf("BeforeMemoryDelete: %v", err)
 	}
-	if err := manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{MemorySlotsDelta: 0}); err != nil {
+	if err := manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
+		MemoryIDs:       []string{"mem-1"},
+		AgentName:       "Codex",
+		ObjectsAffected: 1,
+	}); err != nil {
 		t.Fatalf("AfterMemoryDeleteSuccess: %v", err)
 	}
-	if len(quota.adjusted) != 0 {
-		t.Fatalf("adjustments = %+v, want none", quota.adjusted)
+	if len(quota.reserveOps) != 1 || quota.reserveOps[0].Meter != MeterMemoryWriteRequests || quota.reserveOps[0].Units != 1 {
+		t.Fatalf("reserve ops = %+v", quota.reserveOps)
 	}
-	if len(writer.events) != 0 {
-		t.Fatalf("metering events = %+v, want none", writer.events)
+	wantFinalize := lease.OperationID + ":" + ReservationStatusCommitted + ":" + reservationCommitReason
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
 	}
-}
-
-func TestManagerDeletePositiveDeltaMarksUnknownAndSkipsAdjustment(t *testing.T) {
-	quota := &fakeQuotaClient{}
-	writer := &captureWriter{}
-	outbox := &fakeOutboxStore{}
-	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
-	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
-
-	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
-	if err != nil {
-		t.Fatalf("BeforeMemoryDelete: %v", err)
+	if len(writer.events) != 1 {
+		t.Fatalf("metering events = %+v, want one", writer.events)
 	}
-	err = manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
-		MemoryIDs:        []string{"mem-1"},
-		MemorySlotsDelta: 1,
-		AgentName:        "Codex",
-	})
-	if err == nil {
-		t.Fatal("AfterMemoryDeleteSuccess error = nil, want positive delta error")
+	evt := writer.events[0]
+	if evt.EventType != EventTypeMemoryDeleted || evt.Meter != MeterMemoryWriteRequests || evt.Units != 1 {
+		t.Fatalf("unexpected event: %+v", evt)
 	}
-	if len(quota.adjusted) != 0 {
-		t.Fatalf("adjustments = %+v, want none", quota.adjusted)
-	}
-	if outbox.adjustmentIntent != 1 || outbox.adjustmentPending != 0 || outbox.unknown != 1 {
-		t.Fatalf("outbox = %+v, want adjustment intent marked unknown without pending adjustment", outbox)
-	}
-	if len(writer.events) != 0 {
-		t.Fatalf("metering events = %+v, want none", writer.events)
+	if evt.Metadata["objectsAffected"] != int64(1) {
+		t.Fatalf("metadata = %+v, want objectsAffected=1", evt.Metadata)
 	}
 }
 
-func TestManagerMemoryDeleteFailureNotFoundMarksAdjustmentDone(t *testing.T) {
+func TestManagerMemoryDeleteFailureReleasesReservation(t *testing.T) {
 	quota := &fakeQuotaClient{}
-	writer := &captureWriter{}
 	outbox := &fakeOutboxStore{}
-	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, &captureWriter{}, nil)
 	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
 
-	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
-	if err != nil {
-		t.Fatalf("BeforeMemoryDelete: %v", err)
-	}
-	manager.AfterMemoryDeleteFailure(context.Background(), lease, domain.ErrNotFound)
-
-	if outbox.adjustmentIntent != 1 || outbox.adjustmentDone != 1 || outbox.unknown != 0 {
-		t.Fatalf("outbox = %+v, want adjustment intent done without unknown", outbox)
-	}
-}
-
-func TestManagerMemoryDeleteFailureAmbiguousMarksUnknown(t *testing.T) {
-	quota := &fakeQuotaClient{}
-	writer := &captureWriter{}
-	outbox := &fakeOutboxStore{}
-	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
-	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
-
-	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject)
 	if err != nil {
 		t.Fatalf("BeforeMemoryDelete: %v", err)
 	}
 	manager.AfterMemoryDeleteFailure(context.Background(), lease, errString("delete commit failed"))
 
-	if outbox.adjustmentIntent != 1 || outbox.unknown != 1 || outbox.adjustmentDone != 0 {
-		t.Fatalf("outbox = %+v, want adjustment intent marked unknown", outbox)
+	wantFinalize := lease.OperationID + ":" + ReservationStatusReleased + ":" + reservationReleaseOperationFailed
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
+	}
+	if outbox.releasePending != 1 {
+		t.Fatalf("outbox = %+v, want release pending", outbox)
 	}
 }
 
@@ -277,7 +206,7 @@ func TestManagerCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T
 		t.Fatalf("AfterRecallSuccess: %v", err)
 	}
 
-	if outbox.reservedActive != 0 || outbox.commitPending != 1 || outbox.retryable != 1 {
+	if outbox.commitPending != 1 || outbox.retryable != 1 {
 		t.Fatalf("outbox = %+v, want recall commit pending and retryable without active reservation write", outbox)
 	}
 	if len(writer.events) != 0 {
@@ -301,8 +230,8 @@ func TestManagerMemoryCreateCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(
 		t.Fatalf("AfterMemoryCreateSuccess: %v", err)
 	}
 
-	if outbox.reservedActive != 1 || outbox.commitPending != 1 || outbox.retryable != 1 {
-		t.Fatalf("outbox = %+v, want memory create active reservation, commit pending, retryable", outbox)
+	if outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want memory create commit pending and retryable without active reservation write", outbox)
 	}
 	if len(writer.events) != 0 {
 		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
@@ -328,54 +257,54 @@ func TestManagerCommitFailureWithoutOutboxReturnsError(t *testing.T) {
 	}
 }
 
-func TestManagerAdjustmentFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T) {
-	quota := &fakeQuotaClient{adjustErr: &UnavailableError{Err: errString("timeout")}}
+func TestManagerMemoryDeleteCommitFailureWithOutboxQueuesRetryAndReturnsSuccess(t *testing.T) {
+	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
 	writer := &captureWriter{}
 	outbox := &fakeOutboxStore{}
 	manager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
 	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
 
-	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject)
 	if err != nil {
 		t.Fatalf("BeforeMemoryDelete: %v", err)
 	}
 	err = manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
-		MemoryIDs:        []string{"mem-1"},
-		MemorySlotsDelta: -1,
-		AgentName:        "Codex",
+		MemoryIDs:       []string{"mem-1"},
+		AgentName:       "Codex",
+		ObjectsAffected: 1,
 	})
 	if err != nil {
 		t.Fatalf("AfterMemoryDeleteSuccess: %v", err)
 	}
 
-	if outbox.adjustmentIntent != 1 || outbox.adjustmentPending != 1 || outbox.retryable != 1 {
-		t.Fatalf("outbox = %+v, want adjustment intent, adjustment pending, retryable", outbox)
+	if outbox.commitPending != 1 || outbox.retryable != 1 {
+		t.Fatalf("outbox = %+v, want commit pending and retryable", outbox)
 	}
 	if len(writer.events) != 0 {
-		t.Fatalf("metering events = %+v, want none before quota adjustment", writer.events)
+		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
 	}
 }
 
-func TestManagerAdjustmentFailureWithoutOutboxReturnsError(t *testing.T) {
-	quota := &fakeQuotaClient{adjustErr: &UnavailableError{Err: errString("timeout")}}
+func TestManagerMemoryDeleteCommitFailureWithoutOutboxReturnsError(t *testing.T) {
+	quota := &fakeQuotaClient{finalizeErr: &UnavailableError{Err: errString("timeout")}}
 	writer := &captureWriter{}
 	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
 	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
 
-	lease, err := manager.BeforeMemoryDelete(context.Background(), subject, MemoryDeleteTarget{MemoryIDs: []string{"mem-1"}})
+	lease, err := manager.BeforeMemoryDelete(context.Background(), subject)
 	if err != nil {
 		t.Fatalf("BeforeMemoryDelete: %v", err)
 	}
 	err = manager.AfterMemoryDeleteSuccess(context.Background(), lease, MemoryDeleteResult{
-		MemoryIDs:        []string{"mem-1"},
-		MemorySlotsDelta: -1,
-		AgentName:        "Codex",
+		MemoryIDs:       []string{"mem-1"},
+		AgentName:       "Codex",
+		ObjectsAffected: 1,
 	})
 	if err == nil {
-		t.Fatal("AfterMemoryDeleteSuccess error = nil, want adjustment error without outbox")
+		t.Fatal("AfterMemoryDeleteSuccess error = nil, want commit error without outbox")
 	}
 	if len(writer.events) != 0 {
-		t.Fatalf("metering events = %+v, want none before quota adjustment", writer.events)
+		t.Fatalf("metering events = %+v, want none before quota commit", writer.events)
 	}
 }
 
@@ -399,8 +328,8 @@ func TestManagerRecallCommitPendingFailureCommitsDirectly(t *testing.T) {
 	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
 		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
 	}
-	if outbox.releasePending != 0 || outbox.done != 0 {
-		t.Fatalf("outbox release state = %+v, want no release after successful recall", outbox)
+	if outbox.releasePending != 0 || outbox.done != 1 {
+		t.Fatalf("outbox release state = %+v, want no release and best-effort done after successful recall", outbox)
 	}
 	if len(writer.events) != 1 {
 		t.Fatalf("metering events = %+v, want direct metering after commit", writer.events)

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -156,6 +156,42 @@ func TestManagerMemoryDeleteUsesWriteRequestMeter(t *testing.T) {
 	}
 }
 
+func TestManagerMemoryUpdateUsesWriteRequestMeter(t *testing.T) {
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	manager := NewManager(Config{Enabled: true}, quota, writer, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "tenant-a", AgentName: "Codex"}
+
+	lease, err := manager.BeforeMemoryUpdate(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("BeforeMemoryUpdate: %v", err)
+	}
+	if err := manager.AfterMemoryUpdateSuccess(context.Background(), lease, MemoryUpdateResult{
+		MemoryIDs:       []string{"mem-1"},
+		AgentName:       "Codex",
+		ObjectsAffected: 1,
+	}); err != nil {
+		t.Fatalf("AfterMemoryUpdateSuccess: %v", err)
+	}
+	if len(quota.reserveOps) != 1 || quota.reserveOps[0].Meter != MeterMemoryWriteRequests || quota.reserveOps[0].Units != 1 {
+		t.Fatalf("reserve ops = %+v", quota.reserveOps)
+	}
+	wantFinalize := lease.OperationID + ":" + ReservationStatusCommitted + ":" + reservationCommitReason
+	if len(quota.finalized) != 1 || quota.finalized[0] != wantFinalize {
+		t.Fatalf("finalized = %+v, want [%s]", quota.finalized, wantFinalize)
+	}
+	if len(writer.events) != 1 {
+		t.Fatalf("metering events = %+v, want one", writer.events)
+	}
+	evt := writer.events[0]
+	if evt.EventType != EventTypeMemoryUpdated || evt.Meter != MeterMemoryWriteRequests || evt.Units != 1 {
+		t.Fatalf("unexpected event: %+v", evt)
+	}
+	if evt.Metadata["objectsAffected"] != int64(1) {
+		t.Fatalf("metadata = %+v, want objectsAffected=1", evt.Metadata)
+	}
+}
+
 func TestManagerMemoryDeleteFailureReleasesReservation(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	outbox := &fakeOutboxStore{}

--- a/server/internal/runtimeusage/outbox.go
+++ b/server/internal/runtimeusage/outbox.go
@@ -158,7 +158,7 @@ func (s *SQLStore) StoreCommitPending(ctx context.Context, lease *OperationLease
 		Meter:  lease.Meter,
 		Units:  lease.Units,
 		Status: ReservationStatusCommitted,
-		Reason: "operationSucceeded",
+		Reason: reservationCommitReason,
 		Event:  outboxEventFromMetering(event),
 	}
 	return s.storeOperation(ctx, lease, outboxStepCommitReservation, outboxPhaseCommitPending, payload, time.Time{}, s.now())

--- a/server/internal/runtimeusage/outbox.go
+++ b/server/internal/runtimeusage/outbox.go
@@ -214,6 +214,10 @@ func (s *SQLStore) MarkOperationRetryableFailure(ctx context.Context, operationI
 	return s.markRetryableFailure(ctx, operationID, reason)
 }
 
+func (s *SQLStore) MarkOperationTerminalFailed(ctx context.Context, operationID string, reason string) error {
+	return s.updateStatus(ctx, operationID, outboxStatusTerminalFailed, outboxPhaseTerminalFailed, reason)
+}
+
 func (s *SQLStore) PendingRows(ctx context.Context, limit int) ([]outboxRow, error) {
 	if s == nil || s.db == nil {
 		return nil, nil

--- a/server/internal/runtimeusage/outbox.go
+++ b/server/internal/runtimeusage/outbox.go
@@ -17,18 +17,14 @@ const (
 
 	outboxStepCommitReservation  = "commit_reservation"
 	outboxStepReleaseReservation = "release_reservation"
-	outboxStepApplyAdjustment    = "apply_adjustment"
 	outboxStepSubmitMetering     = "submit_metering_event"
 
-	outboxPhaseReservedActive    = "reserved_active"
-	outboxPhaseCommitPending     = "commit_pending"
-	outboxPhaseReleasePending    = "release_pending"
-	outboxPhaseAdjustmentIntent  = "adjustment_intent"
-	outboxPhaseAdjustmentPending = "adjustment_pending"
-	outboxPhaseMeteringPending   = "metering_pending"
-	outboxPhaseDone              = "done"
-	outboxPhaseUnknown           = "unknown_after_crash"
-	outboxPhaseTerminalFailed    = "terminal_failed"
+	outboxPhaseCommitPending   = "commit_pending"
+	outboxPhaseReleasePending  = "release_pending"
+	outboxPhaseMeteringPending = "metering_pending"
+	outboxPhaseDone            = "done"
+	outboxPhaseUnknown         = "unknown_after_crash"
+	outboxPhaseTerminalFailed  = "terminal_failed"
 
 	outboxStatusPending        = "pending"
 	outboxStatusDone           = "done"
@@ -36,24 +32,23 @@ const (
 )
 
 type outboxPayload struct {
-	APIKeySubject   string                 `json:"apiKeySubject,omitempty"`
-	Meter           string                 `json:"meter,omitempty"`
-	Units           int64                  `json:"units,omitempty"`
-	Delta           int64                  `json:"delta,omitempty"`
-	Status          string                 `json:"status,omitempty"`
-	Reason          string                 `json:"reason,omitempty"`
-	TargetMemoryIDs []string               `json:"targetMemoryIds,omitempty"`
-	Event           *outboxMeteringPayload `json:"event,omitempty"`
+	APIKeySubject string                 `json:"apiKeySubject,omitempty"`
+	Meter         string                 `json:"meter,omitempty"`
+	Units         int64                  `json:"units,omitempty"`
+	Status        string                 `json:"status,omitempty"`
+	Reason        string                 `json:"reason,omitempty"`
+	Event         *outboxMeteringPayload `json:"event,omitempty"`
 }
 
 type outboxMeteringPayload struct {
-	APIKeySubject string    `json:"apiKeySubject,omitempty"`
-	EventType     string    `json:"eventType"`
-	Meter         string    `json:"meter"`
-	Units         int64     `json:"units"`
-	OccurredAt    time.Time `json:"occurredAt"`
-	AgentName     string    `json:"agentName,omitempty"`
-	MemoryIDs     []string  `json:"memoryIds,omitempty"`
+	APIKeySubject string         `json:"apiKeySubject,omitempty"`
+	EventType     string         `json:"eventType"`
+	Meter         string         `json:"meter"`
+	Units         int64          `json:"units"`
+	OccurredAt    time.Time      `json:"occurredAt"`
+	AgentName     string         `json:"agentName,omitempty"`
+	MemoryIDs     []string       `json:"memoryIds,omitempty"`
+	Metadata      map[string]any `json:"metadata,omitempty"`
 }
 
 type outboxRow struct {
@@ -135,23 +130,6 @@ func (s *SQLStore) EnsureSchema(ctx context.Context) error {
 	return nil
 }
 
-func (s *SQLStore) StoreReservedActive(ctx context.Context, lease *OperationLease, reservation *Reservation, expiresAt time.Time) error {
-	if lease == nil {
-		return nil
-	}
-	payload := outboxPayload{
-		APIKeySubject: lease.Subject.APIKeySubject,
-		Meter:         lease.Meter,
-		Units:         lease.Units,
-		Status:        "reserved",
-		Reason:        "reservationAccepted",
-	}
-	if reservation != nil {
-		payload.Status = reservation.Status
-	}
-	return s.storeOperation(ctx, lease, outboxStepCommitReservation, outboxPhaseReservedActive, payload, expiresAt, expiresAt.Add(2*time.Minute))
-}
-
 func (s *SQLStore) StoreCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error {
 	if lease == nil {
 		return nil
@@ -179,37 +157,6 @@ func (s *SQLStore) StoreReleasePending(ctx context.Context, lease *OperationLeas
 		Reason:        reason,
 	}
 	return s.storeOperation(ctx, lease, outboxStepReleaseReservation, outboxPhaseReleasePending, payload, time.Time{}, s.now())
-}
-
-func (s *SQLStore) StoreAdjustmentIntent(ctx context.Context, lease *OperationLease, target MemoryDeleteTarget, expiresAt time.Time) error {
-	if lease == nil {
-		return nil
-	}
-	payload := outboxPayload{
-		APIKeySubject:   lease.Subject.APIKeySubject,
-		Meter:           lease.Meter,
-		Reason:          "memoryDeleteStarted",
-		TargetMemoryIDs: append([]string(nil), target.MemoryIDs...),
-	}
-	return s.storeOperation(ctx, lease, outboxStepApplyAdjustment, outboxPhaseAdjustmentIntent, payload, expiresAt, expiresAt.Add(2*time.Minute))
-}
-
-func (s *SQLStore) StoreAdjustmentDone(ctx context.Context, operationID string, reason string) error {
-	return s.updateStatus(ctx, operationID, outboxStatusDone, outboxPhaseDone, reason)
-}
-
-func (s *SQLStore) StoreAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error {
-	if lease == nil {
-		return nil
-	}
-	payload := outboxPayload{
-		APIKeySubject: lease.Subject.APIKeySubject,
-		Meter:         adj.Meter,
-		Delta:         adj.Delta,
-		Reason:        adj.Reason,
-		Event:         outboxEventFromMetering(event, lease.Subject.APIKeySubject),
-	}
-	return s.storeOperation(ctx, lease, outboxStepApplyAdjustment, outboxPhaseAdjustmentPending, payload, time.Time{}, s.now())
 }
 
 func (s *SQLStore) MarkOperationDone(ctx context.Context, operationID string, reason string) error {
@@ -551,9 +498,10 @@ func outboxEventFromMetering(event MeteringEvent, apiKeySubject string) *outboxM
 		EventType:     event.EventType,
 		Meter:         event.Meter,
 		Units:         event.Units,
-		OccurredAt:    event.OccurredAt.UTC(),
+		OccurredAt:    event.OccurredAt.UTC().Truncate(time.Second),
 		AgentName:     event.AgentName,
 		MemoryIDs:     append([]string(nil), event.MemoryIDs...),
+		Metadata:      cloneAnyMap(event.Metadata),
 	}
 }
 
@@ -564,9 +512,10 @@ func marshalMeteringPendingPayload(evt metering.Event) ([]byte, error) {
 			EventType:     evt.EventType,
 			Meter:         evt.Meter,
 			Units:         evt.Units,
-			OccurredAt:    evt.OccurredAt.UTC(),
+			OccurredAt:    evt.OccurredAt.UTC().Truncate(time.Second),
 			AgentName:     evt.AgentID,
 			MemoryIDs:     append([]string(nil), evt.MemoryIDs...),
+			Metadata:      cloneAnyMap(evt.Metadata),
 		},
 	}
 	payloadJSON, err := json.Marshal(payload)
@@ -574,6 +523,17 @@ func marshalMeteringPendingPayload(evt metering.Event) ([]byte, error) {
 		return nil, fmt.Errorf("marshal runtime usage metering outbox payload: %w", err)
 	}
 	return payloadJSON, nil
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func retryBackoff(attempts int, minDelay, maxDelay time.Duration) time.Duration {

--- a/server/internal/runtimeusage/outbox.go
+++ b/server/internal/runtimeusage/outbox.go
@@ -1,0 +1,583 @@
+package runtimeusage
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/metering"
+)
+
+const (
+	subjectVersionTenantIDV1 = "tenant_id_v1"
+
+	outboxStepCommitReservation  = "commit_reservation"
+	outboxStepReleaseReservation = "release_reservation"
+	outboxStepApplyAdjustment    = "apply_adjustment"
+	outboxStepSubmitMetering     = "submit_metering_event"
+
+	outboxPhaseReservedActive    = "reserved_active"
+	outboxPhaseCommitPending     = "commit_pending"
+	outboxPhaseReleasePending    = "release_pending"
+	outboxPhaseAdjustmentIntent  = "adjustment_intent"
+	outboxPhaseAdjustmentPending = "adjustment_pending"
+	outboxPhaseMeteringPending   = "metering_pending"
+	outboxPhaseDone              = "done"
+	outboxPhaseUnknown           = "unknown_after_crash"
+	outboxPhaseTerminalFailed    = "terminal_failed"
+
+	outboxStatusPending        = "pending"
+	outboxStatusDone           = "done"
+	outboxStatusTerminalFailed = "terminal_failed"
+)
+
+type outboxPayload struct {
+	Meter           string                 `json:"meter,omitempty"`
+	Units           int64                  `json:"units,omitempty"`
+	Delta           int64                  `json:"delta,omitempty"`
+	Status          string                 `json:"status,omitempty"`
+	Reason          string                 `json:"reason,omitempty"`
+	TargetMemoryIDs []string               `json:"targetMemoryIds,omitempty"`
+	Event           *outboxMeteringPayload `json:"event,omitempty"`
+}
+
+type outboxMeteringPayload struct {
+	APIKeySubject string    `json:"apiKeySubject,omitempty"`
+	EventType     string    `json:"eventType"`
+	Meter         string    `json:"meter"`
+	Units         int64     `json:"units"`
+	OccurredAt    time.Time `json:"occurredAt"`
+	AgentName     string    `json:"agentName,omitempty"`
+	MemoryIDs     []string  `json:"memoryIds,omitempty"`
+}
+
+type outboxRow struct {
+	OperationID    string
+	TenantID       string
+	ClusterID      string
+	SubjectVersion string
+	Step           string
+	Phase          string
+	PayloadJSON    []byte
+	PayloadHash    string
+	ExpiresAt      time.Time
+	AttemptCount   int
+}
+
+type SQLStore struct {
+	db      *sql.DB
+	backend string
+	now     func() time.Time
+}
+
+func NewSQLStore(db *sql.DB, backend string) *SQLStore {
+	return &SQLStore{
+		db:      db,
+		backend: backend,
+		now:     time.Now,
+	}
+}
+
+func (s *SQLStore) EnsureSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	query := `CREATE TABLE IF NOT EXISTS runtime_usage_outbox (
+  operation_id      VARCHAR(36) PRIMARY KEY,
+  tenant_id         VARCHAR(36) NOT NULL,
+  cluster_id        VARCHAR(255) NULL,
+  subject_version   VARCHAR(32) NOT NULL DEFAULT 'tenant_id_v1',
+  step              VARCHAR(32) NOT NULL,
+  phase             VARCHAR(32) NOT NULL,
+  payload_json      JSON NOT NULL,
+  payload_hash      VARCHAR(64) NOT NULL,
+  expires_at        TIMESTAMP NULL,
+  status            VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempt_count     INT NOT NULL DEFAULT 0,
+  next_attempt_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_error        TEXT NULL,
+  created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_runtime_usage_outbox_poll (status, next_attempt_at)
+)`
+	if s.backend == "postgres" || s.backend == "db9" {
+		query = `CREATE TABLE IF NOT EXISTS runtime_usage_outbox (
+  operation_id      VARCHAR(36) PRIMARY KEY,
+  tenant_id         VARCHAR(36) NOT NULL,
+  cluster_id        VARCHAR(255) NULL,
+  subject_version   VARCHAR(32) NOT NULL DEFAULT 'tenant_id_v1',
+  step              VARCHAR(32) NOT NULL,
+  phase             VARCHAR(32) NOT NULL,
+  payload_json      JSONB NOT NULL,
+  payload_hash      VARCHAR(64) NOT NULL,
+  expires_at        TIMESTAMP NULL,
+  status            VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempt_count     INT NOT NULL DEFAULT 0,
+  next_attempt_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_error        TEXT NULL,
+  created_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)`
+	}
+	if _, err := s.db.ExecContext(ctx, query); err != nil {
+		return fmt.Errorf("ensure runtime usage outbox schema: %w", err)
+	}
+	if s.backend == "postgres" || s.backend == "db9" {
+		if _, err := s.db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_runtime_usage_outbox_poll ON runtime_usage_outbox (status, next_attempt_at)`); err != nil {
+			return fmt.Errorf("ensure runtime usage outbox poll index: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *SQLStore) StoreReservedActive(ctx context.Context, lease *OperationLease, reservation *Reservation, expiresAt time.Time) error {
+	if lease == nil {
+		return nil
+	}
+	payload := outboxPayload{
+		Meter:  lease.Meter,
+		Units:  lease.Units,
+		Status: "reserved",
+		Reason: "reservationAccepted",
+	}
+	if reservation != nil {
+		payload.Status = reservation.Status
+	}
+	return s.storeOperation(ctx, lease, outboxStepCommitReservation, outboxPhaseReservedActive, payload, expiresAt, expiresAt.Add(2*time.Minute))
+}
+
+func (s *SQLStore) StoreCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error {
+	if lease == nil {
+		return nil
+	}
+	payload := outboxPayload{
+		Meter:  lease.Meter,
+		Units:  lease.Units,
+		Status: ReservationStatusCommitted,
+		Reason: "operationSucceeded",
+		Event:  outboxEventFromMetering(event),
+	}
+	return s.storeOperation(ctx, lease, outboxStepCommitReservation, outboxPhaseCommitPending, payload, time.Time{}, s.now())
+}
+
+func (s *SQLStore) StoreReleasePending(ctx context.Context, lease *OperationLease, reason string) error {
+	if lease == nil {
+		return nil
+	}
+	payload := outboxPayload{
+		Meter:  lease.Meter,
+		Units:  lease.Units,
+		Status: ReservationStatusReleased,
+		Reason: reason,
+	}
+	return s.storeOperation(ctx, lease, outboxStepReleaseReservation, outboxPhaseReleasePending, payload, time.Time{}, s.now())
+}
+
+func (s *SQLStore) StoreAdjustmentIntent(ctx context.Context, lease *OperationLease, target MemoryDeleteTarget, expiresAt time.Time) error {
+	if lease == nil {
+		return nil
+	}
+	payload := outboxPayload{
+		Meter:           lease.Meter,
+		Reason:          "memoryDeleteStarted",
+		TargetMemoryIDs: append([]string(nil), target.MemoryIDs...),
+	}
+	return s.storeOperation(ctx, lease, outboxStepApplyAdjustment, outboxPhaseAdjustmentIntent, payload, expiresAt, expiresAt.Add(2*time.Minute))
+}
+
+func (s *SQLStore) StoreAdjustmentDone(ctx context.Context, operationID string, reason string) error {
+	return s.updateStatus(ctx, operationID, outboxStatusDone, outboxPhaseDone, reason)
+}
+
+func (s *SQLStore) StoreAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error {
+	if lease == nil {
+		return nil
+	}
+	payload := outboxPayload{
+		Meter:  adj.Meter,
+		Delta:  adj.Delta,
+		Reason: adj.Reason,
+		Event:  outboxEventFromMetering(event),
+	}
+	return s.storeOperation(ctx, lease, outboxStepApplyAdjustment, outboxPhaseAdjustmentPending, payload, time.Time{}, s.now())
+}
+
+func (s *SQLStore) MarkOperationDone(ctx context.Context, operationID string, reason string) error {
+	return s.updateStatus(ctx, operationID, outboxStatusDone, outboxPhaseDone, reason)
+}
+
+func (s *SQLStore) MarkOperationRetryableFailure(ctx context.Context, operationID string, reason string) error {
+	return s.markRetryableFailure(ctx, operationID, reason)
+}
+
+func (s *SQLStore) PendingRows(ctx context.Context, limit int) ([]outboxRow, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, s.placeholder(`SELECT operation_id, tenant_id, cluster_id, subject_version, step, phase, payload_json, payload_hash, expires_at, attempt_count
+FROM runtime_usage_outbox
+WHERE status = 'pending' AND next_attempt_at <= CURRENT_TIMESTAMP
+ORDER BY next_attempt_at ASC
+LIMIT ?`), limit)
+	if err != nil {
+		return nil, fmt.Errorf("query runtime usage pending rows: %w", err)
+	}
+	defer rows.Close()
+
+	var out []outboxRow
+	for rows.Next() {
+		var row outboxRow
+		var clusterID sql.NullString
+		var expiresAt sql.NullTime
+		if err := rows.Scan(
+			&row.OperationID,
+			&row.TenantID,
+			&clusterID,
+			&row.SubjectVersion,
+			&row.Step,
+			&row.Phase,
+			&row.PayloadJSON,
+			&row.PayloadHash,
+			&expiresAt,
+			&row.AttemptCount,
+		); err != nil {
+			return nil, fmt.Errorf("scan runtime usage pending row: %w", err)
+		}
+		if clusterID.Valid {
+			row.ClusterID = clusterID.String
+		}
+		if expiresAt.Valid {
+			row.ExpiresAt = expiresAt.Time
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate runtime usage pending rows: %w", err)
+	}
+	return out, nil
+}
+
+func (s *SQLStore) MarkUnknownAfterCrash(ctx context.Context, operationID string, reason string) error {
+	return s.updateStatus(ctx, operationID, outboxStatusTerminalFailed, outboxPhaseUnknown, reason)
+}
+
+func (s *SQLStore) DeferPending(ctx context.Context, operationID string, reason string) error {
+	return s.markRetryableFailure(ctx, operationID, reason)
+}
+
+func (s *SQLStore) UpsertMeteringPending(ctx context.Context, evt metering.Event, _ []byte, payloadHash string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	storedPayload, err := marshalMeteringPendingPayload(evt)
+	if err != nil {
+		return err
+	}
+	reason := "different payload hash for existing metering operation"
+	_, err = s.db.ExecContext(ctx, s.placeholder(s.meteringPendingUpsertSQL()),
+		evt.OperationID,
+		evt.TenantID,
+		nullableString(evt.ClusterID),
+		subjectVersionTenantIDV1,
+		outboxStepSubmitMetering,
+		outboxPhaseMeteringPending,
+		string(storedPayload),
+		payloadHash,
+		outboxStatusPending,
+		reason,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert runtime usage metering outbox: %w", err)
+	}
+	if err := s.rejectMeteringPayloadConflict(ctx, evt.OperationID, reason); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *SQLStore) MarkMeteringDone(ctx context.Context, operationID string) error {
+	return s.updateStatus(ctx, operationID, outboxStatusDone, outboxPhaseDone, "")
+}
+
+func (s *SQLStore) MarkMeteringTerminalFailed(ctx context.Context, operationID, reason string) error {
+	return s.updateStatus(ctx, operationID, outboxStatusTerminalFailed, outboxPhaseTerminalFailed, reason)
+}
+
+func (s *SQLStore) MarkMeteringRetryableFailure(ctx context.Context, operationID, reason string) error {
+	return s.markRetryableFailure(ctx, operationID, reason)
+}
+
+func (s *SQLStore) storeOperation(ctx context.Context, lease *OperationLease, step, phase string, payload outboxPayload, expiresAt time.Time, nextAttemptAt time.Time) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	if nextAttemptAt.IsZero() {
+		nextAttemptAt = s.now()
+	}
+	payloadJSON, payloadHash, err := marshalOutboxPayload(payload)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, s.placeholder(s.operationUpsertSQL()),
+		lease.OperationID,
+		lease.Subject.TenantID,
+		nullableString(lease.Subject.ClusterID),
+		subjectVersionTenantIDV1,
+		step,
+		phase,
+		string(payloadJSON),
+		payloadHash,
+		nullableTime(expiresAt),
+		outboxStatusPending,
+		nextAttemptAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert runtime usage outbox operation: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) operationUpsertSQL() string {
+	if s.backend == "postgres" || s.backend == "db9" {
+		return `INSERT INTO runtime_usage_outbox
+(operation_id, tenant_id, cluster_id, subject_version, step, phase, payload_json, payload_hash, expires_at, status, next_attempt_at, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT (operation_id) DO UPDATE SET
+  tenant_id = EXCLUDED.tenant_id,
+  cluster_id = EXCLUDED.cluster_id,
+  subject_version = EXCLUDED.subject_version,
+  step = EXCLUDED.step,
+  phase = EXCLUDED.phase,
+  payload_json = EXCLUDED.payload_json,
+  payload_hash = EXCLUDED.payload_hash,
+  expires_at = EXCLUDED.expires_at,
+  status = EXCLUDED.status,
+  next_attempt_at = EXCLUDED.next_attempt_at,
+  last_error = NULL,
+  updated_at = CURRENT_TIMESTAMP`
+	}
+	return `INSERT INTO runtime_usage_outbox
+(operation_id, tenant_id, cluster_id, subject_version, step, phase, payload_json, payload_hash, expires_at, status, next_attempt_at, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON DUPLICATE KEY UPDATE
+  tenant_id = VALUES(tenant_id),
+  cluster_id = VALUES(cluster_id),
+  subject_version = VALUES(subject_version),
+  step = VALUES(step),
+  phase = VALUES(phase),
+  payload_json = VALUES(payload_json),
+  payload_hash = VALUES(payload_hash),
+  expires_at = VALUES(expires_at),
+  status = VALUES(status),
+  next_attempt_at = VALUES(next_attempt_at),
+  last_error = NULL,
+  updated_at = CURRENT_TIMESTAMP`
+}
+
+func (s *SQLStore) meteringPendingUpsertSQL() string {
+	if s.backend == "postgres" || s.backend == "db9" {
+		return `INSERT INTO runtime_usage_outbox
+(operation_id, tenant_id, cluster_id, subject_version, step, phase, payload_json, payload_hash, status, next_attempt_at, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON CONFLICT (operation_id) DO UPDATE SET
+  tenant_id = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.tenant_id
+    ELSE EXCLUDED.tenant_id
+  END,
+  cluster_id = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.cluster_id
+    ELSE EXCLUDED.cluster_id
+  END,
+  subject_version = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.subject_version
+    ELSE EXCLUDED.subject_version
+  END,
+  step = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.step
+    ELSE EXCLUDED.step
+  END,
+  phase = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN 'terminal_failed'
+    ELSE EXCLUDED.phase
+  END,
+  payload_json = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.payload_json
+    ELSE EXCLUDED.payload_json
+  END,
+  payload_hash = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.payload_hash
+    ELSE EXCLUDED.payload_hash
+  END,
+  status = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN 'terminal_failed'
+    ELSE EXCLUDED.status
+  END,
+  next_attempt_at = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN runtime_usage_outbox.next_attempt_at
+    ELSE CURRENT_TIMESTAMP
+  END,
+  last_error = CASE
+    WHEN runtime_usage_outbox.step = 'submit_metering_event' AND runtime_usage_outbox.payload_hash <> EXCLUDED.payload_hash THEN ?
+    ELSE NULL
+  END,
+  updated_at = CURRENT_TIMESTAMP`
+	}
+	return `INSERT INTO runtime_usage_outbox
+(operation_id, tenant_id, cluster_id, subject_version, step, phase, payload_json, payload_hash, status, next_attempt_at, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+ON DUPLICATE KEY UPDATE
+  phase = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), 'terminal_failed', VALUES(phase)),
+  status = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), 'terminal_failed', VALUES(status)),
+  next_attempt_at = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), next_attempt_at, CURRENT_TIMESTAMP),
+  last_error = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), ?, NULL),
+  tenant_id = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), tenant_id, VALUES(tenant_id)),
+  cluster_id = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), cluster_id, VALUES(cluster_id)),
+  subject_version = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), subject_version, VALUES(subject_version)),
+  payload_json = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), payload_json, VALUES(payload_json)),
+  step = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), step, VALUES(step)),
+  payload_hash = IF(step = 'submit_metering_event' AND payload_hash <> VALUES(payload_hash), payload_hash, VALUES(payload_hash)),
+  updated_at = CURRENT_TIMESTAMP`
+}
+
+func (s *SQLStore) rejectMeteringPayloadConflict(ctx context.Context, operationID, reason string) error {
+	var status, phase string
+	var lastError sql.NullString
+	err := s.db.QueryRowContext(ctx, s.placeholder("SELECT status, phase, last_error FROM runtime_usage_outbox WHERE operation_id = ?"), operationID).Scan(&status, &phase, &lastError)
+	if err != nil {
+		return fmt.Errorf("query runtime usage metering upsert result: %w", err)
+	}
+	if status == outboxStatusTerminalFailed && phase == outboxPhaseTerminalFailed && lastError.Valid && lastError.String == reason {
+		return fmt.Errorf("runtime usage outbox payload hash conflict for operation %s", operationID)
+	}
+	return nil
+}
+
+func (s *SQLStore) markRetryableFailure(ctx context.Context, operationID, reason string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	nextAttemptAt := s.now().Add(time.Minute)
+	var attempts int
+	if err := s.db.QueryRowContext(ctx, s.placeholder("SELECT attempt_count FROM runtime_usage_outbox WHERE operation_id = ?"), operationID).Scan(&attempts); err == nil {
+		nextAttemptAt = s.now().Add(retryBackoff(attempts, time.Minute, 15*time.Minute))
+	}
+	_, err := s.db.ExecContext(ctx, s.placeholder(`UPDATE runtime_usage_outbox
+SET status = 'pending', attempt_count = attempt_count + 1, next_attempt_at = ?, last_error = ?, updated_at = CURRENT_TIMESTAMP
+WHERE operation_id = ?`), nextAttemptAt, reason, operationID)
+	if err != nil {
+		return fmt.Errorf("mark runtime usage retryable failure: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) updateStatus(ctx context.Context, operationID, status, phase, reason string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	lastError := nullableString(reason)
+	if status == outboxStatusDone {
+		lastError = sql.NullString{}
+	}
+	_, err := s.db.ExecContext(ctx, s.placeholder(`UPDATE runtime_usage_outbox
+SET status = ?, phase = ?, last_error = ?, updated_at = CURRENT_TIMESTAMP
+WHERE operation_id = ?`), status, phase, lastError, operationID)
+	if err != nil {
+		return fmt.Errorf("update runtime usage outbox status: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) placeholder(query string) string {
+	if s.backend != "postgres" && s.backend != "db9" {
+		return query
+	}
+	out := make([]byte, 0, len(query)+8)
+	arg := 1
+	for i := 0; i < len(query); i++ {
+		if query[i] != '?' {
+			out = append(out, query[i])
+			continue
+		}
+		out = append(out, '$')
+		out = append(out, []byte(fmt.Sprint(arg))...)
+		arg++
+	}
+	return string(out)
+}
+
+func nullableString(value string) sql.NullString {
+	if value == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: value, Valid: true}
+}
+
+func nullableTime(value time.Time) sql.NullTime {
+	if value.IsZero() {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: value.UTC(), Valid: true}
+}
+
+func marshalOutboxPayload(payload outboxPayload) ([]byte, string, error) {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("marshal runtime usage outbox payload: %w", err)
+	}
+	sum := sha256.Sum256(payloadJSON)
+	return payloadJSON, hex.EncodeToString(sum[:]), nil
+}
+
+func outboxEventFromMetering(event MeteringEvent) *outboxMeteringPayload {
+	return &outboxMeteringPayload{
+		EventType:  event.EventType,
+		Meter:      event.Meter,
+		Units:      event.Units,
+		OccurredAt: event.OccurredAt.UTC(),
+		AgentName:  event.AgentName,
+		MemoryIDs:  append([]string(nil), event.MemoryIDs...),
+	}
+}
+
+func marshalMeteringPendingPayload(evt metering.Event) ([]byte, error) {
+	payload := outboxPayload{
+		Event: &outboxMeteringPayload{
+			APIKeySubject: evt.APIKeySubject,
+			EventType:     evt.EventType,
+			Meter:         evt.Meter,
+			Units:         evt.Units,
+			OccurredAt:    evt.OccurredAt.UTC(),
+			AgentName:     evt.AgentID,
+			MemoryIDs:     append([]string(nil), evt.MemoryIDs...),
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal runtime usage metering outbox payload: %w", err)
+	}
+	return payloadJSON, nil
+}
+
+func retryBackoff(attempts int, minDelay, maxDelay time.Duration) time.Duration {
+	if minDelay <= 0 {
+		minDelay = time.Minute
+	}
+	if maxDelay <= 0 || maxDelay < minDelay {
+		maxDelay = minDelay
+	}
+	delay := minDelay
+	for i := 0; i < attempts && delay < maxDelay; i++ {
+		delay *= 2
+		if delay > maxDelay {
+			return maxDelay
+		}
+	}
+	return delay
+}

--- a/server/internal/runtimeusage/outbox.go
+++ b/server/internal/runtimeusage/outbox.go
@@ -36,6 +36,7 @@ const (
 )
 
 type outboxPayload struct {
+	APIKeySubject   string                 `json:"apiKeySubject,omitempty"`
 	Meter           string                 `json:"meter,omitempty"`
 	Units           int64                  `json:"units,omitempty"`
 	Delta           int64                  `json:"delta,omitempty"`
@@ -139,10 +140,11 @@ func (s *SQLStore) StoreReservedActive(ctx context.Context, lease *OperationLeas
 		return nil
 	}
 	payload := outboxPayload{
-		Meter:  lease.Meter,
-		Units:  lease.Units,
-		Status: "reserved",
-		Reason: "reservationAccepted",
+		APIKeySubject: lease.Subject.APIKeySubject,
+		Meter:         lease.Meter,
+		Units:         lease.Units,
+		Status:        "reserved",
+		Reason:        "reservationAccepted",
 	}
 	if reservation != nil {
 		payload.Status = reservation.Status
@@ -155,11 +157,12 @@ func (s *SQLStore) StoreCommitPending(ctx context.Context, lease *OperationLease
 		return nil
 	}
 	payload := outboxPayload{
-		Meter:  lease.Meter,
-		Units:  lease.Units,
-		Status: ReservationStatusCommitted,
-		Reason: reservationCommitReason,
-		Event:  outboxEventFromMetering(event),
+		APIKeySubject: lease.Subject.APIKeySubject,
+		Meter:         lease.Meter,
+		Units:         lease.Units,
+		Status:        ReservationStatusCommitted,
+		Reason:        reservationCommitReason,
+		Event:         outboxEventFromMetering(event, lease.Subject.APIKeySubject),
 	}
 	return s.storeOperation(ctx, lease, outboxStepCommitReservation, outboxPhaseCommitPending, payload, time.Time{}, s.now())
 }
@@ -169,10 +172,11 @@ func (s *SQLStore) StoreReleasePending(ctx context.Context, lease *OperationLeas
 		return nil
 	}
 	payload := outboxPayload{
-		Meter:  lease.Meter,
-		Units:  lease.Units,
-		Status: ReservationStatusReleased,
-		Reason: reason,
+		APIKeySubject: lease.Subject.APIKeySubject,
+		Meter:         lease.Meter,
+		Units:         lease.Units,
+		Status:        ReservationStatusReleased,
+		Reason:        reason,
 	}
 	return s.storeOperation(ctx, lease, outboxStepReleaseReservation, outboxPhaseReleasePending, payload, time.Time{}, s.now())
 }
@@ -182,6 +186,7 @@ func (s *SQLStore) StoreAdjustmentIntent(ctx context.Context, lease *OperationLe
 		return nil
 	}
 	payload := outboxPayload{
+		APIKeySubject:   lease.Subject.APIKeySubject,
 		Meter:           lease.Meter,
 		Reason:          "memoryDeleteStarted",
 		TargetMemoryIDs: append([]string(nil), target.MemoryIDs...),
@@ -198,10 +203,11 @@ func (s *SQLStore) StoreAdjustmentPending(ctx context.Context, lease *OperationL
 		return nil
 	}
 	payload := outboxPayload{
-		Meter:  adj.Meter,
-		Delta:  adj.Delta,
-		Reason: adj.Reason,
-		Event:  outboxEventFromMetering(event),
+		APIKeySubject: lease.Subject.APIKeySubject,
+		Meter:         adj.Meter,
+		Delta:         adj.Delta,
+		Reason:        adj.Reason,
+		Event:         outboxEventFromMetering(event, lease.Subject.APIKeySubject),
 	}
 	return s.storeOperation(ctx, lease, outboxStepApplyAdjustment, outboxPhaseAdjustmentPending, payload, time.Time{}, s.now())
 }
@@ -539,14 +545,15 @@ func marshalOutboxPayload(payload outboxPayload) ([]byte, string, error) {
 	return payloadJSON, hex.EncodeToString(sum[:]), nil
 }
 
-func outboxEventFromMetering(event MeteringEvent) *outboxMeteringPayload {
+func outboxEventFromMetering(event MeteringEvent, apiKeySubject string) *outboxMeteringPayload {
 	return &outboxMeteringPayload{
-		EventType:  event.EventType,
-		Meter:      event.Meter,
-		Units:      event.Units,
-		OccurredAt: event.OccurredAt.UTC(),
-		AgentName:  event.AgentName,
-		MemoryIDs:  append([]string(nil), event.MemoryIDs...),
+		APIKeySubject: apiKeySubject,
+		EventType:     event.EventType,
+		Meter:         event.Meter,
+		Units:         event.Units,
+		OccurredAt:    event.OccurredAt.UTC(),
+		AgentName:     event.AgentName,
+		MemoryIDs:     append([]string(nil), event.MemoryIDs...),
 	}
 }
 

--- a/server/internal/runtimeusage/outbox_test.go
+++ b/server/internal/runtimeusage/outbox_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"io"
 	"strings"
 	"sync"
@@ -132,6 +133,37 @@ func TestSQLStoreStoreOperationUsesAtomicUpsert(t *testing.T) {
 				t.Fatalf("query does not contain %q:\n%s", tt.want, rec.execs[0].query)
 			}
 		})
+	}
+}
+
+func TestSQLStoreStoreCommitPendingPersistsAPIKeySubject(t *testing.T) {
+	rec := &recordingStore{}
+	store := NewSQLStore(newRecordingDB(t, rec), "tidb")
+	store.now = func() time.Time { return time.Unix(100, 0).UTC() }
+
+	lease := &OperationLease{
+		OperationID: "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		Subject:     Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "api-key-subject"},
+		Meter:       MeterRecalls,
+		Units:       1,
+		Reserved:    true,
+	}
+	if err := store.StoreCommitPending(context.Background(), lease, MeteringEvent{EventType: EventTypeRecall, Meter: MeterRecalls, Units: 1}); err != nil {
+		t.Fatalf("StoreCommitPending: %v", err)
+	}
+
+	if len(rec.execs) != 1 {
+		t.Fatalf("exec count = %d, want 1", len(rec.execs))
+	}
+	var payload outboxPayload
+	if err := json.Unmarshal([]byte(rec.execs[0].args[6].Value.(string)), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.APIKeySubject != "api-key-subject" {
+		t.Fatalf("payload APIKeySubject = %q, want api-key-subject", payload.APIKeySubject)
+	}
+	if payload.Event == nil || payload.Event.APIKeySubject != "api-key-subject" {
+		t.Fatalf("payload event = %+v, want APIKeySubject", payload.Event)
 	}
 }
 

--- a/server/internal/runtimeusage/outbox_test.go
+++ b/server/internal/runtimeusage/outbox_test.go
@@ -118,11 +118,11 @@ func TestSQLStoreStoreOperationUsesAtomicUpsert(t *testing.T) {
 			lease := &OperationLease{
 				OperationID: "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
 				Subject:     Subject{TenantID: "tenant-a", ClusterID: "cluster-a"},
-				Meter:       MeterRecalls,
+				Meter:       MeterMemoryRecallRequests,
 				Units:       1,
 				Reserved:    true,
 			}
-			if err := store.StoreCommitPending(context.Background(), lease, MeteringEvent{EventType: EventTypeRecall, Meter: MeterRecalls, Units: 1}); err != nil {
+			if err := store.StoreCommitPending(context.Background(), lease, MeteringEvent{EventType: EventTypeMemoryRecall, Meter: MeterMemoryRecallRequests, Units: 1}); err != nil {
 				t.Fatalf("StoreCommitPending: %v", err)
 			}
 
@@ -144,11 +144,11 @@ func TestSQLStoreStoreCommitPendingPersistsAPIKeySubject(t *testing.T) {
 	lease := &OperationLease{
 		OperationID: "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
 		Subject:     Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "api-key-subject"},
-		Meter:       MeterRecalls,
+		Meter:       MeterMemoryRecallRequests,
 		Units:       1,
 		Reserved:    true,
 	}
-	if err := store.StoreCommitPending(context.Background(), lease, MeteringEvent{EventType: EventTypeRecall, Meter: MeterRecalls, Units: 1}); err != nil {
+	if err := store.StoreCommitPending(context.Background(), lease, MeteringEvent{EventType: EventTypeMemoryRecall, Meter: MeterMemoryRecallRequests, Units: 1}); err != nil {
 		t.Fatalf("StoreCommitPending: %v", err)
 	}
 
@@ -177,7 +177,7 @@ func TestSQLStoreUpsertMeteringPendingUsesAtomicUpsertAndDetectsConflict(t *test
 		OperationID: "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
 		TenantID:    "tenant-a",
 		ClusterID:   "cluster-a",
-	}, []byte(`{"eventType":"recall"}`), "hash-a")
+	}, []byte(`{"eventType":"memoryRecall"}`), "hash-a")
 	if err == nil {
 		t.Fatal("UpsertMeteringPending error = nil, want payload hash conflict")
 	}

--- a/server/internal/runtimeusage/outbox_test.go
+++ b/server/internal/runtimeusage/outbox_test.go
@@ -1,0 +1,176 @@
+package runtimeusage
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/metering"
+)
+
+var (
+	recordingDriverOnce sync.Once
+	recordingStores     sync.Map
+)
+
+type recordedExec struct {
+	query string
+	args  []driver.NamedValue
+}
+
+type recordingStore struct {
+	mu          sync.Mutex
+	execs       []recordedExec
+	statusRow   []driver.Value
+	attemptsRow []driver.Value
+}
+
+type recordingDriver struct{}
+
+func (recordingDriver) Open(name string) (driver.Conn, error) {
+	value, _ := recordingStores.Load(name)
+	return &recordingConn{store: value.(*recordingStore)}, nil
+}
+
+type recordingConn struct {
+	store *recordingStore
+}
+
+func (c *recordingConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c *recordingConn) Close() error                        { return nil }
+func (c *recordingConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+
+func (c *recordingConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.store.mu.Lock()
+	defer c.store.mu.Unlock()
+	c.store.execs = append(c.store.execs, recordedExec{query: query, args: append([]driver.NamedValue(nil), args...)})
+	return driver.RowsAffected(1), nil
+}
+
+func (c *recordingConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	c.store.mu.Lock()
+	defer c.store.mu.Unlock()
+	if strings.Contains(query, "SELECT status, phase, last_error") {
+		return &recordingRows{cols: []string{"status", "phase", "last_error"}, values: append([]driver.Value(nil), c.store.statusRow...)}, nil
+	}
+	if strings.Contains(query, "SELECT attempt_count") {
+		return &recordingRows{cols: []string{"attempt_count"}, values: append([]driver.Value(nil), c.store.attemptsRow...)}, nil
+	}
+	return &recordingRows{}, nil
+}
+
+type recordingRows struct {
+	cols   []string
+	values []driver.Value
+	read   bool
+}
+
+func (r *recordingRows) Columns() []string { return r.cols }
+func (r *recordingRows) Close() error      { return nil }
+func (r *recordingRows) Next(dest []driver.Value) error {
+	if r.read || len(r.values) == 0 {
+		return io.EOF
+	}
+	r.read = true
+	copy(dest, r.values)
+	return nil
+}
+
+func newRecordingDB(t *testing.T, store *recordingStore) *sql.DB {
+	t.Helper()
+	recordingDriverOnce.Do(func() {
+		sql.Register("runtimeusage_recording", recordingDriver{})
+	})
+	name := t.Name()
+	recordingStores.Store(name, store)
+	t.Cleanup(func() {
+		recordingStores.Delete(name)
+	})
+	db, err := sql.Open("runtimeusage_recording", name)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = db.Close()
+	})
+	return db
+}
+
+func TestSQLStoreStoreOperationUsesAtomicUpsert(t *testing.T) {
+	for _, tt := range []struct {
+		backend string
+		want    string
+	}{
+		{backend: "tidb", want: "ON DUPLICATE KEY UPDATE"},
+		{backend: "postgres", want: "ON CONFLICT (operation_id) DO UPDATE"},
+	} {
+		t.Run(tt.backend, func(t *testing.T) {
+			rec := &recordingStore{}
+			store := NewSQLStore(newRecordingDB(t, rec), tt.backend)
+			store.now = func() time.Time { return time.Unix(100, 0).UTC() }
+
+			lease := &OperationLease{
+				OperationID: "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+				Subject:     Subject{TenantID: "tenant-a", ClusterID: "cluster-a"},
+				Meter:       MeterRecalls,
+				Units:       1,
+				Reserved:    true,
+			}
+			if err := store.StoreCommitPending(context.Background(), lease, MeteringEvent{EventType: EventTypeRecall, Meter: MeterRecalls, Units: 1}); err != nil {
+				t.Fatalf("StoreCommitPending: %v", err)
+			}
+
+			if len(rec.execs) != 1 {
+				t.Fatalf("exec count = %d, want 1", len(rec.execs))
+			}
+			if !strings.Contains(rec.execs[0].query, tt.want) {
+				t.Fatalf("query does not contain %q:\n%s", tt.want, rec.execs[0].query)
+			}
+		})
+	}
+}
+
+func TestSQLStoreUpsertMeteringPendingUsesAtomicUpsertAndDetectsConflict(t *testing.T) {
+	rec := &recordingStore{
+		statusRow: []driver.Value{outboxStatusTerminalFailed, outboxPhaseTerminalFailed, "different payload hash for existing metering operation"},
+	}
+	store := NewSQLStore(newRecordingDB(t, rec), "tidb")
+
+	err := store.UpsertMeteringPending(context.Background(), metering.Event{
+		OperationID: "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		TenantID:    "tenant-a",
+		ClusterID:   "cluster-a",
+	}, []byte(`{"eventType":"recall"}`), "hash-a")
+	if err == nil {
+		t.Fatal("UpsertMeteringPending error = nil, want payload hash conflict")
+	}
+	if len(rec.execs) != 1 {
+		t.Fatalf("exec count = %d, want 1", len(rec.execs))
+	}
+	if !strings.Contains(rec.execs[0].query, "ON DUPLICATE KEY UPDATE") {
+		t.Fatalf("query does not use atomic upsert:\n%s", rec.execs[0].query)
+	}
+}
+
+func TestSQLStoreDoneStatusClearsLastError(t *testing.T) {
+	rec := &recordingStore{}
+	store := NewSQLStore(newRecordingDB(t, rec), "tidb")
+
+	if err := store.MarkOperationDone(context.Background(), "op-1", "reservationReleased"); err != nil {
+		t.Fatalf("MarkOperationDone: %v", err)
+	}
+	if len(rec.execs) != 1 {
+		t.Fatalf("exec count = %d, want 1", len(rec.execs))
+	}
+	if len(rec.execs[0].args) < 3 {
+		t.Fatalf("args = %+v, want last_error arg", rec.execs[0].args)
+	}
+	if rec.execs[0].args[2].Value != nil {
+		t.Fatalf("last_error arg = %#v, want NULL", rec.execs[0].args[2].Value)
+	}
+}

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -110,6 +110,7 @@ type OutboxStore interface {
 	StoreAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error
 	MarkOperationDone(ctx context.Context, operationID string, reason string) error
 	MarkOperationRetryableFailure(ctx context.Context, operationID string, reason string) error
+	MarkUnknownAfterCrash(ctx context.Context, operationID string, reason string) error
 }
 
 type Manager interface {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -1,0 +1,189 @@
+package runtimeusage
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	MeterRecalls     = "recalls"
+	MeterMemorySlots = "memory_slots"
+
+	EventTypeRecall        = "recall"
+	EventTypeMemoryCreated = "memoryCreated"
+	EventTypeMemoryDeleted = "memoryDeleted"
+
+	ReservationStatusCommitted = "committed"
+	ReservationStatusReleased  = "released"
+)
+
+type Config struct {
+	Enabled         bool
+	BaseURL         string
+	InternalSecret  string
+	Timeout         time.Duration
+	MeteringTimeout time.Duration
+	ReservationTTL  time.Duration
+	OperationTTL    time.Duration
+	FailOpen        bool
+	OutboxEnabled   bool
+	Outbox          OutboxStore
+}
+
+type Subject struct {
+	TenantID      string
+	ClusterID     string
+	APIKeySubject string
+	AgentName     string
+}
+
+type OperationLease struct {
+	OperationID string
+	Subject     Subject
+	Meter       string
+	Units       int64
+	Reserved    bool
+}
+
+type Operation struct {
+	Meter string
+	Units int64
+}
+
+type Reservation struct {
+	OperationID            string    `json:"operationId"`
+	Meter                  string    `json:"meter"`
+	Units                  int64     `json:"units"`
+	Status                 string    `json:"status"`
+	ExpiresAt              time.Time `json:"expiresAt"`
+	RemainingIncludedUnits int64     `json:"remainingIncludedUnits"`
+	ReservedUnits          int64     `json:"reservedUnits"`
+	OverageAllowed         bool      `json:"overageAllowed"`
+}
+
+type Adjustment struct {
+	OperationID string
+	Meter       string
+	Delta       int64
+	Reason      string
+}
+
+type RecallResult struct {
+	MemoryIDs []string
+	AgentName string
+}
+
+type MemoryCreateResult struct {
+	MemoryIDs []string
+	AgentName string
+}
+
+type MemoryDeleteTarget struct {
+	MemoryIDs []string
+}
+
+type MemoryDeleteResult struct {
+	MemoryIDs        []string
+	MemorySlotsDelta int64
+	AgentName        string
+}
+
+type MeteringEvent struct {
+	EventType  string
+	Meter      string
+	Units      int64
+	OccurredAt time.Time
+	AgentName  string
+	MemoryIDs  []string
+}
+
+type OutboxStore interface {
+	StoreReservedActive(ctx context.Context, lease *OperationLease, reservation *Reservation, expiresAt time.Time) error
+	StoreCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error
+	StoreReleasePending(ctx context.Context, lease *OperationLease, reason string) error
+	StoreAdjustmentIntent(ctx context.Context, lease *OperationLease, target MemoryDeleteTarget, expiresAt time.Time) error
+	StoreAdjustmentDone(ctx context.Context, operationID string, reason string) error
+	StoreAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error
+	MarkOperationDone(ctx context.Context, operationID string, reason string) error
+	MarkOperationRetryableFailure(ctx context.Context, operationID string, reason string) error
+}
+
+type Manager interface {
+	Enabled() bool
+	BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error)
+	AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error
+	AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error)
+	BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error)
+	AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error
+	AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error)
+	BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error)
+	AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error
+	AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error)
+}
+
+type QuotaClient interface {
+	Reserve(ctx context.Context, subject Subject, operationID string, op Operation) (*Reservation, error)
+	FinalizeReservation(ctx context.Context, subject Subject, operationID string, status string, reason string) error
+	ApplyAdjustment(ctx context.Context, subject Subject, adj Adjustment) error
+}
+
+type QuotaDeniedError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *QuotaDeniedError) Error() string {
+	return "runtime usage quota denied"
+}
+
+func (e *QuotaDeniedError) ResponseBody() []byte {
+	if len(e.Body) == 0 {
+		body, _ := json.Marshal(map[string]any{
+			"code":      "runtime_quota_denied",
+			"message":   "runtime usage quota denied",
+			"retryable": false,
+		})
+		return body
+	}
+	return append([]byte(nil), e.Body...)
+}
+
+type UnavailableError struct {
+	Err error
+}
+
+func (e *UnavailableError) Error() string {
+	if e.Err == nil {
+		return "runtime usage unavailable"
+	}
+	return fmt.Sprintf("runtime usage unavailable: %v", e.Err)
+}
+
+func (e *UnavailableError) Unwrap() error {
+	return e.Err
+}
+
+type ConflictError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *ConflictError) Error() string {
+	return "runtime usage operation conflict"
+}
+
+func HTTPStatus(err error) int {
+	var denied *QuotaDeniedError
+	if errors.As(err, &denied) {
+		return http.StatusPaymentRequired
+	}
+	var conflict *ConflictError
+	if errors.As(err, &conflict) {
+		return http.StatusBadGateway
+	}
+	return http.StatusServiceUnavailable
+}

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -10,10 +10,11 @@ import (
 )
 
 const (
-	MeterRecalls     = "recalls"
-	MeterMemorySlots = "memory_slots"
+	MeterMemoryRecallRequests = "memory_recall_requests"
+	MeterMemoryWriteRequests  = "memory_write_requests"
 
-	EventTypeRecall        = "recall"
+	EventTypeMemoryRecall = "memoryRecall"
+
 	EventTypeMemoryCreated = "memoryCreated"
 	EventTypeMemoryDeleted = "memoryDeleted"
 
@@ -71,31 +72,21 @@ type Reservation struct {
 	OverageAllowed         bool      `json:"overageAllowed"`
 }
 
-type Adjustment struct {
-	OperationID string
-	Meter       string
-	Delta       int64
-	Reason      string
-}
-
 type RecallResult struct {
 	MemoryIDs []string
 	AgentName string
 }
 
 type MemoryCreateResult struct {
-	MemoryIDs []string
-	AgentName string
-}
-
-type MemoryDeleteTarget struct {
-	MemoryIDs []string
+	MemoryIDs       []string
+	AgentName       string
+	ObjectsAffected int64
 }
 
 type MemoryDeleteResult struct {
-	MemoryIDs        []string
-	MemorySlotsDelta int64
-	AgentName        string
+	MemoryIDs       []string
+	AgentName       string
+	ObjectsAffected int64
 }
 
 type MeteringEvent struct {
@@ -105,15 +96,12 @@ type MeteringEvent struct {
 	OccurredAt time.Time
 	AgentName  string
 	MemoryIDs  []string
+	Metadata   map[string]any
 }
 
 type OutboxStore interface {
-	StoreReservedActive(ctx context.Context, lease *OperationLease, reservation *Reservation, expiresAt time.Time) error
 	StoreCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error
 	StoreReleasePending(ctx context.Context, lease *OperationLease, reason string) error
-	StoreAdjustmentIntent(ctx context.Context, lease *OperationLease, target MemoryDeleteTarget, expiresAt time.Time) error
-	StoreAdjustmentDone(ctx context.Context, operationID string, reason string) error
-	StoreAdjustmentPending(ctx context.Context, lease *OperationLease, adj Adjustment, event MeteringEvent) error
 	MarkOperationDone(ctx context.Context, operationID string, reason string) error
 	MarkOperationRetryableFailure(ctx context.Context, operationID string, reason string) error
 	MarkUnknownAfterCrash(ctx context.Context, operationID string, reason string) error
@@ -127,7 +115,7 @@ type Manager interface {
 	BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error)
 	AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error
 	AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error)
-	BeforeMemoryDelete(ctx context.Context, subject Subject, target MemoryDeleteTarget) (*OperationLease, error)
+	BeforeMemoryDelete(ctx context.Context, subject Subject) (*OperationLease, error)
 	AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error
 	AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error)
 }
@@ -135,7 +123,6 @@ type Manager interface {
 type QuotaClient interface {
 	Reserve(ctx context.Context, subject Subject, operationID string, op Operation) (*Reservation, error)
 	FinalizeReservation(ctx context.Context, subject Subject, operationID string, status string, reason string) error
-	ApplyAdjustment(ctx context.Context, subject Subject, adj Adjustment) error
 }
 
 type QuotaDeniedError struct {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -16,6 +16,7 @@ const (
 	EventTypeMemoryRecall = "memoryRecall"
 
 	EventTypeMemoryCreated = "memoryCreated"
+	EventTypeMemoryUpdated = "memoryUpdated"
 	EventTypeMemoryDeleted = "memoryDeleted"
 
 	ReservationStatusCommitted = "committed"
@@ -83,6 +84,12 @@ type MemoryCreateResult struct {
 	ObjectsAffected int64
 }
 
+type MemoryUpdateResult struct {
+	MemoryIDs       []string
+	AgentName       string
+	ObjectsAffected int64
+}
+
 type MemoryDeleteResult struct {
 	MemoryIDs       []string
 	AgentName       string
@@ -115,6 +122,9 @@ type Manager interface {
 	BeforeMemoryCreate(ctx context.Context, subject Subject, units int64) (*OperationLease, error)
 	AfterMemoryCreateSuccess(ctx context.Context, lease *OperationLease, result MemoryCreateResult) error
 	AfterMemoryCreateFailure(ctx context.Context, lease *OperationLease, cause error)
+	BeforeMemoryUpdate(ctx context.Context, subject Subject) (*OperationLease, error)
+	AfterMemoryUpdateSuccess(ctx context.Context, lease *OperationLease, result MemoryUpdateResult) error
+	AfterMemoryUpdateFailure(ctx context.Context, lease *OperationLease, cause error)
 	BeforeMemoryDelete(ctx context.Context, subject Subject) (*OperationLease, error)
 	AfterMemoryDeleteSuccess(ctx context.Context, lease *OperationLease, result MemoryDeleteResult) error
 	AfterMemoryDeleteFailure(ctx context.Context, lease *OperationLease, cause error)

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -20,7 +20,11 @@ const (
 	ReservationStatusCommitted = "committed"
 	ReservationStatusReleased  = "released"
 
-	reservationCommitReason = "operationSucceeded"
+	reservationCommitReason              = "operationSucceeded"
+	reservationReleaseOperationFailed    = "operationFailed"
+	reservationReleaseOperationAbandoned = "operationAbandoned"
+	reservationReleaseClientCancelled    = "clientCancelled"
+	reservationReleaseTimeout            = "timeout"
 )
 
 type Config struct {
@@ -104,7 +108,6 @@ type MeteringEvent struct {
 }
 
 type OutboxStore interface {
-	StoreReservedActive(ctx context.Context, lease *OperationLease, reservation *Reservation, expiresAt time.Time) error
 	StoreCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error
 	StoreReleasePending(ctx context.Context, lease *OperationLease, reason string) error
 	StoreAdjustmentIntent(ctx context.Context, lease *OperationLease, target MemoryDeleteTarget, expiresAt time.Time) error

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -19,6 +19,8 @@ const (
 
 	ReservationStatusCommitted = "committed"
 	ReservationStatusReleased  = "released"
+
+	reservationCommitReason = "operationSucceeded"
 )
 
 type Config struct {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -68,7 +68,7 @@ type Reservation struct {
 	Units                  int64     `json:"units"`
 	Status                 string    `json:"status"`
 	ExpiresAt              time.Time `json:"expiresAt"`
-	RemainingIncludedUnits int64     `json:"remainingIncludedUnits"`
+	RemainingIncludedUnits *int64    `json:"remainingIncludedUnits"`
 	ReservedUnits          int64     `json:"reservedUnits"`
 	OverageAllowed         bool      `json:"overageAllowed"`
 }

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -108,6 +108,7 @@ type MeteringEvent struct {
 }
 
 type OutboxStore interface {
+	StoreReservedActive(ctx context.Context, lease *OperationLease, reservation *Reservation, expiresAt time.Time) error
 	StoreCommitPending(ctx context.Context, lease *OperationLease, event MeteringEvent) error
 	StoreReleasePending(ctx context.Context, lease *OperationLease, reason string) error
 	StoreAdjustmentIntent(ctx context.Context, lease *OperationLease, target MemoryDeleteTarget, expiresAt time.Time) error

--- a/server/internal/runtimeusage/worker.go
+++ b/server/internal/runtimeusage/worker.go
@@ -114,7 +114,7 @@ func (w *Worker) processCommit(ctx context.Context, row outboxRow, payload outbo
 		w.markUnknown(ctx, row, "commit worker saw unsupported phase")
 		return
 	}
-	subject := rowSubject(row)
+	subject := rowSubject(row, payload)
 	if err := w.client.FinalizeReservation(ctx, subject, row.OperationID, ReservationStatusCommitted, payload.Reason); err != nil {
 		w.markQuotaFailure(ctx, row, err)
 		return
@@ -127,7 +127,7 @@ func (w *Worker) processRelease(ctx context.Context, row outboxRow, payload outb
 		w.markUnknown(ctx, row, "release worker saw unsupported phase")
 		return
 	}
-	subject := rowSubject(row)
+	subject := rowSubject(row, payload)
 	if err := w.client.FinalizeReservation(ctx, subject, row.OperationID, ReservationStatusReleased, payload.Reason); err != nil {
 		w.markQuotaFailure(ctx, row, err)
 		return
@@ -146,7 +146,7 @@ func (w *Worker) processAdjustment(ctx context.Context, row outboxRow, payload o
 		w.markUnknown(ctx, row, "adjustment worker saw unsupported phase")
 		return
 	}
-	subject := rowSubject(row)
+	subject := rowSubject(row, payload)
 	adj := Adjustment{
 		OperationID: row.OperationID,
 		Meter:       payload.Meter,
@@ -172,7 +172,7 @@ func (w *Worker) requeueMetering(ctx context.Context, row outboxRow, payload out
 	if err := w.store.DeferPending(ctx, row.OperationID, "metering event requeued"); err != nil {
 		w.logger.WarnContext(ctx, "runtime usage metering requeue defer failed", "operation_id", row.OperationID, "err", err)
 	}
-	w.metering.Record(eventFromOutbox(row, *payload.Event))
+	w.metering.Record(eventFromOutbox(row, payload))
 }
 
 func (w *Worker) recordPayloadEvent(ctx context.Context, row outboxRow, payload outboxPayload) {
@@ -186,7 +186,7 @@ func (w *Worker) recordPayloadEvent(ctx context.Context, row outboxRow, payload 
 		w.markRetryable(ctx, row, errString("metering writer missing"))
 		return
 	}
-	w.metering.Record(eventFromOutbox(row, *payload.Event))
+	w.metering.Record(eventFromOutbox(row, payload))
 }
 
 func (w *Worker) markUnknownIfExpired(ctx context.Context, row outboxRow, reason string) {
@@ -244,31 +244,38 @@ func (w *Worker) markTerminal(ctx context.Context, row outboxRow, err error) {
 	)
 }
 
-func rowSubject(row outboxRow) Subject {
+func rowSubject(row outboxRow, payload outboxPayload) Subject {
 	return Subject{
 		TenantID:      row.TenantID,
 		ClusterID:     row.ClusterID,
-		APIKeySubject: row.TenantID,
+		APIKeySubject: apiKeySubjectFromOutbox(row, payload),
 	}
 }
 
-func eventFromOutbox(row outboxRow, payload outboxMeteringPayload) metering.Event {
-	apiKeySubject := payload.APIKeySubject
-	if apiKeySubject == "" {
-		apiKeySubject = row.TenantID
+func apiKeySubjectFromOutbox(row outboxRow, payload outboxPayload) string {
+	if payload.Event != nil && payload.Event.APIKeySubject != "" {
+		return payload.Event.APIKeySubject
 	}
+	if payload.APIKeySubject != "" {
+		return payload.APIKeySubject
+	}
+	return row.TenantID
+}
+
+func eventFromOutbox(row outboxRow, payload outboxPayload) metering.Event {
+	event := payload.Event
 	return metering.Event{
 		Category:      "runtime-usage",
 		TenantID:      row.TenantID,
 		ClusterID:     row.ClusterID,
-		AgentID:       payload.AgentName,
+		AgentID:       event.AgentName,
 		OperationID:   row.OperationID,
-		APIKeySubject: apiKeySubject,
-		EventType:     payload.EventType,
-		Meter:         payload.Meter,
-		Units:         payload.Units,
-		OccurredAt:    payload.OccurredAt.UTC(),
-		MemoryIDs:     append([]string(nil), payload.MemoryIDs...),
+		APIKeySubject: apiKeySubjectFromOutbox(row, payload),
+		EventType:     event.EventType,
+		Meter:         event.Meter,
+		Units:         event.Units,
+		OccurredAt:    event.OccurredAt.UTC(),
+		MemoryIDs:     append([]string(nil), event.MemoryIDs...),
 	}
 }
 

--- a/server/internal/runtimeusage/worker.go
+++ b/server/internal/runtimeusage/worker.go
@@ -96,8 +96,6 @@ func (w *Worker) processRow(ctx context.Context, row outboxRow) {
 		w.processCommit(ctx, row, payload)
 	case outboxStepReleaseReservation:
 		w.processRelease(ctx, row, payload)
-	case outboxStepApplyAdjustment:
-		w.processAdjustment(ctx, row, payload)
 	case outboxStepSubmitMetering:
 		w.requeueMetering(ctx, row, payload)
 	default:
@@ -106,10 +104,6 @@ func (w *Worker) processRow(ctx context.Context, row outboxRow) {
 }
 
 func (w *Worker) processCommit(ctx context.Context, row outboxRow, payload outboxPayload) {
-	if row.Phase == outboxPhaseReservedActive {
-		w.markUnknownIfExpired(ctx, row, "reserved operation expired before success/failure was persisted")
-		return
-	}
 	if row.Phase != outboxPhaseCommitPending {
 		w.markUnknown(ctx, row, "commit worker saw unsupported phase")
 		return
@@ -135,29 +129,6 @@ func (w *Worker) processRelease(ctx context.Context, row outboxRow, payload outb
 	if err := w.store.MarkOperationDone(ctx, row.OperationID, "reservationReleased"); err != nil {
 		w.logger.WarnContext(ctx, "runtime usage outbox mark done failed", "operation_id", row.OperationID, "err", err)
 	}
-}
-
-func (w *Worker) processAdjustment(ctx context.Context, row outboxRow, payload outboxPayload) {
-	if row.Phase == outboxPhaseAdjustmentIntent {
-		w.markUnknownIfExpired(ctx, row, "adjustment intent expired before success/failure was persisted")
-		return
-	}
-	if row.Phase != outboxPhaseAdjustmentPending {
-		w.markUnknown(ctx, row, "adjustment worker saw unsupported phase")
-		return
-	}
-	subject := rowSubject(row, payload)
-	adj := Adjustment{
-		OperationID: row.OperationID,
-		Meter:       payload.Meter,
-		Delta:       payload.Delta,
-		Reason:      payload.Reason,
-	}
-	if err := w.client.ApplyAdjustment(ctx, subject, adj); err != nil {
-		w.markQuotaFailure(ctx, row, err)
-		return
-	}
-	w.recordPayloadEvent(ctx, row, payload)
 }
 
 func (w *Worker) requeueMetering(ctx context.Context, row outboxRow, payload outboxPayload) {
@@ -187,16 +158,6 @@ func (w *Worker) recordPayloadEvent(ctx context.Context, row outboxRow, payload 
 		return
 	}
 	w.metering.Record(eventFromOutbox(row, payload))
-}
-
-func (w *Worker) markUnknownIfExpired(ctx context.Context, row outboxRow, reason string) {
-	if row.ExpiresAt.IsZero() || time.Now().UTC().Before(row.ExpiresAt.UTC().Add(2*time.Minute)) {
-		if err := w.store.DeferPending(ctx, row.OperationID, reason); err != nil {
-			w.logger.WarnContext(ctx, "runtime usage outbox defer failed", "operation_id", row.OperationID, "err", err)
-		}
-		return
-	}
-	w.markUnknown(ctx, row, reason)
 }
 
 func (w *Worker) markUnknown(ctx context.Context, row outboxRow, reason string) {
@@ -274,8 +235,9 @@ func eventFromOutbox(row outboxRow, payload outboxPayload) metering.Event {
 		EventType:     event.EventType,
 		Meter:         event.Meter,
 		Units:         event.Units,
-		OccurredAt:    event.OccurredAt.UTC(),
+		OccurredAt:    event.OccurredAt.UTC().Truncate(time.Second),
 		MemoryIDs:     append([]string(nil), event.MemoryIDs...),
+		Metadata:      cloneAnyMap(event.Metadata),
 	}
 }
 

--- a/server/internal/runtimeusage/worker.go
+++ b/server/internal/runtimeusage/worker.go
@@ -3,6 +3,7 @@ package runtimeusage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -23,6 +24,7 @@ type workerStore interface {
 	PendingRows(ctx context.Context, limit int) ([]outboxRow, error)
 	MarkOperationDone(ctx context.Context, operationID string, reason string) error
 	MarkOperationRetryableFailure(ctx context.Context, operationID string, reason string) error
+	MarkOperationTerminalFailed(ctx context.Context, operationID string, reason string) error
 	MarkUnknownAfterCrash(ctx context.Context, operationID string, reason string) error
 	DeferPending(ctx context.Context, operationID string, reason string) error
 }
@@ -114,7 +116,7 @@ func (w *Worker) processCommit(ctx context.Context, row outboxRow, payload outbo
 	}
 	subject := rowSubject(row)
 	if err := w.client.FinalizeReservation(ctx, subject, row.OperationID, ReservationStatusCommitted, payload.Reason); err != nil {
-		w.markRetryable(ctx, row, err)
+		w.markQuotaFailure(ctx, row, err)
 		return
 	}
 	w.recordPayloadEvent(ctx, row, payload)
@@ -127,7 +129,7 @@ func (w *Worker) processRelease(ctx context.Context, row outboxRow, payload outb
 	}
 	subject := rowSubject(row)
 	if err := w.client.FinalizeReservation(ctx, subject, row.OperationID, ReservationStatusReleased, payload.Reason); err != nil {
-		w.markRetryable(ctx, row, err)
+		w.markQuotaFailure(ctx, row, err)
 		return
 	}
 	if err := w.store.MarkOperationDone(ctx, row.OperationID, "reservationReleased"); err != nil {
@@ -152,7 +154,7 @@ func (w *Worker) processAdjustment(ctx context.Context, row outboxRow, payload o
 		Reason:      payload.Reason,
 	}
 	if err := w.client.ApplyAdjustment(ctx, subject, adj); err != nil {
-		w.markRetryable(ctx, row, err)
+		w.markQuotaFailure(ctx, row, err)
 		return
 	}
 	w.recordPayloadEvent(ctx, row, payload)
@@ -216,6 +218,30 @@ func (w *Worker) markRetryable(ctx context.Context, row outboxRow, err error) {
 	if err := w.store.MarkOperationRetryableFailure(ctx, row.OperationID, err.Error()); err != nil {
 		w.logger.WarnContext(ctx, "runtime usage outbox retry update failed", "operation_id", row.OperationID, "err", err)
 	}
+}
+
+func (w *Worker) markQuotaFailure(ctx context.Context, row outboxRow, err error) {
+	var conflict *ConflictError
+	if errors.As(err, &conflict) {
+		w.markTerminal(ctx, row, err)
+		return
+	}
+	w.markRetryable(ctx, row, err)
+}
+
+func (w *Worker) markTerminal(ctx context.Context, row outboxRow, err error) {
+	if err := w.store.MarkOperationTerminalFailed(ctx, row.OperationID, err.Error()); err != nil {
+		w.logger.WarnContext(ctx, "runtime usage outbox terminal update failed", "operation_id", row.OperationID, "err", err)
+	}
+	metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("quota_conflict").Inc()
+	w.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage outbox terminal failed",
+		"operation_id", row.OperationID,
+		"tenant_id", row.TenantID,
+		"cluster_id", row.ClusterID,
+		"step", row.Step,
+		"phase", row.Phase,
+		"err", err,
+	)
 }
 
 func rowSubject(row outboxRow) Subject {

--- a/server/internal/runtimeusage/worker.go
+++ b/server/internal/runtimeusage/worker.go
@@ -1,0 +1,253 @@
+package runtimeusage
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/metering"
+	"github.com/qiffang/mnemos/server/internal/metrics"
+)
+
+type Worker struct {
+	store        workerStore
+	client       QuotaClient
+	metering     metering.Writer
+	logger       *slog.Logger
+	pollInterval time.Duration
+	batchSize    int
+}
+
+type workerStore interface {
+	PendingRows(ctx context.Context, limit int) ([]outboxRow, error)
+	MarkOperationDone(ctx context.Context, operationID string, reason string) error
+	MarkOperationRetryableFailure(ctx context.Context, operationID string, reason string) error
+	MarkUnknownAfterCrash(ctx context.Context, operationID string, reason string) error
+	DeferPending(ctx context.Context, operationID string, reason string) error
+}
+
+func NewWorker(store *SQLStore, client QuotaClient, writer metering.Writer, logger *slog.Logger) *Worker {
+	return newWorker(store, client, writer, logger)
+}
+
+func newWorker(store workerStore, client QuotaClient, writer metering.Writer, logger *slog.Logger) *Worker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Worker{
+		store:        store,
+		client:       client,
+		metering:     writer,
+		logger:       logger,
+		pollInterval: 30 * time.Second,
+		batchSize:    100,
+	}
+}
+
+func (w *Worker) Run(ctx context.Context) error {
+	if w == nil || w.store == nil || w.client == nil {
+		return nil
+	}
+	ticker := time.NewTicker(w.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		if err := w.runOnce(ctx); err != nil && ctx.Err() == nil {
+			w.logger.WarnContext(ctx, "runtime usage outbox poll failed", "err", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (w *Worker) runOnce(ctx context.Context) error {
+	rows, err := w.store.PendingRows(ctx, w.batchSize)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		w.processRow(ctx, row)
+	}
+	return nil
+}
+
+func (w *Worker) processRow(ctx context.Context, row outboxRow) {
+	if row.SubjectVersion != subjectVersionTenantIDV1 {
+		w.markUnknown(ctx, row, "unsupported subject version")
+		return
+	}
+	var payload outboxPayload
+	if err := json.Unmarshal(row.PayloadJSON, &payload); err != nil {
+		w.markUnknown(ctx, row, "invalid outbox payload")
+		return
+	}
+
+	switch row.Step {
+	case outboxStepCommitReservation:
+		w.processCommit(ctx, row, payload)
+	case outboxStepReleaseReservation:
+		w.processRelease(ctx, row, payload)
+	case outboxStepApplyAdjustment:
+		w.processAdjustment(ctx, row, payload)
+	case outboxStepSubmitMetering:
+		w.requeueMetering(ctx, row, payload)
+	default:
+		w.markUnknown(ctx, row, "unsupported outbox step")
+	}
+}
+
+func (w *Worker) processCommit(ctx context.Context, row outboxRow, payload outboxPayload) {
+	if row.Phase == outboxPhaseReservedActive {
+		w.markUnknownIfExpired(ctx, row, "reserved operation expired before success/failure was persisted")
+		return
+	}
+	if row.Phase != outboxPhaseCommitPending {
+		w.markUnknown(ctx, row, "commit worker saw unsupported phase")
+		return
+	}
+	subject := rowSubject(row)
+	if err := w.client.FinalizeReservation(ctx, subject, row.OperationID, ReservationStatusCommitted, payload.Reason); err != nil {
+		w.markRetryable(ctx, row, err)
+		return
+	}
+	w.recordPayloadEvent(ctx, row, payload)
+}
+
+func (w *Worker) processRelease(ctx context.Context, row outboxRow, payload outboxPayload) {
+	if row.Phase != outboxPhaseReleasePending {
+		w.markUnknown(ctx, row, "release worker saw unsupported phase")
+		return
+	}
+	subject := rowSubject(row)
+	if err := w.client.FinalizeReservation(ctx, subject, row.OperationID, ReservationStatusReleased, payload.Reason); err != nil {
+		w.markRetryable(ctx, row, err)
+		return
+	}
+	if err := w.store.MarkOperationDone(ctx, row.OperationID, "reservationReleased"); err != nil {
+		w.logger.WarnContext(ctx, "runtime usage outbox mark done failed", "operation_id", row.OperationID, "err", err)
+	}
+}
+
+func (w *Worker) processAdjustment(ctx context.Context, row outboxRow, payload outboxPayload) {
+	if row.Phase == outboxPhaseAdjustmentIntent {
+		w.markUnknownIfExpired(ctx, row, "adjustment intent expired before success/failure was persisted")
+		return
+	}
+	if row.Phase != outboxPhaseAdjustmentPending {
+		w.markUnknown(ctx, row, "adjustment worker saw unsupported phase")
+		return
+	}
+	subject := rowSubject(row)
+	adj := Adjustment{
+		OperationID: row.OperationID,
+		Meter:       payload.Meter,
+		Delta:       payload.Delta,
+		Reason:      payload.Reason,
+	}
+	if err := w.client.ApplyAdjustment(ctx, subject, adj); err != nil {
+		w.markRetryable(ctx, row, err)
+		return
+	}
+	w.recordPayloadEvent(ctx, row, payload)
+}
+
+func (w *Worker) requeueMetering(ctx context.Context, row outboxRow, payload outboxPayload) {
+	if row.Phase != outboxPhaseMeteringPending {
+		w.markUnknown(ctx, row, "metering worker saw unsupported phase")
+		return
+	}
+	if w.metering == nil || payload.Event == nil {
+		w.markRetryable(ctx, row, errString("metering writer or payload missing"))
+		return
+	}
+	if err := w.store.DeferPending(ctx, row.OperationID, "metering event requeued"); err != nil {
+		w.logger.WarnContext(ctx, "runtime usage metering requeue defer failed", "operation_id", row.OperationID, "err", err)
+	}
+	w.metering.Record(eventFromOutbox(row, *payload.Event))
+}
+
+func (w *Worker) recordPayloadEvent(ctx context.Context, row outboxRow, payload outboxPayload) {
+	if payload.Event == nil {
+		if err := w.store.MarkOperationDone(ctx, row.OperationID, "quotaFinalized"); err != nil {
+			w.logger.WarnContext(ctx, "runtime usage outbox mark done failed", "operation_id", row.OperationID, "err", err)
+		}
+		return
+	}
+	if w.metering == nil {
+		w.markRetryable(ctx, row, errString("metering writer missing"))
+		return
+	}
+	w.metering.Record(eventFromOutbox(row, *payload.Event))
+}
+
+func (w *Worker) markUnknownIfExpired(ctx context.Context, row outboxRow, reason string) {
+	if row.ExpiresAt.IsZero() || time.Now().UTC().Before(row.ExpiresAt.UTC().Add(2*time.Minute)) {
+		if err := w.store.DeferPending(ctx, row.OperationID, reason); err != nil {
+			w.logger.WarnContext(ctx, "runtime usage outbox defer failed", "operation_id", row.OperationID, "err", err)
+		}
+		return
+	}
+	w.markUnknown(ctx, row, reason)
+}
+
+func (w *Worker) markUnknown(ctx context.Context, row outboxRow, reason string) {
+	if err := w.store.MarkUnknownAfterCrash(ctx, row.OperationID, reason); err != nil {
+		w.logger.WarnContext(ctx, "runtime usage outbox unknown mark failed", "operation_id", row.OperationID, "err", err)
+	}
+	metrics.RuntimeUsageManualReconciliationTotal.WithLabelValues("unknown_after_crash").Inc()
+	metrics.RuntimeUsageReservationUnknownTotal.WithLabelValues(row.Phase).Inc()
+	w.logger.ErrorContext(ctx, "manual_reconciliation_required: runtime usage outbox unknown",
+		"operation_id", row.OperationID,
+		"tenant_id", row.TenantID,
+		"cluster_id", row.ClusterID,
+		"phase", row.Phase,
+		"reason", reason,
+	)
+}
+
+func (w *Worker) markRetryable(ctx context.Context, row outboxRow, err error) {
+	if err := w.store.MarkOperationRetryableFailure(ctx, row.OperationID, err.Error()); err != nil {
+		w.logger.WarnContext(ctx, "runtime usage outbox retry update failed", "operation_id", row.OperationID, "err", err)
+	}
+}
+
+func rowSubject(row outboxRow) Subject {
+	return Subject{
+		TenantID:      row.TenantID,
+		ClusterID:     row.ClusterID,
+		APIKeySubject: row.TenantID,
+	}
+}
+
+func eventFromOutbox(row outboxRow, payload outboxMeteringPayload) metering.Event {
+	apiKeySubject := payload.APIKeySubject
+	if apiKeySubject == "" {
+		apiKeySubject = row.TenantID
+	}
+	return metering.Event{
+		Category:      "runtime-usage",
+		TenantID:      row.TenantID,
+		ClusterID:     row.ClusterID,
+		AgentID:       payload.AgentName,
+		OperationID:   row.OperationID,
+		APIKeySubject: apiKeySubject,
+		EventType:     payload.EventType,
+		Meter:         payload.Meter,
+		Units:         payload.Units,
+		OccurredAt:    payload.OccurredAt.UTC(),
+		MemoryIDs:     append([]string(nil), payload.MemoryIDs...),
+	}
+}
+
+type errString string
+
+func (e errString) Error() string {
+	return string(e)
+}

--- a/server/internal/runtimeusage/worker_test.go
+++ b/server/internal/runtimeusage/worker_test.go
@@ -1,0 +1,105 @@
+package runtimeusage
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type fakeWorkerStore struct {
+	rows      []outboxRow
+	done      []string
+	retryable []string
+	unknown   []string
+	deferred  []string
+}
+
+func (s *fakeWorkerStore) PendingRows(context.Context, int) ([]outboxRow, error) {
+	return append([]outboxRow(nil), s.rows...), nil
+}
+
+func (s *fakeWorkerStore) MarkOperationDone(_ context.Context, operationID string, _ string) error {
+	s.done = append(s.done, operationID)
+	return nil
+}
+
+func (s *fakeWorkerStore) MarkOperationRetryableFailure(_ context.Context, operationID string, _ string) error {
+	s.retryable = append(s.retryable, operationID)
+	return nil
+}
+
+func (s *fakeWorkerStore) MarkUnknownAfterCrash(_ context.Context, operationID string, _ string) error {
+	s.unknown = append(s.unknown, operationID)
+	return nil
+}
+
+func (s *fakeWorkerStore) DeferPending(_ context.Context, operationID string, _ string) error {
+	s.deferred = append(s.deferred, operationID)
+	return nil
+}
+
+func TestWorkerCommitPendingFinalizesQuotaBeforeMetering(t *testing.T) {
+	row := outboxRow{
+		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		TenantID:       "tenant-a",
+		ClusterID:      "cluster-a",
+		SubjectVersion: subjectVersionTenantIDV1,
+		Step:           outboxStepCommitReservation,
+		Phase:          outboxPhaseCommitPending,
+		PayloadJSON: []byte(`{
+			"meter":"recalls",
+			"units":1,
+			"status":"committed",
+			"reason":"operationSucceeded",
+			"event":{
+				"eventType":"recall",
+				"meter":"recalls",
+				"units":1,
+				"occurredAt":"2026-05-13T00:00:00Z",
+				"agentName":"Codex",
+				"memoryIds":["mem-1"]
+			}
+		}`),
+	}
+	store := &fakeWorkerStore{rows: []outboxRow{row}}
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	worker := newWorker(store, quota, writer, nil)
+
+	if err := worker.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if len(quota.finalized) != 1 {
+		t.Fatalf("finalized = %+v, want one commit", quota.finalized)
+	}
+	if len(writer.events) != 1 {
+		t.Fatalf("events = %+v, want one metering event", writer.events)
+	}
+	if writer.events[0].OperationID != row.OperationID || writer.events[0].APIKeySubject != "tenant-a" {
+		t.Fatalf("event = %+v", writer.events[0])
+	}
+	if len(store.retryable) != 0 || len(store.unknown) != 0 {
+		t.Fatalf("store retryable=%+v unknown=%+v, want none", store.retryable, store.unknown)
+	}
+}
+
+func TestWorkerReservedActiveMarksUnknownOnlyAfterExpiry(t *testing.T) {
+	row := outboxRow{
+		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		TenantID:       "tenant-a",
+		SubjectVersion: subjectVersionTenantIDV1,
+		Step:           outboxStepCommitReservation,
+		Phase:          outboxPhaseReservedActive,
+		PayloadJSON:    []byte(`{"meter":"recalls","units":1}`),
+		ExpiresAt:      time.Now().UTC().Add(-3 * time.Minute),
+	}
+	store := &fakeWorkerStore{rows: []outboxRow{row}}
+	worker := newWorker(store, &fakeQuotaClient{}, &captureWriter{}, nil)
+
+	if err := worker.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if len(store.unknown) != 1 || store.unknown[0] != row.OperationID {
+		t.Fatalf("unknown = %+v, want operation marked unknown", store.unknown)
+	}
+}

--- a/server/internal/runtimeusage/worker_test.go
+++ b/server/internal/runtimeusage/worker_test.go
@@ -3,7 +3,6 @@ package runtimeusage
 import (
 	"context"
 	"testing"
-	"time"
 )
 
 type fakeWorkerStore struct {
@@ -53,13 +52,13 @@ func TestWorkerCommitPendingFinalizesQuotaBeforeMetering(t *testing.T) {
 		Step:           outboxStepCommitReservation,
 		Phase:          outboxPhaseCommitPending,
 		PayloadJSON: []byte(`{
-			"meter":"recalls",
+			"meter":"memory_recall_requests",
 			"units":1,
 			"status":"committed",
 			"reason":"operationSucceeded",
 			"event":{
-				"eventType":"recall",
-				"meter":"recalls",
+				"eventType":"memoryRecall",
+				"meter":"memory_recall_requests",
 				"units":1,
 				"occurredAt":"2026-05-13T00:00:00Z",
 				"agentName":"Codex",
@@ -99,14 +98,14 @@ func TestWorkerCommitPendingReplaysStoredAPIKeySubject(t *testing.T) {
 		Phase:          outboxPhaseCommitPending,
 		PayloadJSON: []byte(`{
 			"apiKeySubject":"api-key-subject",
-			"meter":"recalls",
+			"meter":"memory_recall_requests",
 			"units":1,
 			"status":"committed",
 			"reason":"operationSucceeded",
 			"event":{
 				"apiKeySubject":"api-key-subject",
-				"eventType":"recall",
-				"meter":"recalls",
+				"eventType":"memoryRecall",
+				"meter":"memory_recall_requests",
 				"units":1,
 				"occurredAt":"2026-05-13T00:00:00Z",
 				"agentName":"Codex",
@@ -130,46 +129,6 @@ func TestWorkerCommitPendingReplaysStoredAPIKeySubject(t *testing.T) {
 	}
 }
 
-func TestWorkerAdjustmentPendingReplaysStoredAPIKeySubject(t *testing.T) {
-	row := outboxRow{
-		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
-		TenantID:       "tenant-a",
-		ClusterID:      "cluster-a",
-		SubjectVersion: subjectVersionTenantIDV1,
-		Step:           outboxStepApplyAdjustment,
-		Phase:          outboxPhaseAdjustmentPending,
-		PayloadJSON: []byte(`{
-			"apiKeySubject":"api-key-subject",
-			"meter":"memory_slots",
-			"delta":-1,
-			"reason":"memoryDeleted",
-			"event":{
-				"apiKeySubject":"api-key-subject",
-				"eventType":"memoryDeleted",
-				"meter":"memory_slots",
-				"units":-1,
-				"occurredAt":"2026-05-13T00:00:00Z",
-				"agentName":"Codex",
-				"memoryIds":["mem-1"]
-			}
-		}`),
-	}
-	store := &fakeWorkerStore{rows: []outboxRow{row}}
-	quota := &fakeQuotaClient{}
-	writer := &captureWriter{}
-	worker := newWorker(store, quota, writer, nil)
-
-	if err := worker.runOnce(context.Background()); err != nil {
-		t.Fatalf("runOnce: %v", err)
-	}
-	if len(quota.adjustSubjects) != 1 || quota.adjustSubjects[0].APIKeySubject != "api-key-subject" {
-		t.Fatalf("adjust subjects = %+v, want stored API key subject", quota.adjustSubjects)
-	}
-	if len(writer.events) != 1 || writer.events[0].APIKeySubject != "api-key-subject" {
-		t.Fatalf("events = %+v, want stored API key subject", writer.events)
-	}
-}
-
 func TestWorkerCommitConflictMarksTerminalFailed(t *testing.T) {
 	row := outboxRow{
 		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
@@ -178,7 +137,7 @@ func TestWorkerCommitConflictMarksTerminalFailed(t *testing.T) {
 		SubjectVersion: subjectVersionTenantIDV1,
 		Step:           outboxStepCommitReservation,
 		Phase:          outboxPhaseCommitPending,
-		PayloadJSON:    []byte(`{"meter":"recalls","units":1,"status":"committed","reason":"operationSucceeded"}`),
+		PayloadJSON:    []byte(`{"meter":"memory_recall_requests","units":1,"status":"committed","reason":"operationSucceeded"}`),
 	}
 	store := &fakeWorkerStore{rows: []outboxRow{row}}
 	quota := &fakeQuotaClient{finalizeErr: &ConflictError{StatusCode: 409}}
@@ -192,26 +151,5 @@ func TestWorkerCommitConflictMarksTerminalFailed(t *testing.T) {
 	}
 	if len(store.retryable) != 0 {
 		t.Fatalf("retryable = %+v, want none", store.retryable)
-	}
-}
-
-func TestWorkerReservedActiveMarksUnknownOnlyAfterExpiry(t *testing.T) {
-	row := outboxRow{
-		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
-		TenantID:       "tenant-a",
-		SubjectVersion: subjectVersionTenantIDV1,
-		Step:           outboxStepCommitReservation,
-		Phase:          outboxPhaseReservedActive,
-		PayloadJSON:    []byte(`{"meter":"recalls","units":1}`),
-		ExpiresAt:      time.Now().UTC().Add(-3 * time.Minute),
-	}
-	store := &fakeWorkerStore{rows: []outboxRow{row}}
-	worker := newWorker(store, &fakeQuotaClient{}, &captureWriter{}, nil)
-
-	if err := worker.runOnce(context.Background()); err != nil {
-		t.Fatalf("runOnce: %v", err)
-	}
-	if len(store.unknown) != 1 || store.unknown[0] != row.OperationID {
-		t.Fatalf("unknown = %+v, want operation marked unknown", store.unknown)
 	}
 }

--- a/server/internal/runtimeusage/worker_test.go
+++ b/server/internal/runtimeusage/worker_test.go
@@ -10,6 +10,7 @@ type fakeWorkerStore struct {
 	rows      []outboxRow
 	done      []string
 	retryable []string
+	terminal  []string
 	unknown   []string
 	deferred  []string
 }
@@ -25,6 +26,11 @@ func (s *fakeWorkerStore) MarkOperationDone(_ context.Context, operationID strin
 
 func (s *fakeWorkerStore) MarkOperationRetryableFailure(_ context.Context, operationID string, _ string) error {
 	s.retryable = append(s.retryable, operationID)
+	return nil
+}
+
+func (s *fakeWorkerStore) MarkOperationTerminalFailed(_ context.Context, operationID string, _ string) error {
+	s.terminal = append(s.terminal, operationID)
 	return nil
 }
 
@@ -80,6 +86,31 @@ func TestWorkerCommitPendingFinalizesQuotaBeforeMetering(t *testing.T) {
 	}
 	if len(store.retryable) != 0 || len(store.unknown) != 0 {
 		t.Fatalf("store retryable=%+v unknown=%+v, want none", store.retryable, store.unknown)
+	}
+}
+
+func TestWorkerCommitConflictMarksTerminalFailed(t *testing.T) {
+	row := outboxRow{
+		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		TenantID:       "tenant-a",
+		ClusterID:      "cluster-a",
+		SubjectVersion: subjectVersionTenantIDV1,
+		Step:           outboxStepCommitReservation,
+		Phase:          outboxPhaseCommitPending,
+		PayloadJSON:    []byte(`{"meter":"recalls","units":1,"status":"committed","reason":"operationSucceeded"}`),
+	}
+	store := &fakeWorkerStore{rows: []outboxRow{row}}
+	quota := &fakeQuotaClient{finalizeErr: &ConflictError{StatusCode: 409}}
+	worker := newWorker(store, quota, &captureWriter{}, nil)
+
+	if err := worker.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if len(store.terminal) != 1 || store.terminal[0] != row.OperationID {
+		t.Fatalf("terminal = %+v, want operation marked terminal", store.terminal)
+	}
+	if len(store.retryable) != 0 {
+		t.Fatalf("retryable = %+v, want none", store.retryable)
 	}
 }
 

--- a/server/internal/runtimeusage/worker_test.go
+++ b/server/internal/runtimeusage/worker_test.go
@@ -89,6 +89,87 @@ func TestWorkerCommitPendingFinalizesQuotaBeforeMetering(t *testing.T) {
 	}
 }
 
+func TestWorkerCommitPendingReplaysStoredAPIKeySubject(t *testing.T) {
+	row := outboxRow{
+		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		TenantID:       "tenant-a",
+		ClusterID:      "cluster-a",
+		SubjectVersion: subjectVersionTenantIDV1,
+		Step:           outboxStepCommitReservation,
+		Phase:          outboxPhaseCommitPending,
+		PayloadJSON: []byte(`{
+			"apiKeySubject":"api-key-subject",
+			"meter":"recalls",
+			"units":1,
+			"status":"committed",
+			"reason":"operationSucceeded",
+			"event":{
+				"apiKeySubject":"api-key-subject",
+				"eventType":"recall",
+				"meter":"recalls",
+				"units":1,
+				"occurredAt":"2026-05-13T00:00:00Z",
+				"agentName":"Codex",
+				"memoryIds":["mem-1"]
+			}
+		}`),
+	}
+	store := &fakeWorkerStore{rows: []outboxRow{row}}
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	worker := newWorker(store, quota, writer, nil)
+
+	if err := worker.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if len(quota.finalizeSubjects) != 1 || quota.finalizeSubjects[0].APIKeySubject != "api-key-subject" {
+		t.Fatalf("finalize subjects = %+v, want stored API key subject", quota.finalizeSubjects)
+	}
+	if len(writer.events) != 1 || writer.events[0].APIKeySubject != "api-key-subject" {
+		t.Fatalf("events = %+v, want stored API key subject", writer.events)
+	}
+}
+
+func TestWorkerAdjustmentPendingReplaysStoredAPIKeySubject(t *testing.T) {
+	row := outboxRow{
+		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",
+		TenantID:       "tenant-a",
+		ClusterID:      "cluster-a",
+		SubjectVersion: subjectVersionTenantIDV1,
+		Step:           outboxStepApplyAdjustment,
+		Phase:          outboxPhaseAdjustmentPending,
+		PayloadJSON: []byte(`{
+			"apiKeySubject":"api-key-subject",
+			"meter":"memory_slots",
+			"delta":-1,
+			"reason":"memoryDeleted",
+			"event":{
+				"apiKeySubject":"api-key-subject",
+				"eventType":"memoryDeleted",
+				"meter":"memory_slots",
+				"units":-1,
+				"occurredAt":"2026-05-13T00:00:00Z",
+				"agentName":"Codex",
+				"memoryIds":["mem-1"]
+			}
+		}`),
+	}
+	store := &fakeWorkerStore{rows: []outboxRow{row}}
+	quota := &fakeQuotaClient{}
+	writer := &captureWriter{}
+	worker := newWorker(store, quota, writer, nil)
+
+	if err := worker.runOnce(context.Background()); err != nil {
+		t.Fatalf("runOnce: %v", err)
+	}
+	if len(quota.adjustSubjects) != 1 || quota.adjustSubjects[0].APIKeySubject != "api-key-subject" {
+		t.Fatalf("adjust subjects = %+v, want stored API key subject", quota.adjustSubjects)
+	}
+	if len(writer.events) != 1 || writer.events[0].APIKeySubject != "api-key-subject" {
+		t.Fatalf("events = %+v, want stored API key subject", writer.events)
+	}
+}
+
 func TestWorkerCommitConflictMarksTerminalFailed(t *testing.T) {
 	row := outboxRow{
 		OperationID:    "018f7f3a-7b8c-7c2d-9a5b-6d7e8f901234",

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1168,8 +1168,8 @@ func (m *memoryRepoMock) UpdateOptimistic(ctx context.Context, mem *domain.Memor
 	return m.updateOptimisticErr
 }
 
-func (m *memoryRepoMock) SoftDelete(ctx context.Context, id, agentName string) error {
-	return nil
+func (m *memoryRepoMock) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
+	return 1, nil
 }
 
 func (m *memoryRepoMock) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -836,7 +836,7 @@ func (s *MemoryService) Update(ctx context.Context, agentName, id, content strin
 	return updated, nil
 }
 
-func (s *MemoryService) Delete(ctx context.Context, id, agentName string) error {
+func (s *MemoryService) Delete(ctx context.Context, id, agentName string) (int64, error) {
 	return s.memories.SoftDelete(ctx, id, agentName)
 }
 

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -843,11 +843,20 @@ func (s *MemoryService) Delete(ctx context.Context, id, agentName string) (int64
 // BulkDelete soft-deletes multiple memories by ID. Returns the number of
 // memories actually deleted (already-deleted rows are excluded from the count).
 func (s *MemoryService) BulkDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	unique, err := ValidateBulkDeleteIDs(ids)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.memories.BulkSoftDelete(ctx, unique, agentName)
+}
+
+func ValidateBulkDeleteIDs(ids []string) ([]string, error) {
 	if len(ids) == 0 {
-		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
+		return nil, &domain.ValidationError{Field: "ids", Message: "required"}
 	}
 	if len(ids) > maxBulkDeleteSize {
-		return 0, &domain.ValidationError{Field: "ids", Message: "too many (max 1000)"}
+		return nil, &domain.ValidationError{Field: "ids", Message: "too many (max 1000)"}
 	}
 
 	seen := make(map[string]struct{}, len(ids))
@@ -862,10 +871,9 @@ func (s *MemoryService) BulkDelete(ctx context.Context, ids []string, agentName 
 		}
 	}
 	if len(unique) == 0 {
-		return 0, &domain.ValidationError{Field: "ids", Message: "required"}
+		return nil, &domain.ValidationError{Field: "ids", Message: "required"}
 	}
-
-	return s.memories.BulkSoftDelete(ctx, unique, agentName)
+	return unique, nil
 }
 
 func (s *MemoryService) Bootstrap(ctx context.Context, limit int) ([]domain.Memory, error) {
@@ -880,24 +888,13 @@ func (s *MemoryService) Bootstrap(ctx context.Context, limit int) ([]domain.Memo
 
 // BulkCreate creates multiple memories at once.
 func (s *MemoryService) BulkCreate(ctx context.Context, agentName string, items []BulkMemoryInput) ([]domain.Memory, error) {
-	if len(items) == 0 {
-		return nil, &domain.ValidationError{Field: "memories", Message: "required"}
-	}
-	if len(items) > maxBulkSize {
-		return nil, &domain.ValidationError{Field: "memories", Message: "too many (max 100)"}
+	if err := ValidateBulkMemoryInputs(items); err != nil {
+		return nil, err
 	}
 
 	now := time.Now()
 	memories := make([]*domain.Memory, 0, len(items))
-	for i, item := range items {
-		if err := validateMemoryInput(item.Content, item.Tags); err != nil {
-			var ve *domain.ValidationError
-			if errors.As(err, &ve) {
-				ve.Field = "memories[" + strconv.Itoa(i) + "]." + ve.Field
-			}
-			return nil, err
-		}
-
+	for _, item := range items {
 		var embedding []float32
 		if s.autoModel == "" && s.embedder != nil {
 			var err error
@@ -935,6 +932,26 @@ func (s *MemoryService) BulkCreate(ctx context.Context, agentName string, items 
 		result[i] = *m
 	}
 	return result, nil
+}
+
+func ValidateBulkMemoryInputs(items []BulkMemoryInput) error {
+	if len(items) == 0 {
+		return &domain.ValidationError{Field: "memories", Message: "required"}
+	}
+	if len(items) > maxBulkSize {
+		return &domain.ValidationError{Field: "memories", Message: "too many (max 100)"}
+	}
+
+	for i, item := range items {
+		if err := validateMemoryInput(item.Content, item.Tags); err != nil {
+			var ve *domain.ValidationError
+			if errors.As(err, &ve) {
+				ve.Field = "memories[" + strconv.Itoa(i) + "]." + ve.Field
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 // BulkMemoryInput is the input shape for each item in a bulk create request.

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -186,3 +186,22 @@ CREATE TABLE IF NOT EXISTS upload_tasks (
   INDEX idx_upload_tenant (tenant_id),
   INDEX idx_upload_poll (status, created_at)
 );
+
+CREATE TABLE IF NOT EXISTS runtime_usage_outbox (
+  operation_id      VARCHAR(36) PRIMARY KEY,
+  tenant_id         VARCHAR(36) NOT NULL,
+  cluster_id        VARCHAR(255) NULL,
+  subject_version   VARCHAR(32) NOT NULL DEFAULT 'tenant_id_v1',
+  step              VARCHAR(32) NOT NULL,
+  phase             VARCHAR(32) NOT NULL,
+  payload_json      JSON        NOT NULL,
+  payload_hash      VARCHAR(64) NOT NULL,
+  expires_at        TIMESTAMP   NULL,
+  status            VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempt_count     INT         NOT NULL DEFAULT 0,
+  next_attempt_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_error        TEXT        NULL,
+  created_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_runtime_usage_outbox_poll (status, next_attempt_at)
+);


### PR DESCRIPTION
## Summary

This PR adds mem9-server runtime usage integration for commercial mode. It introduces a synchronous quota gate for billable runtime operations and an async console metering path that reuses the existing `metering.Writer` pattern.

## Agent Reading Map

1. Design proposal: `docs/design/mem9-runtime-usage-client-proposal.md`.
2. Config and env validation: `server/internal/config/config.go`.
3. Server wiring: `server/cmd/mnemo-server/main.go` and `server/internal/handler/runtime_usage.go`.
4. Recall/create/delete hook points: `server/internal/handler/memory.go`.
5. Runtime usage core: `server/internal/runtimeusage/`.
6. Console-shaped metering writer: `server/internal/metering/console_writer.go` and `server/internal/metering/writer.go`.
7. Durable outbox schema: `server/schema.sql` and `runtimeusage.SQLStore.EnsureSchema`.

## Runtime Workflow

1. With `MNEMO_RUNTIME_USAGE_ENABLED=false`, runtime usage is a no-op and OSS/self-hosted behavior is unchanged.
2. With runtime usage enabled, handlers build a `runtimeusage.Subject` from authenticated tenant, cluster, agent, and API-key subject context.
3. Recall and memory create reserve quota before normal execution. Quota denial blocks the request and returns the console quota response.
4. Successful recall/create finalizes the reservation as `committed`, then records console metering through `metering.Writer`.
5. Failed recall/create finalizes the reservation as `released` and does not emit metering.
6. Delete creates an adjustment intent before the destructive operation, applies a quota adjustment after success, and meters only non-zero memory-slot deltas.
7. The SQL outbox and worker retry quota commit, release, adjustment, and console metering handoff using the same `operationId`.
8. Quota operations are synchronous and fail closed by default; metering remains async, non-blocking, and sidecar-shaped.

## Config Contract

1. `MNEMO_RUNTIME_USAGE_ENABLED` enables the combined commercial runtime usage path.
2. `MNEMO_RUNTIME_USAGE_BASE_URL` is the console-server base URL used for both quota and console metering APIs.
3. `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` is the bearer secret for console internal APIs.
4. `MNEMO_RUNTIME_USAGE_TIMEOUT` controls synchronous quota API calls.
5. `MNEMO_RUNTIME_USAGE_METERING_TIMEOUT` controls async console metering delivery calls.
6. `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` and `MNEMO_RUNTIME_USAGE_OPERATION_TTL` bound local retry/watchdog behavior.
7. `MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED` controls the durable retry outbox and cannot be disabled in fail-closed runtime usage mode.
8. `MNEMO_METERING_*` remains the legacy/export metering surface and is not required for console billing metering correctness.

## Important Design Choices

1. Quota and metering are intentionally separate phases: quota can block the normal recall/create/delete path; metering cannot.
2. Console metering does not introduce a second writer interface. It extends `metering.Event` and keeps `Writer.Record` as the async handoff point.
3. The quota manager owns `operationId` generation so quota and metering use the same operation identity.
4. Console metering URL construction comes from `MNEMO_RUNTIME_USAGE_BASE_URL`, not `MNEMO_METERING_URL`.
5. The outbox table lives in the control-plane database because it tracks cross-tenant runtime usage operations, not per-tenant memory data.

## Tests / Validation

1. `cd server && go test ./...`
2. `make test` passed with existing macOS linker warnings about malformed `LC_DYSYMTAB`.
3. `make vet`
4. `make build`
5. `git diff --check`