### PR TITLE
Add Space Chain e2e smoke coverage

### DIFF
--- a/docs/design/issue-311-space-chain-e2e-proposal.md
+++ b/docs/design/issue-311-space-chain-e2e-proposal.md
@@ -1,0 +1,101 @@
+---
+title: "Issue 311 Space Chain E2E Proposal"
+---
+
+# Issue 311 Space Chain E2E Proposal
+
+## Context
+
+Issue #311, opened on 2026-05-15, asks for missing end-to-end coverage for the Space Chain feature. The issue acceptance criteria are:
+
+1. E2E test exists for the Space Chain feature.
+2. Test covers the primary happy path.
+3. Test is wired into the existing e2e test workflow.
+4. Required setup and cleanup are handled by the test.
+
+PR #308 merged Space Chain runtime support on 2026-05-15. The implementation added server-side chain management, `chain_` key auth, ordered recall/write behavior, and provenance. The remaining gap is a live smoke script that proves those pieces work together against a running server.
+
+## Current Evidence
+
+1. The PRD defines Space Chain as an ordered chain of Spaces, queried with a `chain_` key, where earlier nodes get the first chance to answer. See [docs/design/space-chain-prd.md:11](space-chain-prd.md).
+2. The server exposes management endpoints for create, get-by-key, nodes, bindings, and disable under `/v1alpha2/space-chains`. See [server/internal/handler/handler.go:192](../../server/internal/handler/handler.go).
+3. Runtime memory routes already accept `X-API-Key` through `/v1alpha2/mem9s/...`. See [server/internal/handler/handler.go:225](../../server/internal/handler/handler.go).
+4. Chain recall iterates nodes in order, applies `chain_source`, and stops on the configured threshold. See [server/internal/handler/chain_runtime.go:66](../../server/internal/handler/chain_runtime.go).
+5. Chain get/update/delete locate the target memory across nodes in order. See [server/internal/handler/chain_runtime.go:116](../../server/internal/handler/chain_runtime.go).
+6. Existing live e2e coverage is bash-based and documented in `e2e/AGENTS.md`; the full smoke suite is currently documented as individual script invocations, not as one central runner. See [e2e/AGENTS.md:39](../../e2e/AGENTS.md).
+
+## Proposed Scope
+
+Create a new live API e2e script:
+
+```text
+e2e/api-smoke-test-space-chain.sh
+```
+
+This should be a server/API e2e test, not a dashboard UI test. The current repo has Space Chain runtime and management APIs, but no Space Chain dashboard UI route. If console UI coverage is required later, it should be added where the console Space Chain frontend/backend lives.
+
+## Happy Path
+
+The script should run against `MNEMO_BASE` and create all state it needs:
+
+1. Healthcheck `GET /healthz`.
+2. Provision two fresh Spaces with `POST /v1alpha1/mem9s`.
+3. Create a Space Chain with `POST /v1alpha2/space-chains`, capturing `chain.id`, `chain_api_key`, and `binding_id`.
+4. Verify `GET /v1alpha2/status` returns `{"status":"active"}` for the `chain_` key.
+5. Replace nodes with the two provisioned tenant IDs using `PUT /v1alpha2/space-chains/{chainID}/nodes`, authenticated by the `chain_` key.
+6. Verify `GET /v1alpha2/space-chains/{chainID}/nodes` returns two nodes in positions `0` and `1`.
+7. Write a deterministic memory through the `chain_` key to `POST /v1alpha2/mem9s/memories`.
+8. Poll `GET /v1alpha2/mem9s/memories?limit=50` with the `chain_` key until the memory materializes.
+9. Assert the returned memory includes `chain_source.chain_id == chainID`, `node_position == 0`, and `tenant_id == first tenant`.
+10. Get the memory by id through the `chain_` key and verify the same provenance.
+11. Update the memory by id through the `chain_` key and verify version advances and provenance remains first-node.
+12. Delete the memory by id through the `chain_` key and verify a later chain get returns `404`.
+13. Soft-delete the chain with `DELETE /v1alpha2/space-chains/{chainID}` as best-effort cleanup.
+14. Verify the deleted chain key is no longer active by expecting `GET /v1alpha2/status` to return `404` for the chain key.
+
+## Secondary Checks
+
+Keep these in the same script if they stay simple:
+
+1. `GET /v1alpha2/space-chains/by-key` returns the created chain before cleanup.
+2. `GET /v1alpha2/space-chains/{chainID}/bindings` returns the initial binding and raw `chain_api_key`.
+3. Duplicate node replacement returns `400`.
+4. Empty chain runtime behavior returns `400` before nodes are added, if this can be checked without making the happy path noisy.
+
+I would not add threshold/short-circuit scoring assertions in this e2e script. Those are better covered by handler/service tests because live semantic scoring is environment-dependent.
+
+## Wiring
+
+1. Add the script to `e2e/`.
+2. Update [e2e/AGENTS.md](../../e2e/AGENTS.md) quick reference, coverage table, env var table, and full smoke suite snippet.
+3. Update [e2e/README.md](../../e2e/README.md) if we want that file to continue documenting all e2e scripts, though it currently focuses on CRDT scripts.
+4. Do not wire this into GitHub Actions unless a live server secret/environment is already available. Current workflows do not appear to run the live e2e smoke suite automatically.
+
+## Test Design Notes
+
+1. Use the same bash style as existing smoke scripts: `set -euo pipefail`, `curl_json`, `http_code`, `body`, `check`, and `check_contains`.
+2. Use Python stdlib for JSON extraction to match existing scripts.
+3. Use `X-Mnemo-Agent-Id` on all memory/runtime calls.
+4. Use `X-API-Key: $CHAIN_API_KEY` for chain management after create and for runtime memory operations.
+5. Keep `POLL_TIMEOUT_S` configurable, defaulting to `30` or `60` seconds. Space Chain writes still use the same async memory ingestion path as normal v1alpha2 writes.
+6. Generate unique names and session IDs with timestamp suffixes so repeated runs do not collide.
+7. Treat cleanup as best-effort in a `cleanup` trap because the main test result should report the real failing step.
+
+## Risks
+
+1. Live async ingest may not materialize within the default timeout on slow environments. Mitigation: expose `POLL_TIMEOUT_S` and document using `60` seconds for dev ALB runs.
+2. Search behavior depends on vector/full-text readiness. Mitigation: the primary assertion should use non-query list/get after writing a known memory; avoid score-specific recall expectations.
+3. Provisioned test Spaces are not deleted by existing APIs. Mitigation: isolate by fresh tenant IDs and clean up the Space Chain itself.
+4. The issue mentions API/UI behavior, but this repo does not currently expose Space Chain UI. Mitigation: document API e2e as this repo's coverage and leave UI e2e to the console repo when UI exists.
+
+## Validation
+
+After implementation:
+
+1. `bash -n e2e/api-smoke-test-space-chain.sh`
+2. `MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-space-chain.sh`
+3. Optional local/server validation if a local server and DSN are available.
+
+## Effort Estimate
+
+~120-180 LoC.

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -22,6 +22,9 @@ MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-round2.sh
 MNEMO_BASE=$DEV bash e2e/api-smoke-test-v1alpha2.sh
 MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-round2-v1alpha2.sh
 
