### PR TITLE
feat(codex-plugin): add recall prompt threshold

### DIFF
--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Persistent memory for Codex. Run $mem9:setup once, then mem9 recalls before prompts and saves recent turns on stop.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/README.md
+++ b/codex-plugin/README.md
@@ -7,6 +7,8 @@ After setup, it does two things automatically:
 - recalls relevant memories before each user prompt
 - saves a recent `user` / `assistant` window when Codex stops
 
+Automatic recall uses `recallMinPromptLength`, which defaults to `5`, after stripping already-injected memory context from the current prompt.
+
 The plugin exposes:
 
 - `$mem9:setup`
@@ -39,7 +41,7 @@ codex plugin marketplace add mem9-ai/mem9
    $mem9:setup
    ```
 
-5. If one repository needs a different profile or timeout, rerun `$mem9:setup` in that repository and apply project scope.
+5. If one repository needs a different profile, timeout, or recall prompt-length threshold, rerun `$mem9:setup` in that repository and apply project scope.
 6. When you want an on-demand recall or an explicit store, run:
 
    ```text
@@ -92,7 +94,7 @@ What it does:
 - repairs the Codex hooks feature flag, `$CODEX_HOME/hooks.json`, and the managed hook shims
 - keeps API key entry out of the Codex TUI
 
-Project scope keeps profile and timeout overrides.
+Project scope keeps profile, timeout, and recall prompt-length overrides.
 User scope also owns `updateCheck.enabled` and `updateCheck.intervalHours`.
 
 ### `$mem9:cleanup`
@@ -217,7 +219,7 @@ Common issues:
 - If `$mem9:setup` returns `no matches` after installing from `/plugins`, restart Codex or open a fresh Codex session. Codex loads plugin skills when the session starts.
 - If `inspect` reports `missing_install_metadata` before setup finishes, continue with `$mem9:setup`. `scope apply` writes `$CODEX_HOME/mem9/install.json`.
 - If `SessionStart` says mem9 is not configured, run `$mem9:setup`.
-- If a repository needs a different profile, timeout, or a cleared local override, rerun `$mem9:setup` in that repository and apply or clear project scope.
+- If a repository needs a different profile, timeout, recall prompt-length threshold, or a cleared local override, rerun `$mem9:setup` in that repository and apply or clear project scope.
 - If you want to remove the managed Codex files before reinstalling or resetting mem9, run `$mem9:cleanup`.
 - If the selected profile is missing, run `$mem9:setup` to create or repair global profiles.
 - If the selected profile is missing an API key, run `$mem9:setup` and choose `create-new`, or add the profile manually in `$MEM9_HOME/.credentials.json` and rerun `$mem9:setup`, then choose `use-existing`.
@@ -289,6 +291,7 @@ Global default config:
   "profileId": "default",
   "defaultTimeoutMs": 8000,
   "searchTimeoutMs": 15000,
+  "recallMinPromptLength": 5,
   "updateCheck": {
     "enabled": true,
     "intervalHours": 24
@@ -301,11 +304,13 @@ Project override example:
 ```json
 {
   "schemaVersion": 1,
-  "profileId": "work"
+  "profileId": "work",
+  "recallMinPromptLength": 5
 }
 ```
 
 Remote update-check settings stay in the global config.
+Set `recallMinPromptLength` to `0` to recall on every non-empty stripped user prompt.
 
 ### Environment Overrides
 

--- a/codex-plugin/hooks/user-prompt-submit.mjs
+++ b/codex-plugin/hooks/user-prompt-submit.mjs
@@ -19,6 +19,7 @@ let debugContext = {};
  *   apiKey: string,
  *   agentId: string,
  *   searchTimeoutMs: number,
+ *   recallMinPromptLength: number,
  * }} RecallRuntime
  */
 
@@ -80,6 +81,15 @@ export async function runUserPromptSubmit(input) {
   if (!query) {
     debug("prompt_empty", {
       promptChars: prompt.length,
+    });
+    return "";
+  }
+
+  if (query.length < input.runtime.recallMinPromptLength) {
+    debug("prompt_too_short", {
+      promptChars: prompt.length,
+      queryChars: query.length,
+      recallMinPromptLength: input.runtime.recallMinPromptLength,
     });
     return "";
   }

--- a/codex-plugin/lib/config.mjs
+++ b/codex-plugin/lib/config.mjs
@@ -13,6 +13,7 @@ import {
 export const DEFAULT_AGENT_ID = "codex";
 export const DEFAULT_REQUEST_TIMEOUT_MS = 8_000;
 export const DEFAULT_SEARCH_TIMEOUT_MS = 15_000;
+export const DEFAULT_RECALL_MIN_PROMPT_LENGTH = 5;
 
 const DEFAULT_API_URL = "https://api.mem9.ai";
 const DEFAULT_PLUGIN_ID = "mem9@mem9-ai";
@@ -84,6 +85,7 @@ const PLUGINS_CACHE_DIR = path.join("plugins", "cache");
  *   profileId?: string,
  *   defaultTimeoutMs?: number,
  *   searchTimeoutMs?: number,
+ *   recallMinPromptLength?: number,
  *   updateCheck?: UpdateCheckConfig,
  * }} ScopeConfig
  */
