### PR TITLE
[codex] Skip raw session recall when session save is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only appli
 | `MNEMO_LLM_MODEL` | No | `gpt-4o-mini` | LLM model for smart ingest |
 | `MNEMO_LLM_TEMPERATURE` | No | `0.1` | LLM temperature for smart ingest |
 | `MNEMO_INGEST_MODE` | No | `smart` | Ingest mode: `smart` or `raw` |
+| `MNEMO_DISABLE_SESSION_SAVE` | No | `false` | Disable raw session row persistence for message ingest while still extracting and reconciling facts |
 | `MNEMO_FTS_ENABLED` | No | `false` | Enable TiDB full-text search path. Only set this on clusters that support TiDB FTS |
 
 #### Search Source Turns

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only appli
 | `MNEMO_LLM_MODEL` | No | `gpt-4o-mini` | LLM model for smart ingest |
 | `MNEMO_LLM_TEMPERATURE` | No | `0.1` | LLM temperature for smart ingest |
 | `MNEMO_INGEST_MODE` | No | `smart` | Ingest mode: `smart` or `raw` |
-| `MNEMO_DISABLE_SESSION_SAVE` | No | `false` | Disable raw session row persistence for message ingest while still extracting and reconciling facts |
+| `MNEMO_DISABLE_SESSION_SAVE` | No | `false` | Disable raw session row persistence and raw session recall while still extracting and reconciling facts |
 | `MNEMO_FTS_ENABLED` | No | `false` | Enable TiDB full-text search path. Only set this on clusters that support TiDB FTS |
 
 #### Search Source Turns

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1723,6 +1723,10 @@
           "sync": {
             "type": "boolean",
             "description": "When true, wait for ingest completion up to the server timeout. When false or omitted, ingest runs asynchronously."
+          },
+          "disableSessionSave": {
+            "type": "boolean",
+            "description": "When true on message ingest requests, skip raw session message persistence and only run fact extraction and reconciliation. Defaults to false."
           }
         }
       },

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -262,7 +262,8 @@ func main() {
 		WithSpaceChainService(spaceChainSvc, cfg.ChainRecallStopScore).
 		WithMetering(meteringWriter).
 		WithRuntimeUsage(runtimeUsageManager).
-		WithActivityTracker(activityTracker)
+		WithActivityTracker(activityTracker).
+		WithDisableSessionSave(cfg.DisableSessionSave)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW)
 
 	httpSrv := &http.Server{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -37,6 +37,10 @@ type Config struct {
 	LLMTemperature float64
 	IngestMode     string
 
+	// DisableSessionSave skips raw session row persistence for message ingest.
+	// Smart ingest still extracts and reconciles facts into insight memories.
+	DisableSessionSave bool
+
 	TiDBZeroEnabled          bool
 	TiDBZeroAPIURL           string
 	TenantPoolMaxIdle        int
@@ -169,6 +173,7 @@ func Load() (*Config, error) {
 		LLMModel:                    envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
 		LLMTemperature:              envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
 		IngestMode:                  envOr("MNEMO_INGEST_MODE", "smart"),
+		DisableSessionSave:          envBool("MNEMO_DISABLE_SESSION_SAVE", false),
 		TiDBZeroEnabled:             envBool("MNEMO_TIDB_ZERO_ENABLED", true),
 		TiDBZeroAPIURL:              envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
 		TiDBCloudAPIURL:             envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	LLMTemperature float64
 	IngestMode     string
 
-	// DisableSessionSave skips raw session row persistence for message ingest.
+	// DisableSessionSave skips raw session row persistence and session recall.
 	// Smart ingest still extracts and reconciles facts into insight memories.
 	DisableSessionSave bool
 

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -35,6 +35,19 @@ func TestLoad_ChainRecallStopScoreDefaultsToHighConfidence(t *testing.T) {
 	}
 }
 
+func TestLoad_DisableSessionSave(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_DISABLE_SESSION_SAVE", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.DisableSessionSave {
+		t.Fatal("DisableSessionSave = false, want true")
+	}
+}
+
 func TestLoad_MeteringSupportedFields(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_METERING_ENABLED", "true")

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -169,7 +169,11 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 			perNodeFilter.MemoryType == string(domain.TypeInsight)):
 			memories, _, err = s.singlePoolConfidenceRecallSearch(ctx, nodeAuth, svc, perNodeFilter)
 		case perNodeFilter.MemoryType == string(domain.TypeSession):
-			memories, _, err = svc.session.List(ctx, perNodeFilter)
+			if s.disableSessionSave {
+				memories = []domain.Memory{}
+			} else {
+				memories, _, err = svc.session.List(ctx, perNodeFilter)
+			}
 		case perNodeFilter.MemoryType != string(domain.TypeSession):
 			memories, _, err = svc.memory.Search(ctx, perNodeFilter)
 		}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -46,6 +46,7 @@ type Server struct {
 	startedAt            time.Time
 	svcCache             sync.Map
 	chainRecallStopScore float64
+	disableSessionSave   bool
 }
 
 // NewServer creates a new HTTP handler server.