+# Space Chain management/runtime
+MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-space-chain.sh
+
 # Session storage tests (both API versions)
 MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-sessions.sh
 MNEMO_BASE=$DEV MNEMO_API_VERSION=v1alpha2 POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-sessions.sh
@@ -42,6 +45,7 @@ for script in \
   "e2e/api-smoke-test-v1alpha2.sh" \
   "POLL_TIMEOUT_S=60 e2e/api-smoke-test-round2.sh" \
   "POLL_TIMEOUT_S=60 e2e/api-smoke-test-round2-v1alpha2.sh" \
+  "POLL_TIMEOUT_S=60 e2e/api-smoke-test-space-chain.sh" \
   "POLL_TIMEOUT_S=60 e2e/api-smoke-test-sessions.sh" \
   "e2e/api-smoke-test-utm.sh"; do
   eval "MNEMO_BASE=$DEV bash $script"
@@ -89,6 +93,36 @@ concurrent async ingest bumps.
 | 7   | Delete                  | `DELETE /memories/{id}` returns 204                                                   |
 | 8   | Get after delete        | `GET /memories/{id}` returns 404                                                      |
 | 9   | Idempotent re-delete    | Second `DELETE` on already-deleted ID returns 204 (no-op, not 404)                    |
+
+### Space Chain (`api-smoke-test-space-chain.sh`)
+
+Validates the primary Space Chain happy path against a live server. The script
+provisions two fresh Spaces, creates a Space Chain, verifies the empty-chain
+runtime error, replaces nodes with the exact management API payload shape,
+writes through the `chain_` key, verifies `chain_source` provenance, exercises
+get/update/delete by id through the chain key, soft-deletes the chain, and
+confirms the deleted chain key is no longer active.
+
+| #   | Case                     | What is verified                                                                                 |
+| --- | ------------------------ | ------------------------------------------------------------------------------------------------ |
+| 1   | Healthcheck              | `GET /healthz` returns 200 with `status=ok`                                                       |
+| 2   | Provision Spaces         | Two `POST /v1alpha1/mem9s` calls return fresh tenant IDs                                          |
+| 3   | Create Space Chain       | `POST /v1alpha2/space-chains` returns a chain id, binding id, and `chain_` key                    |
+| 4   | Chain key status         | `GET /v1alpha2/status` returns `active` for the chain key                                         |
+| 5   | Empty-chain write        | Runtime write through a chain with no nodes returns 400 with a clear error                        |
+| 6   | By-key lookup            | `GET /v1alpha2/space-chains/by-key` resolves the created chain                                    |
+| 7   | Binding list             | `GET /v1alpha2/space-chains/{id}/bindings` includes the initial binding and key                   |
+| 8   | Duplicate nodes rejected | Duplicate `tenant_id` node replacement returns 400                                                |
+| 9   | Replace nodes            | `PUT /v1alpha2/space-chains/{id}/nodes` stores two nodes with positions 0 and 1                   |
+| 10  | List nodes               | `GET /v1alpha2/space-chains/{id}/nodes` returns the stored order                                  |
+| 11  | Chain write              | `POST /v1alpha2/mem9s/memories` with the chain key returns 202 `accepted`                         |
+| 12  | Chain list provenance    | Polled list result includes `chain_source` for node position 0 and the first Space tenant         |
+| 13  | Chain get by id          | `GET /v1alpha2/mem9s/memories/{id}` returns the memory and same `chain_source`                    |
+| 14  | Chain update by id       | `PUT /v1alpha2/mem9s/memories/{id}` advances version and preserves first-node provenance          |
+| 15  | Chain delete by id       | `DELETE /v1alpha2/mem9s/memories/{id}` returns 204                                                |
+| 16  | Deleted memory 404       | Subsequent chain `GET /memories/{id}` returns 404                                                 |
+| 17  | Chain soft-delete        | `DELETE /v1alpha2/space-chains/{id}` returns 204                                                  |
+| 18  | Deleted key inactive     | `GET /v1alpha2/status` returns 404 for the deleted chain key                                      |
 
 ### Session storage (`api-smoke-test-sessions.sh`)
 
