### PR TITLE
[codex] Disable raw fallback fact extraction

### DIFF
--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -919,7 +919,7 @@ func (m *failSearchMemoryRepo) KeywordSearch(context.Context, string, domain.Mem
 	return nil, errors.New("simulated search failure")
 }
 
-func TestCreateMemory_SyncMessages_Phase1Error_FallsBackToSuccess(t *testing.T) {
+func TestCreateMemory_SyncMessages_Phase1ErrorReturnsServerError(t *testing.T) {
 	// Mock LLM that always returns 500.
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -953,8 +953,8 @@ func TestCreateMemory_SyncMessages_Phase1Error_FallsBackToSuccess(t *testing.T) 
 
 	srv.createMemory(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 
@@ -1078,7 +1078,7 @@ func TestCreateMemory_SyncMessages_ReconcileFailure_Returns500(t *testing.T) {
 	}
 }
 
-func TestCreateMemory_SyncMessages_Timeout_FallsBackToSuccess(t *testing.T) {
+func TestCreateMemory_SyncMessages_TimeoutReturnsGatewayTimeout(t *testing.T) {
 	oldTimeout := syncIngestTimeout
 	syncIngestTimeout = 10 * time.Millisecond
 	defer func() { syncIngestTimeout = oldTimeout }()
@@ -1115,8 +1115,8 @@ func TestCreateMemory_SyncMessages_Timeout_FallsBackToSuccess(t *testing.T) {
 
 	srv.createMemory(rr, req)
 
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected 504, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -186,7 +186,6 @@ type preparedExtractionInput struct {
 	messages        []IngestMessage
 	originalIndices []int
 	formatted       string
-	fallbackText    string
 }
 
 func prepareExtractionInput(messages []IngestMessage, maxConversationRunes int) preparedExtractionInput {
@@ -207,7 +206,6 @@ func prepareExtractionInput(messages []IngestMessage, maxConversationRunes int) 
 		return input
 	}
 	input.formatted = truncateRunes(formatConversation(input.messages), maxConversationRunes)
-	input.fallbackText = truncateRunes(buildRawFallbackSourceText(input.messages), maxConversationRunes)
 	return input
 }
 
@@ -247,43 +245,6 @@ func parseConversationMessages(conversation string) []IngestMessage {
 	return messages
 }
 
-func buildRawFallbackSourceText(messages []IngestMessage) string {
-	var userParts []string
-	var allParts []string
-	for _, msg := range messages {
-		content := strings.TrimSpace(msg.Content)
-		if content == "" {
-			continue
-		}
-		allParts = append(allParts, content)
-		if strings.EqualFold(msg.Role, "user") {
-			userParts = append(userParts, content)
-		}
-	}
-	if len(userParts) > 0 {
-		return strings.Join(userParts, "\n\n")
-	}
-	return strings.Join(allParts, "\n\n")
-}
-
-func buildRawFallbackFact(text string) ExtractedFact {
-	return ExtractedFact{
-		Text:     text,
-		Tags:     []string{rawFallbackTag},
-		FactType: factTypeRawFallback,
-	}
-}
-
-func buildRawFallbackFacts(input preparedExtractionInput, reason string) []ExtractedFact {
-	text := strings.TrimSpace(input.fallbackText)
-	if text == "" {
-		slog.Warn("raw fallback unavailable", "reason", reason)
-		return nil
-	}
-	slog.Warn("using raw fallback fact", "reason", reason, "len", len(text))
-	return annotateFactsWithSourceSeqs(input, normalizeRawFallbackFacts(input, []ExtractedFact{buildRawFallbackFact(text)}))
-}
-
 func finalizeExtractedFacts(input preparedExtractionInput, parsed []ExtractedFact, emptyReason string) []ExtractedFact {
 	facts := dropQueryIntentFacts(parsed)
 	if len(facts) > 0 {
@@ -293,7 +254,8 @@ func finalizeExtractedFacts(input preparedExtractionInput, parsed []ExtractedFac
 	if len(parsed) > 0 {
 		reason = "query_intent_only"
 	}
-	return buildRawFallbackFacts(input, reason)
+	slog.Info("no facts extracted", "reason", reason)
+	return nil
 }
 
 func normalizeMessageTags(tags [][]string, messageCount int) [][]string {
@@ -322,30 +284,6 @@ func expandMessageTags(cleanedTags [][]string, input preparedExtractionInput, or
 		}
 	}
 	return out
-}
-
-func hasTag(tags []string, target string) bool {
-	for _, tag := range tags {
-		if strings.EqualFold(tag, target) {
-			return true
-		}
-	}
-	return false
-}
-
-func ensureRawFallbackTag(tags []string, facts []ExtractedFact) []string {
-	if len(facts) != 1 {
-		return tags
-	}
-	fact := facts[0]
-	if !strings.EqualFold(fact.FactType, factTypeRawFallback) && !hasTag(fact.Tags, rawFallbackTag) {
-		return tags
-	}
-	if hasTag(tags, rawFallbackTag) {
-		return tags
-	}
-	out := append([]string{}, tags...)
-	return append(out, rawFallbackTag)
 }
 
 func projectReconcileFactText(fact ExtractedFact) string {
@@ -739,8 +677,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 	scope := llm.CallScope{Step: "extraction"}
 	raw, err := s.llm.CompleteJSONWithScope(ctx, systemPrompt, userPrompt, scope)
 	if err != nil {
-		slog.Warn("extraction LLM call failed, using raw fallback", "err", err)
-		return buildRawFallbackFacts(input, "llm_error_fallback"), nil
+		slog.Warn("extraction LLM call failed; returning no facts", "err", err)
+		return nil, nil
 	}
 
 	parsed, err := llm.ParseJSON[extractResponse](raw)
@@ -751,8 +689,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt,
 			scope)
 		if retryErr != nil {
-			slog.Warn("extraction retry failed, using raw fallback", "err", retryErr)
-			return buildRawFallbackFacts(input, "llm_error_fallback"), nil
+			slog.Warn("extraction retry failed; returning no facts", "err", retryErr)
+			return nil, nil
 		}
 		parsed, err = llm.ParseJSON[extractResponse](raw2)
 		if err != nil {
@@ -762,13 +700,12 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 				return facts, nil
 			}
 			if s.llm.DebugLLM() {
-				slog.Warn("json parse llm resp failed, using raw fallback", "len", len(raw2), "raw", raw2, "err", err)
+				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "raw", raw2, "err", err)
 			} else {
-				slog.Warn("json parse llm resp failed, using raw fallback", "len", len(raw2), "err", err)
+				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "err", err)
 			}
-			facts := buildRawFallbackFacts(input, "parse_error_fallback")
-			slog.Info("facts extracted", "facts", len(facts))
-			return facts, nil
+			slog.Info("facts extracted", "facts", 0)
+			return nil, nil
 		}
 		lastRaw = raw2
 	}
@@ -912,8 +849,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 	scope := llm.CallScope{Step: "extraction_and_classification"}
 	raw, err := s.llm.CompleteJSONWithScope(ctx, systemPrompt, userPrompt, scope)
 	if err != nil {
-		slog.Warn("extraction LLM call failed, using raw fallback", "err", err)
-		return buildRawFallbackFacts(input, "llm_error_fallback"), normalizeMessageTags(nil, messageCount), nil
+		slog.Warn("extraction LLM call failed; returning no facts", "err", err)
+		return nil, normalizeMessageTags(nil, messageCount), nil
 	}
 
 	parsed, err := llm.ParseJSON[extractResponse](raw)
@@ -924,8 +861,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt,
 			scope)
 		if retryErr != nil {
-			slog.Warn("extraction retry failed, using raw fallback", "err", retryErr)
-			return buildRawFallbackFacts(input, "llm_error_fallback"), normalizeMessageTags(nil, messageCount), nil
+			slog.Warn("extraction retry failed; returning no facts", "err", retryErr)
+			return nil, normalizeMessageTags(nil, messageCount), nil
 		}
 		parsed, err = llm.ParseJSON[extractResponse](raw2)
 		if err != nil {
@@ -943,13 +880,12 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 				return facts, messageTags, nil
 			}
 			if s.llm.DebugLLM() {
-				slog.Warn("json parse llm resp failed, using raw fallback", "len", len(raw2), "raw", raw2, "err", err)
+				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "raw", raw2, "err", err)
 			} else {
-				slog.Warn("json parse llm resp failed, using raw fallback", "len", len(raw2), "err", err)
+				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "err", err)
 			}