@@ -98,6 +100,7 @@ const PLUGINS_CACHE_DIR = path.join("plugins", "cache");
  *   agentId: string,
  *   defaultTimeoutMs: number,
  *   searchTimeoutMs: number,
+ *   recallMinPromptLength: number,
  *   updateCheck: { enabled: boolean, intervalHours: number },
  * }} RuntimeConfig
  */
@@ -310,6 +313,34 @@ function resolveScopedTimeout(projectValue, globalValue, fallback) {
   return fallback;
 }
 
+function resolveScopedNonNegativeInteger(projectValue, globalValue, fallback) {
+  if (
+    typeof projectValue === "number"
+    && Number.isFinite(projectValue)
+    && projectValue >= 0
+  ) {
+    return Math.floor(projectValue);
+  }
+
+  if (
+    typeof globalValue === "number"
+    && Number.isFinite(globalValue)
+    && globalValue >= 0
+  ) {
+    return Math.floor(globalValue);
+  }
+
+  return fallback;
+}
+
+function normalizeNonNegativeInteger(value, fallback) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return Math.floor(value);
+}
+
 function resolveScopedEnabled(globalConfig, projectConfig) {
   if (projectConfig != null) {
     return projectConfig.enabled !== false;
@@ -336,6 +367,11 @@ function buildEffectiveScopeConfig(globalConfig, projectConfig) {
       projectConfig?.searchTimeoutMs,
       globalConfig?.searchTimeoutMs,
       DEFAULT_SEARCH_TIMEOUT_MS,
+    ),
+    recallMinPromptLength: resolveScopedNonNegativeInteger(
+      projectConfig?.recallMinPromptLength,
+      globalConfig?.recallMinPromptLength,
+      DEFAULT_RECALL_MIN_PROMPT_LENGTH,
     ),
     updateCheck: normalizeUpdateCheckConfig(globalConfig?.updateCheck),
   };
@@ -650,6 +686,10 @@ export function resolveRuntimeConfig(input) {
     searchTimeoutMs: normalizeTimeoutMs(
       config.searchTimeoutMs,
       DEFAULT_SEARCH_TIMEOUT_MS,
+    ),
+    recallMinPromptLength: normalizeNonNegativeInteger(
+      config.recallMinPromptLength,
+      DEFAULT_RECALL_MIN_PROMPT_LENGTH,
     ),
     updateCheck: normalizeUpdateCheckConfig(config.updateCheck),
   };

--- a/codex-plugin/package.json
+++ b/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/codex-plugin",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Persistent memory for Codex with setup-driven hooks, prompt recall, and stop-time save.",
   "type": "module",
   "license": "Apache-2.0",

--- a/codex-plugin/skills/setup/SKILL.md
+++ b/codex-plugin/skills/setup/SKILL.md
@@ -66,7 +66,7 @@ node ./scripts/setup.mjs inspect
    Do not jump straight to `scope apply`.
    `scope apply` only runs after the user has chosen a profile and that profile already has an API key.
 4. Keep the default flow global-first.
-   Apply project scope only when the user explicitly asks for a repo-local profile or timeout override.
+   Apply project scope only when the user explicitly asks for a repo-local profile, timeout, or recall prompt-length override.
    Remote release-check settings live in user scope.
 5. When the user wants mem9 to create a new API key, run:
 
@@ -105,6 +105,7 @@ node ./scripts/setup.mjs scope apply \
   --profile <profile-id> \
   --default-timeout-ms <ms> \
   --search-timeout-ms <ms> \
+  --recall-min-prompt-length <chars> \
   --update-check enabled \
   --update-check-interval-hours <hours>
 ```
@@ -117,7 +118,8 @@ node ./scripts/setup.mjs scope apply \
   --scope project \
   --profile <profile-id> \
   --default-timeout-ms <ms> \
-  --search-timeout-ms <ms>
+  --search-timeout-ms <ms> \
+  --recall-min-prompt-length <chars>
 ```
 
 ```bash
@@ -125,7 +127,7 @@ set -euo pipefail
 node ./scripts/setup.mjs scope clear --scope project
 ```
 
-Project scope keeps `profileId`, `defaultTimeoutMs`, and `searchTimeoutMs`.
+Project scope keeps `profileId`, `defaultTimeoutMs`, `searchTimeoutMs`, and `recallMinPromptLength`.
 User scope also owns `updateCheck.enabled` and `updateCheck.intervalHours`.
 
 Common flags:
@@ -143,11 +145,13 @@ Common flags:
 - `--scope user|project`
 - `--default-timeout-ms <ms>`
 - `--search-timeout-ms <ms>`
+- `--recall-min-prompt-length <chars>`
 - `--update-check enabled|disabled`
 - `--update-check-interval-hours <hours>`
 - `--cwd <repo-root>`
 
 `--update-check` flags apply to `scope apply --scope user`.
+`--recall-min-prompt-length` defaults to `5`; use `0` to recall on every non-empty stripped user prompt.
 Most mem9 plugin releases take effect after a Codex restart. Migration releases may ask for `$mem9:setup` once after restart.
 
 `scope apply` and `scope clear` install or repair the managed mem9 runtime in `$CODEX_HOME`.

--- a/codex-plugin/skills/setup/scripts/setup.mjs
+++ b/codex-plugin/skills/setup/scripts/setup.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   DEFAULT_REQUEST_TIMEOUT_MS,
+  DEFAULT_RECALL_MIN_PROMPT_LENGTH,
   DEFAULT_SEARCH_TIMEOUT_MS,
   loadRuntimeStateFromDisk,
   resolveInstalledPluginCacheVersion,
@@ -94,10 +95,27 @@ function normalizeTimeoutMs(value, fallback) {
   return Math.floor(value);
 }
 
+function normalizeNonNegativeInteger(value, fallback) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return fallback;
+  }
+
+  return Math.floor(value);
+}
+
 function parseIntegerArg(flag, value) {
   const parsed = Number.parseInt(String(value ?? ""), 10);
   if (!Number.isFinite(parsed) || parsed <= 0) {
     throw new Error(`${flag} must be a positive integer.`);
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeIntegerArg(flag, value) {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`${flag} must be a non-negative integer.`);
   }
 
   return parsed;
@@ -353,6 +371,7 @@ function buildSetupHelpText(command = "", subcommand = "") {
         "    --profile <profile-id> \\",
         "    [--default-timeout-ms <ms>] \\",
         "    [--search-timeout-ms <ms>] \\",
+        "    [--recall-min-prompt-length <chars>] \\",
         "    [--update-check <enabled|disabled>] \\",
         "    [--update-check-interval-hours <hours>] \\",
         "    [--cwd <path>]",
@@ -364,13 +383,14 @@ function buildSetupHelpText(command = "", subcommand = "") {
         "Optional flags:",
         "  --default-timeout-ms <ms>             Defaults to the existing value or runtime default.",
         "  --search-timeout-ms <ms>              Defaults to the existing value or runtime default.",
+        "  --recall-min-prompt-length <chars>    Defaults to the existing value or 5. Set 0 to recall every non-empty prompt.",
         "  --update-check <enabled|disabled>     User scope only.",
         "  --update-check-interval-hours <hours> User scope only.",
         "  --cwd <path>                          Resolve repo-local paths from this directory.",
         "",
         "Examples:",
-        "  node ./scripts/setup.mjs scope apply --scope user --profile default --default-timeout-ms 8000 --search-timeout-ms 15000 --update-check enabled --update-check-interval-hours 24",
-        "  node ./scripts/setup.mjs scope apply --scope project --profile work --default-timeout-ms 8000 --search-timeout-ms 15000 --cwd .",
+        "  node ./scripts/setup.mjs scope apply --scope user --profile default --default-timeout-ms 8000 --search-timeout-ms 15000 --recall-min-prompt-length 5 --update-check enabled --update-check-interval-hours 24",
+        "  node ./scripts/setup.mjs scope apply --scope project --profile work --default-timeout-ms 8000 --search-timeout-ms 15000 --recall-min-prompt-length 5 --cwd .",
         "",
       ].join("\n");
     case "scope:clear":
@@ -400,7 +420,7 @@ function buildSetupHelpText(command = "", subcommand = "") {
         "  node ./scripts/setup.mjs inspect [--cwd <path>]",
         "  node ./scripts/setup.mjs profile create --profile <profile-id> [--label <profile-label>] [--base-url <mem9-api-base-url>] --provision-api-key [--cwd <path>]",
         "  node ./scripts/setup.mjs profile save-key --profile <profile-id> [--label <profile-label>] [--base-url <mem9-api-base-url>] --api-key-env <env-var> [--cwd <path>]",
-        "  node ./scripts/setup.mjs scope apply --scope <user|project> --profile <profile-id> [--default-timeout-ms <ms>] [--search-timeout-ms <ms>] [--update-check <enabled|disabled>] [--update-check-interval-hours <hours>] [--cwd <path>]",
+        "  node ./scripts/setup.mjs scope apply --scope <user|project> --profile <profile-id> [--default-timeout-ms <ms>] [--search-timeout-ms <ms>] [--recall-min-prompt-length <chars>] [--update-check <enabled|disabled>] [--update-check-interval-hours <hours>] [--cwd <path>]",
         "  node ./scripts/setup.mjs scope clear --scope project [--cwd <path>]",
         "",
         "Commands:",
@@ -419,7 +439,7 @@ function buildSetupHelpText(command = "", subcommand = "") {
         "  node ./scripts/setup.mjs inspect --cwd .",
         "  node ./scripts/setup.mjs profile create --profile default --label Default --provision-api-key",
         "  MEM9_API_KEY='<your-mem9-api-key>' node ./scripts/setup.mjs profile save-key --profile default --label Default --base-url https://api.mem9.ai --api-key-env MEM9_API_KEY",
-        "  node ./scripts/setup.mjs scope apply --scope user --profile default --default-timeout-ms 8000 --search-timeout-ms 15000 --update-check enabled --update-check-interval-hours 24",
+        "  node ./scripts/setup.mjs scope apply --scope user --profile default --default-timeout-ms 8000 --search-timeout-ms 15000 --recall-min-prompt-length 5 --update-check enabled --update-check-interval-hours 24",
         "",
         "Run a subcommand with --help for more detail.",
         "",
@@ -925,6 +945,10 @@ function summarizeScopeConfigState(config, options = {}) {
       config.searchTimeoutMs,
       DEFAULT_SEARCH_TIMEOUT_MS,
     ),
+    recallMinPromptLength: normalizeNonNegativeInteger(
+      config.recallMinPromptLength,
+      DEFAULT_RECALL_MIN_PROMPT_LENGTH,
+    ),
     legacyEnabledFalse: config.enabled === false,
   };
 
@@ -1024,6 +1048,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
     scope: "",
     defaultTimeoutMs: undefined,
     searchTimeoutMs: undefined,
+    recallMinPromptLength: undefined,
     updateCheck: "",
     updateCheckIntervalHours: undefined,
   };
@@ -1086,6 +1111,10 @@ export function parseArgs(argv = process.argv.slice(2)) {
         break;
       case "--search-timeout-ms":
         args.searchTimeoutMs = parseIntegerArg(token, nextValue);
+        index += 1;
+        break;
+      case "--recall-min-prompt-length":
+        args.recallMinPromptLength = parseNonNegativeIntegerArg(token, nextValue);
         index += 1;
         break;
       case "--update-check":
@@ -1156,6 +1185,7 @@ export function parseArgs(argv = process.argv.slice(2)) {
       || args.provisionApiKey
       || args.defaultTimeoutMs !== undefined
       || args.searchTimeoutMs !== undefined
+      || args.recallMinPromptLength !== undefined
       || args.updateCheck
       || args.updateCheckIntervalHours !== undefined
     ) {
@@ -1556,6 +1586,10 @@ export function buildScopeConfig(profileId, options = {}) {
       options.searchTimeoutMs ?? existingConfig.searchTimeoutMs,
       DEFAULT_SEARCH_TIMEOUT_MS,
     ),
+    recallMinPromptLength: normalizeNonNegativeInteger(
+      options.recallMinPromptLength ?? existingConfig.recallMinPromptLength,
+      DEFAULT_RECALL_MIN_PROMPT_LENGTH,
+    ),
     updateCheck: scope === "user"
       ? {
         enabled: options.updateCheck === "enabled"
@@ -1932,6 +1966,7 @@ export function inspectSetup(argv = process.argv.slice(2), options = {}) {
       profileId: runtimeState.runtime.profileId,
       defaultTimeoutMs: runtimeState.runtime.defaultTimeoutMs,
       searchTimeoutMs: runtimeState.runtime.searchTimeoutMs,
+      recallMinPromptLength: runtimeState.runtime.recallMinPromptLength,
       warnings: runtimeState.warnings,
       legacyPausedSources: runtimeState.legacyPausedSources,
       effectiveLegacyPausedSource: runtimeState.effectiveLegacyPausedSource,
@@ -2123,6 +2158,7 @@ function resolveConfigWriteFallback(scope, targetConfig, globalConfig) {
   return {
     defaultTimeoutMs: targetConfig?.defaultTimeoutMs ?? globalConfig?.defaultTimeoutMs,
     searchTimeoutMs: targetConfig?.searchTimeoutMs ?? globalConfig?.searchTimeoutMs,
+    recallMinPromptLength: targetConfig?.recallMinPromptLength ?? globalConfig?.recallMinPromptLength,
   };
 }
 
@@ -2193,6 +2229,7 @@ async function runScopeApply(args, options = {}) {
     existingConfig: resolveConfigWriteFallback(args.scope, targetConfig, globalConfig),
     defaultTimeoutMs: args.defaultTimeoutMs,
     searchTimeoutMs: args.searchTimeoutMs,
+    recallMinPromptLength: args.recallMinPromptLength,
     updateCheck: args.updateCheck,
     updateCheckIntervalHours: args.updateCheckIntervalHours,
   });

--- a/codex-plugin/tests/plugin-files.test.mjs
+++ b/codex-plugin/tests/plugin-files.test.mjs
@@ -12,11 +12,11 @@ test("plugin manifest exposes mem9 setup skill and basic metadata", () => {
   );
 
   assert.equal(manifest.name, "mem9");
-  assert.equal(manifest.version, "0.2.2");
+  assert.equal(manifest.version, "0.2.3");
   assert.equal(manifest.skills, "./skills/");
   assert.equal(typeof manifest.description, "string");
   assert.match(manifest.description, /\$mem9:setup/);
-  assert.equal(packageManifest.version, "0.2.2");
+  assert.equal(packageManifest.version, "0.2.3");
   assert.equal(packageManifest.version, manifest.version);
   assert.equal(packageManifest.engines.node, ">=22");
   assert.equal(packageManifest.files.includes("lib/"), true);
@@ -66,6 +66,7 @@ test("plugin templates and skills exist with mem9 hook wiring", () => {
   assert.match(setupSkill, /Do not rewrite it into generic text like `key saved`/);
   assert.match(setupSkill, /Example: `default \(019d\.\.\.4356\) · https:\/\/api\.mem9\.ai`/);
   assert.match(setupSkill, /updateCheck/);
+  assert.match(setupSkill, /--recall-min-prompt-length <chars>/);
   assert.match(setupSkill, /--update-check enabled\|disabled/);
   assert.match(setupSkill, /--update-check-interval-hours <hours>/);
   assert.doesNotMatch(setupSkill, /disable-model-invocation:\s*true/);
@@ -133,6 +134,8 @@ test("README explains global hooks and project overrides", () => {
   assert.match(readme, /## Reference: Files, Config, Environment/);
   assert.match(readme, /### File Layout/);
   assert.match(readme, /### Config Files/);
+  assert.match(readme, /Automatic recall uses `recallMinPromptLength`/);
+  assert.match(readme, /"recallMinPromptLength": 5/);
   assert.match(readme, /<project>\/\.codex\/mem9\/config\.json/);
   assert.match(readme, /\$MEM9_HOME\/\.credentials\.json/);
   assert.match(readme, /\$CODEX_HOME\/mem9\/install\.json/);

--- a/codex-plugin/tests/runtime-config.test.mjs
+++ b/codex-plugin/tests/runtime-config.test.mjs
@@ -6,6 +6,7 @@ import test from "node:test";
 import { buildSessionStartMessage } from "../hooks/session-start.mjs";
 import {
   DEFAULT_AGENT_ID,
+  DEFAULT_RECALL_MIN_PROMPT_LENGTH,
   DEFAULT_REQUEST_TIMEOUT_MS,
   DEFAULT_SEARCH_TIMEOUT_MS,
   loadRuntimeFromDisk,
@@ -223,11 +224,13 @@ test("project override resolves fields by precedence", () => {
       profileId: "default",
       defaultTimeoutMs: 8_100,
       searchTimeoutMs: 15_100,
+      recallMinPromptLength: 6,
     },
     projectConfig: {
       schemaVersion: 1,
       profileId: "work",
       searchTimeoutMs: 16_200,
+      recallMinPromptLength: 3,
     },
     credentials: DEFAULT_CREDENTIALS,
     installMetadata: DEFAULT_INSTALL,
@@ -240,11 +243,13 @@ test("project override resolves fields by precedence", () => {
       profileId: "default",
       defaultTimeoutMs: 8_100,
       searchTimeoutMs: 15_100,
+      recallMinPromptLength: 6,
     },
     projectConfig: {
       schemaVersion: 1,
       profileId: "work",
       searchTimeoutMs: 16_200,
+      recallMinPromptLength: 3,
     },
     credentials: DEFAULT_CREDENTIALS,
     installMetadata: DEFAULT_INSTALL,
@@ -263,6 +268,7 @@ test("project override resolves fields by precedence", () => {
   assert.equal(runtime.apiKey, "project-key");
   assert.equal(runtime.defaultTimeoutMs, 8_100);
   assert.equal(runtime.searchTimeoutMs, 16_200);
+  assert.equal(runtime.recallMinPromptLength, 3);
   assert.equal(runtime.updateCheck.enabled, true);
   assert.equal(runtime.updateCheck.intervalHours, 24);
 });
@@ -321,6 +327,7 @@ test("a project override can be ready without a global config file", () => {
       schemaVersion: 1,
       profileId: "work",
       defaultTimeoutMs: 8_250,
+      recallMinPromptLength: 0,
     },
     credentials: DEFAULT_CREDENTIALS,
     installMetadata: DEFAULT_INSTALL,
@@ -332,6 +339,7 @@ test("a project override can be ready without a global config file", () => {
   assert.equal(runtime.profileId, "work");
   assert.equal(runtime.baseUrl, "https://work.mem9.ai");
   assert.equal(runtime.defaultTimeoutMs, 8_250);
+  assert.equal(runtime.recallMinPromptLength, 0);
 });
 
 test("plugin disabled via config.toml returns plugin_disabled", () => {
@@ -746,6 +754,7 @@ test("env overrides still replace api url and api key", () => {
   assert.equal(runtime.agentId, DEFAULT_AGENT_ID);
   assert.equal(runtime.defaultTimeoutMs, DEFAULT_REQUEST_TIMEOUT_MS);
   assert.equal(runtime.searchTimeoutMs, DEFAULT_SEARCH_TIMEOUT_MS);
+  assert.equal(runtime.recallMinPromptLength, DEFAULT_RECALL_MIN_PROMPT_LENGTH);
   assert.equal(runtime.updateCheck.enabled, true);
   assert.equal(runtime.updateCheck.intervalHours, 24);
 });

--- a/codex-plugin/tests/setup.test.mjs
+++ b/codex-plugin/tests/setup.test.mjs
@@ -58,6 +58,7 @@ test("parseArgs supports the setup subcommands", () => {
       scope: "",
       defaultTimeoutMs: undefined,
       searchTimeoutMs: undefined,
+      recallMinPromptLength: undefined,
       updateCheck: "",
       updateCheckIntervalHours: undefined,
     },
@@ -87,6 +88,7 @@ test("parseArgs supports the setup subcommands", () => {
       scope: "",
       defaultTimeoutMs: undefined,
       searchTimeoutMs: undefined,
+      recallMinPromptLength: undefined,
       updateCheck: "",
       updateCheckIntervalHours: undefined,
     },
@@ -104,6 +106,8 @@ test("parseArgs supports the setup subcommands", () => {
       "8100",
       "--search-timeout-ms",
       "15100",
+      "--recall-min-prompt-length",
+      "0",
     ]),
     {
       command: "scope",
@@ -117,6 +121,7 @@ test("parseArgs supports the setup subcommands", () => {
       scope: "project",
       defaultTimeoutMs: 8100,
       searchTimeoutMs: 15100,
+      recallMinPromptLength: 0,
       updateCheck: "",
       updateCheckIntervalHours: undefined,
     },
@@ -147,6 +152,7 @@ test("parseArgs supports the setup subcommands", () => {
       scope: "user",
       defaultTimeoutMs: undefined,
       searchTimeoutMs: undefined,
+      recallMinPromptLength: undefined,
       updateCheck: "disabled",
       updateCheckIntervalHours: 72,
     },
@@ -462,6 +468,7 @@ test("inspect reports runtime, plugin, configs, and saved profiles without expos
       profileId: "default",
       defaultTimeoutMs: 8300,
       searchTimeoutMs: 15300,
+      recallMinPromptLength: 8,
       updateCheck: {
         enabled: false,
         intervalHours: 72,
@@ -473,6 +480,7 @@ test("inspect reports runtime, plugin, configs, and saved profiles without expos
       profileId: "work",
       defaultTimeoutMs: 9100,
       searchTimeoutMs: 15500,
+      recallMinPromptLength: 4,
       updateCheck: {
         enabled: true,
         intervalHours: 6,
@@ -513,6 +521,7 @@ test("inspect reports runtime, plugin, configs, and saved profiles without expos
     assert.equal(summary.command, "inspect");
     assert.equal(summary.environment.nodeVersionSupported, true);
     assert.equal(summary.runtime.pluginState, "enabled");
+    assert.equal(summary.runtime.recallMinPromptLength, 4);
     assert.deepEqual(summary.runtime.legacyPausedSources, ["global", "project"]);
     assert.equal(summary.runtime.effectiveLegacyPausedSource, "project");
     assert.equal(summary.plugin.hooksFeatureEnabled, true);
@@ -528,9 +537,11 @@ test("inspect reports runtime, plugin, configs, and saved profiles without expos
       enabled: false,
       intervalHours: 72,
     });
+    assert.equal(summary.globalConfig.summary.recallMinPromptLength, 8);
     assert.equal(summary.projectConfig.summary.profileId, "work");
     assert.equal(summary.projectConfig.summary.legacyEnabledFalse, true);
     assert.equal(summary.projectConfig.summary.updateCheck, undefined);
+    assert.equal(summary.projectConfig.summary.recallMinPromptLength, 4);
     assert.deepEqual(summary.profiles.usableProfileIds, ["default"]);
     assert.match(
       summary.profiles.manualSaveKeyTemplate,
@@ -1082,6 +1093,8 @@ test("scope apply user installs global config, hooks, metadata, and repairs lega
         "disabled",
         "--update-check-interval-hours",
         "72",
+        "--recall-min-prompt-length",
+        "6",
       ],
       {
         cwd: projectRoot,
@@ -1106,6 +1119,7 @@ test("scope apply user installs global config, hooks, metadata, and repairs lega
       enabled: false,
       intervalHours: 72,
     });
+    assert.equal(result.configSummary.recallMinPromptLength, 6);
     assert.equal(
       existsSync(path.join(codexHome, "mem9", "hooks", "session-start.mjs")),
       true,
@@ -1128,6 +1142,7 @@ test("scope apply user installs global config, hooks, metadata, and repairs lega
     assert.equal(globalConfig.profileId, "work");
     assert.equal(globalConfig.defaultTimeoutMs, 8000);
     assert.equal(globalConfig.searchTimeoutMs, 15000);
+    assert.equal(globalConfig.recallMinPromptLength, 6);
     assert.deepEqual(globalConfig.updateCheck, {
       enabled: false,
       intervalHours: 72,
@@ -1161,6 +1176,7 @@ test("scope apply user installs global config, hooks, metadata, and repairs lega
       enabled: false,
       intervalHours: 72,
     });
+    assert.equal(stdoutSummary.configSummary.recallMinPromptLength, 6);
     assert.equal(stdoutText.includes("key-1"), false);
     assert.equal(JSON.stringify(stdoutSummary).includes("key-1"), false);
   } finally {
@@ -1290,6 +1306,7 @@ test("scope apply project writes a local override and clears legacy enabled fals
       profileId: "default",
       defaultTimeoutMs: 8200,
       searchTimeoutMs: 15200,
+      recallMinPromptLength: 7,
     });
     writeJson(path.join(mem9Home, ".credentials.json"), {
       schemaVersion: 1,
@@ -1311,6 +1328,7 @@ test("scope apply project writes a local override and clears legacy enabled fals
       enabled: false,
       profileId: "default",
       defaultTimeoutMs: 9100,
+      recallMinPromptLength: 3,
     });
 
     await runSetup(
@@ -1334,6 +1352,7 @@ test("scope apply project writes a local override and clears legacy enabled fals
     assert.equal(saved.profileId, "work");
     assert.equal(saved.defaultTimeoutMs, 9100);
     assert.equal(saved.searchTimeoutMs, 15200);
+    assert.equal(saved.recallMinPromptLength, 3);
     assert.equal("enabled" in saved, false);
     assert.equal("updateCheck" in saved, false);
   } finally {
@@ -1532,6 +1551,7 @@ test("scope apply repairs malformed json files and rewrites them with valid conf
     const repairedInstall = readJson(path.join(codexHome, "mem9", "install.json"));
 
     assert.equal(repairedConfig.profileId, "work");
+    assert.equal(repairedConfig.recallMinPromptLength, 5);
     assert.deepEqual(repairedConfig.updateCheck, {
       enabled: true,
       intervalHours: 24,

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -203,6 +203,7 @@ test("user prompt submit recalls memories with the search timeout bucket", async
       apiKey: "key-1",
       agentId: "codex",
       searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
     },
     async search(url, options) {
       requestedUrl = url;
@@ -245,6 +246,7 @@ test("user prompt submit skips empty queries after stripping injected memories",
       apiKey: "key-1",
       agentId: "codex",
       searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
     },
     async search() {
       called = true;
@@ -258,6 +260,69 @@ test("user prompt submit skips empty queries after stripping injected memories",
   assert.equal(called, false);
   assert.equal(output, "");
   assert.equal(debugEvents[0]?.stage, "prompt_empty");
+});
+
+test("user prompt submit skips recall when the stripped query is shorter than the configured minimum", async () => {
+  let called = false;
+  /** @type {Array<{stage: string, fields: Record<string, unknown> | undefined}>} */
+  const debugEvents = [];
+  const prompt = "<relevant-memories>\n1. old\n</relevant-memories>\n\nhi";
+
+  const output = await runUserPromptSubmit({
+    prompt,
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
+    },
+    async search() {
+      called = true;
+      return { memories: [] };
+    },
+    debug(stage, fields) {
+      debugEvents.push({ stage, fields });
+    },
+  });
+
+  assert.equal(called, false);
+  assert.equal(output, "");
+  assert.equal(debugEvents[0]?.stage, "prompt_too_short");
+  assert.deepEqual(debugEvents[0]?.fields, {
+    promptChars: prompt.length,
+    queryChars: 2,
+    recallMinPromptLength: 5,
+  });
+});
+
+test("user prompt submit allows short non-empty queries when the configured minimum is zero", async () => {
+  /** @type {string | null} */
+  let requestedUrl = null;
+
+  const output = await runUserPromptSubmit({
+    prompt: "hi",
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      searchTimeoutMs: 15_000,
+      recallMinPromptLength: 0,
+    },
+    async search(url) {
+      requestedUrl = url;
+      return {
+        memories: [
+          { content: "Short prompts can still recall when configured." },
+        ],
+      };
+    },
+  });
+
+  assert.ok(requestedUrl);
+  const url = new URL(requestedUrl);
+  assert.equal(url.searchParams.get("q"), "hi");
+  assert.match(output, /Short prompts can still recall/);
 });
 
 for (const issueCode of NON_READY_ISSUE_CODES) {

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -335,19 +335,19 @@ test("user prompt submit entrypoint skips short prompts using runtime config fro
       schemaVersion: 1,
       enabled: true,
       profileId: "default",
-      recallMinPromptLength: 5,
+      recallMinPromptLength: 6,
     });
 
     const result = await runNodeHook(USER_PROMPT_SUBMIT_ENTRY, {
       cwd: runtime.cwd,
       env: {
-        ...process.env,
         CODEX_HOME: runtime.codexHome,
         MEM9_HOME: runtime.mem9Home,
+        PATH: process.env.PATH,
       },
       input: JSON.stringify({
         cwd: runtime.cwd,
-        prompt: "hi",
+        prompt: "hello",
       }),
     });
 

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -106,7 +106,7 @@ async function runNodeHook(scriptPath, input) {
 
 /**
  * @param {string} tempRoot
- * @param {"plugin_disabled" | "plugin_missing" | "legacy_paused"} issueCode
+ * @param {"ready" | "plugin_disabled" | "plugin_missing" | "legacy_paused"} issueCode
  * @param {string} baseUrl
  */
 function createRuntimeLayout(tempRoot, issueCode, baseUrl) {
@@ -323,6 +323,43 @@ test("user prompt submit allows short non-empty queries when the configured mini
   const url = new URL(requestedUrl);
   assert.equal(url.searchParams.get("q"), "hi");
   assert.match(output, /Short prompts can still recall/);
+});
+
+test("user prompt submit entrypoint skips short prompts using runtime config from disk", async () => {
+  const tempRoot = createTempRoot();
+  const server = await createCountingServer();
+
+  try {
+    const runtime = createRuntimeLayout(tempRoot, "ready", server.origin);
+    writeJson(path.join(runtime.codexHome, "mem9", "config.json"), {
+      schemaVersion: 1,
+      enabled: true,
+      profileId: "default",
+      recallMinPromptLength: 5,
+    });
+
+    const result = await runNodeHook(USER_PROMPT_SUBMIT_ENTRY, {
+      cwd: runtime.cwd,
+      env: {
+        ...process.env,
+        CODEX_HOME: runtime.codexHome,
+        MEM9_HOME: runtime.mem9Home,
+      },
+      input: JSON.stringify({
+        cwd: runtime.cwd,
+        prompt: "hi",
+      }),
+    });
+
+    assert.equal(result.code, 0);
+    assert.equal(result.signal, null);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+    assert.equal(server.getRequestCount(), 0);
+  } finally {
+    await server.close();
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 for (const issueCode of NON_READY_ISSUE_CODES) {


### PR DESCRIPTION
## Context

The OpenClaw plugin skips automatic recall for very short prompts so quick confirmations and tiny inputs do not trigger unnecessary memory searches. The Codex plugin now uses the same default behavior and exposes the threshold as runtime configuration.

## Summary

- Add `recallMinPromptLength` to Codex plugin runtime config with a default value of `5`.
- Skip automatic recall when the stripped user prompt is shorter than the configured threshold.
- Support `recallMinPromptLength: 0` to recall on every non-empty stripped prompt.
- Expose the setting through setup scope config for user and project overrides.
- Update README, setup skill docs, and tests to cover the new option.
- Bump Codex plugin metadata to `0.2.3`.

## Validation

- `git diff --check`
- Node tests and typecheck are deferred until maintainer review, per workflow request.