@@ -163,6 +197,9 @@ is not set.
 bash e2e/api-smoke-test.sh
 bash e2e/api-smoke-test-round2.sh
 
+# Space Chain management/runtime smoke
+bash e2e/api-smoke-test-space-chain.sh
+
 # Session storage regression tests
 bash e2e/api-smoke-test-sessions.sh
 
@@ -195,6 +232,7 @@ python3 e2e/concurrent-real-doc-test.py
 
 - `api-smoke-test.sh` / `api-smoke-test-v1alpha2.sh` — CRUD smoke, ingest, search, tag filter (tests 1–11)
 - `api-smoke-test-round2.sh` / `api-smoke-test-round2-v1alpha2.sh` — per-ID ops: GET, PUT, If-Match LWW, DELETE, idempotent re-delete (tests 1–9)
+- `api-smoke-test-space-chain.sh` — Space Chain management/runtime: create chain, validate nodes/bindings, write/read/update/delete via `chain_` key, cleanup (tests 1–18)
 - `api-smoke-test-sessions.sh` — session storage: write, dedup, unified search, type filter, metadata, no-query exclusion, lazy migration (tests 1–13; tests 11–13 require `MNEMO_EXISTING_TENANT_ID`)
 - `api-smoke-test-existing-tenant.sh` — backward-compat: pre-existing tenant read/write/search across v1alpha1 and v1alpha2 (tests 1–12)
 - `api-smoke-test-utm.sh` — UTM attribution: param normalization, filtering, empty-value dropping (tests 1–5 always; tests 6–10 require `MNEMO_METADB_DSN` and `MNEMO_UTM_ENABLED=true` on server)
@@ -207,7 +245,7 @@ python3 e2e/concurrent-real-doc-test.py
 | -------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
 | `MNEMO_BASE`               | `https://api.mem9.ai`          | all smoke scripts                                                                              |
 | `MNEMO_API_VERSION`        | `v1alpha1`                     | `api-smoke-test.sh`, `api-smoke-test-round2.sh`, `api-smoke-test-sessions.sh`                  |
-| `POLL_TIMEOUT_S`           | `20` (round2), `30` (sessions) | `api-smoke-test-round2*.sh`, `api-smoke-test-sessions.sh`, `api-smoke-test-existing-tenant.sh` |
+| `POLL_TIMEOUT_S`           | `20` (round2), `30` (sessions, Space Chain) | `api-smoke-test-round2*.sh`, `api-smoke-test-space-chain.sh`, `api-smoke-test-sessions.sh`, `api-smoke-test-existing-tenant.sh` |
 | `MNEMO_EXISTING_TENANT_ID` | —                              | `api-smoke-test-existing-tenant.sh`, `api-smoke-test-sessions.sh` (tests 11–13)                |
 | `MNEMO_METADB_DSN`         | —                              | `api-smoke-test-utm.sh` (tests 6–10); format: `user:pass@tcp(host:port)/dbname`                |
 | `MNEMO_TEST_BASE`          | `http://127.0.0.1:18081`       | CRDT scripts                                                                                   |
@@ -221,6 +259,7 @@ python3 e2e/concurrent-real-doc-test.py
 | `api-smoke-test-v1alpha2.sh`        | v1alpha2                       | One-liner wrapper — sets `MNEMO_API_VERSION=v1alpha2`                |
 | `api-smoke-test-round2.sh`          | v1alpha1 (default) or v1alpha2 | Per-ID ops: GET, PUT, If-Match LWW, DELETE, idempotent re-delete     |
 | `api-smoke-test-round2-v1alpha2.sh` | v1alpha2                       | One-liner wrapper — sets `MNEMO_API_VERSION=v1alpha2`                |
+| `api-smoke-test-space-chain.sh`     | v1alpha2                       | Space Chain management/runtime happy path                            |
 | `api-smoke-test-sessions.sh`        | v1alpha1 (default) or v1alpha2 | Session storage: write, dedup, unified search, type filter, metadata |
 | `api-smoke-test-existing-tenant.sh` | v1alpha1 + v1alpha2            | Backward-compat: pre-existing tenant full lifecycle, both auth modes |
 | `api-smoke-test-utm.sh`             | v1alpha1                       | UTM attribution: param normalization + optional DB row verification  |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -122,7 +122,7 @@ confirms the deleted chain key is no longer active.
 | 15  | Chain delete by id       | `DELETE /v1alpha2/mem9s/memories/{id}` returns 204                                                |
 | 16  | Deleted memory 404       | Subsequent chain `GET /memories/{id}` returns 404                                                 |
 | 17  | Chain soft-delete        | `DELETE /v1alpha2/space-chains/{id}` returns 204                                                  |
-| 18  | Deleted key inactive     | `GET /v1alpha2/status` returns 404 for the deleted chain key                                      |
+| 18  | Deleted key inactive     | `GET /v1alpha2/status` returns `inactive` for the deleted chain key                               |
 
 ### Session storage (`api-smoke-test-sessions.sh`)
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,18 +2,29 @@
 title: E2E Tests
 ---
 