-			facts := buildRawFallbackFacts(input, "parse_error_fallback")
-			slog.Info("facts and tags extracted", "facts", len(facts), "tagged_messages", messageCount)
-			return facts, messageTags, nil
+			slog.Info("facts and tags extracted", "facts", 0, "tagged_messages", messageCount)
+			return nil, messageTags, nil
 		}
 		lastRaw = raw2
 	}
@@ -1083,8 +1019,6 @@ Assign 1-3 short lowercase tags to each ADD or UPDATE entry.
 Tags describe the topic or category of the memory.
 Examples: "tech", "personal", "preference", "work", "location", "habit"
 Use hyphens for multi-word tags: "programming-language", "work-tool".
-If a new fact includes the tag "raw-fallback", every ADD or UPDATE derived from it
-must also include the tag "raw-fallback" to preserve provenance.
 Omit the "tags" field entirely for DELETE entries.
 
 ## Examples
@@ -1210,7 +1144,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				agentID,
 				sessionID,
 				normalizedText,
-				ensureRawFallbackTag(event.Tags, facts),
+				event.Tags,
 				SetSourceProvenanceMetadata(MergeTemporalMetadata(nil, temporal), sourceSeqs, sourceTurns),
 			)
 			if addErr != nil {
@@ -1240,7 +1174,6 @@ Analyze the new facts and determine whether each should be added, updated, or de
 			if effectiveTags == nil {
 				effectiveTags = existingMemories[intID].Tags
 			}
-			effectiveTags = ensureRawFallbackTag(effectiveTags, facts)
 			sourceSeqs := sourceSeqsForReconcileText(event.Text, facts)
 			sourceTurns := sourceTurnsForReconcileText(event.Text, facts)
 			metadata := SetSourceProvenanceMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs, sourceTurns)

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -677,8 +677,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 	scope := llm.CallScope{Step: "extraction"}
 	raw, err := s.llm.CompleteJSONWithScope(ctx, systemPrompt, userPrompt, scope)
 	if err != nil {
-		slog.Warn("extraction LLM call failed; returning no facts", "err", err)
-		return nil, nil
+		slog.Warn("extraction LLM call failed", "err", err)
+		return nil, fmt.Errorf("extraction llm call: %w", err)
 	}
 
 	parsed, err := llm.ParseJSON[extractResponse](raw)
