### PR TITLE
[codex] Tune space chain recall stop threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ The `MEM9_SOURCE_TURN_*` variables control how many source turn conversations ar
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `MNEMO_CHAIN_RECALL_STOP_SCORE` | No | `0.5` | Stop querying later Space Chain nodes once a node result score reaches this threshold. Must be between `0` and `1` |
+| `MNEMO_CHAIN_RECALL_STOP_SCORE` | No | `0.8` | Stop querying later Space Chain nodes only when an eligible query has a top normalized confidence at or above this threshold. Raw search `score` values do not trigger chain stop. Must be between `0` and `1` |
 
 #### Provisioning And Pooling
 

--- a/docs/design/space-chain-prd.md
+++ b/docs/design/space-chain-prd.md
@@ -173,8 +173,8 @@ For query-based recall:
 1. Load active nodes ordered by `position`.
 2. Search node 1 using the existing memory/session recall path.
 3. Add node 1 candidates to the visited candidate set.
-4. If node 1's top fused score is greater than or equal to
-   `MNEMO_CHAIN_RECALL_STOP_SCORE`, stop.
+4. If the query is stop-eligible and node 1's top normalized confidence is
+   greater than or equal to `MNEMO_CHAIN_RECALL_STOP_SCORE`, stop.
 5. Otherwise continue to node 2, and repeat.
 6. If no node reaches the threshold, all nodes are visited.
 7. Return a final reranked result set built from all visited nodes.
@@ -182,7 +182,12 @@ For query-based recall:
 Configuration:
 
 - `MNEMO_CHAIN_RECALL_STOP_SCORE`
-- Default: `0.5`
+- Default: `0.8`
+
+Raw search `score` values are not used for stopping because FTS scores are not
+normalized and may exceed 1.0. Single-token keyword queries and enumeration
+queries are not stop-eligible, so they visit all chain nodes and rerank the
+aggregate candidate set.
 
 The final result set must merge facts and raw session results across visited
 nodes. Existing per-node recall behavior, type weighting, session recall, and
@@ -321,7 +326,7 @@ Required logging:
 - `chain_` key status returns active/inactive through existing status response.
 - Duplicate nodes are rejected.
 - Empty chain reads and writes return a clear error.
-- Recall visits nodes in order and stops when top score is at least
+- Recall visits nodes in order and stops when top normalized confidence is at least
   `MNEMO_CHAIN_RECALL_STOP_SCORE`.
 - If no node reaches the threshold, recall searches all nodes and reranks the
   aggregate candidate set.

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -178,7 +178,7 @@ func Load() (*Config, error) {
 		TenantPoolConnectTimeout:    envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
 		TenantPoolIdleTimeout:       envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
 		TenantPoolTotalLimit:        envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
-		ChainRecallStopScore:        envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.5),
+		ChainRecallStopScore:        envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.8),
 		UploadDir:                   envOr("MNEMO_UPLOAD_DIR", "./uploads"),
 		FTSEnabled:                  envBool("MNEMO_FTS_ENABLED", false),
 		WorkerConcurrency:           envInt("MNEMO_WORKER_CONCURRENCY", 5),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -23,6 +23,18 @@ func TestConfig_MeteringSurfaceReduced(t *testing.T) {
 	}
 }
 
