### PR TITLE
Support session memory management

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -304,6 +304,9 @@
           },
           {
             "$ref": "#/components/parameters/SessionID"
+          },
+          {
+            "$ref": "#/components/parameters/ScanAll"
           }
         ],
         "responses": {
@@ -1248,6 +1251,16 @@
         "description": "Session identifier filter.",
         "schema": {
           "type": "string"
+        }
+      },
+      "ScanAll": {
+        "name": "scanAll",
+        "in": "query",
+        "required": false,
+        "description": "When using a Space Chain API key, search every Space Chain node instead of stopping after a high-confidence result. Ignored for ordinary Space keys.",
+        "schema": {
+          "type": "boolean",
+          "default": false
         }
       },
       "SessionIDRepeated": {

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -151,6 +151,7 @@ type MemoryFilter struct {
 	SessionID  string
 	Limit      int
 	Offset     int
+	ScanAll    bool
 	MinScore   float64 // minimum cosine similarity for vector results; 0 = use default (0.3); -1 = disabled (return all)
 }
 

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -125,6 +125,7 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 	stopEligible := false
 	stopBlockedReason := ""
 	queryMode := filter.Query != ""
+	scanAll := filter.ScanAll
 	profile := buildRecallQueryProfile(filter.Query)
 
 	perNodeFilter := filter
@@ -170,9 +171,12 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 			}
 			stopEligible = decision.eligible
 			stopBlockedReason = decision.blockedReason
-			if decision.stop {
+			if decision.stop && !scanAll {
 				stopReason = "threshold_hit"
 				break
+			}
+			if decision.stop && scanAll {
+				stopReason = "scan_all"
 			}
 		}
 	}
@@ -188,6 +192,7 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 		"stop_eligible", stopEligible,
 		"stop_blocked_reason", stopBlockedReason,
 		"threshold", s.chainRecallStopScore,
+		"scan_all", scanAll,
 		"returned", len(memories),
 	)
 	return memories, totalBeforePage, nil

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -59,6 +59,14 @@ type chainDeleteGroup struct {
 }
 
 func (s *Server) findChainMemoryTarget(ctx context.Context, auth *domain.AuthInfo, id string) (chainMemoryTarget, error) {
+	return s.findChainMemoryTargetWithOptions(ctx, auth, id, false)
+}
+
+func (s *Server) findChainDeleteTarget(ctx context.Context, auth *domain.AuthInfo, id string) (chainMemoryTarget, error) {
+	return s.findChainMemoryTargetWithOptions(ctx, auth, id, true)
+}
+
+func (s *Server) findChainMemoryTargetWithOptions(ctx context.Context, auth *domain.AuthInfo, id string, includeSessions bool) (chainMemoryTarget, error) {
 	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
 		return chainMemoryTarget{}, &domain.ValidationError{Message: "Space Chain has no nodes."}
 	}
@@ -67,9 +75,18 @@ func (s *Server) findChainMemoryTarget(ctx context.Context, auth *domain.AuthInf
 		svc := s.resolveServices(nodeAuth)
 		if _, err := svc.memory.Get(ctx, id); err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				continue
+				if !includeSessions {
+					continue
+				}
+				if _, sessionErr := svc.session.Get(ctx, id); sessionErr != nil {
+					if errors.Is(sessionErr, domain.ErrNotFound) || errors.Is(sessionErr, domain.ErrNotSupported) {
+						continue
+					}
+					return chainMemoryTarget{}, sessionErr
+				}
+			} else {
+				return chainMemoryTarget{}, err
 			}
