### PR TITLE
feat: label console entry as preview

### DIFF
--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -107,7 +107,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
           class="nav-login-link"
         >
           <span data-i18n="nav.login">{nav.login}</span>
-          <span class="nav-preview-badge">Preview</span>
+          <span class="nav-preview-badge" data-i18n="nav.preview">{nav.preview}</span>
         </a>
 
         <div class="menu-shell" data-menu-shell="language" data-open="false">

--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -105,9 +105,9 @@ const isActivePath = (path: string): boolean => currentPath === path;
         <a
           href="https://mem9.ai/console"
           class="nav-login-link"
-          data-i18n="nav.login"
         >
-          {nav.login}
+          <span data-i18n="nav.login">{nav.login}</span>
+          <span class="nav-preview-badge">Preview</span>
         </a>
 
         <div class="menu-shell" data-menu-shell="language" data-open="false">
@@ -464,6 +464,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 0.48rem;
     min-width: 5.4rem;
     height: 2.55rem;
     padding: 0 1.15rem;
@@ -482,6 +483,22 @@ const isActivePath = (path: string): boolean => currentPath === path;
       border-color 0.2s ease,
       box-shadow 0.2s ease,
       color 0.2s ease;
+  }
+
+  .nav-preview-badge {
+    display: inline-flex;
+    align-items: center;
+    height: 1.05rem;
+    padding: 0 0.36rem;
+    border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+    border-radius: 999px;
+    background: color-mix(in srgb, currentColor 11%, transparent);
+    color: currentColor;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    font-weight: 700;
+    line-height: 1;
+    text-transform: uppercase;
   }
 
   .nav-login-link:hover,
@@ -612,8 +629,15 @@ const isActivePath = (path: string): boolean => currentPath === path;
     .nav-login-link {
       min-width: 0;
       height: 2.35rem;
-      padding: 0 0.9rem;
+      gap: 0.38rem;
+      padding: 0 0.75rem;
       font-size: 0.84rem;
+    }
+
+    .nav-preview-badge {
+      height: 0.95rem;
+      padding: 0 0.3rem;
+      font-size: 0.53rem;
     }
 
     .icon-button {

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -44,6 +44,7 @@ export interface SiteNavCopy {
   openclaw: string;
   yourMemory: string;
   login: string;
+  preview: string;
   billing: string;
   security: string;
   faq: string;
@@ -2410,6 +2411,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: 'Your Memory',
       login: 'Log in',
+      preview: 'Preview',
       billing: 'Pricing',
       security: 'Security',
       faq: 'FAQ',
@@ -2759,6 +2761,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: '你的记忆',
       login: '登录',
+      preview: 'Preview',
       billing: '定价',
       security: '安全',
       faq: '常见问题',
@@ -3094,6 +3097,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: '你的記憶',
       login: '登入',
+      preview: 'Preview',
       billing: '定價',
       security: '安全',
       faq: '常見問題',
@@ -3434,6 +3438,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: 'あなたの記憶',
       login: 'ログイン',
+      preview: 'Preview',
       billing: '料金',
       security: 'セキュリティ',
       faq: 'よくある質問',
@@ -3779,6 +3784,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: '당신의 기억',
       login: '로그인',
+      preview: 'Preview',
       billing: '요금',
       security: '보안',
       faq: '자주 묻는 질문',
@@ -4121,6 +4127,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: 'Memori Anda',
       login: 'Masuk',
+      preview: 'Preview',
       billing: 'Harga',
       security: 'Keamanan',
       faq: 'FAQ',
@@ -4466,6 +4473,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       openclaw: 'OpenClaw',
       yourMemory: 'ความทรงจำของคุณ',
       login: 'ล็อกอิน',
+      preview: 'Preview',
       billing: 'ราคา',
       security: 'ความปลอดภัย',
       faq: 'คำถามที่พบบ่อย',


### PR DESCRIPTION
## What changed
- Added a compact `Preview` badge inside the site navbar console login CTA.
- Kept the existing localized login label with `data-i18n` on the inner text span.
- Tuned desktop and mobile sizing so the CTA keeps its pill shape.

## Context
- Background: The public mem9 site now links directly to the hosted console while the console experience is still in a preview-quality beta state.
- Why this approach: The navbar CTA is the earliest expectation-setting point before a visitor opens `/console`.
- How it works: The badge is styled inline with the existing Navbar component and inherits the CTA color through `currentColor`.

## Validation
- `npx tsc --noEmit`
- `npm run build`
- Local browser check for desktop and 390px mobile navbar badge rendering via system Chrome + Playwright runtime