@@ -689,8 +689,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt,
 			scope)
 		if retryErr != nil {
-			slog.Warn("extraction retry failed; returning no facts", "err", retryErr)
-			return nil, nil
+			slog.Warn("extraction retry failed", "err", retryErr)
+			return nil, fmt.Errorf("extraction retry: %w", retryErr)
 		}
 		parsed, err = llm.ParseJSON[extractResponse](raw2)
 		if err != nil {
@@ -700,12 +700,11 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 				return facts, nil
 			}
 			if s.llm.DebugLLM() {
-				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "raw", raw2, "err", err)
+				slog.Warn("json parse llm resp failed", "len", len(raw2), "raw", raw2, "err", err)
 			} else {
-				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "err", err)
+				slog.Warn("json parse llm resp failed", "len", len(raw2), "err", err)
 			}
-			slog.Info("facts extracted", "facts", 0)
-			return nil, nil
+			return nil, fmt.Errorf("extraction response parse: %w", err)
 		}
 		lastRaw = raw2
 	}
@@ -849,8 +848,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 	scope := llm.CallScope{Step: "extraction_and_classification"}
 	raw, err := s.llm.CompleteJSONWithScope(ctx, systemPrompt, userPrompt, scope)
 	if err != nil {
-		slog.Warn("extraction LLM call failed; returning no facts", "err", err)
-		return nil, normalizeMessageTags(nil, messageCount), nil
+		slog.Warn("extraction LLM call failed", "err", err)
+		return nil, normalizeMessageTags(nil, messageCount), fmt.Errorf("extraction llm call: %w", err)
 	}
 
 	parsed, err := llm.ParseJSON[extractResponse](raw)