@@ -97,6 +98,11 @@ func (s *Server) WithRuntimeUsage(manager runtimeusage.Manager) *Server {
 
 func (s *Server) WithActivityTracker(tracker *service.ActivityTracker) *Server {
 	s.activity = tracker
+	return s
+}
+
+func (s *Server) WithDisableSessionSave(disabled bool) *Server {
+	s.disableSessionSave = disabled
 	return s
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -27,6 +27,8 @@ import (
 	"github.com/qiffang/mnemos/server/internal/service"
 )
 
+const statusClientClosedRequest = 499
+
 // Server holds the HTTP handlers and their dependencies.
 type Server struct {
 	tenant               *service.TenantService
@@ -275,6 +277,9 @@ func respondError(w http.ResponseWriter, status int, msg string) {
 // handleError maps domain errors to HTTP status codes.
 func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err error) {
 	switch {
+	case errors.Is(err, context.Canceled) && errors.Is(ctx.Err(), context.Canceled):
+		s.logger.Info("request canceled by client", "err", err, "request_id", reqid.FromContext(ctx))
+		respondError(w, statusClientClosedRequest, "client closed request")
 	case errors.Is(err, domain.ErrNotFound):
 		respondError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, domain.ErrWriteConflict):

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -26,15 +26,16 @@ var (
 )
 
 type createMemoryRequest struct {
-	Content    string                  `json:"content,omitempty"`
-	MemoryType string                  `json:"memory_type,omitempty"`
-	AgentID    string                  `json:"agent_id,omitempty"`
-	Tags       []string                `json:"tags,omitempty"`
-	Metadata   json.RawMessage         `json:"metadata,omitempty"`
-	Messages   []service.IngestMessage `json:"messages,omitempty"`
-	SessionID  string                  `json:"session_id,omitempty"`
-	Mode       service.IngestMode      `json:"mode,omitempty"`
-	Sync       bool                    `json:"sync,omitempty"`
+	Content            string                  `json:"content,omitempty"`
+	MemoryType         string                  `json:"memory_type,omitempty"`
+	AgentID            string                  `json:"agent_id,omitempty"`
+	Tags               []string                `json:"tags,omitempty"`
+	Metadata           json.RawMessage         `json:"metadata,omitempty"`
+	Messages           []service.IngestMessage `json:"messages,omitempty"`
+	SessionID          string                  `json:"session_id,omitempty"`
+	Mode               service.IngestMode      `json:"mode,omitempty"`
+	Sync               bool                    `json:"sync,omitempty"`
+	DisableSessionSave bool                    `json:"disableSessionSave,omitempty"`
 }
 
 func isSyncIngestTimeout(ctx context.Context, err error) bool {
@@ -84,10 +85,11 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	if hasMessages {
 		messages := append([]service.IngestMessage(nil), req.Messages...)
 		ingestReq := service.IngestRequest{
-			Messages:  messages,
-			SessionID: req.SessionID,
-			AgentID:   agentID,
-			Mode:      req.Mode,
+			Messages:           messages,
+			SessionID:          req.SessionID,
+			AgentID:            agentID,
+			Mode:               req.Mode,
+			DisableSessionSave: s.disableSessionSave || req.DisableSessionSave,
 		}
 
 		if req.Sync {
@@ -404,7 +406,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// ingestMessages runs the full ingest pipeline: BulkCreate → ExtractPhase1 → PatchTags + ReconcilePhase2.
+// ingestMessages runs the full ingest pipeline: optional BulkCreate → ExtractPhase1 → optional PatchTags + ReconcilePhase2.
 // TODO: wrap all database writes (BulkCreate, PatchTags, ReconcilePhase2) in a single transaction to guarantee atomicity.
 func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc resolvedSvc, req service.IngestRequest) (*service.IngestResult, error) {
 	start := time.Now()
@@ -434,15 +436,17 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 	// This is the single sanitization point for the handler-driven pipeline (BulkCreate, ExtractPhase1, etc.).
 	req.Messages = service.StripInjectedContext(req.Messages)
 
-	// Session persistence is best-effort for both sync and async paths.
-	// sync=true guarantees only that reconcile (memory extraction) completed —
-	// raw session rows in /session-messages may be absent if BulkCreate fails.
-	bulkCreateStart := time.Now()
-	if err := svc.session.BulkCreate(ctx, auth.AgentName, req); err != nil {
-		slog.Error("session raw save failed",
-			"cluster_id", auth.ClusterID, "session", req.SessionID, "err", err)
+	if !req.DisableSessionSave {
+		// Session persistence is best-effort for both sync and async paths.
+		// sync=true guarantees only that reconcile (memory extraction) completed —
+		// raw session rows in /session-messages may be absent if BulkCreate fails.
+		bulkCreateStart := time.Now()
+		if err := svc.session.BulkCreate(ctx, auth.AgentName, req); err != nil {
+			slog.Error("session raw save failed",
+				"cluster_id", auth.ClusterID, "session", req.SessionID, "err", err)
+		}
+		bulkCreateDuration = time.Since(bulkCreateStart)
 	}
-	bulkCreateDuration = time.Since(bulkCreateStart)
 
 	extractPhase1Start := time.Now()
 	phase1, err := svc.ingest.ExtractPhase1(ctx, req.Messages)
@@ -458,26 +462,29 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 	var reconcileResult *service.IngestResult
 	var reconcileErr error
 
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		patchTagsStart := time.Now()
-		defer func() {
-			patchTagsDuration = time.Since(patchTagsStart)
+	if !req.DisableSessionSave {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			patchTagsStart := time.Now()
+			defer func() {
+				patchTagsDuration = time.Since(patchTagsStart)
+			}()
+			for i, msg := range req.Messages {
+				tags := tagsAtIndex(phase1.MessageTags, i)
+				if len(tags) == 0 {
+					continue
+				}
+				hash := service.SessionContentHash(req.SessionID, msg.Role, msg.Content, msg.Seq)
+				if err := svc.session.PatchTags(ctx, req.SessionID, hash, tags); err != nil {
+					slog.Warn("session tag patch failed",
+						"cluster_id", auth.ClusterID, "session", req.SessionID, "err", err)
+				}
+			}
 		}()
-		for i, msg := range req.Messages {
-			tags := tagsAtIndex(phase1.MessageTags, i)
-			if len(tags) == 0 {
-				continue
-			}
-			hash := service.SessionContentHash(req.SessionID, msg.Role, msg.Content, msg.Seq)
-			if err := svc.session.PatchTags(ctx, req.SessionID, hash, tags); err != nil {
-				slog.Warn("session tag patch failed",
-					"cluster_id", auth.ClusterID, "session", req.SessionID, "err", err)
-			}
-		}
-	}()
+	}
 
+	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		reconcileStart := time.Now()

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -581,7 +581,11 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 			filter.MemoryType == string(domain.TypeInsight)):
 			memories, total, err = s.singlePoolConfidenceRecallSearch(r.Context(), auth, svc, filter)
 		case onlySession:
-			memories, total, err = svc.session.List(r.Context(), filter)
+			if s.disableSessionSave {
+				memories, total = []domain.Memory{}, 0
+			} else {
+				memories, total, err = svc.session.List(r.Context(), filter)
+			}
 		case !onlySession:
 			memories, total, err = svc.memory.Search(r.Context(), filter)
 		}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1135,7 +1135,8 @@ func TestCreateMemory_AsyncContent_Returns202(t *testing.T) {
 }
 
 func TestCreateMemory_SyncMessages_Returns200(t *testing.T) {
-	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	sessRepo := &testSessionRepo{}
+	srv := newTestServer(&testMemoryRepo{}, sessRepo)
 
 	body := map[string]any{
 		"messages": []map[string]string{
@@ -1152,6 +1153,126 @@ func TestCreateMemory_SyncMessages_Returns200(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Errorf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !sessRepo.bulkCreateCalled {
+		t.Fatal("expected raw sessions to be persisted by default")
+	}
+}
+
+func TestCreateMemory_SyncMessages_DisableSessionSaveSkipsRawSessionAndStoresFacts(t *testing.T) {
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{
+					"content": `{"facts":[{"text":"User prefers tea","tags":["preference"]}],"message_tags":[["preference"],[]]}`,
+				}},
+			},
+		})
+	}))
+	defer llmServer.Close()
+
+	llmClient := llm.New(llm.Config{
+		APIKey:  "test-key",
+		BaseURL: llmServer.URL,
+		Model:   "test-model",
+	})
+
+	memRepo := &testMemoryRepo{}
+	sessRepo := &testSessionRepo{}
+	srv := NewServer(nil, nil, "", nil, llmClient, "", false, service.ModeSmart, "", slog.Default())
+	svc := resolvedSvc{
+		memory:  service.NewMemoryService(memRepo, llmClient, nil, "", service.ModeSmart),
+		ingest:  service.NewIngestService(memRepo, llmClient, nil, "", service.ModeSmart),
+		session: service.NewSessionService(sessRepo, nil, ""),
+	}
+	srv.svcCache.Store(tenantSvcKey("db-0x0"), svc)
+
+	body := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "I prefer tea"},
+			{"role": "assistant", "content": "Noted"},
+		},
+		"session_id":         "test-session",
+		"sync":               true,
+		"disableSessionSave": true,
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if sessRepo.bulkCreateCalled {
+		t.Fatal("did not expect raw session BulkCreate when disableSessionSave=true")
+	}
+	if sessRepo.patchTagsCalled {
+		t.Fatal("did not expect session PatchTags when disableSessionSave=true")
+	}
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("expected one extracted fact memory, got %d", len(memRepo.createCalls))
+	}
+	if memRepo.createCalls[0].Content != "User prefers tea" {
+		t.Fatalf("created memory content = %q, want extracted fact", memRepo.createCalls[0].Content)
+	}
+}
+
+func TestCreateMemory_SyncMessages_ServerDisableSessionSaveSkipsRawSession(t *testing.T) {
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{
+					"content": `{"facts":[{"text":"User prefers coffee","tags":["preference"]}],"message_tags":[["preference"],[]]}`,
+				}},
+			},
+		})
+	}))
+	defer llmServer.Close()
+
+	llmClient := llm.New(llm.Config{
+		APIKey:  "test-key",
+		BaseURL: llmServer.URL,
+		Model:   "test-model",
+	})
+
+	memRepo := &testMemoryRepo{}
+	sessRepo := &testSessionRepo{}
+	srv := NewServer(nil, nil, "", nil, llmClient, "", false, service.ModeSmart, "", slog.Default()).
+		WithDisableSessionSave(true)
+	svc := resolvedSvc{
+		memory:  service.NewMemoryService(memRepo, llmClient, nil, "", service.ModeSmart),
+		ingest:  service.NewIngestService(memRepo, llmClient, nil, "", service.ModeSmart),
+		session: service.NewSessionService(sessRepo, nil, ""),
+	}
+	srv.svcCache.Store(tenantSvcKey("db-0x0"), svc)
+
+	body := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "I prefer coffee"},
+			{"role": "assistant", "content": "Noted"},
+		},
+		"session_id": "test-session",
+		"sync":       true,
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if sessRepo.bulkCreateCalled {
+		t.Fatal("did not expect raw session BulkCreate when server disables session save")
+	}
+	if sessRepo.patchTagsCalled {
+		t.Fatal("did not expect session PatchTags when server disables session save")
+	}
+	if len(memRepo.createCalls) != 1 {
+		t.Fatalf("expected one extracted fact memory, got %d", len(memRepo.createCalls))
 	}
 }
 