-			return chainMemoryTarget{}, err
 		}
 		return chainMemoryTarget{
 			nodeAuth: nodeAuth,
@@ -88,7 +105,7 @@ func (s *Server) chainDeleteGroups(ctx context.Context, auth *domain.AuthInfo, i
 	groups := make([]chainDeleteGroup, 0)
 	groupIndexes := make(map[string]int)
 	for _, id := range deleteIDs {
-		target, err := s.findChainMemoryTarget(ctx, auth, id)
+		target, err := s.findChainDeleteTarget(ctx, auth, id)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
 				continue

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -301,9 +301,16 @@ func (s *Server) getChainMemory(ctx context.Context, auth *domain.AuthInfo, id s
 		mem, err := svc.memory.Get(ctx, id)
 		if err != nil {
 			if errors.Is(err, domain.ErrNotFound) {
-				continue
+				mem, err = svc.session.Get(ctx, id)
+				if err != nil {
+					if errors.Is(err, domain.ErrNotFound) || errors.Is(err, domain.ErrNotSupported) {
+						continue
+					}
+					return nil, err
+				}
+			} else {
+				return nil, err
 			}
-			return nil, err
 		}
 		mem.ChainSource = chainSource(auth, node)
 		return mem, nil

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -168,6 +168,8 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 			perNodeFilter.MemoryType == string(domain.TypePinned) ||
 			perNodeFilter.MemoryType == string(domain.TypeInsight)):
 			memories, _, err = s.singlePoolConfidenceRecallSearch(ctx, nodeAuth, svc, perNodeFilter)
+		case perNodeFilter.MemoryType == string(domain.TypeSession):
+			memories, _, err = svc.session.List(ctx, perNodeFilter)
 		case perNodeFilter.MemoryType != string(domain.TypeSession):
 			memories, _, err = svc.memory.Search(ctx, perNodeFilter)
 		}

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -319,10 +319,15 @@ func finalizeChainMemories(memories []domain.Memory, limit, offset int, queryMod
 	memories = uniqueChainMemories(memories)
 	if queryMode {
 		sort.SliceStable(memories, func(i, j int) bool {
-			left := chainRankScore(memories[i])
-			right := chainRankScore(memories[j])
-			if left != right {
-				return left > right
+			leftConfidence := chainStopConfidence(memories[i])
+			rightConfidence := chainStopConfidence(memories[j])
+			if leftConfidence != rightConfidence {
+				return leftConfidence > rightConfidence
+			}
+			leftScore := chainRankScore(memories[i])
+			rightScore := chainRankScore(memories[j])
+			if leftScore != rightScore {
+				return leftScore > rightScore
 			}
 			return memories[i].UpdatedAt.After(memories[j].UpdatedAt)
 		})

--- a/server/internal/handler/chain_runtime_test.go
+++ b/server/internal/handler/chain_runtime_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"testing"
+	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
@@ -134,5 +135,28 @@ func TestChainRecallStopConfidenceThreshold_ConvertsFractionToPercent(t *testing
 				t.Fatalf("threshold = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFinalizeChainMemories_QueryModeSortsAndClipsByConfidence(t *testing.T) {
+	now := time.Now()
+	lowConfidence := 55
+	lowScore := 99.0
+	midConfidence := 75
+	midScore := 2.0
+	highConfidence := 90
+	highScore := 1.0
+
+	got := finalizeChainMemories([]domain.Memory{
+		{ID: "low-confidence-high-score", Score: &lowScore, Confidence: &lowConfidence, UpdatedAt: now},
+		{ID: "mid-confidence", Score: &midScore, Confidence: &midConfidence, UpdatedAt: now.Add(-time.Minute)},
+		{ID: "high-confidence", Score: &highScore, Confidence: &highConfidence, UpdatedAt: now.Add(-2 * time.Minute)},
+	}, 2, 0, true)
+
+	if len(got) != 2 {
+		t.Fatalf("memories = %d, want 2", len(got))
+	}
+	if got[0].ID != "high-confidence" || got[1].ID != "mid-confidence" {
+		t.Fatalf("ordered IDs = [%s, %s], want high-confidence then mid-confidence", got[0].ID, got[1].ID)
 	}
 }

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -726,6 +726,9 @@ func (s *Server) getMemory(w http.ResponseWriter, r *http.Request) {
 	mem, err := svc.memory.Get(r.Context(), id)
 	if errors.Is(err, domain.ErrNotFound) {
 		mem, err = svc.session.Get(r.Context(), id)
+		if errors.Is(err, domain.ErrNotSupported) {
+			err = domain.ErrNotFound
+		}
 	}
 	if err != nil {
 		s.handleError(r.Context(), w, err)
@@ -867,7 +870,7 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
 	if auth.IsChain() {
-		target, err := s.findChainMemoryTarget(r.Context(), auth, id)
+		target, err := s.findChainDeleteTarget(r.Context(), auth, id)
 		if err != nil {
 			s.handleError(r.Context(), w, err)
 			return

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -572,6 +572,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 			filter.MemoryType == string(domain.TypePinned) ||
 			filter.MemoryType == string(domain.TypeInsight)):
 			memories, total, err = s.singlePoolConfidenceRecallSearch(r.Context(), auth, svc, filter)
+		case onlySession:
+			memories, total, err = svc.session.List(r.Context(), filter)
 		case !onlySession:
 			memories, total, err = svc.memory.Search(r.Context(), filter)
 		}
@@ -716,6 +718,9 @@ func (s *Server) getMemory(w http.ResponseWriter, r *http.Request) {
 
 	svc := s.resolveServices(auth)
 	mem, err := svc.memory.Get(r.Context(), id)
+	if errors.Is(err, domain.ErrNotFound) {
+		mem, err = svc.session.Get(r.Context(), id)
+	}
 	if err != nil {
 		s.handleError(r.Context(), w, err)
 		return
@@ -876,6 +881,9 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 			}()
 		}
 		deleted, err := target.svc.memory.Delete(r.Context(), id, auth.AgentName)
+		if errors.Is(err, domain.ErrNotFound) {
+			deleted, err = target.svc.session.Delete(r.Context(), id, auth.AgentName)
+		}
 		if err != nil {
 			if s.runtimeUsageEnabled() {
 				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
@@ -926,6 +934,12 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	deleted, err := svc.memory.Delete(r.Context(), id, auth.AgentName)
+	if errors.Is(err, domain.ErrNotFound) {
+		deleted, err = svc.session.Delete(r.Context(), id, auth.AgentName)
+		if errors.Is(err, domain.ErrNotSupported) {
+			err = domain.ErrNotFound
+		}
+	}
 	if err != nil {
 		if s.runtimeUsageEnabled() {
 			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
@@ -1000,6 +1014,16 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				s.handleError(r.Context(), w, err)
 				return
 			}
+			sessionDeleted, sessionErr := group.target.svc.session.BulkDelete(r.Context(), group.ids, auth.AgentName)
+			if sessionErr != nil && !errors.Is(sessionErr, domain.ErrNotSupported) {
+				if s.runtimeUsageEnabled() {
+					s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, sessionErr)
+					finalized = true
+				}
+				s.handleError(r.Context(), w, sessionErr)
+				return
+			}
+			groupDeleted += sessionDeleted
 			if s.runtimeUsageEnabled() {
 				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
 					return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
@@ -1063,6 +1087,16 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		s.handleError(r.Context(), w, err)
 		return
 	}
+	sessionDeleted, sessionErr := svc.session.BulkDelete(r.Context(), deleteIDs, auth.AgentName)
+	if sessionErr != nil && !errors.Is(sessionErr, domain.ErrNotSupported) {
+		if s.runtimeUsageEnabled() {
+			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, sessionErr)
+			finalized = true
+		}
+		s.handleError(r.Context(), w, sessionErr)
+		return
+	}
+	deleted += sessionDeleted
 	if s.runtimeUsageEnabled() {
 		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
 			return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -539,6 +539,7 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		SessionID:  q.Get("session_id"),
 		Limit:      limit,
 		Offset:     offset,
+		ScanAll:    parseBoolQuery(q.Get("scanAll")),
 	}
 	onlySession := filter.MemoryType == string(domain.TypeSession)
 
@@ -624,6 +625,11 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		Limit:    limit,
 		Offset:   offset,
 	})
+}
+
+func parseBoolQuery(value string) bool {
+	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
+	return err == nil && parsed
 }
 
 func normalizeRecallQuery(query string, now time.Time) string {

--- a/server/internal/handler/memory_batch_delete_test.go
+++ b/server/internal/handler/memory_batch_delete_test.go
@@ -48,6 +48,43 @@ func TestBatchDeleteMemories_Success_ReturnsDeletedCount(t *testing.T) {
 	}
 }
 
+func TestBatchDeleteMemories_IncludesSessionRows(t *testing.T) {
+	memRepo := &testMemoryRepo{bulkSoftDeleteResult: 2}
+	sessionRepo := &testSessionRepo{bulkSoftDeleteResult: 1}
+	srv := newTestServer(memRepo, sessionRepo)
+
+	body := map[string]any{"ids": []string{"mem-1", "sess-row-1", "mem-2"}}
+	req := makeRequest(t, http.MethodPost, "/memories/batch-delete", body)
+	rr := httptest.NewRecorder()
+
+	srv.batchDeleteMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Deleted int64 `json:"deleted"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Deleted != 3 {
+		t.Fatalf("deleted = %d, want 3", resp.Deleted)
+	}
+	if len(sessionRepo.bulkSoftDeleteCalls) != 1 {
+		t.Fatalf("expected session BulkSoftDelete called once, got %d", len(sessionRepo.bulkSoftDeleteCalls))
+	}
+	got := append([]string(nil), sessionRepo.bulkSoftDeleteCalls[0]...)
+	sort.Strings(got)
+	want := []string{"mem-1", "mem-2", "sess-row-1"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("session repo ids = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestBatchDeleteMemories_EmptyIDs_Returns400(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	srv := newTestServer(memRepo, &testSessionRepo{})

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -592,6 +592,34 @@ func TestGetMemory_SessionUnsupportedFallbackReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestGetMemory_ChainFallsBackToSessionRow(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		getResult: &domain.Memory{
+			ID:         "sess-row-1",
+			Content:    "raw turn",
+			MemoryType: domain.TypeSession,
+			State:      domain.StateActive,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := withURLParam(makeChainRequest(t, http.MethodGet, "/memories/sess-row-1", nil), "id", "sess-row-1")
+	rr := httptest.NewRecorder()
+
+	srv.getMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"memory_type":"session"`) {
+		t.Fatalf("body = %s, want session memory type", rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"chain_source"`) {
+		t.Fatalf("body = %s, want chain source", rr.Body.String())
+	}
+}
+
 func TestDeleteMemory_FallsBackToSessionRow(t *testing.T) {
 	memRepo := &testMemoryRepo{softDeleteErr: domain.ErrNotFound}
 	sessionRepo := &testSessionRepo{}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -35,6 +35,7 @@ type testMemoryRepo struct {
 	lastKeywordFilter    domain.MemoryFilter
 	softDeleteCalls      []string
 	softDeleteResult     int64
+	softDeleteErr        error
 	bulkSoftDeleteCalls  [][]string
 	bulkSoftDeleteResult int64
 	countStatsTotal      int64
@@ -78,6 +79,9 @@ func (m *testMemoryRepo) SoftDelete(_ context.Context, id string, _ string) (int
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.softDeleteCalls = append(m.softDeleteCalls, id)
+	if m.softDeleteErr != nil {
+		return 0, m.softDeleteErr
+	}
 	if m.softDeleteResult != 0 {
 		return m.softDeleteResult, nil
 	}
@@ -165,6 +169,15 @@ type testSessionRepo struct {
 	sessionListResults   []*domain.Session
 	lastSessionIDs       []string
 	lastSessionLimit     int
+	getResult            *domain.Memory
+	getErr               error
+	listResults          []domain.Memory
+	listTotal            int
+	lastListFilter       domain.MemoryFilter
+	softDeleteCalls      []string
+	softDeleteErr        error
+	bulkSoftDeleteCalls  [][]string
+	bulkSoftDeleteResult int64
 }
 
 func (s *testSessionRepo) BulkCreate(_ context.Context, sessions []*domain.Session) error {
@@ -183,6 +196,46 @@ func (s *testSessionRepo) PatchTags(_ context.Context, sessionID, hash string, t
 	s.patchedHash = hash
 	s.patchedTags = append([]string(nil), tags...)
 	return nil
+}
+
+func (s *testSessionRepo) GetByID(_ context.Context, id string) (*domain.Memory, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	if s.getResult != nil && s.getResult.ID == id {
+		cp := *s.getResult
+		return &cp, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (s *testSessionRepo) List(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lastListFilter = filter
+	return append([]domain.Memory(nil), s.listResults...), s.listTotal, nil
+}
+
+func (s *testSessionRepo) SoftDelete(_ context.Context, id, _ string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.softDeleteCalls = append(s.softDeleteCalls, id)
+	if s.softDeleteErr != nil {
+		return 0, s.softDeleteErr
+	}
+	return 1, nil
+}
+
+func (s *testSessionRepo) BulkSoftDelete(_ context.Context, ids []string, _ string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.bulkSoftDeleteCalls = append(s.bulkSoftDeleteCalls, append([]string(nil), ids...))
+	if s.bulkSoftDeleteResult != 0 {
+		return s.bulkSoftDeleteResult, nil
+	}
+	return 0, nil
 }
 
 func (s *testSessionRepo) AutoVectorSearch(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
@@ -455,6 +508,92 @@ func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	srv.svcCache.Store(tenantSvcKey("db-0x0"), svc)
 	srv.svcCache.Store(tenantSvcKey("tenant-a-0x0"), svc)
 	return srv
+}
+
+func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "sess-row-1",
+				Content:    "hello from a raw turn",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			},
+		},
+		listTotal: 7,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories?memory_type=session&limit=10&offset=20&state=active&agent_id=codex&session_id=sess-1&source=cli&tags=alpha,beta", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 7 || resp.Limit != 10 || resp.Offset != 20 {
+		t.Fatalf("page = total:%d limit:%d offset:%d, want 7/10/20", resp.Total, resp.Limit, resp.Offset)
+	}
+	if len(resp.Memories) != 1 || resp.Memories[0].MemoryType != domain.TypeSession {
+		t.Fatalf("memories = %+v, want one session memory", resp.Memories)
+	}
+	if sessionRepo.lastListFilter.MemoryType != "session" ||
+		sessionRepo.lastListFilter.AgentID != "codex" ||
+		sessionRepo.lastListFilter.SessionID != "sess-1" ||
+		sessionRepo.lastListFilter.Source != "cli" ||
+		len(sessionRepo.lastListFilter.Tags) != 2 {
+		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
+	}
+}
+
+func TestGetMemory_FallsBackToSessionRow(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		getResult: &domain.Memory{
+			ID:         "sess-row-1",
+			Content:    "raw turn",
+			MemoryType: domain.TypeSession,
+			State:      domain.StateActive,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories/sess-row-1", nil)
+	req = withURLParam(req, "id", "sess-row-1")
+	rr := httptest.NewRecorder()
+
+	srv.getMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"memory_type":"session"`) {
+		t.Fatalf("body = %s, want session memory type", rr.Body.String())
+	}
+}
+
+func TestDeleteMemory_FallsBackToSessionRow(t *testing.T) {
+	memRepo := &testMemoryRepo{softDeleteErr: domain.ErrNotFound}
+	sessionRepo := &testSessionRepo{}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodDelete, "/memories/sess-row-1", nil)
+	req = withURLParam(req, "id", "sess-row-1")
+	rr := httptest.NewRecorder()
+
+	srv.deleteMemory(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", rr.Code, rr.Body.String())
+	}
+	if len(sessionRepo.softDeleteCalls) != 1 || sessionRepo.softDeleteCalls[0] != "sess-row-1" {
+		t.Fatalf("session delete calls = %+v, want sess-row-1", sessionRepo.softDeleteCalls)
+	}
 }
 
 // makeRequest creates an HTTP request with auth context injected.

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -174,6 +174,7 @@ type testSessionRepo struct {
 	listResults          []domain.Memory
 	listTotal            int
 	lastListFilter       domain.MemoryFilter
+	listCalls            int
 	softDeleteCalls      []string
 	softDeleteErr        error
 	bulkSoftDeleteCalls  [][]string
@@ -214,6 +215,7 @@ func (s *testSessionRepo) GetByID(_ context.Context, id string) (*domain.Memory,
 func (s *testSessionRepo) List(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.listCalls++
 	s.lastListFilter = filter
 	return append([]domain.Memory(nil), s.listResults...), s.listTotal, nil
 }
@@ -548,6 +550,51 @@ func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 		sessionRepo.lastListFilter.SessionID != "sess-1" ||
 		sessionRepo.lastListFilter.Source != "cli" ||
 		len(sessionRepo.lastListFilter.Tags) != 2 {
+		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
+	}
+}
+
+func TestListMemories_ChainSessionTypeListsSessionRowsWithoutQuery(t *testing.T) {
+	now := time.Now()
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "sess-row-1",
+				Content:    "hello from a raw turn",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+		listTotal: 1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := makeChainRequestWithNodes(t, http.MethodGet, "/memories?memory_type=session&limit=10&offset=0&state=active", nil, 2)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sessionRepo.listCalls != 2 {
+		t.Fatalf("session list calls = %d, want one per chain node", sessionRepo.listCalls)
+	}
+	if resp.Total != 1 {
+		t.Fatalf("total = %d, want deduplicated total 1", resp.Total)
+	}
+	if len(resp.Memories) != 1 || resp.Memories[0].MemoryType != domain.TypeSession {
+		t.Fatalf("memories = %+v, want one session memory", resp.Memories)
+	}
+	if resp.Memories[0].ChainSource == nil || resp.Memories[0].ChainSource.ChainID != "chain-a" {
+		t.Fatalf("chain source = %+v, want chain-a", resp.Memories[0].ChainSource)
+	}
+	if sessionRepo.lastListFilter.MemoryType != "session" || sessionRepo.lastListFilter.State != "active" {
 		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
 	}
 }

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -578,12 +578,52 @@ func TestGetMemory_FallsBackToSessionRow(t *testing.T) {
 	}
 }
 
+func TestGetMemory_SessionUnsupportedFallbackReturnsNotFound(t *testing.T) {
+	sessionRepo := &testSessionRepo{getErr: domain.ErrNotSupported}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories/missing-id", nil)
+	req = withURLParam(req, "id", "missing-id")
+	rr := httptest.NewRecorder()
+
+	srv.getMemory(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rr.Code, rr.Body.String())
+	}
+}
+
 func TestDeleteMemory_FallsBackToSessionRow(t *testing.T) {
 	memRepo := &testMemoryRepo{softDeleteErr: domain.ErrNotFound}
 	sessionRepo := &testSessionRepo{}
 	srv := newTestServer(memRepo, sessionRepo)
 	req := makeRequest(t, http.MethodDelete, "/memories/sess-row-1", nil)
 	req = withURLParam(req, "id", "sess-row-1")
+	rr := httptest.NewRecorder()
+
+	srv.deleteMemory(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204: %s", rr.Code, rr.Body.String())
+	}
+	if len(sessionRepo.softDeleteCalls) != 1 || sessionRepo.softDeleteCalls[0] != "sess-row-1" {
+		t.Fatalf("session delete calls = %+v, want sess-row-1", sessionRepo.softDeleteCalls)
+	}
+}
+
+func TestDeleteMemory_ChainFallsBackToSessionRow(t *testing.T) {
+	memRepo := &testMemoryRepo{softDeleteErr: domain.ErrNotFound}
+	sessionRepo := &testSessionRepo{
+		getResult: &domain.Memory{
+			ID:         "sess-row-1",
+			Content:    "raw turn",
+			MemoryType: domain.TypeSession,
+			State:      domain.StateActive,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		},
+	}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := withURLParam(makeChainRequest(t, http.MethodDelete, "/memories/sess-row-1", nil), "id", "sess-row-1")
 	rr := httptest.NewRecorder()
 
 	srv.deleteMemory(rr, req)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -627,21 +627,28 @@ func makeTenantRequest(t *testing.T, method, path string, body any) *http.Reques
 
 func makeChainRequest(t *testing.T, method, path string, body any) *http.Request {
 	t.Helper()
+	return makeChainRequestWithNodes(t, method, path, body, 1)
+}
+
+func makeChainRequestWithNodes(t *testing.T, method, path string, body any, count int) *http.Request {
+	t.Helper()
 	req := makeRequest(t, method, path, body)
+	nodes := make([]domain.ChainAuthNode, 0, count)
+	for i := 0; i < count; i++ {
+		nodes = append(nodes, domain.ChainAuthNode{
+			SpaceChainNode: domain.SpaceChainNode{
+				TenantID: "tenant-a",
+				Position: i + 1,
+			},
+			ClusterID: "10006636",
+		})
+	}
 	auth := &domain.AuthInfo{
 		AgentName: "test-agent",
 		Chain: &domain.ChainAuth{
 			ChainID: "chain-a",
 			APIKey:  "chain-key-a",
-			Nodes: []domain.ChainAuthNode{
-				{
-					SpaceChainNode: domain.SpaceChainNode{
-						TenantID: "tenant-a",
-						Position: 1,
-					},
-					ClusterID: "10006636",
-				},
-			},
+			Nodes:   nodes,
 		},
 	}
 	ctx := middleware.WithAuthContext(req.Context(), auth)
@@ -1426,6 +1433,64 @@ func TestListMemories_ChainRuntimeUsageRecallUsesChainAPIKeySubject(t *testing.T
 	}
 	if len(runtimeUsage.beforeRecallSubjects) != 1 || runtimeUsage.beforeRecallSubjects[0].APIKeySubject != "chain-key-a" {
 		t.Fatalf("recall subject = %+v, want chain-key-a API key subject", runtimeUsage.beforeRecallSubjects)
+	}
+}
+
+func TestListMemories_ChainStopsAfterHighConfidenceByDefault(t *testing.T) {
+	now := time.Now()
+	calls := 0
+	sessionRepo := &testSessionRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			calls++
+			return []domain.Memory{
+				{ID: "session-memory", Content: "Bosn's timezone is Asia/Shanghai.", MemoryType: domain.TypeSession, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	srv.chainRecallStopScore = 0.1
+
+	req := makeChainRequestWithNodes(t, http.MethodGet, "/memories?q=what%20timezone%20does%20Bosn%20use&memory_type=session&limit=10", nil, 2)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if calls != 1 {
+		t.Fatalf("node searches = %d, want 1", calls)
+	}
+}
+
+func TestListMemories_ChainScanAllContinuesPastHighConfidence(t *testing.T) {
+	now := time.Now()
+	calls := 0
+	sessionRepo := &testSessionRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			calls++
+			id := "session-memory-a"
+			if calls > 1 {
+				id = "session-memory-b"
+			}
+			return []domain.Memory{
+				{ID: id, Content: "Bosn's timezone is Asia/Shanghai.", MemoryType: domain.TypeSession, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	srv.chainRecallStopScore = 0.1
+
+	req := makeChainRequestWithNodes(t, http.MethodGet, "/memories?q=what%20timezone%20does%20Bosn%20use&memory_type=session&limit=10&scanAll=true", nil, 2)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if calls != 2 {
+		t.Fatalf("node searches = %d, want 2", calls)
 	}
 }
 

--- a/server/internal/repository/factory.go
+++ b/server/internal/repository/factory.go
@@ -111,6 +111,18 @@ func (stubSessionRepo) BulkCreate(_ context.Context, _ []*domain.Session) error 
 func (stubSessionRepo) PatchTags(_ context.Context, _, _ string, _ []string) error {
 	return nil
 }
+func (stubSessionRepo) GetByID(_ context.Context, _ string) (*domain.Memory, error) {
+	return nil, fmt.Errorf("session memory: %w", domain.ErrNotSupported)
+}
+func (stubSessionRepo) List(_ context.Context, _ domain.MemoryFilter) ([]domain.Memory, int, error) {
+	return nil, 0, fmt.Errorf("session memories: %w", domain.ErrNotSupported)
+}
+func (stubSessionRepo) SoftDelete(_ context.Context, _, _ string) (int64, error) {
+	return 0, fmt.Errorf("session memory delete: %w", domain.ErrNotSupported)
+}
+func (stubSessionRepo) BulkSoftDelete(_ context.Context, _ []string, _ string) (int64, error) {
+	return 0, fmt.Errorf("session memory batch delete: %w", domain.ErrNotSupported)
+}
 func (stubSessionRepo) AutoVectorSearch(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
 	return nil, domain.ErrAutoVectorSearchSkipped
 }

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -104,6 +104,10 @@ type UTMRepo interface {
 type SessionRepo interface {
 	BulkCreate(ctx context.Context, sessions []*domain.Session) error
 	PatchTags(ctx context.Context, sessionID, contentHash string, tags []string) error
+	GetByID(ctx context.Context, id string) (*domain.Memory, error)
+	List(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, total int, err error)
+	SoftDelete(ctx context.Context, id, agentName string) (int64, error)
+	BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error)
 	AutoVectorSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error)
 	VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) ([]domain.Memory, error)
 	FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error)

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -216,12 +216,18 @@ func (c *scriptedConn) Prepare(string) (driver.Stmt, error) {
 func (c *scriptedConn) Close() error { return nil }
 
 func (c *scriptedConn) Begin() (driver.Tx, error) {
-	return nil, fmt.Errorf("Begin not supported")
+	return scriptedTx{}, nil
 }
 
 func (c *scriptedConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	return c.script.query(query, args)
 }
+
+type scriptedTx struct{}
+
+func (scriptedTx) Commit() error { return nil }
+
+func (scriptedTx) Rollback() error { return nil }
 
 type scriptedRows struct {
 	columns []string

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -102,6 +102,85 @@ func (r *SessionRepo) PatchTags(ctx context.Context, sessionID, contentHash stri
 	return err
 }
 
+func (r *SessionRepo) GetByID(ctx context.Context, id string) (*domain.Memory, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+		 FROM sessions WHERE id = ? AND state = 'active'`,
+		id,
+	)
+	return scanSessionMemory(row)
+}
+
+func (r *SessionRepo) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("session soft delete begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var state sql.NullString
+	err = tx.QueryRowContext(ctx,
+		`SELECT state FROM sessions WHERE id = ? FOR UPDATE`,
+		id,
+	).Scan(&state)
+	if err == sql.ErrNoRows {
+		return 0, domain.ErrNotFound
+	}
+	if err != nil {
+		return 0, fmt.Errorf("session soft delete lock row: %w", err)
+	}
+
+	if state.String == string(domain.StateDeleted) {
+		return 0, tx.Commit()
+	}
+	result, err := tx.ExecContext(ctx,
+		`UPDATE sessions SET state = 'deleted', updated_at = NOW() WHERE id = ?`,
+		id,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("session soft delete update: %w", err)
+	}
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("session soft delete rows affected: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return deleted, nil
+}
+
+func (r *SessionRepo) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `UPDATE sessions SET state = 'deleted', updated_at = NOW()
+		 WHERE id IN (` + strings.Join(placeholders, ",") + `) AND state != 'deleted'`
+
+	result, err := r.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("session bulk soft delete: %w", err)
+	}
+
+	deleted, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("session bulk soft delete rows affected: %w", err)
+	}
+	return deleted, nil
+}
+
 func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, []any) {
 	conds := []string{}
 	args := []any{}
@@ -139,6 +218,56 @@ func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, 
 		conds = append(conds, "1=1")
 	}
 	return conds, args
+}
+
+func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	conds, args := r.buildSessionFilterConds(f)
+	if f.Query != "" {
+		conds = append(conds, "content LIKE ?")
+		args = append(args, "%"+f.Query+"%")
+	}
+	where := strings.Join(conds, " AND ")
+
+	var total int
+	countQuery := "SELECT COUNT(*) FROM sessions WHERE " + where
+	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return nil, 0, nil
+		}
+		slog.Error("list session memories: count failed", "cluster_id", r.clusterID, "err", err)
+		return nil, 0, fmt.Errorf("count session memories: %w", err)
+	}
+
+	limit := f.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	dataQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+		FROM sessions WHERE ` + where + ` ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?`
+	dataArgs := make([]any, len(args), len(args)+2)
+	copy(dataArgs, args)
+	dataArgs = append(dataArgs, limit, offset)
+
+	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return nil, 0, nil
+		}
+		slog.Error("list session memories: query failed", "cluster_id", r.clusterID, "err", err)
+		return nil, 0, fmt.Errorf("list session memories: %w", err)
+	}
+	defer rows.Close()
+
+	memories, err := scanSessionRows(rows)
+	if err != nil {
+		return nil, 0, err
+	}
+	return memories, total, nil
 }
 
 func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
@@ -435,7 +564,11 @@ func scanSessionRowsWithFTSScore(rows *sql.Rows) ([]domain.Memory, error) {
 	return result, rows.Err()
 }
 
-func scanSessionRowNoScore(rows *sql.Rows) (*domain.Memory, error) {
+type sessionMemoryScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSessionMemory(scanner sessionMemoryScanner) (*domain.Memory, error) {
 	var (
 		sessionID, agentID, source, role, contentType sql.NullString
 		tagsJSON                                      []byte
@@ -444,14 +577,21 @@ func scanSessionRowNoScore(rows *sql.Rows) (*domain.Memory, error) {
 		createdAt                                     time.Time
 		m                                             domain.Memory
 	)
-	if err := rows.Scan(
+	if err := scanner.Scan(
 		&m.ID, &sessionID, &agentID, &source,
 		&seq, &role, &m.Content, &contentType,
 		&tagsJSON, &state, &createdAt,
 	); err != nil {
-		return nil, fmt.Errorf("scan session row: %w", err)
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("scan session memory: %w", err)
 	}
 	return fillSessionMemory(&m, sessionID, agentID, source, role, contentType, seq, tagsJSON, state, createdAt), nil
+}
+
+func scanSessionRowNoScore(rows *sql.Rows) (*domain.Memory, error) {
+	return scanSessionMemory(rows)
 }
 
 func scanSessionRowWithDistance(rows *sql.Rows) (*domain.Memory, error) {

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -108,7 +108,14 @@ func (r *SessionRepo) GetByID(ctx context.Context, id string) (*domain.Memory, e
 		 FROM sessions WHERE id = ? AND state = 'active'`,
 		id,
 	)
-	return scanSessionMemory(row)
+	mem, err := scanSessionMemory(row)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	return mem, nil
 }
 
 func (r *SessionRepo) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
@@ -127,6 +134,9 @@ func (r *SessionRepo) SoftDelete(ctx context.Context, id, agentName string) (int
 		return 0, domain.ErrNotFound
 	}
 	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return 0, domain.ErrNotFound
+		}
 		return 0, fmt.Errorf("session soft delete lock row: %w", err)
 	}
 

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -1,12 +1,65 @@
 package tidb
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
 	"testing"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
+
+func TestSessionRepoListFiltersAndPaginates(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT COUNT(*) FROM sessions WHERE state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{"active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: []string{"COUNT(*)"},
+				values:  [][]driver.Value{{int64(2)}},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions WHERE state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+				"ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
+			},
+			wantArgs: []any{"active", "agent-1", "sess-1", "chat", `"tag-a"`, int64(10), int64(20)},
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+				values: [][]driver.Value{
+					sessionRow("s-2", "sess-1", "agent-1", "chat", 2, "assistant", "second", []byte(`["tag-a"]`), "active", now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", false, "cluster-1")
+	memories, total, err := repo.List(context.Background(), domain.MemoryFilter{
+		State:     "active",
+		AgentID:   "agent-1",
+		SessionID: "sess-1",
+		Source:    "chat",
+		Tags:      []string{"tag-a"},
+		Limit:     10,
+		Offset:    20,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total = %d, want 2", total)
+	}
+	if len(memories) != 1 || memories[0].ID != "s-2" || memories[0].MemoryType != domain.TypeSession {
+		t.Fatalf("memories = %+v, want session s-2", memories)
+	}
+}
 
 func TestFillSessionMemory_SetsMemoryType(t *testing.T) {
 	var m domain.Memory

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
@@ -58,6 +60,48 @@ func TestSessionRepoListFiltersAndPaginates(t *testing.T) {
 	}
 	if len(memories) != 1 || memories[0].ID != "s-2" || memories[0].MemoryType != domain.TypeSession {
 		t.Fatalf("memories = %+v, want session s-2", memories)
+	}
+}
+
+func TestSessionRepoGetByIDMissingTableReturnsNotFound(t *testing.T) {
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions WHERE id = ? AND state = 'active'",
+			},
+			wantArgs: []any{"missing-session-row"},
+			err:      &mysql.MySQLError{Number: 1146, Message: "Table doesn't exist"},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", false, "cluster-1")
+	_, err := repo.GetByID(context.Background(), "missing-session-row")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("GetByID error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSessionRepoSoftDeleteMissingTableReturnsNotFound(t *testing.T) {
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT state FROM sessions WHERE id = ? FOR UPDATE",
+			},
+			wantArgs: []any{"missing-session-row"},
+			err:      &mysql.MySQLError{Number: 1146, Message: "Table doesn't exist"},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", false, "cluster-1")
+	deleted, err := repo.SoftDelete(context.Background(), "missing-session-row", "agent-1")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("SoftDelete error = %v, want ErrNotFound", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("deleted = %d, want 0", deleted)
 	}
 }
 

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -72,6 +72,27 @@ func (s *SessionService) CreateRawTurn(ctx context.Context, sessionID, agentID, 
 	return nil
 }
 
+func (s *SessionService) Get(ctx context.Context, id string) (*domain.Memory, error) {
+	return s.sessions.GetByID(ctx, id)
+}
+
+func (s *SessionService) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	return s.sessions.List(ctx, f)
+}
+
+func (s *SessionService) Delete(ctx context.Context, id, agentName string) (int64, error) {
+	return s.sessions.SoftDelete(ctx, id, agentName)
+}
+
+func (s *SessionService) BulkDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	unique, err := ValidateBulkDeleteIDs(ids)
+	if err != nil {
+		return 0, err
+	}
+
+	return s.sessions.BulkSoftDelete(ctx, unique, agentName)
+}
+
 func (s *SessionService) Search(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
 	limit := f.Limit
 	if limit <= 0 || limit > 200 {

--- a/server/internal/service/session_test.go
+++ b/server/internal/service/session_test.go
@@ -33,6 +33,13 @@ type stubSessionRepo struct {
 	sessionRows    []*domain.Session
 	listSessionIDs []string
 	listLimit      int
+	getResult      *domain.Memory
+	getErr         error
+	listResults    []domain.Memory
+	listTotal      int
+	listFilter     domain.MemoryFilter
+	softDeleteID   string
+	bulkDeleteIDs  []string
 }
 
 func intPtr(v int) *int {
@@ -51,6 +58,25 @@ func (s *stubSessionRepo) PatchTags(_ context.Context, sessionID, contentHash st
 	s.patchedHash = contentHash
 	s.patchedTags = tags
 	return s.patchTagsErr
+}
+
+func (s *stubSessionRepo) GetByID(_ context.Context, _ string) (*domain.Memory, error) {
+	return s.getResult, s.getErr
+}
+
+func (s *stubSessionRepo) List(_ context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	s.listFilter = f
+	return append([]domain.Memory(nil), s.listResults...), s.listTotal, nil
+}
+
+func (s *stubSessionRepo) SoftDelete(_ context.Context, id, _ string) (int64, error) {
+	s.softDeleteID = id
+	return 1, nil
+}
+
+func (s *stubSessionRepo) BulkSoftDelete(_ context.Context, ids []string, _ string) (int64, error) {
+	s.bulkDeleteIDs = append([]string(nil), ids...)
+	return int64(len(ids)), nil
 }
 
 func (s *stubSessionRepo) AutoVectorSearch(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
@@ -284,6 +310,45 @@ func TestSessionService_Search_defaultLimit(t *testing.T) {
 	}
 }
 
+func TestSessionService_ListDelegatesToRepo(t *testing.T) {
+	repo := &stubSessionRepo{
+		listResults: []domain.Memory{{ID: "s-1", MemoryType: domain.TypeSession}},
+		listTotal:   3,
+	}
+	svc := newTestSessionService(repo)
+
+	results, total, err := svc.List(context.Background(), domain.MemoryFilter{
+		MemoryType: "session",
+		Limit:      10,
+		Offset:     20,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 3 || len(results) != 1 || results[0].ID != "s-1" {
+		t.Fatalf("results=%+v total=%d, want s-1 total 3", results, total)
+	}
+	if repo.listFilter.Limit != 10 || repo.listFilter.Offset != 20 {
+		t.Fatalf("repo list filter = %+v", repo.listFilter)
+	}
+}
+
+func TestSessionService_BulkDeleteDeduplicatesIDs(t *testing.T) {
+	repo := &stubSessionRepo{}
+	svc := newTestSessionService(repo)
+
+	deleted, err := svc.BulkDelete(context.Background(), []string{"s-1", "s-1", "", "s-2"}, "agent")
+	if err != nil {
+		t.Fatalf("BulkDelete: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("deleted = %d, want 2", deleted)
+	}
+	if len(repo.bulkDeleteIDs) != 2 || repo.bulkDeleteIDs[0] != "s-1" || repo.bulkDeleteIDs[1] != "s-2" {
+		t.Fatalf("bulk delete ids = %+v", repo.bulkDeleteIDs)
+	}
+}
+
 func TestSessionService_SearchCandidates_ExpandsAdjacentTurns(t *testing.T) {
 	now := time.Now()
 	repo := &stubSessionRepo{
@@ -368,6 +433,18 @@ func (c *capturingSessionRepo) BulkCreate(ctx context.Context, s []*domain.Sessi
 }
 func (c *capturingSessionRepo) PatchTags(ctx context.Context, sid, hash string, tags []string) error {
 	return c.stub.PatchTags(ctx, sid, hash, tags)
+}
+func (c *capturingSessionRepo) GetByID(ctx context.Context, id string) (*domain.Memory, error) {
+	return c.stub.GetByID(ctx, id)
+}
+func (c *capturingSessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	return c.stub.List(ctx, f)
+}
+func (c *capturingSessionRepo) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
+	return c.stub.SoftDelete(ctx, id, agentName)
+}
+func (c *capturingSessionRepo) BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error) {
+	return c.stub.BulkSoftDelete(ctx, ids, agentName)
 }
 func (c *capturingSessionRepo) AutoVectorSearch(ctx context.Context, q string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	*c.capturedFilter = f


### PR DESCRIPTION
## Summary
- add paginated session memory listing through the existing memories API
- support soft deletion of session rows via single and batch memory delete paths
- cover handler, service, and TiDB repository behavior for session management

## Validation
- cd server && go test ./internal/handler ./internal/service ./internal/repository/tidb