@@ -861,8 +860,8 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt,
 			scope)
 		if retryErr != nil {
-			slog.Warn("extraction retry failed; returning no facts", "err", retryErr)
-			return nil, normalizeMessageTags(nil, messageCount), nil
+			slog.Warn("extraction retry failed", "err", retryErr)
+			return nil, normalizeMessageTags(nil, messageCount), fmt.Errorf("extraction retry: %w", retryErr)
 		}
 		parsed, err = llm.ParseJSON[extractResponse](raw2)
 		if err != nil {
@@ -880,12 +879,11 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 				return facts, messageTags, nil
 			}
 			if s.llm.DebugLLM() {
-				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "raw", raw2, "err", err)
+				slog.Warn("json parse llm resp failed", "len", len(raw2), "raw", raw2, "err", err)
 			} else {
-				slog.Warn("json parse llm resp failed; returning no facts", "len", len(raw2), "err", err)
+				slog.Warn("json parse llm resp failed", "len", len(raw2), "err", err)
 			}
-			slog.Info("facts and tags extracted", "facts", 0, "tagged_messages", messageCount)
-			return nil, messageTags, nil
+			return nil, messageTags, fmt.Errorf("extraction response parse: %w", err)
 		}
 		lastRaw = raw2
 	}

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -616,6 +616,60 @@ func TestExtractFactsSingleMessageEmptyResultReturnsNoFacts(t *testing.T) {
 	}
 }
 
