### PR TITLE
Add site login nav CTA

### DIFF
--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -433,7 +433,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.5rem;
     color: var(--text-soft);
     transition: color 0.2s ease;
   }

--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -91,6 +91,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
           title={nav.github}
           data-i18n-attr="aria-label:nav.github;title:nav.github"
         >
+          <span class="nav-github-label">GitHub</span>
           <svg class="nav-github-icon" viewBox="0 0 24 24" aria-hidden="true">
             <path
               fill="currentColor"
@@ -101,6 +102,14 @@ const isActivePath = (path: string): boolean => currentPath === path;
       </div>
 
       <div class="nav-actions">
+        <a
+          href="https://mem9.ai/console"
+          class="nav-login-link"
+          data-i18n="nav.login"
+        >
+          {nav.login}
+        </a>
+
         <div class="menu-shell" data-menu-shell="language" data-open="false">
           <button
             type="button"
@@ -424,6 +433,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 0.35rem;
     color: var(--text-soft);
     transition: color 0.2s ease;
   }
@@ -439,10 +449,49 @@ const isActivePath = (path: string): boolean => currentPath === path;
     display: block;
   }
 
+  .nav-github-label {
+    font-size: 0.95rem;
+    line-height: 1;
+  }
+
   .nav-actions {
     display: flex;
     align-items: center;
     gap: 0.7rem;
+  }
+
+  .nav-login-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 5.4rem;
+    height: 2.55rem;
+    padding: 0 1.15rem;
+    border: 1px solid var(--text);
+    border-radius: 999px;
+    background: var(--text);
+    color: var(--bg-deep);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+    font-size: 0.93rem;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    transition:
+      transform 0.2s ease,
+      background-color 0.2s ease,
+      border-color 0.2s ease,
+      box-shadow 0.2s ease,
+      color 0.2s ease;
+  }
+
+  .nav-login-link:hover,
+  .nav-login-link:focus-visible {
+    transform: translateY(-1px);
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg-deep);
+    opacity: 1;
+    box-shadow: 0 16px 34px rgba(0, 0, 0, 0.18);
   }
 
   .menu-shell {
@@ -556,6 +605,22 @@ const isActivePath = (path: string): boolean => currentPath === path;
       font-size: 0.84rem;
     }
 
+    .nav-actions {
+      gap: 0.45rem;
+    }
+
+    .nav-login-link {
+      min-width: 0;
+      height: 2.35rem;
+      padding: 0 0.9rem;
+      font-size: 0.84rem;
+    }
+
+    .icon-button {
+      width: 2.35rem;
+      height: 2.35rem;
+    }
+
     .language-menu {
       min-width: min(18rem, calc(100vw - 2rem));
       max-height: min(50vh, 16rem);
@@ -566,6 +631,19 @@ const isActivePath = (path: string): boolean => currentPath === path;
     .language-menu .menu-option {
       min-height: 3rem;
       white-space: normal;
+    }
+  }
+
+  @media (max-width: 460px) {
+    .nav-links .nav-docs-link,
+    .nav-links .nav-api-link {
+      display: none;
+    }
+  }
+
+  @media (max-width: 360px) {
+    .nav-github-label {
+      display: none;
     }
   }
 </style>

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -43,6 +43,7 @@ export interface SiteNavCopy {
   benchmark: string;
   openclaw: string;
   yourMemory: string;
+  login: string;
   billing: string;
   security: string;
   faq: string;
@@ -2408,6 +2409,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'Benchmark',
       openclaw: 'OpenClaw',
       yourMemory: 'Your Memory',
+      login: 'Log in',
       billing: 'Pricing',
       security: 'Security',
       faq: 'FAQ',
@@ -2756,6 +2758,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: '基准测试',
       openclaw: 'OpenClaw',
       yourMemory: '你的记忆',
+      login: '登录',
       billing: '定价',
       security: '安全',
       faq: '常见问题',
@@ -3090,6 +3093,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: '基準測試',
       openclaw: 'OpenClaw',
       yourMemory: '你的記憶',
+      login: '登入',
       billing: '定價',
       security: '安全',
       faq: '常見問題',
@@ -3429,6 +3433,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'ベンチマーク',
       openclaw: 'OpenClaw',
       yourMemory: 'あなたの記憶',
+      login: 'ログイン',
       billing: '料金',
       security: 'セキュリティ',
       faq: 'よくある質問',
@@ -3773,6 +3778,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: '벤치마크',
       openclaw: 'OpenClaw',
       yourMemory: '당신의 기억',
+      login: '로그인',
       billing: '요금',
       security: '보안',
       faq: '자주 묻는 질문',
@@ -4114,6 +4120,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'Benchmark',
       openclaw: 'OpenClaw',
       yourMemory: 'Memori Anda',
+      login: 'Masuk',
       billing: 'Harga',
       security: 'Keamanan',
       faq: 'FAQ',
@@ -4458,6 +4465,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'เบนช์มาร์ก',
       openclaw: 'OpenClaw',
       yourMemory: 'ความทรงจำของคุณ',
+      login: 'ล็อกอิน',
       billing: 'ราคา',
       security: 'ความปลอดภัย',
       faq: 'คำถามที่พบบ่อย',


### PR DESCRIPTION
## Summary

- Add a prominent localized login CTA to the site navbar linking to https://mem9.ai/console.
- Place the CTA in the right-side action cluster before the language/theme icon buttons.
- Add a fixed non-localized GitHub text label beside the GitHub icon.

## Validation

- npm run build
- Browser check on http://127.0.0.1:4321/ for CTA placement, link target, and login i18n.