-End-to-end tests for the CRDT branch with user/space model. All scripts run
-against a live mnemo-server instance using the `user_space_test_01` database
-with auto-embedding enabled.
+End-to-end tests against a live mnemo-server instance. Server API smoke scripts
+use `MNEMO_BASE`; CRDT user/space scripts use `MNEMO_TEST_BASE` and
+`MNEMO_TEST_USER_TOKEN`.
+
+## Server API Smoke
+
+| Script | What it tests |
+|--------|--------------|
+| `api-smoke-test-space-chain.sh` | Space Chain management/runtime happy path: create chain, validate nodes and bindings, write/read/update/delete through a `chain_` key, and cleanup |
+
+```bash
+MNEMO_BASE=https://api.mem9.ai POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-space-chain.sh
+```
 
 ## Prerequisites
 
-- mnemo-server running (default `127.0.0.1:18081`, override with `MNEMO_TEST_BASE`)
+- mnemo-server running (`MNEMO_BASE` for server API smoke scripts;
+  `MNEMO_TEST_BASE` defaults to `127.0.0.1:18081` for CRDT scripts)
 - `MNEMO_TEST_USER_TOKEN` env var set to a valid user token (see below)
 - Python 3.8+ or bash (no extra dependencies — stdlib only)
 - `jq` installed (for bash script)
 
-## Scripts
+## CRDT Scripts
 
 | Script | What it tests |
 |--------|--------------|

--- a/e2e/api-smoke-test-space-chain.sh
+++ b/e2e/api-smoke-test-space-chain.sh
@@ -79,6 +79,19 @@ check() {
   return 1
 }
 