+func TestIngestExtractionLLMFailureReturnsFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer mockLLM.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
+	memRepo := &memoryRepoMock{}
+	svc := NewIngestService(memRepo, llmClient, nil, "auto-model", ModeSmart)
+
+	res, err := svc.Ingest(context.Background(), "agent-1", IngestRequest{
+		Mode:      ModeSmart,
+		SessionID: "sess-extraction-failure",
+		AgentID:   "agent-1",
+		Messages: []IngestMessage{
+			{Role: "user", Content: "I use Go 1.22"},
+			{Role: "assistant", Content: "Noted."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Ingest() error = %v", err)
+	}
+	if res == nil || res.Status != "failed" {
+		t.Fatalf("expected failed ingest result, got %+v", res)
+	}
+	if len(memRepo.createCalls) != 0 {
+		t.Fatalf("expected no create calls after extraction failure, got %d", len(memRepo.createCalls))
+	}
+}
+
+func TestExtractPhase1ExtractionLLMFailureReturnsError(t *testing.T) {
+	t.Parallel()
+
+	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer mockLLM.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	result, err := svc.ExtractPhase1(context.Background(), []IngestMessage{
+		{Role: "user", Content: "I use Go 1.22"},
+	})
+	if err == nil {
+		t.Fatal("expected ExtractPhase1() error after extraction LLM failure")
+	}
+	if result != nil {
+		t.Fatalf("expected nil result after extraction LLM failure, got %+v", result)
+	}
+}
+
 func TestExtractPhase1SingleMessageEmptyResultReturnsNoFacts(t *testing.T) {
 	t.Parallel()
 
@@ -2820,8 +2874,8 @@ func TestExtractFactsFlattenedFactNoTextNoTags(t *testing.T) {
 	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
 
 	facts, err := svc.extractFacts(context.Background(), "User: hello\n\nAssistant: ok")
-	if err != nil {
-		t.Fatalf("extractFacts() error = %v", err)
+	if err == nil {
+		t.Fatal("expected extractFacts() error for unrecoverable junk response")
 	}
 	if len(facts) != 0 {
 		t.Fatalf("expected unrecoverable junk response to return no facts, got %v", facts)
@@ -2839,8 +2893,8 @@ func TestExtractFactsFlattenedFactTagsOnly(t *testing.T) {
 	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
 
 	facts, err := svc.extractFacts(context.Background(), "User: hello\n\nAssistant: ok")
-	if err != nil {
-		t.Fatalf("extractFacts() error = %v", err)
+	if err == nil {
+		t.Fatal("expected extractFacts() error when flattened-fact has tags but no text")
 	}
 	if len(facts) != 0 {
 		t.Fatalf("expected flattened-fact with tags but no text to return no facts, got %v", facts)

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -561,7 +561,7 @@ func TestExtractPhase1SingleMessageUsesLLMExtraction(t *testing.T) {
 	}
 }
 
-func TestExtractFactsEmptyResultFallsBackToRawFact(t *testing.T) {
+func TestExtractFactsEmptyResultReturnsNoFacts(t *testing.T) {
 	t.Parallel()
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -581,12 +581,12 @@ func TestExtractFactsEmptyResultFallsBackToRawFact(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extractFacts() error = %v", err)
 	}
-	if len(facts) != 1 || facts[0].FactType != factTypeRawFallback || facts[0].Text != "I use Go 1.22" {
-		t.Fatalf("expected raw fallback fact after empty extraction, got %v", facts)
+	if len(facts) != 0 {
+		t.Fatalf("expected no facts after empty extraction, got %v", facts)
 	}
 }
 
-func TestExtractFactsSingleMessageEmptyResultFallsBackToRawFact(t *testing.T) {
+func TestExtractFactsSingleMessageEmptyResultReturnsNoFacts(t *testing.T) {
 	t.Parallel()
 
 	callCount := 0
@@ -611,12 +611,12 @@ func TestExtractFactsSingleMessageEmptyResultFallsBackToRawFact(t *testing.T) {
 	if callCount != 1 {
 		t.Fatalf("expected 1 LLM call for single-message extraction, got %d", callCount)
 	}
-	if len(facts) != 1 || facts[0].FactType != factTypeRawFallback || facts[0].Text != "I use Go 1.22" {
-		t.Fatalf("expected raw fallback fact after empty extraction, got %v", facts)
+	if len(facts) != 0 {
+		t.Fatalf("expected no facts after empty extraction, got %v", facts)
 	}
 }
 
-func TestExtractPhase1SingleMessageEmptyResultFallsBackToRawFact(t *testing.T) {
+func TestExtractPhase1SingleMessageEmptyResultReturnsNoFacts(t *testing.T) {
 	t.Parallel()
 
 	callCount := 0
@@ -643,15 +643,15 @@ func TestExtractPhase1SingleMessageEmptyResultFallsBackToRawFact(t *testing.T) {
 	if callCount != 1 {
 		t.Fatalf("expected 1 LLM call for single-message extraction, got %d", callCount)
 	}
-	if len(result.Facts) != 1 || result.Facts[0].FactType != factTypeRawFallback || result.Facts[0].Text != "I use Go 1.22" {
-		t.Fatalf("expected raw fallback fact after empty extraction, got %v", result.Facts)
+	if len(result.Facts) != 0 {
+		t.Fatalf("expected no facts after empty extraction, got %v", result.Facts)
 	}
 	if len(result.MessageTags) != 1 || len(result.MessageTags[0]) != 1 || result.MessageTags[0][0] != "tech" {
 		t.Fatalf("expected message_tags[0] = [tech], got %v", result.MessageTags)
 	}
 }
 
-func TestExtractFactsRetryFallbackDropsFlattenedQueryIntent(t *testing.T) {
+func TestExtractFactsRetryRecoveryDropsFlattenedQueryIntent(t *testing.T) {
 	t.Parallel()
 
 	callCount := 0
@@ -682,18 +682,12 @@ func TestExtractFactsRetryFallbackDropsFlattenedQueryIntent(t *testing.T) {
 	if callCount != 2 {
 		t.Fatalf("expected 2 LLM calls, got %d", callCount)
 	}
-	if len(facts) != 1 {
-		t.Fatalf("expected 1 raw fallback fact, got %v", facts)
-	}
-	if facts[0].FactType != factTypeRawFallback {
-		t.Fatalf("expected fact_type %q, got %q", factTypeRawFallback, facts[0].FactType)
-	}
-	if facts[0].Text != "how do I configure nginx?" {
-		t.Fatalf("expected fallback text to preserve user content, got %q", facts[0].Text)
+	if len(facts) != 0 {
+		t.Fatalf("expected query_intent-only extraction to return no facts, got %v", facts)
 	}
 }
 
-func TestExtractFactsAndTagsRetryFallbackDropsFlattenedQueryIntent(t *testing.T) {
+func TestExtractFactsAndTagsRetryRecoveryDropsFlattenedQueryIntent(t *testing.T) {
 	t.Parallel()
 
 	callCount := 0
@@ -724,8 +718,8 @@ func TestExtractFactsAndTagsRetryFallbackDropsFlattenedQueryIntent(t *testing.T)
 	if callCount != 2 {
 		t.Fatalf("expected 2 LLM calls, got %d", callCount)
 	}
-	if len(facts) != 1 || facts[0].FactType != factTypeRawFallback {
-		t.Fatalf("expected 1 raw fallback fact, got %v", facts)
+	if len(facts) != 0 {
+		t.Fatalf("expected query_intent-only extraction to return no facts, got %v", facts)
 	}
 	if len(messageTags) != 2 {
 		t.Fatalf("expected 2 message_tags entries, got %d", len(messageTags))
@@ -1076,7 +1070,7 @@ func TestReconcilePinnedFallbackCarriesTags(t *testing.T) {
 	}
 }
 
-func TestReconcileAddPreservesRawFallbackTag(t *testing.T) {
+func TestIngestDoesNotReconcileWhenExtractionReturnsNoFacts(t *testing.T) {
 	t.Parallel()
 
 	callCount := 0
@@ -1108,15 +1102,11 @@ func TestReconcileAddPreservesRawFallbackTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Ingest() error = %v", err)
 	}
-	if callCount != 2 {
-		t.Fatalf("expected 2 LLM calls (extract + reconcile), got %d", callCount)
+	if callCount != 1 {
+		t.Fatalf("expected 1 LLM call for extraction only, got %d", callCount)
 	}
-	if len(memRepo.createCalls) != 1 {
-		t.Fatalf("expected 1 create call, got %d", len(memRepo.createCalls))
-	}
-	got := memRepo.createCalls[0].Tags
-	if len(got) != 2 || got[0] != "tech" || got[1] != rawFallbackTag {
-		t.Fatalf("expected reconcile ADD tags [tech %s], got %v", rawFallbackTag, got)
+	if len(memRepo.createCalls) != 0 {
+		t.Fatalf("expected no create calls when extraction returns no facts, got %d", len(memRepo.createCalls))
 	}
 }
 
@@ -2783,7 +2773,7 @@ func TestExtractPhase1FencedLegacyStringArrayFallback(t *testing.T) {
 	}
 }
 
-func TestExtractFactsAlternativeKeyFallsBackToRawFact(t *testing.T) {
+func TestExtractFactsAlternativeKeyReturnsNoFacts(t *testing.T) {
 	t.Parallel()
 
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -2803,11 +2793,8 @@ func TestExtractFactsAlternativeKeyFallsBackToRawFact(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extractFacts() error = %v", err)
 	}
-	if len(facts) != 1 {
-		t.Fatalf("expected 1 raw fallback fact for alternative-key schema, got %d: %v", len(facts), facts)
-	}
-	if facts[0].FactType != factTypeRawFallback || facts[0].Text != "I use Go 1.22" {
-		t.Fatalf("expected raw fallback fact preserving user text, got %+v", facts[0])
+	if len(facts) != 0 {
+		t.Fatalf("expected alternative-key schema to return no facts, got %d: %v", len(facts), facts)
 	}
 }
 
@@ -2836,8 +2823,8 @@ func TestExtractFactsFlattenedFactNoTextNoTags(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extractFacts() error = %v", err)
 	}
-	if len(facts) != 1 || facts[0].FactType != factTypeRawFallback || facts[0].Text != "hello" {
-		t.Fatalf("expected raw fallback fact for unrecoverable junk response, got %v", facts)
+	if len(facts) != 0 {
+		t.Fatalf("expected unrecoverable junk response to return no facts, got %v", facts)
 	}
 }
 
@@ -2855,8 +2842,8 @@ func TestExtractFactsFlattenedFactTagsOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extractFacts() error = %v", err)
 	}
-	if len(facts) != 1 || facts[0].FactType != factTypeRawFallback || facts[0].Text != "hello" {
-		t.Fatalf("expected raw fallback fact when flattened-fact has tags but no text, got %v", facts)
+	if len(facts) != 0 {
+		t.Fatalf("expected flattened-fact with tags but no text to return no facts, got %v", facts)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the extraction fallback that stored raw user text as a `raw_fallback` fact when no facts were extracted.
- Return no facts on empty extraction, query-intent-only extraction, LLM errors, and unrecoverable parse errors.
- Stop instructing reconciliation to propagate the `raw-fallback` tag and update service tests for the new behavior.

## Validation

- `go test -count=1 ./internal/service/`
- `make test`