+func TestLoad_ChainRecallStopScoreDefaultsToHighConfidence(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ChainRecallStopScore != 0.8 {
+		t.Fatalf("ChainRecallStopScore = %v, want 0.8", cfg.ChainRecallStopScore)
+	}
+}
+
 func TestLoad_MeteringSupportedFields(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_METERING_ENABLED", "true")

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sort"
+	"strings"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/service"
@@ -119,8 +120,12 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 	visited := make([]domain.Memory, 0, requestLimit*len(auth.Chain.Nodes))
 	visitedNodes := 0
 	stopReason := "exhausted_chain"
-	stopScore := 0.0
+	topScore := 0.0
+	stopConfidence := 0
+	stopEligible := false
+	stopBlockedReason := ""
 	queryMode := filter.Query != ""
+	profile := buildRecallQueryProfile(filter.Query)
 
 	perNodeFilter := filter
 	perNodeFilter.Offset = 0
@@ -156,10 +161,16 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 
 		if queryMode {
 			nodeTopScore := topChainScore(memories)
-			if nodeTopScore > stopScore {
-				stopScore = nodeTopScore
+			if nodeTopScore > topScore {
+				topScore = nodeTopScore
 			}
-			if nodeTopScore >= s.chainRecallStopScore {
+			decision := chainRecallStopDecision(profile, memories, s.chainRecallStopScore)
+			if decision.confidence > stopConfidence {
+				stopConfidence = decision.confidence
+			}
+			stopEligible = decision.eligible
+			stopBlockedReason = decision.blockedReason
+			if decision.stop {
 				stopReason = "threshold_hit"
 				break
 			}
@@ -172,11 +183,90 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 		"chain_id", auth.Chain.ChainID,
 		"visited_node_count", visitedNodes,
 		"stop_reason", stopReason,
-		"stop_score", stopScore,
+		"top_score", topScore,
+		"stop_confidence", stopConfidence,
+		"stop_eligible", stopEligible,
+		"stop_blocked_reason", stopBlockedReason,
 		"threshold", s.chainRecallStopScore,
 		"returned", len(memories),
 	)
 	return memories, totalBeforePage, nil
+}
+
+type chainRecallStopStatus struct {
+	stop          bool
+	eligible      bool
+	confidence    int
+	blockedReason string
+}
+
+func chainRecallStopDecision(profile recallQueryProfile, memories []domain.Memory, threshold float64) chainRecallStopStatus {
+	confidence := topChainStopConfidence(memories)
+	eligible, blockedReason := chainRecallStopEligible(profile)
+	if !eligible {
+		return chainRecallStopStatus{
+			eligible:      false,
+			confidence:    confidence,
+			blockedReason: blockedReason,
+		}
+	}
+	thresholdConfidence := chainRecallStopConfidenceThreshold(threshold)
+	return chainRecallStopStatus{
+		stop:       confidence >= thresholdConfidence,
+		eligible:   true,
+		confidence: confidence,
+	}
+}
+
+func chainRecallStopEligible(profile recallQueryProfile) (bool, string) {
+	if strings.TrimSpace(profile.lower) == "" {
+		return false, "empty_query"
+	}
+	if profile.shape == recallQueryShapeEnumeration {
+		return false, "enumeration_query"
+	}
+	switch profile.shape {
+	case recallQueryShapeEntity, recallQueryShapeCount, recallQueryShapeTime, recallQueryShapeLocation, recallQueryShapeExact:
+		return true, ""
+	}
+	if len(extractRecallQueryTokens(profile.lower)) < 2 {
+		return false, "single_token_query"
+	}
+	return true, ""
+}
+
+func chainRecallStopConfidenceThreshold(threshold float64) int {
+	if threshold < 0 {
+		threshold = 0
+	}
+	if threshold > 1 {
+		threshold = 1
+	}
+	return int(threshold*100 + 0.5)
+}
+
+func topChainStopConfidence(memories []domain.Memory) int {
+	best := 0
+	for _, mem := range memories {
+		confidence := chainStopConfidence(mem)
+		if confidence > best {
+			best = confidence
+		}
+	}
+	return best
+}
+
+func chainStopConfidence(mem domain.Memory) int {
+	if mem.Confidence == nil {
+		return 0
+	}
+	if *mem.Confidence < 0 {
+		return 0
+	}
+	if *mem.Confidence > 100 {
+		return 100
+	}
+	return *mem.Confidence
 }
 
 func (s *Server) getChainMemory(ctx context.Context, auth *domain.AuthInfo, id string) (*domain.Memory, error) {

--- a/server/internal/handler/chain_runtime_test.go
+++ b/server/internal/handler/chain_runtime_test.go
@@ -1,0 +1,138 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestChainRecallStopDecision_IgnoresRawScore(t *testing.T) {
+	score := 1.3
+	confidence := 70
+
+	decision := chainRecallStopDecision(
+		buildRecallQueryProfile("what timezone does Bosn use"),
+		[]domain.Memory{{
+			ID:         "mem-high-raw-score",
+			Content:    "Bosn uses Asia/Shanghai.",
+			Score:      &score,
+			Confidence: &confidence,
+		}},
+		0.8,
+	)
+
+	if decision.stop {
+		t.Fatal("expected raw score above 1.0 not to stop chain recall when confidence is below threshold")
+	}
+	if !decision.eligible {
+		t.Fatalf("expected specific question to be stop eligible, blocked by %q", decision.blockedReason)
+	}
+	if decision.confidence != confidence {
+		t.Fatalf("stop confidence = %d, want %d", decision.confidence, confidence)
+	}
+}
+
+func TestChainRecallStopDecision_BlocksSingleTokenQueries(t *testing.T) {
+	confidence := 81
+
+	decision := chainRecallStopDecision(
+		buildRecallQueryProfile("Bosn"),
+		[]domain.Memory{{
+			ID:         "mem-bosn",
+			Content:    "Bosn每天工作时间是08:00~23:00",
+			Confidence: &confidence,
+		}},
+		0.8,
+	)
+
+	if decision.stop {
+		t.Fatal("expected single-token keyword query not to stop chain recall")
+	}
+	if decision.eligible {
+		t.Fatal("expected single-token keyword query to be stop ineligible")
+	}
+	if decision.blockedReason != "single_token_query" {
+		t.Fatalf("blocked reason = %q, want single_token_query", decision.blockedReason)
+	}
+}
+
+func TestChainRecallStopDecision_AllowsSpecificQuestionsAboveThreshold(t *testing.T) {
+	confidence := 85
+
+	decision := chainRecallStopDecision(
+		buildRecallQueryProfile("what timezone does Bosn use"),
+		[]domain.Memory{{ID: "mem-timezone", Confidence: &confidence}},
+		0.8,
+	)
+
+	if !decision.stop {
+		t.Fatalf("expected specific question with confidence %d to stop chain recall", confidence)
+	}
+	if !decision.eligible {
+		t.Fatalf("expected specific question to be stop eligible, blocked by %q", decision.blockedReason)
+	}
+}
+
+func TestChainRecallStopDecision_RequiresConfiguredConfidenceThreshold(t *testing.T) {
+	confidence := 70
+
+	decision := chainRecallStopDecision(
+		buildRecallQueryProfile("what timezone does Bosn use"),
+		[]domain.Memory{{ID: "mem-timezone", Confidence: &confidence}},
+		0.8,
+	)
+	if decision.stop {
+		t.Fatal("expected confidence below the default 80 threshold not to stop chain recall")
+	}
+
+	nextConfidence := 72
+	decision = chainRecallStopDecision(
+		buildRecallQueryProfile("what timezone does Bosn use"),
+		[]domain.Memory{{ID: "mem-timezone", Confidence: &nextConfidence}},
+		0.7,
+	)
+	if !decision.stop {
+		t.Fatal("expected confidence above configured 70 threshold to stop chain recall")
+	}
+}
+
+func TestChainRecallStopDecision_BlocksEnumerationQueries(t *testing.T) {
+	confidence := 95
+
+	decision := chainRecallStopDecision(
+		buildRecallQueryProfile("what projects has Bosn done"),
+		[]domain.Memory{{ID: "mem-project", Confidence: &confidence}},
+		0.8,
+	)
+
+	if decision.stop {
+		t.Fatal("expected enumeration query not to stop chain recall")
+	}
+	if decision.eligible {
+		t.Fatal("expected enumeration query to be stop ineligible")
+	}
+	if decision.blockedReason != "enumeration_query" {
+		t.Fatalf("blocked reason = %q, want enumeration_query", decision.blockedReason)
+	}
+}
+
+func TestChainRecallStopConfidenceThreshold_ConvertsFractionToPercent(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold float64
+		want      int
+	}{
+		{name: "default", threshold: 0.8, want: 80},
+		{name: "recommended floor", threshold: 0.7, want: 70},
+		{name: "clamps low", threshold: -1, want: 0},
+		{name: "clamps high", threshold: 1.3, want: 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chainRecallStopConfidenceThreshold(tt.threshold); got != tt.want {
+				t.Fatalf("threshold = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -73,7 +73,7 @@ func NewServer(
 		dbBackend:            dbBackend,
 		logger:               logger,
 		startedAt:            time.Now().UTC(),
-		chainRecallStopScore: 0.5,
+		chainRecallStopScore: 0.8,
 	}
 }
 


### PR DESCRIPTION
## Summary

- change Space Chain early-stop to use normalized recall confidence instead of raw search score
- make single-token keyword and enumeration queries visit all chain nodes before final rerank
- raise the default `MNEMO_CHAIN_RECALL_STOP_SCORE` from `0.5` to `0.8` and document the new confidence-threshold semantics

## Root Cause

Raw FTS `score` values are not normalized and can exceed `1.0`, so comparing them to a `0..1` chain stop threshold caused Space Chain recall to stop too early on generic keyword searches.

## Validation

- `cd server && go test -race -count=1 ./internal/handler ./internal/config`
- `git diff --check`