+check_secret_equal() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    ok "$desc"
+    PASS=$((PASS+1))
+    return 0
+  fi
+  fail "$desc - expected value did not match actual value (redacted)"
+  FAIL=$((FAIL+1))
+  return 1
+}
+
 check_contains() {
   local desc="$1" haystack="$2" needle="$3"
   TOTAL=$((TOTAL+1))
@@ -327,7 +340,7 @@ check "GET /space-chains/{id}/bindings returns 200" "$code" "200"
 GOT_BINDING_ID=$(printf '%s' "$bdy" | json_field "bindings.0.id")
 GOT_BINDING_KEY=$(printf '%s' "$bdy" | json_field "bindings.0.chain_api_key")
 check "initial binding ID matches" "$GOT_BINDING_ID" "$BINDING_ID"
-check "initial binding key matches" "$GOT_BINDING_KEY" "$CHAIN_API_KEY"
+check_secret_equal "initial binding key matches" "$GOT_BINDING_KEY" "$CHAIN_API_KEY"
 
 # ============================================================================
 # TEST 8 - Duplicate node replacement is rejected
@@ -552,7 +565,10 @@ CHAIN_DELETED=true
 step "18" "Verify deleted chain key is inactive"
 resp=$(curl_chain_json "$BASE/v1alpha2/status")
 code=$(http_code "$resp")
-check "GET /v1alpha2/status returns 404 for deleted chain key" "$code" "404"
+bdy=$(body "$resp")
+check "GET /v1alpha2/status returns 200 for deleted chain key" "$code" "200"
+STATUS=$(printf '%s' "$bdy" | json_field "status")
+check "deleted chain key status is inactive" "$STATUS" "inactive"
 
 echo ""
 echo "========================================================"

--- a/e2e/api-smoke-test-space-chain.sh
+++ b/e2e/api-smoke-test-space-chain.sh
@@ -1,0 +1,570 @@
+#!/bin/bash
+# api-smoke-test-space-chain.sh
+# Live Space Chain smoke test against https://api.mem9.ai or any mnemo-server.
+#
+# Tests covered:
+#   1. Healthcheck
+#   2. Provision two fresh Spaces
+#   3. Create a Space Chain and capture the chain_ key
+#   4. Validate chain key status
+#   5. Verify empty-chain runtime writes fail clearly
+#   6. Resolve chain by key
+#   7. List initial chain bindings
+#   8. Reject duplicate nodes
+#   9. Replace nodes with two Spaces
+#  10. List nodes and verify order
+#  11. Write a deterministic memory through the chain key
+#  12. Poll until the memory materialises with chain_source
+#  13. Get, update, and delete the memory by id through the chain key
+#  14. Soft-delete the chain and verify the key is inactive
+#
+# Usage:
+#   bash e2e/api-smoke-test-space-chain.sh
+#   MNEMO_BASE=http://<dev-alb> POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-space-chain.sh
+set -euo pipefail
+
+BASE="${MNEMO_BASE:-https://api.mem9.ai}"
+AGENT_A="smoke-chain-agent"
+RUN_ID="$(date +%s)-$$"
+SESSION_ID="smoke-chain-$RUN_ID"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-30}"
+POLL_INTERVAL_S=1
+
+CHAIN_ID=""
+CHAIN_API_KEY=""
+CHAIN_DELETED=false
+PROVISIONED_TENANT_ID=""
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}  ->${RESET} $*"; }
+ok()    { echo -e "${GREEN}  PASS${RESET} $*"; }
+fail()  { echo -e "${RED}  FAIL${RESET} $*"; }
+step()  { echo -e "\n${YELLOW}[$1]${RESET} $2"; }
+
+cleanup() {
+  if [ -n "${CHAIN_ID:-}" ] && [ -n "${CHAIN_API_KEY:-}" ] && [ "$CHAIN_DELETED" != "true" ]; then
+    curl -s --connect-timeout 5 --max-time 30 -o /dev/null \
+      -X DELETE \
+      -H "X-API-Key: $CHAIN_API_KEY" \
+      "$BASE/v1alpha2/space-chains/$CHAIN_ID" || true
+  fi
+}
+trap cleanup EXIT
+
+curl_json() {
+  curl -s --connect-timeout 5 --max-time 30 -w '\n__HTTP__%{http_code}' "$@"
+}
+
+http_code() { printf '%s' "$1" | grep '__HTTP__' | sed 's/__HTTP__//'; }
+body()      { printf '%s' "$1" | grep -v '__HTTP__'; }
+
+check() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    ok "$desc (got=$got)"
+    PASS=$((PASS+1))
+    return 0
+  fi
+  fail "$desc - expected '$want', got '$got'"
+  FAIL=$((FAIL+1))
+  return 1
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  TOTAL=$((TOTAL+1))
+  if printf '%s' "$haystack" | grep -q "$needle"; then
+    ok "$desc (contains '$needle')"
+    PASS=$((PASS+1))
+    return 0
+  fi
+  fail "$desc - '$needle' not found in: $haystack"
+  FAIL=$((FAIL+1))
+  return 1
+}
+
+check_nonempty() {
+  local desc="$1" got="$2"
+  TOTAL=$((TOTAL+1))
+  if [ -n "$got" ]; then
+    ok "$desc"
+    PASS=$((PASS+1))
+    return 0
+  fi
+  fail "$desc - value is empty"
+  FAIL=$((FAIL+1))
+  return 1
+}
+
+check_gt() {
+  local desc="$1" got="$2" min="$3"
+  TOTAL=$((TOTAL+1))
+  if [[ "$got" =~ ^[0-9]+$ ]] && [[ "$min" =~ ^[0-9]+$ ]] && [ "$got" -gt "$min" ]; then
+    ok "$desc (got=$got, before=$min)"
+    PASS=$((PASS+1))
+    return 0
+  fi
+  fail "$desc - expected integer > $min, got '$got'"
+  FAIL=$((FAIL+1))
+  return 1
+}
+
+json_field() {
+  local path="$1"
+  python3 -c '
+import json
+import sys
+
+path = sys.argv[1].split(".")
+try:
+    cur = json.load(sys.stdin)
+    for part in path:
+        if isinstance(cur, list):
+            cur = cur[int(part)]
+        elif isinstance(cur, dict):
+            cur = cur.get(part, "")
+        else:
+            cur = ""
+            break
+    if cur is None:
+        cur = ""
+    if isinstance(cur, (dict, list)):
+        print(json.dumps(cur, separators=(",", ":")))
+    else:
+        print(cur)
+except Exception:
+    print("")
+' "$path"
+}
+
+memory_field_by_tag() {
+  local tag="$1"
+  local path="$2"
+  python3 -c '
+import json
+import sys
+
+tag = sys.argv[1]
+path = sys.argv[2].split(".")
+try:
+    data = json.load(sys.stdin)
+    found = None
+    for mem in data.get("memories", []):
+        if tag in mem.get("tags", []):
+            found = mem
+            break
+    if found is None:
+        print("")
+        sys.exit(0)
+    cur = found
+    for part in path:
+        if isinstance(cur, list):
+            cur = cur[int(part)]
+        elif isinstance(cur, dict):
+            cur = cur.get(part, "")
+        else:
+            cur = ""
+            break
+    if cur is None:
+        cur = ""
+    print(cur)
+except Exception:
+    print("")
+' "$tag" "$path"
+}
+
+curl_chain_json() {
+  local url="$1"
+  shift
+  curl_json "$@" \
+    -H "X-API-Key: $CHAIN_API_KEY" \
+    "$url"
+}
+
+curl_chain_mem_json() {
+  local url="$1"
+  shift
+  curl_json "$@" \
+    -H "X-Mnemo-Agent-Id: $AGENT_A" \
+    -H "X-API-Key: $CHAIN_API_KEY" \
+    "$url"
+}
+
+provision_space() {
+  local label="$1"
+  local resp code bdy tenant_id
+  resp=$(curl_json -X POST "$BASE/v1alpha1/mem9s")
+  code=$(http_code "$resp")
+  bdy=$(body "$resp")
+  check "POST /v1alpha1/mem9s returns 201 for $label" "$code" "201"
+  tenant_id=$(printf '%s' "$bdy" | json_field "id")
+  check_nonempty "tenant ID extracted for $label" "$tenant_id"
+  PROVISIONED_TENANT_ID="$tenant_id"
+}
+
+echo "========================================================"
+echo "  mnemos API smoke test - Space Chain"
+echo "  Base URL      : $BASE"
+echo "  Session       : $SESSION_ID"
+echo "  Poll timeout  : ${POLL_TIMEOUT_S}s"
+echo "  Started       : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+
+# ============================================================================
+# TEST 1 - Healthcheck
+# ============================================================================
+step "1" "Healthcheck"
+resp=$(curl_json "$BASE/healthz")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /healthz returns 200" "$code" "200"
+check_contains "status=ok in body" "$bdy" '"ok"'
+
+# ============================================================================
+# TEST 2 - Provision two fresh Spaces
+# ============================================================================
+step "2" "Provision two fresh Spaces"
+provision_space "space-1"
+SPACE1_ID="$PROVISIONED_TENANT_ID"
+provision_space "space-2"
+SPACE2_ID="$PROVISIONED_TENANT_ID"
+info "Space 1 tenant: $SPACE1_ID"
+info "Space 2 tenant: $SPACE2_ID"
+
+# ============================================================================
+# TEST 3 - Create Space Chain
+# ============================================================================
+step "3" "Create Space Chain"
+CREATE_PAYLOAD=$(RUN_ID="$RUN_ID" python3 -c '
+import json
+import os
+
+print(json.dumps({
+    "project_id": "e2e-space-chain-project",
+    "name": "E2E Space Chain " + os.environ["RUN_ID"],
+    "description": "Created by api-smoke-test-space-chain.sh",
+    "created_by_user_id": "e2e-space-chain",
+}))
+')
+resp=$(curl_json -X POST "$BASE/v1alpha2/space-chains" \
+  -H "Content-Type: application/json" \
+  -d "$CREATE_PAYLOAD")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "POST /v1alpha2/space-chains returns 201" "$code" "201"
+CHAIN_ID=$(printf '%s' "$bdy" | json_field "chain.id")
+CHAIN_API_KEY=$(printf '%s' "$bdy" | json_field "chain_api_key")
+BINDING_ID=$(printf '%s' "$bdy" | json_field "binding_id")
+KEY_PREFIX=$(printf '%s' "$bdy" | json_field "key_prefix")
+check_nonempty "chain ID extracted" "$CHAIN_ID"
+check_nonempty "chain API key extracted" "$CHAIN_API_KEY"
+check_nonempty "binding ID extracted" "$BINDING_ID"
+check "key prefix is chain_" "$KEY_PREFIX" "chain_"
+info "Chain: $CHAIN_ID"
+info "Binding: $BINDING_ID"
+
+# ============================================================================
+# TEST 4 - Validate chain key status
+# ============================================================================
+step "4" "Validate chain key status"
+resp=$(curl_chain_json "$BASE/v1alpha2/status")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /v1alpha2/status returns 200 for chain key" "$code" "200"
+STATUS=$(printf '%s' "$bdy" | json_field "status")
+check "chain key status is active" "$STATUS" "active"
+
+# ============================================================================
+# TEST 5 - Empty-chain runtime write fails clearly
+# ============================================================================
+step "5" "Empty-chain runtime write fails clearly"
+EMPTY_WRITE_PAYLOAD=$(SESSION_ID="$SESSION_ID" python3 -c '
+import json
+import os
+
+print(json.dumps({
+    "content": "This write should fail because the Space Chain has no nodes.",
+    "tags": ["space-chain-empty"],
+    "session_id": os.environ["SESSION_ID"],
+}))
+')
+resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories" -X POST \
+  -H "Content-Type: application/json" \
+  -d "$EMPTY_WRITE_PAYLOAD")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "empty-chain POST /memories returns 400" "$code" "400"
+check_contains "empty-chain error is clear" "$bdy" "Space Chain has no nodes"
+
+# ============================================================================
+# TEST 6 - Resolve chain by key
+# ============================================================================
+step "6" "Resolve chain by key"
+resp=$(curl_chain_json "$BASE/v1alpha2/space-chains/by-key")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /space-chains/by-key returns 200" "$code" "200"
+BY_KEY_ID=$(printf '%s' "$bdy" | json_field "id")
+check "by-key chain ID matches" "$BY_KEY_ID" "$CHAIN_ID"
+
+# ============================================================================
+# TEST 7 - List initial bindings
+# ============================================================================
+step "7" "List initial chain bindings"
+resp=$(curl_chain_json "$BASE/v1alpha2/space-chains/$CHAIN_ID/bindings")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /space-chains/{id}/bindings returns 200" "$code" "200"
+GOT_BINDING_ID=$(printf '%s' "$bdy" | json_field "bindings.0.id")
+GOT_BINDING_KEY=$(printf '%s' "$bdy" | json_field "bindings.0.chain_api_key")
+check "initial binding ID matches" "$GOT_BINDING_ID" "$BINDING_ID"
+check "initial binding key matches" "$GOT_BINDING_KEY" "$CHAIN_API_KEY"
+
+# ============================================================================
+# TEST 8 - Duplicate node replacement is rejected
+# ============================================================================
+step "8" "Reject duplicate nodes"
+DUP_NODE_PAYLOAD=$(SPACE1_ID="$SPACE1_ID" RUN_ID="$RUN_ID" python3 -c '
+import json
+import os
+
+space_id = os.environ["SPACE1_ID"]
+print(json.dumps({
+    "nodes": [
+        {"tenant_id": space_id, "external_space_id": "e2e-dup-a-" + os.environ["RUN_ID"]},
+        {"tenant_id": space_id, "external_space_id": "e2e-dup-b-" + os.environ["RUN_ID"]},
+    ],
+}))
+')
+resp=$(curl_chain_json "$BASE/v1alpha2/space-chains/$CHAIN_ID/nodes" -X PUT \
+  -H "Content-Type: application/json" \
+  -d "$DUP_NODE_PAYLOAD")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "duplicate node replacement returns 400" "$code" "400"
+check_contains "duplicate error mentions tenant_id" "$bdy" "duplicate tenant_id"
+
+# ============================================================================
+# TEST 9 - Replace nodes with two Spaces
+# ============================================================================
+step "9" "Replace chain nodes"
+NODE_PAYLOAD=$(SPACE1_ID="$SPACE1_ID" SPACE2_ID="$SPACE2_ID" RUN_ID="$RUN_ID" python3 -c '
+import json
+import os
+
+print(json.dumps({
+    "nodes": [
+        {
+            "tenant_id": os.environ["SPACE1_ID"],
+            "external_space_id": "e2e-space-chain-space-1-" + os.environ["RUN_ID"],
+            "display_name": "E2E Space Chain Node 1",
+        },
+        {
+            "tenant_id": os.environ["SPACE2_ID"],
+            "external_space_id": "e2e-space-chain-space-2-" + os.environ["RUN_ID"],
+            "display_name": "E2E Space Chain Node 2",
+        },
+    ],
+}))
+')
+resp=$(curl_chain_json "$BASE/v1alpha2/space-chains/$CHAIN_ID/nodes" -X PUT \
+  -H "Content-Type: application/json" \
+  -d "$NODE_PAYLOAD")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "PUT /space-chains/{id}/nodes returns 200" "$code" "200"
+NODE0_TENANT=$(printf '%s' "$bdy" | json_field "nodes.0.tenant_id")
+NODE1_TENANT=$(printf '%s' "$bdy" | json_field "nodes.1.tenant_id")
+NODE0_POS=$(printf '%s' "$bdy" | json_field "nodes.0.position")
+NODE1_POS=$(printf '%s' "$bdy" | json_field "nodes.1.position")
+check "node 0 tenant matches first Space" "$NODE0_TENANT" "$SPACE1_ID"
+check "node 1 tenant matches second Space" "$NODE1_TENANT" "$SPACE2_ID"
+check "node 0 position is 0" "$NODE0_POS" "0"
+check "node 1 position is 1" "$NODE1_POS" "1"
+
+# ============================================================================
+# TEST 10 - List nodes and verify order
+# ============================================================================
+step "10" "List chain nodes"
+resp=$(curl_chain_json "$BASE/v1alpha2/space-chains/$CHAIN_ID/nodes")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /space-chains/{id}/nodes returns 200" "$code" "200"
+LIST_NODE0_TENANT=$(printf '%s' "$bdy" | json_field "nodes.0.tenant_id")
+LIST_NODE1_TENANT=$(printf '%s' "$bdy" | json_field "nodes.1.tenant_id")
+LIST_NODE0_POS=$(printf '%s' "$bdy" | json_field "nodes.0.position")
+LIST_NODE1_POS=$(printf '%s' "$bdy" | json_field "nodes.1.position")
+check "listed node 0 tenant matches first Space" "$LIST_NODE0_TENANT" "$SPACE1_ID"
+check "listed node 1 tenant matches second Space" "$LIST_NODE1_TENANT" "$SPACE2_ID"
+check "listed node 0 position is 0" "$LIST_NODE0_POS" "0"
+check "listed node 1 position is 1" "$LIST_NODE1_POS" "1"
+
+# ============================================================================
+# TEST 11 - Write deterministic memory through chain key
+# ============================================================================
+step "11" "Write deterministic memory through chain key"
+RUN_TAG="space-chain-e2e-$RUN_ID"
+KNOWN_CONTENT="Space Chain smoke test $RUN_ID writes through a chain key to the first node."
+WRITE_PAYLOAD=$(KNOWN_CONTENT="$KNOWN_CONTENT" RUN_TAG="$RUN_TAG" SESSION_ID="$SESSION_ID" python3 -c '
+import json
+import os
+
+print(json.dumps({
+    "content": os.environ["KNOWN_CONTENT"],
+    "tags": ["space-chain-smoke", os.environ["RUN_TAG"]],
+    "session_id": os.environ["SESSION_ID"],
+}))
+')
+resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories" -X POST \
+  -H "Content-Type: application/json" \
+  -d "$WRITE_PAYLOAD")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "POST /memories with chain key returns 202" "$code" "202"
+check_contains "write response has status=accepted" "$bdy" '"accepted"'
+
+# ============================================================================
+# TEST 12 - Poll until memory materialises with chain_source
+# ============================================================================
+step "12" "Poll chain list until memory materialises"
+FIRST_MEM_ID=""
+ELAPSED=0
+while [ "$ELAPSED" -lt "$POLL_TIMEOUT_S" ]; do
+  list_resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories?limit=50")
+  list_code=$(http_code "$list_resp")
+  list_bdy=$(body "$list_resp")
+
+  if [ "$list_code" = "200" ]; then
+    FIRST_MEM_ID=$(printf '%s' "$list_bdy" | memory_field_by_tag "$RUN_TAG" "id")
+    if [ -n "$FIRST_MEM_ID" ]; then
+      info "Memory appeared after ~${ELAPSED}s - ID: $FIRST_MEM_ID"
+      TOTAL=$((TOTAL+1))
+      ok "Memory materialised within ${POLL_TIMEOUT_S}s"
+      PASS=$((PASS+1))
+      break
+    fi
+  fi
+
+  sleep "$POLL_INTERVAL_S"
+  ELAPSED=$((ELAPSED+POLL_INTERVAL_S))
+done
+
+if [ -z "$FIRST_MEM_ID" ]; then
+  TOTAL=$((TOTAL+1))
+  fail "Memory did NOT appear within ${POLL_TIMEOUT_S}s"
+  FAIL=$((FAIL+1))
+  exit "$FAIL"
+fi
+
+LIST_CHAIN_ID=$(printf '%s' "$list_bdy" | memory_field_by_tag "$RUN_TAG" "chain_source.chain_id")
+LIST_NODE_POS=$(printf '%s' "$list_bdy" | memory_field_by_tag "$RUN_TAG" "chain_source.node_position")
+LIST_SOURCE_TENANT=$(printf '%s' "$list_bdy" | memory_field_by_tag "$RUN_TAG" "chain_source.tenant_id")
+check "list chain_source.chain_id matches" "$LIST_CHAIN_ID" "$CHAIN_ID"
+check "list chain_source.node_position is 0" "$LIST_NODE_POS" "0"
+check "list chain_source.tenant_id is first Space" "$LIST_SOURCE_TENANT" "$SPACE1_ID"
+
+# ============================================================================
+# TEST 13 - Get memory by id through chain key
+# ============================================================================
+step "13" "Get memory by ID through chain key"
+resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories/$FIRST_MEM_ID")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories/{id} returns 200" "$code" "200"
+GOT_ID=$(printf '%s' "$bdy" | json_field "id")
+ORIG_VERSION=$(printf '%s' "$bdy" | json_field "version")
+GET_CHAIN_ID=$(printf '%s' "$bdy" | json_field "chain_source.chain_id")
+GET_NODE_POS=$(printf '%s' "$bdy" | json_field "chain_source.node_position")
+GET_SOURCE_TENANT=$(printf '%s' "$bdy" | json_field "chain_source.tenant_id")
+check "returned ID matches" "$GOT_ID" "$FIRST_MEM_ID"
+check_nonempty "original version extracted" "$ORIG_VERSION"
+check "get chain_source.chain_id matches" "$GET_CHAIN_ID" "$CHAIN_ID"
+check "get chain_source.node_position is 0" "$GET_NODE_POS" "0"
+check "get chain_source.tenant_id is first Space" "$GET_SOURCE_TENANT" "$SPACE1_ID"
+
+# ============================================================================
+# TEST 14 - Update memory by id through chain key
+# ============================================================================
+step "14" "Update memory by ID through chain key"
+UPDATED_CONTENT="$KNOWN_CONTENT (updated)"
+UPDATE_PAYLOAD=$(UPDATED_CONTENT="$UPDATED_CONTENT" RUN_TAG="$RUN_TAG" python3 -c '
+import json
+import os
+
+print(json.dumps({
+    "content": os.environ["UPDATED_CONTENT"],
+    "tags": ["space-chain-smoke", os.environ["RUN_TAG"], "updated"],
+}))
+')
+resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories/$FIRST_MEM_ID" -X PUT \
+  -H "Content-Type: application/json" \
+  -d "$UPDATE_PAYLOAD")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "PUT /memories/{id} returns 200" "$code" "200"
+UPD_VERSION=$(printf '%s' "$bdy" | json_field "version")
+UPD_CHAIN_ID=$(printf '%s' "$bdy" | json_field "chain_source.chain_id")
+UPD_NODE_POS=$(printf '%s' "$bdy" | json_field "chain_source.node_position")
+UPD_SOURCE_TENANT=$(printf '%s' "$bdy" | json_field "chain_source.tenant_id")
+check_gt "version advanced" "$UPD_VERSION" "$ORIG_VERSION"
+check_contains "updated tag present" "$bdy" '"updated"'
+check "update chain_source.chain_id matches" "$UPD_CHAIN_ID" "$CHAIN_ID"
+check "update chain_source.node_position is 0" "$UPD_NODE_POS" "0"
+check "update chain_source.tenant_id is first Space" "$UPD_SOURCE_TENANT" "$SPACE1_ID"
+
+# ============================================================================
+# TEST 15 - Delete memory by id through chain key
+# ============================================================================
+step "15" "Delete memory by ID through chain key"
+resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories/$FIRST_MEM_ID" -X DELETE)
+code=$(http_code "$resp")
+check "DELETE /memories/{id} returns 204" "$code" "204"
+
+# ============================================================================
+# TEST 16 - Verify deleted memory returns 404 through chain key
+# ============================================================================
+step "16" "Verify deleted memory returns 404"
+resp=$(curl_chain_mem_json "$BASE/v1alpha2/mem9s/memories/$FIRST_MEM_ID")
+code=$(http_code "$resp")
+check "GET deleted memory returns 404" "$code" "404"
+
+# ============================================================================
+# TEST 17 - Soft-delete chain
+# ============================================================================
+step "17" "Soft-delete Space Chain"
+resp=$(curl_chain_json "$BASE/v1alpha2/space-chains/$CHAIN_ID" -X DELETE)
+code=$(http_code "$resp")
+check "DELETE /space-chains/{id} returns 204" "$code" "204"
+CHAIN_DELETED=true
+
+# ============================================================================
+# TEST 18 - Deleted chain key is no longer active
+# ============================================================================
+step "18" "Verify deleted chain key is inactive"
+resp=$(curl_chain_json "$BASE/v1alpha2/status")
+code=$(http_code "$resp")
+check "GET /v1alpha2/status returns 404 for deleted chain key" "$code" "404"
+
+echo ""
+echo "========================================================"
+echo "  RESULTS: $PASS / $TOTAL passed, $FAIL failed"
+echo "  Base URL : $BASE"
+echo "  Chain    : $CHAIN_ID"
+if [ "$FAIL" -eq 0 ]; then
+  echo -e "  ${GREEN}All tests passed.${RESET}"
+else
+  echo -e "  ${RED}$FAIL test(s) failed.${RESET}"
+fi
+echo "  Finished : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+
+exit "$FAIL"


### PR DESCRIPTION
## Summary

- Add `e2e/api-smoke-test-space-chain.sh` covering Space Chain creation, key status/by-key lookup, empty-chain runtime failure, duplicate-node rejection, node replacement/listing, and cleanup.
- Exercise runtime memory write/list/get/update/delete through a `chain_` key and assert `chain_source` provenance points to the first Space node.
- Move the issue proposal into `docs/design/` and document the new e2e workflow in `e2e/AGENTS.md` and `e2e/README.md`.

Closes #311.

## Validation

- `bash -n e2e/api-smoke-test-space-chain.sh`
- `git diff --cached --check`

Not run: live smoke test against `api.mem9.ai`, because it creates external service state.