### PR TITLE
Fix console root redirect loop

### DIFF
--- a/site/scripts/netlify-build.sh
+++ b/site/scripts/netlify-build.sh
@@ -65,6 +65,7 @@ cat > "${site_dist_dir}/_redirects" <<REDIRECTS
 /console/auth/*    ${console_api_origin}/auth/:splat            200!
 /console/assets/*  ${console_fe_origin}/console/assets/:splat   200
 /console/favicon.svg  ${console_fe_origin}/console/favicon.svg  200
-/console           /console/                                    301
+/console           ${console_fe_origin}/console/index.html      200
+/console/          ${console_fe_origin}/console/index.html      200
 /console/*         ${console_fe_origin}/console/index.html      200
 REDIRECTS


### PR DESCRIPTION
## What changed
- Serve the console app shell directly for both `/console` and `/console/` in generated Netlify redirects.
- Keep console API, auth, assets, and SPA fallback routing through the configured console origins.

## Context
- Background: after PR #321 deployed, `https://mem9.ai/console/` returned repeated 301 responses with `Location: /console/`.
- Why this approach: Netlify was applying the `/console -> /console/` redirect to the slash form as well, creating a self-redirect at the console root.
- How it works: both console root paths now proxy to `/console/index.html` with a 200 response, while deeper routes continue to use the existing SPA fallback.

## Validation
- `bash -n site/scripts/netlify-build.sh`
- `git diff --check upstream/main...HEAD`
- `CONSOLE_FE_ORIGIN=https://mem9-console-fe-prod.netlify.app CONSOLE_API_ORIGIN=http://k8s-mem9cons-consoles-375a9a8a97-1912163298.ap-southeast-1.elb.amazonaws.com bash site/scripts/netlify-build.sh`
- Verified generated `site/dist/_redirects` includes 200 rules for both `/console` and `/console/`.