@@ -1297,6 +1418,78 @@ func TestCreateMemory_AsyncMessages_Returns202(t *testing.T) {
 	}
 	if resp["status"] != "accepted" {
 		t.Errorf("expected status=accepted, got %q", resp["status"])
+	}
+}
+
+func TestCreateMemory_AsyncMessages_DisableSessionSaveSkipsRawSession(t *testing.T) {
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{
+					"content": `{"facts":[{"text":"User likes green tea","tags":["preference"]}],"message_tags":[["preference"]]}`,
+				}},
+			},
+		})
+	}))
+	defer llmServer.Close()
+
+	llmClient := llm.New(llm.Config{
+		APIKey:  "test-key",
+		BaseURL: llmServer.URL,
+		Model:   "test-model",
+	})
+
+	memRepo := &testMemoryRepo{}
+	sessRepo := &testSessionRepo{}
+	srv := NewServer(nil, nil, "", nil, llmClient, "", false, service.ModeSmart, "", slog.Default())
+	svc := resolvedSvc{
+		memory:  service.NewMemoryService(memRepo, llmClient, nil, "", service.ModeSmart),
+		ingest:  service.NewIngestService(memRepo, llmClient, nil, "", service.ModeSmart),
+		session: service.NewSessionService(sessRepo, nil, ""),
+	}
+	srv.svcCache.Store(tenantSvcKey("db-0x0"), svc)
+
+	body := map[string]any{
+		"messages": []map[string]string{
+			{"role": "user", "content": "I like green tea"},
+		},
+		"session_id":         "test-session",
+		"disableSessionSave": true,
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	deadline := time.Now().Add(time.Second)
+	var created int
+	for time.Now().Before(deadline) {
+		memRepo.mu.Lock()
+		created = len(memRepo.createCalls)
+		memRepo.mu.Unlock()
+		if created > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if created != 1 {
+		t.Fatalf("expected one extracted fact memory, got %d", created)
+	}
+
+	sessRepo.mu.Lock()
+	bulkCreateCalled := sessRepo.bulkCreateCalled
+	patchTagsCalled := sessRepo.patchTagsCalled
+	sessRepo.mu.Unlock()
+	if bulkCreateCalled {
+		t.Fatal("did not expect raw session BulkCreate when disableSessionSave=true")
+	}
+	if patchTagsCalled {
+		t.Fatal("did not expect session PatchTags when disableSessionSave=true")
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -512,6 +513,19 @@ func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	return srv
 }
 
+func TestHandleError_ClientCanceledUses499(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rr := httptest.NewRecorder()
+
+	srv.handleError(ctx, rr, fmt.Errorf("auto vector search: %w", context.Canceled))
+
+	if rr.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want %d: %s", rr.Code, statusClientClosedRequest, rr.Body.String())
+	}
+}
+
 func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 	sessionRepo := &testSessionRepo{
 		listResults: []domain.Memory{
@@ -551,6 +565,41 @@ func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 		sessionRepo.lastListFilter.Source != "cli" ||
 		len(sessionRepo.lastListFilter.Tags) != 2 {
 		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
+	}
+}
+
+func TestListMemories_ServerDisableSessionSaveSkipsSessionRows(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "sess-row-1",
+				Content:    "hello from a raw turn",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			},
+		},
+		listTotal: 1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo).WithDisableSessionSave(true)
+	req := makeRequest(t, http.MethodGet, "/memories?memory_type=session&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sessionRepo.listCalls != 0 {
+		t.Fatalf("session list calls = %d, want 0", sessionRepo.listCalls)
+	}
+	if resp.Total != 0 || len(resp.Memories) != 0 {
+		t.Fatalf("response = total:%d memories:%+v, want empty", resp.Total, resp.Memories)
 	}
 }
 
