### PR TITLE
test(e2e): cover session memory lifecycle

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -127,8 +127,9 @@ confirms the deleted chain key is no longer active.
 ### Session storage (`api-smoke-test-sessions.sh`)
 
 Regression tests for raw session storage (PR #103). Provisions a fresh tenant,
-ingests messages, and verifies all session-specific behaviors: session exclusion from
-unified recall, `memory_type` filtering, metadata projection, no-query exclusion, and deduplication.
+ingests messages, and verifies session-specific behavior: unified recall inclusion,
+`memory_type` filtering, metadata projection, no-query session listing, per-ID
+get/delete fallback, batch delete, no-query unified-list exclusion, and deduplication.
 Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
 
 | #   | Case                                    | What is verified                                                                                     |
@@ -143,9 +144,13 @@ Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
 | 8   | No-query list excludes sessions         | `GET /memories` (no `?q=`) returns no `memory_type=session` rows                                     |
 | 9   | `session_id` scoped filter              | All results belong to the expected `session_id`                                                      |
 | 10  | Deduplication                           | Re-sending identical messages does not increase row count                                            |
-| 11  | Existing tenant: session write          | `POST /memories {messages}` on pre-existing tenant returns 202 (requires `MNEMO_EXISTING_TENANT_ID`) |
-| 12  | Existing tenant: lazy migration         | Poll + retry writes until sessions appear — proves `EnsureSessionsTable` creates table in flight     |
-| 13  | Existing tenant: filter after migration | `memory_type=session` filter works correctly after lazy migration                                    |
+| 11  | No-query session listing                | `GET /memories?session_id=...&memory_type=session` returns raw session rows without `q`              |
+| 12  | Session row get fallback                | `GET /memories/{session-row-id}` returns `memory_type=session`                                       |
+| 13  | Session row delete fallback             | `DELETE /memories/{session-row-id}` returns 204 and subsequent get returns 404                       |
+| 14  | Session row batch delete                | `POST /memories/batch-delete` deletes remaining session rows                                         |
+| 15  | Existing tenant: session write          | `POST /memories {messages}` on pre-existing tenant returns 202 (requires `MNEMO_EXISTING_TENANT_ID`) |
+| 16  | Existing tenant: lazy migration         | Poll + retry writes until sessions appear — proves `EnsureSessionsTable` creates table in flight     |
+| 17  | Existing tenant: filter after migration | `memory_type=session` filter works correctly after lazy migration                                    |
 
 ### Existing-tenant compat (`api-smoke-test-existing-tenant.sh`)
 
@@ -233,7 +238,7 @@ python3 e2e/concurrent-real-doc-test.py
 - `api-smoke-test.sh` / `api-smoke-test-v1alpha2.sh` — CRUD smoke, ingest, search, tag filter (tests 1–11)
 - `api-smoke-test-round2.sh` / `api-smoke-test-round2-v1alpha2.sh` — per-ID ops: GET, PUT, If-Match LWW, DELETE, idempotent re-delete (tests 1–9)
 - `api-smoke-test-space-chain.sh` — Space Chain management/runtime: create chain, validate nodes/bindings, write/read/update/delete via `chain_` key, cleanup (tests 1–18)
-- `api-smoke-test-sessions.sh` — session storage: write, dedup, unified search, type filter, metadata, no-query exclusion, lazy migration (tests 1–13; tests 11–13 require `MNEMO_EXISTING_TENANT_ID`)
+- `api-smoke-test-sessions.sh` — session storage: write, dedup, unified search, type filter, metadata, no-query session list, per-ID get/delete, batch delete, lazy migration (tests 1–17; tests 15–17 require `MNEMO_EXISTING_TENANT_ID`)
 - `api-smoke-test-existing-tenant.sh` — backward-compat: pre-existing tenant read/write/search across v1alpha1 and v1alpha2 (tests 1–12)
 - `api-smoke-test-utm.sh` — UTM attribution: param normalization, filtering, empty-value dropping (tests 1–5 always; tests 6–10 require `MNEMO_METADB_DSN` and `MNEMO_UTM_ENABLED=true` on server)
 - `crdt-*` and `plugin-crdt-*` use the CRDT branch `/api/users`, `/api/spaces/provision`, `/api/memories` surface.
@@ -246,7 +251,7 @@ python3 e2e/concurrent-real-doc-test.py
 | `MNEMO_BASE`               | `https://api.mem9.ai`          | all smoke scripts                                                                              |
 | `MNEMO_API_VERSION`        | `v1alpha1`                     | `api-smoke-test.sh`, `api-smoke-test-round2.sh`, `api-smoke-test-sessions.sh`                  |
 | `POLL_TIMEOUT_S`           | `20` (round2), `30` (sessions, Space Chain) | `api-smoke-test-round2*.sh`, `api-smoke-test-space-chain.sh`, `api-smoke-test-sessions.sh`, `api-smoke-test-existing-tenant.sh` |
-| `MNEMO_EXISTING_TENANT_ID` | —                              | `api-smoke-test-existing-tenant.sh`, `api-smoke-test-sessions.sh` (tests 11–13)                |
+| `MNEMO_EXISTING_TENANT_ID` | —                              | `api-smoke-test-existing-tenant.sh`, `api-smoke-test-sessions.sh` (tests 15–17)                |
 | `MNEMO_METADB_DSN`         | —                              | `api-smoke-test-utm.sh` (tests 6–10); format: `user:pass@tcp(host:port)/dbname`                |
 | `MNEMO_TEST_BASE`          | `http://127.0.0.1:18081`       | CRDT scripts                                                                                   |
 | `MNEMO_TEST_USER_TOKEN`    | —                              | CRDT scripts                                                                                   |
@@ -260,7 +265,7 @@ python3 e2e/concurrent-real-doc-test.py
 | `api-smoke-test-round2.sh`          | v1alpha1 (default) or v1alpha2 | Per-ID ops: GET, PUT, If-Match LWW, DELETE, idempotent re-delete     |
 | `api-smoke-test-round2-v1alpha2.sh` | v1alpha2                       | One-liner wrapper — sets `MNEMO_API_VERSION=v1alpha2`                |
 | `api-smoke-test-space-chain.sh`     | v1alpha2                       | Space Chain management/runtime happy path                            |
-| `api-smoke-test-sessions.sh`        | v1alpha1 (default) or v1alpha2 | Session storage: write, dedup, unified search, type filter, metadata |
+| `api-smoke-test-sessions.sh`        | v1alpha1 (default) or v1alpha2 | Session storage: write, dedup, unified search, lifecycle             |
 | `api-smoke-test-existing-tenant.sh` | v1alpha1 + v1alpha2            | Backward-compat: pre-existing tenant full lifecycle, both auth modes |
 | `api-smoke-test-utm.sh`             | v1alpha1                       | UTM attribution: param normalization + optional DB row verification  |
 | `crdt-e2e-tests.sh`                 | CRDT branch                    | Core CRDT server behavior                                            |

--- a/e2e/api-smoke-test-sessions.sh
+++ b/e2e/api-smoke-test-sessions.sh
@@ -1,22 +1,26 @@
 #!/bin/bash
 # api-smoke-test-sessions.sh
 # Session storage smoke test: verifies raw session write, deduplication,
-# memory_type filtering, and metadata projection.
+# memory_type filtering, metadata projection, and memory endpoint lifecycle.
 #
 # Tests covered:
 #   1. Provision tenant
 #   2. Session write via messages — expect 202
 #   3. Poll until sessions appear via memory_type=session filter
-#   4. Unified search (no memory_type) excludes session rows
+#   4. Unified search (no memory_type) includes session rows
 #   5. memory_type=session filter returns only sessions
 #   6. memory_type=insight filter excludes sessions
 #   7. Session metadata projection (role, seq, content_type in metadata field)
 #   8. No-query list excludes sessions
 #   9. session_id scoped filter
 #  10. Deduplication — same messages sent twice produce no extra rows
-#  11. Existing tenant: session write triggers lazy migration (requires MNEMO_EXISTING_TENANT_ID)
-#  12. Existing tenant: poll + retry until sessions appear after lazy table creation
-#  13. Existing tenant: memory_type=session filter works after migration
+#  11. No-query memory_type=session list returns raw sessions
+#  12. Get raw session row through memory endpoint
+#  13. Delete raw session row through memory endpoint
+#  14. Batch delete remaining raw session rows through memory endpoint
+#  15. Existing tenant: session write triggers lazy migration (requires MNEMO_EXISTING_TENANT_ID)
+#  16. Existing tenant: poll + retry until sessions appear after lazy table creation
+#  17. Existing tenant: memory_type=session filter works after migration
 #
 # Usage:
 #   bash e2e/api-smoke-test-sessions.sh
@@ -360,7 +364,120 @@ info "Session rows after re-send: $COUNT_AFTER"
 check "row count unchanged after duplicate send (dedup via content hash)" "$COUNT_AFTER" "$COUNT_BEFORE"
 
 # ============================================================================
-# TESTS 11-13 — Existing tenant: lazy sessions table migration
+# TEST 11 — No-query memory_type=session list returns raw sessions
+# ============================================================================
+step "11" "No-query session list: GET /memories?session_id=&memory_type=session"
+resp=$(curl_mem_json "$MEM_BASE?session_id=${SESSION_ID}&memory_type=session&limit=20")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories?session_id=&memory_type=session returns 200" "$code" "200"
+
+NO_QUERY_SESSION_CHECK=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+mems = data.get('memories', [])
+if not mems:
+    print('no-results')
+    sys.exit()
+wrong_type = [m.get('memory_type') for m in mems if m.get('memory_type') != 'session']
+wrong_session = [m.get('session_id') for m in mems if m.get('session_id') != '$SESSION_ID']
+if wrong_type:
+    print('wrong-types:' + str(wrong_type))
+elif wrong_session:
+    print('wrong-sessions:' + str(wrong_session))
+else:
+    print('ok')
+" 2>/dev/null || true)
+check "no-query session list returns only rows for this session" "$NO_QUERY_SESSION_CHECK" "ok"
+
+SESSION_ROW_ID=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+print(mems[0].get('id', '') if mems else '')
+" 2>/dev/null || true)
+if [ -n "$SESSION_ROW_ID" ]; then
+  SESSION_ROW_ID_FOUND="yes"
+else
+  SESSION_ROW_ID_FOUND="no"
+fi
+check "session row ID extracted for per-ID lifecycle checks" "$SESSION_ROW_ID_FOUND" "yes"
+
+REMAINING_SESSION_IDS_JSON=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+ids = [m.get('id') for m in mems[1:] if m.get('id')]
+print(json.dumps(ids))
+" 2>/dev/null || true)
+
+# ============================================================================
+# TEST 12 — Get raw session row through memory endpoint
+# ============================================================================
+step "12" "Get session row by ID through memory endpoint"
+resp=$(curl_mem_json "$MEM_BASE/$SESSION_ROW_ID")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "GET /memories/{session-row-id} returns 200" "$code" "200"
+
+GET_SESSION_CHECK=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)
+if m.get('memory_type') != 'session':
+    print('wrong-type:' + str(m.get('memory_type')))
+elif m.get('session_id') != '$SESSION_ID':
+    print('wrong-session:' + str(m.get('session_id')))
+else:
+    print('ok')
+" 2>/dev/null || true)
+check "GET by ID returns the expected session row" "$GET_SESSION_CHECK" "ok"
+
+# ============================================================================
+# TEST 13 — Delete raw session row through memory endpoint
+# ============================================================================
+step "13" "Delete session row by ID through memory endpoint"
+resp=$(curl_mem_json "$MEM_BASE/$SESSION_ROW_ID" -X DELETE)
+code=$(http_code "$resp")
+check "DELETE /memories/{session-row-id} returns 204" "$code" "204"
+
+resp=$(curl_mem_json "$MEM_BASE/$SESSION_ROW_ID")
+code=$(http_code "$resp")
+check "GET deleted session row returns 404" "$code" "404"
+
+# ============================================================================
+# TEST 14 — Batch delete remaining raw session rows through memory endpoint
+# ============================================================================
+step "14" "Batch delete remaining session rows through memory endpoint"
+REMAINING_SESSION_COUNT=$(printf '%s' "$REMAINING_SESSION_IDS_JSON" | python3 -c "
+import sys, json
+print(len(json.load(sys.stdin)))
+" 2>/dev/null || true)
+
+if [ -n "$REMAINING_SESSION_COUNT" ] && [ "$REMAINING_SESSION_COUNT" -gt 0 ]; then
+  BATCH_DELETE_PAYLOAD=$(REMAINING_SESSION_IDS_JSON="$REMAINING_SESSION_IDS_JSON" python3 -c '
+import json
+import os
+
+print(json.dumps({"ids": json.loads(os.environ["REMAINING_SESSION_IDS_JSON"])}))
+')
+  resp=$(curl_mem_json "$MEM_BASE/batch-delete" -X POST \
+    -H "Content-Type: application/json" \
+    -d "$BATCH_DELETE_PAYLOAD")
+  code=$(http_code "$resp")
+  bdy=$(body "$resp")
+  check "POST /memories/batch-delete returns 200" "$code" "200"
+
+  BATCH_DELETED=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+print(json.load(sys.stdin).get('deleted', ''))
+" 2>/dev/null || true)
+  check "batch delete removed remaining session rows" "$BATCH_DELETED" "$REMAINING_SESSION_COUNT"
+else
+  TOTAL=$((TOTAL+1))
+  ok "No remaining session rows to batch delete"
+  PASS=$((PASS+1))
+fi
+
+# ============================================================================
+# TESTS 15-17 — Existing tenant: lazy sessions table migration
 # Only runs when MNEMO_EXISTING_TENANT_ID is set.
 # The tenant database must NOT have a sessions table yet (created before PR #103).
 # On first request, EnsureSessionsTable fires in background (error 1146 is
@@ -398,7 +515,7 @@ if [ -n "$EXISTING_TENANT_ID" ]; then
   EXIST_UNIQUE_MARKER="MNEMO_EXIST_SESS_$(date +%s)"
   EXIST_SESSION_ID="smoke-exist-sessions-${EXIST_UNIQUE_MARKER}"
 
-  step "11" "Existing tenant: session write triggers lazy migration (POST /memories)"
+  step "15" "Existing tenant: session write triggers lazy migration (POST /memories)"
   resp=$(curl_exist_json "$EXIST_MEM_BASE" -X POST \
     -H "Content-Type: application/json" \
     -d "{
@@ -413,7 +530,7 @@ if [ -n "$EXISTING_TENANT_ID" ]; then
   check "existing tenant POST /memories (messages) returns 202" "$code" "202"
   check_contains "response has status=accepted" "$bdy" '"accepted"'
 
-  step "12" "Existing tenant: poll + retry writes until sessions appear (lazy table creation)"
+  step "16" "Existing tenant: poll + retry writes until sessions appear (lazy table creation)"
   info "First write may be silently dropped (error 1146 swallowed) — retrying until table is ready"
   EXIST_SESSION_APPEARED=false
   ELAPSED=0
@@ -457,7 +574,7 @@ print(len(json.load(sys.stdin).get('memories', [])))
     FAIL=$((FAIL+1))
   fi
 
-  step "13" "Existing tenant: session memory_type=session filter works after migration"
+  step "17" "Existing tenant: session memory_type=session filter works after migration"
   resp=$(curl_exist_json "$EXIST_MEM_BASE?q=${EXIST_UNIQUE_MARKER}&memory_type=session&limit=10")
   code=$(http_code "$resp")
   bdy=$(body "$resp")
@@ -476,7 +593,7 @@ else:
 " 2>/dev/null || true)
   check "existing tenant: all results have memory_type=session" "$EXIST_SESSION_ONLY" "yes"
 else
-  info "MNEMO_EXISTING_TENANT_ID not set — skipping lazy migration tests (11-13)"
+  info "MNEMO_EXISTING_TENANT_ID not set — skipping lazy migration tests (15-17)"
 fi
 
 


### PR DESCRIPTION
## Summary
- add session smoke coverage for no-query memory_type=session listing
- verify session row GET/DELETE fallback through the memory endpoint
- verify batch-delete handles remaining session rows
- update e2e coverage docs for the expanded session smoke cases

## Validation
- bash -n e2e/api-smoke-test-sessions.sh
- git diff --check

Live e2e was not run against an API endpoint.