### PR TITLE
fix: detect embedding schema mode mismatch

### DIFF
--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -115,6 +115,7 @@ func main() {
 		IdleTimeout:    cfg.TenantPoolIdleTimeout,
 		TotalLimit:     cfg.TenantPoolTotalLimit,
 		Backend:        cfg.DBBackend,
+		EmbedAutoModel: cfg.EmbedAutoModel,
 	})
 	defer tenantPool.Close()
 

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -154,7 +154,7 @@ func main() {
 	// Check for TiDB Cloud credentials (only if Zero is not enabled)
 	if provisioner == nil && cfg.DBBackend == "tidb" {
 		if os.Getenv("MNEMO_TIDBCLOUD_API_KEY") != "" && os.Getenv("MNEMO_TIDBCLOUD_API_SECRET") != "" {
-			provisioner = tenant.NewTiDBCloudProvisioner(cfg.TiDBCloudAPIURL, cfg.TiDBCloudPoolID)
+			provisioner = tenant.NewTiDBCloudProvisioner(cfg.TiDBCloudAPIURL, cfg.TiDBCloudPoolID, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.EmbedDims, cfg.FTSEnabled)
 			logger.Info("using TiDB Cloud Pool provisioner")
 		}
 	}
@@ -169,7 +169,7 @@ func main() {
 	var autoSpendLimitCfg middleware.AutoSpendLimitConfig
 	if cfg.AutoSpendLimitEnabled {
 		if os.Getenv("MNEMO_TIDBCLOUD_API_KEY") != "" && os.Getenv("MNEMO_TIDBCLOUD_API_SECRET") != "" {
-			spendLimitAdjuster = tenant.NewTiDBCloudProvisioner(cfg.TiDBCloudAPIURL, cfg.TiDBCloudPoolID)
+			spendLimitAdjuster = tenant.NewTiDBCloudProvisioner(cfg.TiDBCloudAPIURL, cfg.TiDBCloudPoolID, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.EmbedDims, cfg.FTSEnabled)
 			spendLimitCooldown = middleware.NewSpendLimitCooldown(cfg.AutoSpendLimitCooldown)
 			autoSpendLimitCfg = middleware.AutoSpendLimitConfig{Enabled: true, Increment: cfg.AutoSpendLimitIncrement, Max: cfg.AutoSpendLimitMax}
 			logger.Info("auto spend limit enabled", "increment", cfg.AutoSpendLimitIncrement, "max", cfg.AutoSpendLimitMax, "cooldown", cfg.AutoSpendLimitCooldown.String())

--- a/server/internal/domain/errors.go
+++ b/server/internal/domain/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrWriteConflict           = errors.New("write conflict, retry")
 	ErrNotSupported            = errors.New("not supported")
 	ErrAutoVectorSearchSkipped = errors.New("auto vector search skipped")
+	ErrSchemaIncompatible      = errors.New("schema incompatible")
 )
 
 // ValidationError wraps ErrValidation with a field-level message.
@@ -27,4 +28,17 @@ func (e *ValidationError) Error() string {
 
 func (e *ValidationError) Unwrap() error {
 	return ErrValidation
+}
+
+// SchemaCompatibilityError reports a tenant schema/runtime configuration mismatch.
+type SchemaCompatibilityError struct {
+	Message string
+}
+
+func (e *SchemaCompatibilityError) Error() string {
+	return e.Message
+}
+
+func (e *SchemaCompatibilityError) Unwrap() error {
+	return ErrSchemaIncompatible
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -274,6 +274,8 @@ func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err err
 		respondError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, domain.ErrNotSupported):
 		respondError(w, http.StatusNotImplemented, err.Error())
+	case errors.Is(err, domain.ErrSchemaIncompatible):
+		respondError(w, http.StatusConflict, err.Error())
 	default:
 		s.logger.Error("internal error", "err", err, "request_id", reqid.FromContext(ctx))
 		respondError(w, http.StatusInternalServerError, "internal server error")

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -167,6 +168,10 @@ func ResolveTenant(
 					}
 				}
 				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", poolDuration.Milliseconds(), "classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err), "err", err)
+				if errors.Is(err, domain.ErrSchemaIncompatible) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
 					writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
 					return
@@ -286,6 +291,10 @@ func ResolveApiKey(
 							"duration_ms", poolDuration.Milliseconds(),
 							"classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err),
 							"err", err)
+						if errors.Is(err, domain.ErrSchemaIncompatible) {
+							writeError(w, http.StatusConflict, err.Error())
+							return
+						}
 						if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
 							writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
 							return
@@ -380,6 +389,10 @@ func ResolveApiKey(
 					}
 				}
 				slog.ErrorContext(r.Context(), "cannot connect to tenant database", "cluster_id", t.ClusterID, "duration_ms", poolDuration.Milliseconds(), "classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err), "err", err)
+				if errors.Is(err, domain.ErrSchemaIncompatible) {
+					writeError(w, http.StatusConflict, err.Error())
+					return
+				}
 				if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
 					writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
 					return

--- a/server/internal/tenant/pool.go
+++ b/server/internal/tenant/pool.go
@@ -186,7 +186,9 @@ func (p *TenantPool) openTenantDB(tenantID string, dsn string) (*sql.DB, error) 
 		return nil, err
 	}
 	if p.backend == "tidb" {
-		if err := CheckEmbeddingSchemaCompatibility(openCtx, db, p.embedAutoModel); err != nil {
+		schemaCtx, schemaCancel := context.WithTimeout(context.Background(), p.connectTimeout)
+		defer schemaCancel()
+		if err := CheckEmbeddingSchemaCompatibility(schemaCtx, db, p.embedAutoModel); err != nil {
 			_ = db.Close()
 			p.mu.Lock()
 			p.opening--

--- a/server/internal/tenant/pool.go
+++ b/server/internal/tenant/pool.go
@@ -22,6 +22,7 @@ type TenantPool struct {
 	idleTimeout    time.Duration
 	totalLimit     int
 	backend        string // "tidb", "postgres", or "db9"
+	embedAutoModel string
 	stopCh         chan struct{}
 	connectGroup   singleflight.Group
 	opening        int
@@ -41,6 +42,7 @@ type PoolConfig struct {
 	IdleTimeout    time.Duration
 	TotalLimit     int
 	Backend        string // "tidb" (default), "postgres", or "db9"
+	EmbedAutoModel string
 	ConnectTimeout time.Duration
 }
 
@@ -76,6 +78,7 @@ func NewPool(cfg PoolConfig) *TenantPool {
 		idleTimeout:    cfg.IdleTimeout,
 		totalLimit:     cfg.TotalLimit,
 		backend:        backend,
+		embedAutoModel: cfg.EmbedAutoModel,
 		stopCh:         make(chan struct{}),
 		connectTimeout: cfg.ConnectTimeout,
 	}
@@ -181,6 +184,15 @@ func (p *TenantPool) openTenantDB(tenantID string, dsn string) (*sql.DB, error) 
 		p.opening--
 		p.mu.Unlock()
 		return nil, err
+	}
+	if p.backend == "tidb" {
+		if err := CheckEmbeddingSchemaCompatibility(openCtx, db, p.embedAutoModel); err != nil {
+			_ = db.Close()
+			p.mu.Lock()
+			p.opening--
+			p.mu.Unlock()
+			return nil, err
+		}
 	}
 
 	now := time.Now()

--- a/server/internal/tenant/pool_test.go
+++ b/server/internal/tenant/pool_test.go
@@ -6,10 +6,13 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
 type testDriver struct{}
@@ -23,7 +26,15 @@ type testConnector struct {
 	pingRelease  chan struct{}
 	pingErr      error
 	connectErr   error
+	schemaRows   []schemaTestRow
 	connectCalls atomic.Int32
+	queryCalls   atomic.Int32
+}
+
+type schemaTestRow struct {
+	table                string
+	extra                string
+	generationExpression string
 }
 
 func (c *testConnector) Connect(context.Context) (driver.Conn, error) {
@@ -50,6 +61,14 @@ func (c *testConn) Begin() (driver.Tx, error) {
 	return nil, errors.New("begin not supported")
 }
 
+func (c *testConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "information_schema.COLUMNS") {
+		c.connector.queryCalls.Add(1)
+		return &schemaRows{rows: c.connector.schemaRows}, nil
+	}
+	return nil, errors.New("query not supported")
+}
+
 func (c *testConn) Ping(ctx context.Context) error {
 	if c.connector.pingStarted != nil {
 		select {
@@ -65,6 +84,29 @@ func (c *testConn) Ping(ctx context.Context) error {
 		}
 	}
 	return c.connector.pingErr
+}
+
+type schemaRows struct {
+	rows []schemaTestRow
+	idx  int
+}
+
+func (*schemaRows) Columns() []string {
+	return []string{"TABLE_NAME", "EXTRA", "GENERATION_EXPRESSION"}
+}
+
+func (*schemaRows) Close() error { return nil }
+
+func (r *schemaRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.rows) {
+		return io.EOF
+	}
+	row := r.rows[r.idx]
+	r.idx++
+	dest[0] = row.table
+	dest[1] = row.extra
+	dest[2] = row.generationExpression
+	return nil
 }
 
 type getResult struct {
@@ -427,5 +469,65 @@ func TestPool_Get_InFlightOpenCountsTowardTotalLimit(t *testing.T) {
 	close(slowConnector.pingRelease)
 	if slow := <-slowCh; slow.err != nil {
 		t.Fatalf("slow tenant Get error: %v", slow.err)
+	}
+}
+
+func TestPool_Get_EmbeddingSchemaMismatchFailsBeforeCaching(t *testing.T) {
+	pool := NewPool(PoolConfig{ConnectTimeout: time.Second})
+	defer pool.Close()
+
+	connector := &testConnector{
+		schemaRows: []schemaTestRow{
+			{table: "memories", extra: "STORED GENERATED"},
+		},
+	}
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		return sql.OpenDB(connector), nil
+	})
+
+	_, err := pool.Get(context.Background(), "tenant-1", "tenant-1")
+	if err == nil {
+		t.Fatal("expected schema compatibility error, got nil")
+	}
+	if !errors.Is(err, domain.ErrSchemaIncompatible) {
+		t.Fatalf("expected ErrSchemaIncompatible, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "memories.embedding is a generated Auto Embed column") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if connector.queryCalls.Load() != 1 {
+		t.Fatalf("schema query calls = %d, want 1", connector.queryCalls.Load())
+	}
+	if got := pool.Stats(); len(got) != 0 {
+		t.Fatalf("expected mismatched tenant not to be cached, got %+v", got)
+	}
+}
+
+func TestPool_Get_EmbeddingSchemaCheckRunsOnlyOnFirstOpen(t *testing.T) {
+	pool := NewPool(PoolConfig{ConnectTimeout: time.Second})
+	defer pool.Close()
+
+	connector := &testConnector{
+		schemaRows: []schemaTestRow{
+			{table: "memories"},
+		},
+	}
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		return sql.OpenDB(connector), nil
+	})
+
+	first, err := pool.Get(context.Background(), "tenant-1", "tenant-1")
+	if err != nil {
+		t.Fatalf("first Get error: %v", err)
+	}
+	second, err := pool.Get(context.Background(), "tenant-1", "tenant-1")
+	if err != nil {
+		t.Fatalf("second Get error: %v", err)
+	}
+	if first != second {
+		t.Fatal("expected cached DB on second Get")
+	}
+	if connector.queryCalls.Load() != 1 {
+		t.Fatalf("schema query calls = %d, want 1", connector.queryCalls.Load())
 	}
 }

--- a/server/internal/tenant/pool_test.go
+++ b/server/internal/tenant/pool_test.go
@@ -24,8 +24,10 @@ func (testDriver) Open(name string) (driver.Conn, error) {
 type testConnector struct {
 	pingStarted  chan struct{}
 	pingRelease  chan struct{}
+	pingDelay    time.Duration
 	pingErr      error
 	connectErr   error
+	queryDelay   time.Duration
 	schemaRows   []schemaTestRow
 	connectCalls atomic.Int32
 	queryCalls   atomic.Int32
@@ -61,9 +63,16 @@ func (c *testConn) Begin() (driver.Tx, error) {
 	return nil, errors.New("begin not supported")
 }
 
-func (c *testConn) QueryContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
+func (c *testConn) QueryContext(ctx context.Context, query string, _ []driver.NamedValue) (driver.Rows, error) {
 	if strings.Contains(query, "information_schema.COLUMNS") {
 		c.connector.queryCalls.Add(1)
+		if c.connector.queryDelay > 0 {
+			select {
+			case <-time.After(c.connector.queryDelay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
 		return &schemaRows{rows: c.connector.schemaRows}, nil
 	}
 	return nil, errors.New("query not supported")
@@ -79,6 +88,13 @@ func (c *testConn) Ping(ctx context.Context) error {
 	if c.connector.pingRelease != nil {
 		select {
 		case <-c.connector.pingRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	if c.connector.pingDelay > 0 {
+		select {
+		case <-time.After(c.connector.pingDelay):
 		case <-ctx.Done():
 			return ctx.Err()
 		}
@@ -500,6 +516,33 @@ func TestPool_Get_EmbeddingSchemaMismatchFailsBeforeCaching(t *testing.T) {
 	}
 	if got := pool.Stats(); len(got) != 0 {
 		t.Fatalf("expected mismatched tenant not to be cached, got %+v", got)
+	}
+}
+
+func TestPool_Get_EmbeddingSchemaCheckUsesFreshTimeoutAfterPing(t *testing.T) {
+	pool := NewPool(PoolConfig{ConnectTimeout: 200 * time.Millisecond})
+	defer pool.Close()
+
+	connector := &testConnector{
+		pingDelay:  150 * time.Millisecond,
+		queryDelay: 100 * time.Millisecond,
+		schemaRows: []schemaTestRow{
+			{table: "memories"},
+		},
+	}
+	withSQLOpen(t, func(driverName, dsn string) (*sql.DB, error) {
+		return sql.OpenDB(connector), nil
+	})
+
+	db, err := pool.Get(context.Background(), "tenant-1", "tenant-1")
+	if err != nil {
+		t.Fatalf("Get error: %v", err)
+	}
+	if db == nil {
+		t.Fatal("expected opened DB")
+	}
+	if connector.queryCalls.Load() != 1 {
+		t.Fatalf("schema query calls = %d, want 1", connector.queryCalls.Load())
 	}
 }
 

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -2,8 +2,11 @@ package tenant
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -22,6 +25,78 @@ func setupTiDBCloudEnv(t *testing.T) func() {
 		os.Setenv("MNEMO_TIDBCLOUD_API_KEY", oldKey)
 		os.Setenv("MNEMO_TIDBCLOUD_API_SECRET", oldSecret)
 	}
+}
+
+type schemaInitConnector struct {
+	execs          []string
+	existingTables map[string]bool
+}
+
+func (c *schemaInitConnector) Connect(context.Context) (driver.Conn, error) {
+	return &schemaInitConn{recorder: c}, nil
+}
+
+func (c *schemaInitConnector) Driver() driver.Driver {
+	return schemaInitDriver{}
+}
+
+type schemaInitDriver struct{}
+
+func (schemaInitDriver) Open(string) (driver.Conn, error) {
+	return nil, fmt.Errorf("open not supported")
+}
+
+type schemaInitConn struct {
+	recorder *schemaInitConnector
+}
+
+func (c *schemaInitConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare not supported")
+}
+
+func (c *schemaInitConn) Close() error { return nil }
+
+func (c *schemaInitConn) Begin() (driver.Tx, error) {
+	return nil, fmt.Errorf("begin not supported")
+}
+
+func (c *schemaInitConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	c.recorder.execs = append(c.recorder.execs, query)
+	return driver.RowsAffected(0), nil
+}
+
+func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if strings.Contains(query, "information_schema.TABLES") {
+		var count int64
+		if len(args) > 0 {
+			if table, ok := args[0].Value.(string); ok && c.recorder.existingTables[table] {
+				count = 1
+			}
+		}
+		return &schemaInitRows{values: [][]driver.Value{{count}}}, nil
+	}
+	if strings.Contains(query, "information_schema.STATISTICS") {
+		return &schemaInitRows{values: [][]driver.Value{{int64(0)}}}, nil
+	}
+	return nil, fmt.Errorf("unexpected query %q with args %v", query, args)
+}
+
+type schemaInitRows struct {
+	values [][]driver.Value
+	idx    int
+}
+
+func (*schemaInitRows) Columns() []string { return []string{"COUNT(*)"} }
+
+func (*schemaInitRows) Close() error { return nil }
+
+func (r *schemaInitRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.values) {
+		return io.EOF
+	}
+	copy(dest, r.values[r.idx])
+	r.idx++
+	return nil
 }
 
 // TestTiDBCloudProvisioner_Provision_Success tests successful cluster provisioning
@@ -89,7 +164,7 @@ func TestTiDBCloudProvisioner_Provision_Success(t *testing.T) {
 	defer server.Close()
 
 	// Create provisioner
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 
 	ctx := context.Background()
 	info, err := p.Provision(ctx)
@@ -143,7 +218,7 @@ func TestTiDBCloudProvisioner_Provision_APIError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "pool")
+	p := NewTiDBCloudProvisioner(server.URL, "pool", "", 0, 0, false)
 	ctx := context.Background()
 
 	_, err := p.Provision(ctx)
@@ -164,17 +239,108 @@ func TestTiDBCloudProvisioner_ProviderType(t *testing.T) {
 	}
 }
 
-// TestTiDBCloudProvisioner_InitSchema tests schema initialization (no-op)
-func TestTiDBCloudProvisioner_InitSchema(t *testing.T) {
+// TestTiDBCloudProvisioner_InitSchema_NilDB tests schema initialization error handling.
+func TestTiDBCloudProvisioner_InitSchema_NilDB(t *testing.T) {
 	cleanup := setupTiDBCloudEnv(t)
 	defer cleanup()
 
-	p := NewTiDBCloudProvisioner("http://localhost", "pool")
+	p := NewTiDBCloudProvisioner("http://localhost", "pool", "", 0, 0, false)
 
-	// InitSchema should return nil even with nil db (it's a no-op)
 	err := p.InitSchema(context.Background(), nil)
-	if err != nil {
-		t.Errorf("expected no error, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "db connection is nil") {
+		t.Fatalf("expected nil DB error, got %v", err)
+	}
+}
+
+func TestTiDBCloudProvisioner_InitSchema_AutoEmbedding(t *testing.T) {
+	p := NewTiDBCloudProvisioner("http://localhost", "pool", "tidbcloud_free/amazon/titan-embed-text-v2", 1024, 1536, true)
+	recorder := &schemaInitConnector{}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	if err := p.InitSchema(context.Background(), db); err != nil {
+		t.Fatalf("InitSchema failed: %v", err)
+	}
+
+	executed := strings.Join(recorder.execs, "\n")
+	wantSubstrings := []string{
+		"CREATE TABLE IF NOT EXISTS memories",
+		"embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{\"dimensions\": 1024}')) STORED",
+		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
+		"ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content",
+		"CREATE TABLE IF NOT EXISTS sessions",
+		"embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{\"dimensions\": 1024}')) STORED",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
+		"ALTER TABLE sessions ADD FULLTEXT INDEX idx_sessions_fts",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(executed, want) {
+			t.Fatalf("executed DDL missing %q\n%s", want, executed)
+		}
+	}
+}
+
+func TestTiDBCloudProvisioner_InitSchema_ClientEmbedding(t *testing.T) {
+	p := NewTiDBCloudProvisioner("http://localhost", "pool", "", 1024, 1536, false)
+	recorder := &schemaInitConnector{}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	if err := p.InitSchema(context.Background(), db); err != nil {
+		t.Fatalf("InitSchema failed: %v", err)
+	}
+
+	executed := strings.Join(recorder.execs, "\n")
+	wantSubstrings := []string{
+		"CREATE TABLE IF NOT EXISTS memories",
+		"embedding VECTOR(1536) NULL",
+		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
+		"CREATE TABLE IF NOT EXISTS sessions",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(executed, want) {
+			t.Fatalf("executed DDL missing %q\n%s", want, executed)
+		}
+	}
+	if strings.Contains(executed, "EMBED_TEXT(") {
+		t.Fatalf("client embedding schema should not use EMBED_TEXT:\n%s", executed)
+	}
+	if strings.Contains(executed, "FULLTEXT INDEX") {
+		t.Fatalf("FTS disabled schema should not create fulltext indexes:\n%s", executed)
+	}
+}
+
+func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T) {
+	p := NewTiDBCloudProvisioner("http://localhost", "pool", "", 1024, 1536, false)
+	recorder := &schemaInitConnector{
+		existingTables: map[string]bool{
+			"memories": true,
+			"sessions": true,
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	if err := p.InitSchema(context.Background(), db); err != nil {
+		t.Fatalf("InitSchema failed: %v", err)
+	}
+
+	executed := strings.Join(recorder.execs, "\n")
+	if strings.Contains(executed, "CREATE TABLE") {
+		t.Fatalf("existing tables should skip CREATE TABLE:\n%s", executed)
+	}
+	wantSubstrings := []string{
+		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(executed, want) {
+			t.Fatalf("executed DDL missing %q\n%s", want, executed)
+		}
 	}
 }
 

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -1,6 +1,8 @@
 package tenant
 
 import (
+	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 )
@@ -165,4 +167,86 @@ func BuildSessionsSchema(autoModel string, autoDims int, clientDims int) string 
 		embeddingCol = fmt.Sprintf(`embedding VECTOR(%d) NULL,`, dims)
 	}
 	return fmt.Sprintf(TenantSessionsSchemaBase, embeddingCol)
+}
+
+// InitTiDBTenantSchema creates or completes the TiDB tenant data-plane schema.
+func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
+	if db == nil {
+		return fmt.Errorf("init schema: db connection is nil")
+	}
+
+	if err := ensureTable(ctx, db, "memories", BuildMemorySchema(autoModel, autoDims, clientDims)); err != nil {
+		return fmt.Errorf("init schema: memories table: %w", err)
+	}
+	if err := ensureVectorIndex(ctx, db, "memories", "idx_cosine"); err != nil {
+		return fmt.Errorf("init schema: memories vector index: %w", err)
+	}
+	if ftsEnabled {
+		if err := ensureFullTextIndex(ctx, db, "memories", "idx_fts_content"); err != nil {
+			return fmt.Errorf("init schema: memories fulltext index: %w", err)
+		}
+	}
+
+	if err := ensureTable(ctx, db, "sessions", BuildSessionsSchema(autoModel, autoDims, clientDims)); err != nil {
+		return fmt.Errorf("init schema: sessions table: %w", err)
+	}
+	if err := ensureVectorIndex(ctx, db, "sessions", "idx_sessions_cosine"); err != nil {
+		return fmt.Errorf("init schema: sessions vector index: %w", err)
+	}
+	if ftsEnabled {
+		if err := ensureFullTextIndex(ctx, db, "sessions", "idx_sessions_fts"); err != nil {
+			return fmt.Errorf("init schema: sessions fulltext index: %w", err)
+		}
+	}
+	return nil
+}
+
+func ensureTable(ctx context.Context, db *sql.DB, table, createSQL string) error {
+	exists, err := TableExists(ctx, db, table)
+	if err != nil {
+		return fmt.Errorf("check table: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, createSQL); err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+	return nil
+}
+
+func ensureVectorIndex(ctx context.Context, db *sql.DB, table, indexName string) error {
+	exists, err := IndexExists(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check vector index: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %s ADD VECTOR INDEX %s ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+		table,
+		indexName,
+	)); err != nil && !IsIndexExistsError(err) {
+		return err
+	}
+	return nil
+}
+
+func ensureFullTextIndex(ctx context.Context, db *sql.DB, table, indexName string) error {
+	exists, err := IndexExists(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check fulltext index: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %s ADD FULLTEXT INDEX %s (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+		table,
+		indexName,
+	)); err != nil && !IsIndexExistsError(err) {
+		return err
+	}
+	return nil
 }

--- a/server/internal/tenant/schema_compat.go
+++ b/server/internal/tenant/schema_compat.go
@@ -1,0 +1,78 @@
+package tenant
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+type embeddingColumnInfo struct {
+	table     string
+	generated bool
+}
+
+// CheckEmbeddingSchemaCompatibility verifies that existing tenant embedding
+// columns match the current embedding mode. Missing tables are ignored because
+// new tenant provisioning opens the DB before schema initialization.
+func CheckEmbeddingSchemaCompatibility(ctx context.Context, db *sql.DB, autoModel string) error {
+	rows, err := db.QueryContext(ctx,
+		`SELECT TABLE_NAME, COALESCE(EXTRA, ''), COALESCE(GENERATION_EXPRESSION, '')
+		   FROM information_schema.COLUMNS
+		  WHERE TABLE_SCHEMA = DATABASE()
+		    AND TABLE_NAME IN ('memories', 'sessions')
+		    AND COLUMN_NAME = 'embedding'
+		  ORDER BY TABLE_NAME`)
+	if err != nil {
+		return fmt.Errorf("check embedding schema compatibility: %w", err)
+	}
+	defer rows.Close()
+
+	var columns []embeddingColumnInfo
+	for rows.Next() {
+		var table, extra, generationExpression string
+		if err := rows.Scan(&table, &extra, &generationExpression); err != nil {
+			return fmt.Errorf("scan embedding schema compatibility: %w", err)
+		}
+		columns = append(columns, embeddingColumnInfo{
+			table:     table,
+			generated: isGeneratedColumn(extra, generationExpression),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate embedding schema compatibility: %w", err)
+	}
+	return validateEmbeddingSchemaCompatibility(autoModel != "", columns)
+}
+
+func isGeneratedColumn(extra, generationExpression string) bool {
+	return strings.Contains(strings.ToUpper(extra), "GENERATED") || strings.TrimSpace(generationExpression) != ""
+}
+
+func validateEmbeddingSchemaCompatibility(autoModelEnabled bool, columns []embeddingColumnInfo) error {
+	for _, col := range columns {
+		if col.generated == autoModelEnabled {
+			continue
+		}
+		return newEmbeddingSchemaMismatchError(col.table, autoModelEnabled, col.generated)
+	}
+	return nil
+}
+
+func newEmbeddingSchemaMismatchError(table string, autoModelEnabled bool, generated bool) error {
+	if table == "" {
+		table = "memories"
+	}
+	if generated && !autoModelEnabled {
+		return &domain.SchemaCompatibilityError{Message: fmt.Sprintf(
+			"tenant schema incompatible with embedding mode: %s.embedding is a generated Auto Embed column, but MNEMO_EMBED_AUTO_MODEL is disabled; re-enable Auto Embed or migrate/recreate this tenant schema",
+			table,
+		)}
+	}
+	return &domain.SchemaCompatibilityError{Message: fmt.Sprintf(
+		"tenant schema incompatible with embedding mode: %s.embedding is a regular vector column, but MNEMO_EMBED_AUTO_MODEL is enabled; disable Auto Embed or migrate/recreate this tenant schema",
+		table,
+	)}
+}

--- a/server/internal/tenant/schema_compat_test.go
+++ b/server/internal/tenant/schema_compat_test.go
@@ -1,0 +1,98 @@
+package tenant
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestValidateEmbeddingSchemaCompatibility(t *testing.T) {
+	tests := []struct {
+		name             string
+		autoModelEnabled bool
+		columns          []embeddingColumnInfo
+		wantErrContains  string
+	}{
+		{
+			name:             "auto model with generated columns",
+			autoModelEnabled: true,
+			columns: []embeddingColumnInfo{
+				{table: "memories", generated: true},
+				{table: "sessions", generated: true},
+			},
+		},
+		{
+			name:             "no auto model with regular columns",
+			autoModelEnabled: false,
+			columns: []embeddingColumnInfo{
+				{table: "memories", generated: false},
+				{table: "sessions", generated: false},
+			},
+		},
+		{
+			name:             "missing tables are ignored",
+			autoModelEnabled: false,
+		},
+		{
+			name:             "generated column with auto model disabled",
+			autoModelEnabled: false,
+			columns: []embeddingColumnInfo{
+				{table: "memories", generated: true},
+			},
+			wantErrContains: "memories.embedding is a generated Auto Embed column, but MNEMO_EMBED_AUTO_MODEL is disabled",
+		},
+		{
+			name:             "regular column with auto model enabled",
+			autoModelEnabled: true,
+			columns: []embeddingColumnInfo{
+				{table: "sessions", generated: false},
+			},
+			wantErrContains: "sessions.embedding is a regular vector column, but MNEMO_EMBED_AUTO_MODEL is enabled",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateEmbeddingSchemaCompatibility(tt.autoModelEnabled, tt.columns)
+			if tt.wantErrContains == "" {
+				if err != nil {
+					t.Fatalf("expected nil error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, domain.ErrSchemaIncompatible) {
+				t.Fatalf("expected ErrSchemaIncompatible, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tt.wantErrContains)
+			}
+		})
+	}
+}
+
+func TestIsGeneratedColumn(t *testing.T) {
+	tests := []struct {
+		name                 string
+		extra                string
+		generationExpression string
+		want                 bool
+	}{
+		{name: "stored generated extra", extra: "STORED GENERATED", want: true},
+		{name: "virtual generated extra", extra: "VIRTUAL GENERATED", want: true},
+		{name: "generation expression", generationExpression: "embed_text(...)", want: true},
+		{name: "regular column", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGeneratedColumn(tt.extra, tt.generationExpression); got != tt.want {
+				t.Fatalf("isGeneratedColumn() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/tenant/starter.go
+++ b/server/internal/tenant/starter.go
@@ -22,21 +22,29 @@ import (
 // Note: MNEMO_TIDBCLOUD_API_KEY and MNEMO_TIDBCLOUD_API_SECRET are read via os.Getenv()
 // (not Config) as these are sensitive credentials that should not be persisted.
 type TiDBCloudProvisioner struct {
-	apiURL    string
-	apiKey    string
-	apiSecret string
-	poolID    string
-	client    *http.Client
+	apiURL     string
+	apiKey     string
+	apiSecret  string
+	poolID     string
+	autoModel  string
+	autoDims   int
+	clientDims int
+	ftsEnabled bool
+	client     *http.Client
 }
 
 // NewTiDBCloudProvisioner creates a provisioner for TiDB Cloud Pool API.
-func NewTiDBCloudProvisioner(apiURL, poolID string) *TiDBCloudProvisioner {
+func NewTiDBCloudProvisioner(apiURL, poolID, autoModel string, autoDims int, clientDims int, ftsEnabled bool) *TiDBCloudProvisioner {
 	return &TiDBCloudProvisioner{
-		apiURL:    apiURL,
-		apiKey:    os.Getenv("MNEMO_TIDBCLOUD_API_KEY"),
-		apiSecret: os.Getenv("MNEMO_TIDBCLOUD_API_SECRET"),
-		poolID:    poolID,
-		client:    &http.Client{Timeout: 60 * time.Second},
+		apiURL:     apiURL,
+		apiKey:     os.Getenv("MNEMO_TIDBCLOUD_API_KEY"),
+		apiSecret:  os.Getenv("MNEMO_TIDBCLOUD_API_SECRET"),
+		poolID:     poolID,
+		autoModel:  autoModel,
+		autoDims:   autoDims,
+		clientDims: clientDims,
+		ftsEnabled: ftsEnabled,
+		client:     &http.Client{Timeout: 60 * time.Second},
 	}
 }
 
@@ -103,12 +111,11 @@ func (p *TiDBCloudProvisioner) ProviderType() string {
 
 var _ SpendLimitAdjuster = (*TiDBCloudProvisioner)(nil)
 
-// InitSchema for TiDB Cloud Pool is intentionally a no-op.
-// The Pool API guarantees every claimed cluster already has the memories
-// table pre-created before takeover. If this guarantee is ever violated,
-// activation failure will surface at first memory write (no cluster_id context).
+// InitSchema creates or completes the tenant schema for TiDB Cloud Pool clusters.
+// Some deployments can use TiDB Cloud's pool init-schema feature, but it is not
+// required; these DDLs are idempotent when the pool already pre-created tables.
 func (p *TiDBCloudProvisioner) InitSchema(ctx context.Context, db *sql.DB) error {
-	return nil
+	return InitTiDBTenantSchema(ctx, db, p.autoModel, p.autoDims, p.clientDims, p.ftsEnabled)
 }
 
 // GetSpendLimit returns the monthly spend limit in USD cents.

--- a/server/internal/tenant/starter_test.go
+++ b/server/internal/tenant/starter_test.go
@@ -97,7 +97,7 @@ func TestTiDBCloudProvisioner_SpendLimit_GetSpendLimit_Success(t *testing.T) {
 	})
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 	got, err := p.GetSpendLimit(context.Background(), "cluster-123")
 	if err != nil {
 		t.Fatalf("GetSpendLimit error: %v", err)
@@ -117,7 +117,7 @@ func TestTiDBCloudProvisioner_SpendLimit_GetSpendLimit_InvalidJSON(t *testing.T)
 	})
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 	_, err := p.GetSpendLimit(context.Background(), "cluster-123")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -137,7 +137,7 @@ func TestTiDBCloudProvisioner_SpendLimit_GetSpendLimit_APIError(t *testing.T) {
 	})
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 	_, err := p.GetSpendLimit(context.Background(), "cluster-123")
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -158,7 +158,7 @@ func TestTiDBCloudProvisioner_SpendLimit_IncreaseSpendLimit_Success(t *testing.T
 	})
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 	if err := p.IncreaseSpendLimit(context.Background(), "cluster-123", wantMonthly); err != nil {
 		t.Fatalf("IncreaseSpendLimit error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestTiDBCloudProvisioner_SpendLimit_IncreaseSpendLimit_403(t *testing.T) {
 	})
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 	err := p.IncreaseSpendLimit(context.Background(), "cluster-123", wantMonthly)
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -198,7 +198,7 @@ func TestTiDBCloudProvisioner_SpendLimit_IncreaseSpendLimit_404(t *testing.T) {
 	})
 	defer server.Close()
 
-	p := NewTiDBCloudProvisioner(server.URL, "test-pool")
+	p := NewTiDBCloudProvisioner(server.URL, "test-pool", "", 0, 0, false)
 	err := p.IncreaseSpendLimit(context.Background(), "cluster-123", wantMonthly)
 	if err == nil {
 		t.Fatal("expected error, got nil")

--- a/server/internal/tenant/util.go
+++ b/server/internal/tenant/util.go
@@ -42,3 +42,18 @@ func IndexExists(ctx context.Context, db *sql.DB, table, indexName string) (bool
 	}
 	return count > 0, nil
 }
+
+// TableExists reports whether the named table exists in the current database.
+func TableExists(ctx context.Context, db *sql.DB, table string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.TABLES
+		 WHERE TABLE_SCHEMA = DATABASE()
+		   AND TABLE_NAME = ?`,
+		table,
+	).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/server/internal/tenant/zero.go
+++ b/server/internal/tenant/zero.go
@@ -162,9 +162,6 @@ func (p *ZeroProvisioner) ProviderType() string {
 // InitSchema executes DDL to create the schema for Zero clusters.
 // Note: Zero mode only supports tidb backend for auto-provisioning.
 func (p *ZeroProvisioner) InitSchema(ctx context.Context, db *sql.DB) error {
-	if db == nil {
-		return fmt.Errorf("init schema: db connection is nil")
-	}
 	/*
 		case "postgres":
 			if _, err := db.ExecContext(ctx, `CREATE EXTENSION IF NOT EXISTS vector`); err != nil {
@@ -192,60 +189,5 @@ func (p *ZeroProvisioner) InitSchema(ctx context.Context, db *sql.DB) error {
 			}
 			return nil
 	*/
-	if _, err := db.ExecContext(ctx, BuildMemorySchema(p.autoModel, p.autoDims, p.clientDims)); err != nil {
-		return fmt.Errorf("init schema: create table: %w", err)
-	}
-	if p.autoModel != "" {
-		exists, err := IndexExists(ctx, db, "memories", "idx_cosine")
-		if err != nil {
-			return fmt.Errorf("init schema: check vector index: %w", err)
-		}
-		if !exists {
-			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE memories ADD VECTOR INDEX idx_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !IsIndexExistsError(err) {
-				return fmt.Errorf("init schema: vector index: %w", err)
-			}
-		}
-	}
-	if p.ftsEnabled {
-		exists, err := IndexExists(ctx, db, "memories", "idx_fts_content")
-		if err != nil {
-			return fmt.Errorf("init schema: check fulltext index: %w", err)
-		}
-		if !exists {
-			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !IsIndexExistsError(err) {
-				return fmt.Errorf("init schema: fulltext index: %w", err)
-			}
-		}
-	}
-	if _, err := db.ExecContext(ctx, BuildSessionsSchema(p.autoModel, p.autoDims, p.clientDims)); err != nil {
-		return fmt.Errorf("init schema: sessions table: %w", err)
-	}
-	if p.autoModel != "" {
-		exists, err := IndexExists(ctx, db, "sessions", "idx_sessions_cosine")
-		if err != nil {
-			return fmt.Errorf("init schema: check sessions vector index: %w", err)
-		}
-		if !exists {
-			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !IsIndexExistsError(err) {
-				return fmt.Errorf("init schema: sessions vector index: %w", err)
-			}
-		}
-	}
-	if p.ftsEnabled {
-		exists, err := IndexExists(ctx, db, "sessions", "idx_sessions_fts")
-		if err != nil {
-			return fmt.Errorf("init schema: check sessions fulltext index: %w", err)
-		}
-		if !exists {
-			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE sessions ADD FULLTEXT INDEX idx_sessions_fts (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !IsIndexExistsError(err) {
-				return fmt.Errorf("init schema: sessions fulltext index: %w", err)
-			}
-		}
-	}
-	return nil
-
+	return InitTiDBTenantSchema(ctx, db, p.autoModel, p.autoDims, p.clientDims, p.ftsEnabled)
 }


### PR DESCRIPTION
## Summary
- add a tenant DB first-open compatibility check for generated vs regular embedding columns
- return a clear schema mismatch error instead of surfacing TiDB generated-column write failures
- cover mismatch and cached-connection behavior with focused tests

## Tests
- cd server && go test ./...
- make test

Fixes #310