@@ -596,6 +645,41 @@ func TestListMemories_ChainSessionTypeListsSessionRowsWithoutQuery(t *testing.T)
 	}
 	if sessionRepo.lastListFilter.MemoryType != "session" || sessionRepo.lastListFilter.State != "active" {
 		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
+	}
+}
+
+func TestListMemories_ChainServerDisableSessionSaveSkipsSessionRows(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "sess-row-1",
+				Content:    "hello from a raw turn",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			},
+		},
+		listTotal: 1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo).WithDisableSessionSave(true)
+	req := makeChainRequestWithNodes(t, http.MethodGet, "/memories?memory_type=session&limit=10", nil, 2)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if sessionRepo.listCalls != 0 {
+		t.Fatalf("session list calls = %d, want 0", sessionRepo.listCalls)
+	}
+	if resp.Total != 0 || len(resp.Memories) != 0 {
+		t.Fatalf("response = total:%d memories:%+v, want empty", resp.Total, resp.Memories)
 	}
 }
 
@@ -3226,6 +3310,41 @@ func TestDefaultConfidenceRecallSearch_FansOutPoolSearchesConcurrently(t *testin
 	}
 	if gotMaxInFlight != 3 {
 		t.Fatalf("expected all 3 pool searches to overlap, max_in_flight=%d", gotMaxInFlight)
+	}
+}
+
+func TestListMemories_ServerDisableSessionSaveSkipsDefaultRecallSessionPool(t *testing.T) {
+	now := time.Now()
+	sessionCalls := 0
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			if filter.MemoryType == string(domain.TypeInsight) {
+				return []domain.Memory{
+					{ID: "m1", Content: "John likes Under Armour.", MemoryType: domain.TypeInsight, UpdatedAt: now, State: domain.StateActive},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			sessionCalls++
+			return []domain.Memory{
+				{ID: "s1", Content: "session result", MemoryType: domain.TypeSession, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	srv := newTestServer(memRepo, sessRepo).WithDisableSessionSave(true)
+	req := makeRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if sessionCalls != 0 {
+		t.Fatalf("session recall calls = %d, want 0", sessionCalls)
 	}
 }
 

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -189,16 +189,18 @@ func (s *Server) defaultConfidenceRecallSearch(
 		insightCandidates = candidates
 		return nil
 	})
-	group.Go(func() error {
-		branchStart := time.Now()
-		candidates, err := svc.session.SearchCandidates(groupCtx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
-		sessionDuration = time.Since(branchStart)
-		if err != nil {
-			return err
-		}
-		sessionCandidates = candidates
-		return nil
-	})
+	if !s.disableSessionSave {
+		group.Go(func() error {
+			branchStart := time.Now()
+			candidates, err := svc.session.SearchCandidates(groupCtx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
+			sessionDuration = time.Since(branchStart)
+			if err != nil {
+				return err
+			}
+			sessionCandidates = candidates
+			return nil
+		})
+	}
 	if err := group.Wait(); err != nil {
 		return nil, 0, err
 	}
@@ -265,6 +267,9 @@ func (s *Server) singlePoolConfidenceRecallSearch(
 	candidateStart := time.Now()
 	switch filter.MemoryType {
 	case string(domain.TypeSession):
+		if s.disableSessionSave {
+			return []domain.Memory{}, 0, nil
+		}
 		candidates, err = svc.session.SearchCandidates(ctx, effectiveFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
 	case string(domain.TypePinned):
 		candidates, err = svc.memory.SearchCandidates(ctx, effectiveFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -40,10 +40,11 @@ var formattedConversationMessageRE = regexp.MustCompile(`(?:^|\n\n)([A-Za-z][A-Z
 
 // IngestRequest is the input for the ingest pipeline.
 type IngestRequest struct {
-	Messages  []IngestMessage `json:"messages"`
-	SessionID string          `json:"session_id"`
-	AgentID   string          `json:"agent_id"`
-	Mode      IngestMode      `json:"mode"`
+	Messages           []IngestMessage `json:"messages"`
+	SessionID          string          `json:"session_id"`
+	AgentID            string          `json:"agent_id"`
+	Mode               IngestMode      `json:"mode"`
+	DisableSessionSave bool            `json:"disableSessionSave,omitempty"`
 }
 
 // IngestMessage represents a single conversation message.


### PR DESCRIPTION
## Summary

- extend `MNEMO_DISABLE_SESSION_SAVE` so raw session rows do not participate in `/memories` recall/list paths
- skip session fan-out in default confidence recall and return empty results for explicit `memory_type=session` when the server switch is enabled
- map client-canceled request contexts to HTTP 499 instead of logging them as internal 500s

## Why

Local logs showed `GET /memories` requests reaching client cancellation around 30s while session recall was still running despite `MNEMO_DISABLE_SESSION_SAVE=true`. This keeps the switch aligned with the intended facts-only mode and makes canceled requests easier to distinguish from server failures.

## Validation

- `cd server && go test -race -count=1 ./internal/config/`
- `cd server && go test -race -count=1 ./internal/handler/`
- `cd server && go test -race -count=1 ./internal/service/`