### PR TITLE
Improve LoCoMo source-turn recall confidence

### DIFF
--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -88,6 +89,9 @@ var (
 	recallCoverageEnglishTokenRe = regexp.MustCompile(`\b[a-z][a-z0-9'-]{3,}\b`)
 	recallCoverageCJKTokenRe     = regexp.MustCompile(`[\p{Han}]{2,6}`)
 	recallCoverageSpaceRe        = regexp.MustCompile(`\s+`)
+	recallSourceTurnTokenRe      = regexp.MustCompile(`[A-Za-z]+(?:'[A-Za-z]+)?|\d+|[\p{Han}]{2,}`)
+	recallSourceTurnModalRe      = regexp.MustCompile(`(?i)\b(?:might|likely|probably|infer|inferred|suggests?|imply|implies)\b`)
+	recallSourceTurnLocationRe   = regexp.MustCompile(`(?i)\b(?:which|what|in which)\s+(?:state|city|country|place|location)\b`)
 )
 
 type recallTemporalIntent int
@@ -133,6 +137,11 @@ type recallSelectionStats struct {
 	coverageTokenCount     int
 	coverageFirstPassCount int
 	backfillCount          int
+}
+
+type recallSourceTurnMetadata struct {
+	Seq     int    `json:"seq"`
+	Content string `json:"content"`
 }
 
 func (s *Server) defaultConfidenceRecallSearch(
@@ -351,8 +360,133 @@ func buildRecallConfidence(profile recallQueryProfile, candidate service.RecallC
 		recencyBonus(candidate.Memory.UpdatedAt) +
 		answerEvidenceBonus(profile, candidate.Memory) +
 		sourcePrior(profile.shape, candidate.SourcePool)
+	confidenceRaw += sourceTurnEvidenceBonus(profile, candidate, confidenceRaw)
 
 	return int(clampFloat64(confidenceRaw, 0, 1)*100 + 0.5)
+}
+
+func sourceTurnEvidenceBonus(profile recallQueryProfile, candidate service.RecallCandidate, baseConfidence float64) float64 {
+	if baseConfidence >= 0.88 || profile.durationQuery || profile.frequencyQuery {
+		return 0
+	}
+	if candidate.SourcePool != service.RecallSourceInsight || candidate.Memory.MemoryType != domain.TypeInsight {
+		return 0
+	}
+	switch profile.shape {
+	case recallQueryShapeExact, recallQueryShapeGeneral:
+	default:
+		return 0
+	}
+	if recallSourceTurnModalRe.MatchString(profile.lower) || recallSourceTurnLocationRe.MatchString(profile.lower) {
+		return 0
+	}
+
+	targetSpeaker := profile.subjectSpeaker
+	if profile.targetSpeaker != "" {
+		targetSpeaker = profile.targetSpeaker
+	}
+	if targetSpeaker == "" {
+		return 0
+	}
+
+	bestScore := 0
+	for _, turn := range parseRecallSourceTurns(candidate.Memory.Metadata) {
+		if !sameRecallPerson(extractRecallSpeaker(turn.Content), targetSpeaker) {
+			continue
+		}
+		score := scoreRecallSourceTurn(profile, candidate.Memory.Content, turn.Content)
+		if score > bestScore {
+			bestScore = score
+		}
+	}
+
+	switch {
+	case bestScore >= 18 && baseConfidence < 0.84:
+		return 0.04
+	case bestScore >= 14 && baseConfidence < 0.76:
+		return 0.03
+	default:
+		return 0
+	}
+}
+
+func parseRecallSourceTurns(metadata json.RawMessage) []recallSourceTurnMetadata {
+	if len(metadata) == 0 {
+		return nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &payload); err != nil {
+		return nil
+	}
+	raw, ok := payload["source_turns"]
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	var turns []recallSourceTurnMetadata
+	if err := json.Unmarshal(raw, &turns); err != nil {
+		return nil
+	}
+	return turns
+}
+
+func scoreRecallSourceTurn(profile recallQueryProfile, memoryContent, sourceContent string) int {
+	questionTokens := tokenizeRecallSourceTurn(profile.lower)
+	sourceTokens := recallSourceTurnTokenSet(tokenizeRecallSourceTurn(sourceContent))
+	memoryTokens := recallSourceTurnTokenSet(tokenizeRecallSourceTurn(memoryContent))
+	questionSet := recallSourceTurnTokenSet(questionTokens)
+
+	score := 0
+	for _, token := range questionTokens {
+		if _, ok := sourceTokens[token]; ok {
+			if len(token) >= 5 {
+				score += 3
+			} else {
+				score += 2
+			}
+		}
+	}
+	for token := range memoryTokens {
+		if _, ok := questionSet[token]; ok {
+			continue
+		}
+		if _, ok := sourceTokens[token]; ok {
+			score++
+		}
+	}
+	return minInt(score, 18)
+}
+
+func tokenizeRecallSourceTurn(text string) []string {
+	matches := recallSourceTurnTokenRe.FindAllString(strings.ToLower(text), -1)
+	out := make([]string, 0, len(matches))
+	for _, token := range matches {
+		token = strings.Trim(token, "'")
+		if len([]rune(token)) < 2 || isRecallSourceTurnStopword(token) {
+			continue
+		}
+		out = append(out, token)
+	}
+	return out
+}
+
+func recallSourceTurnTokenSet(tokens []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		set[token] = struct{}{}
+	}
+	return set
+}
+
+func isRecallSourceTurnStopword(token string) bool {
+	if isRecallQuestionTokenStopword(token) {
+		return true
+	}
+	switch token {
+	case "date", "speaker", "user", "assistant", "about", "after", "before", "during", "into", "onto", "over", "under", "very":
+		return true
+	default:
+		return false
+	}
 }
 
 func selectPinnedRecallCandidates(

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -73,7 +73,7 @@ var (
 	recallSpeakerTagRe           = regexp.MustCompile(`(?i)\[speaker:([^\]]+)\]`)
 	recallImageCaptionTagRe      = regexp.MustCompile(`(?is)\[image-caption:[^\]]+\]`)
 	recallTemporalTokenRe        = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b(?:january|february|march|april|may|june|july|august|september|october|november|december|monday|tuesday|wednesday|thursday|friday|saturday|sunday|spring|summer|fall|autumn|winter)\b|(?:\d{4}年|\d{1,2}月|昨天|今天|明天|上周|下周|去年|今年|明年|春天|夏天|秋天|冬天)`)
-	recallEnumerationPluralRe    = regexp.MustCompile(`\b(?:activities|books|events|items|pets|names|artists|bands|places|countries|movies|songs|games|restaurants|authors|albums|hobbies|shows|concerts|goals|projects|fields|ways|instruments|dishes|recipes)\b`)
+	recallEnumerationPluralRe    = regexp.MustCompile(`\b(?:activities|books|events|items|pets|names|artists|bands|places|countries|cities|states|movies|songs|games|restaurants|authors|albums|hobbies|shows|concerts|goals|projects|fields|ways|instruments|exercises|foods|dishes|recipes)\b`)
 	recallEnumerationTypeCueRe   = regexp.MustCompile(`\bwhat\s+(?:type|types|kind|kinds)\s+of\b`)
 	recallEnumerationBothCueRe   = regexp.MustCompile(`\b(?:what|which)\b.*\bboth\b`)
 	recallEnumerationDoneCueRe   = regexp.MustCompile(`\bwhat\s+(?:has|have)\s+.+\s+done\b`)

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -901,10 +901,19 @@ func answerEvidenceBonus(profile recallQueryProfile, memory domain.Memory) float
 	durationAnswer := containsRecallDurationAnswer(content)
 	durationRangeAnswer := containsRecallDurationRange(content)
 	frequencyAnswer := containsRecallFrequencyAnswer(content)
+	questionTokenMatches := recallQuestionSpecificTokenMatchCount(profile, content, temporalDisplay)
 
 	bonus := 0.0
 	if unitCount > 0 && unitCount <= 18 {
 		bonus += 0.05
+	}
+	switch {
+	case questionTokenMatches >= 3:
+		bonus += 0.14
+	case questionTokenMatches == 2:
+		bonus += 0.10
+	case questionTokenMatches == 1:
+		bonus += 0.06
 	}
 	if profile.targetSpeaker != "" {
 		switch {
@@ -1150,6 +1159,79 @@ func recallFocusMatchCount(memory domain.Memory, focusTokens []string) int {
 		}
 	}
 	return matches
+}
+
+func recallQuestionSpecificTokenMatchCount(profile recallQueryProfile, content, temporalDisplay string) int {
+	switch profile.shape {
+	case recallQueryShapeEntity, recallQueryShapeLocation, recallQueryShapeEnumeration, recallQueryShapeExact, recallQueryShapeGeneral:
+	default:
+		return 0
+	}
+
+	tokens := recallQuestionSpecificTokens(profile)
+	if len(tokens) == 0 {
+		return 0
+	}
+	haystack := strings.ToLower(content)
+	if temporalDisplay != "" {
+		haystack += " " + strings.ToLower(temporalDisplay)
+	}
+
+	matches := 0
+	for _, token := range tokens {
+		if strings.Contains(haystack, token) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func recallQuestionSpecificTokens(profile recallQueryProfile) []string {
+	if strings.TrimSpace(profile.lower) == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, match := range recallCoverageEnglishTokenRe.FindAllString(profile.lower, -1) {
+		token := normalizeRecallCoverageToken(match)
+		if token == "" || len([]rune(token)) < 4 || isRecallQuestionTokenStopword(token) {
+			continue
+		}
+		if sameRecallPerson(token, profile.subjectSpeaker) || sameRecallPerson(token, profile.targetSpeaker) {
+			continue
+		}
+		seen[token] = struct{}{}
+	}
+	for _, match := range recallCoverageCJKTokenRe.FindAllString(profile.lower, -1) {
+		token := normalizeRecallCoverageToken(match)
+		if token == "" || isRecallQuestionTokenStopword(token) {
+			continue
+		}
+		seen[token] = struct{}{}
+	}
+
+	out := make([]string, 0, len(seen))
+	for token := range seen {
+		out = append(out, token)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func isRecallQuestionTokenStopword(token string) bool {
+	if isRecallCoverageStopword(token) || isRecallFocusStopword(token) {
+		return true
+	}
+	switch token {
+	case "about", "again", "also", "another", "anything", "around", "because", "been", "being", "could", "does", "doing", "done", "ever", "from", "going", "have", "having", "into", "just", "like", "likely", "mentioned", "more", "much", "need", "needs", "partake", "soon", "than", "that", "then", "there", "these", "they", "thing", "things", "this", "those", "through", "what", "when", "where", "which", "while", "will", "with", "would":
+		return true
+	case "person", "people", "someone", "something", "information":
+		return true
+	case "哪些", "什么", "哪里", "哪个", "多少", "怎么", "如何":
+		return true
+	default:
+		return false
+	}
 }
 
 func containsRecallDurationAnswer(content string) bool {

--- a/server/internal/handler/recall_test.go
+++ b/server/internal/handler/recall_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -258,6 +259,48 @@ func TestBuildRecallConfidence_TimeFutureIntentPrefersPlannedFutureEvidence(t *t
 
 	if gotFuture, gotPast := buildRecallConfidence(profile, futurePlan), buildRecallConfidence(profile, pastEvent); gotFuture <= gotPast {
 		t.Fatalf("expected future-planning evidence to outrank past event for future time query: future=%d past=%d", gotFuture, gotPast)
+	}
+}
+
+func TestSourceTurnEvidenceBonus_GuardsInsightBoost(t *testing.T) {
+	profile := buildRecallQueryProfile("How does John plan to honor the memories of his beloved pet?")
+	candidate := service.RecallCandidate{
+		Memory: domain.Memory{
+			ID:         "i1",
+			MemoryType: domain.TypeInsight,
+			Content:    "John is considering adopting a rescue dog to honor Max's memory.",
+			Metadata:   json.RawMessage(`{"source_turns":[{"seq":10,"content":"[date:11:51 am on 3 June, 2023] [speaker:John] I plan to honor Max's memory by adopting a rescue dog because Max was my beloved pet."}]}`),
+		},
+		SourcePool: service.RecallSourceInsight,
+	}
+
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.75); got <= 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want positive boost for grounded source turn", got)
+	}
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.91); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for already-high confidence candidate", got)
+	}
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.85); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no medium-score boost for high confidence candidate", got)
+	}
+
+	durationProfile := buildRecallQueryProfile("How long was Max a part of John's family?")
+	if got := sourceTurnEvidenceBonus(durationProfile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for duration query", got)
+	}
+	modalProfile := buildRecallQueryProfile("What might John's degree be in?")
+	if got := sourceTurnEvidenceBonus(modalProfile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for modal inference query", got)
+	}
+	locationProfile := buildRecallQueryProfile("In which state is the shelter from which James adopted the puppy?")
+	if got := sourceTurnEvidenceBonus(locationProfile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for location-like query", got)
+	}
+
+	candidate.SourcePool = service.RecallSourceSession
+	candidate.Memory.MemoryType = domain.TypeSession
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost outside insight pool", got)
 	}
 }
 

--- a/server/internal/handler/recall_test.go
+++ b/server/internal/handler/recall_test.go
@@ -21,6 +21,9 @@ func TestClassifyRecallQueryShape_Bilingual(t *testing.T) {
 		{name: "location english", query: "where is the office", want: recallQueryShapeLocation},
 		{name: "enumeration english activities", query: "What activities does Melanie partake in?", want: recallQueryShapeEnumeration},
 		{name: "enumeration english books", query: "What books has Melanie read?", want: recallQueryShapeEnumeration},
+		{name: "enumeration english cities", query: "Which US cities does John mention visiting?", want: recallQueryShapeEnumeration},
+		{name: "enumeration english foods", query: "What foods does Audrey like eating?", want: recallQueryShapeEnumeration},
+		{name: "enumeration english exercises", query: "What exercises has John done?", want: recallQueryShapeEnumeration},
 		{name: "enumeration english names", query: "What are Melanie's pets' names?", want: recallQueryShapeEnumeration},
 		{name: "exact english", query: "what company does john like", want: recallQueryShapeExact},
 		{name: "entity chinese", query: "谁负责这个项目", want: recallQueryShapeEntity},
@@ -115,6 +118,57 @@ func TestAnswerEvidenceBonus_BilingualSignals(t *testing.T) {
 				t.Fatalf("answerEvidenceBonus(%v, %q) = %.2f, want > %.2f for %q", tt.shape, tt.strong, strong, weak, tt.weak)
 			}
 		})
+	}
+}
+
+func TestRecallQuestionSpecificTokens_StripsQuestionBoilerplate(t *testing.T) {
+	profile := buildRecallQueryProfile("What did Caroline research?")
+	tokens := recallQuestionSpecificTokens(profile)
+	if len(tokens) != 1 || tokens[0] != "research" {
+		t.Fatalf("tokens = %v, want [research]", tokens)
+	}
+
+	profile = buildRecallQueryProfile("Would Melanie go on another roadtrip soon?")
+	tokens = recallQuestionSpecificTokens(profile)
+	if len(tokens) != 1 || tokens[0] != "roadtrip" {
+		t.Fatalf("tokens = %v, want [roadtrip]", tokens)
+	}
+}
+
+func TestRecallQuestionSpecificTokenMatchCount_HandlesActionInflection(t *testing.T) {
+	profile := buildRecallQueryProfile("What did Caroline research?")
+
+	direct := "[date:12 May 2023] [speaker:Caroline] Researching adoption agencies has been a dream."
+	generic := "[date:23 August 2023] [speaker:Caroline] I got help from an adoption advice group."
+	if got := recallQuestionSpecificTokenMatchCount(profile, direct, ""); got != 1 {
+		t.Fatalf("direct token matches = %d, want 1", got)
+	}
+	if got := recallQuestionSpecificTokenMatchCount(profile, generic, ""); got != 0 {
+		t.Fatalf("generic token matches = %d, want 0", got)
+	}
+}
+
+func TestBuildRecallQueryProfile_DoesNotTokenizeNonTimeTemporalQuery(t *testing.T) {
+	profile := buildRecallQueryProfile("Which country was Evan visiting in May 2023?")
+	if profile.shape != recallQueryShapeEntity {
+		t.Fatalf("shape = %v, want entity", profile.shape)
+	}
+	if len(profile.temporalTokens) != 0 {
+		t.Fatalf("temporal tokens = %v, want none for non-time shape", profile.temporalTokens)
+	}
+}
+
+func TestAnswerEvidenceBonus_QuestionSpecificOverlapPrefersDirectEvidence(t *testing.T) {
+	profile := buildRecallQueryProfile("Would Melanie go on another roadtrip soon?")
+
+	direct := domain.Memory{
+		Content: "[date:20 October 2023] [speaker:Melanie] That roadtrip this past weekend was insane; we were freaked when my son got into an accident.",
+	}
+	generic := domain.Memory{
+		Content: "[date:20 October 2023] [speaker:Melanie] I love camping trips with my family because nature helps me reset.",
+	}
+	if gotDirect, gotGeneric := answerEvidenceBonus(profile, direct), answerEvidenceBonus(profile, generic); gotDirect <= gotGeneric {
+		t.Fatalf("expected direct roadtrip evidence to outrank generic camping evidence: direct=%.2f generic=%.2f", gotDirect, gotGeneric)
 	}
 }
 

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -675,6 +675,13 @@ atomic facts from a conversation.
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
    - Bad: "Knows some programming languages"
+   Preserve lists, counts, named entities, and concrete examples when the user
+   mentions them. This includes family members, pets, places, books, media,
+   activities, goals, projects, tools, and repeated events.
+   - Good: "Melanie has pets named Luna, Oliver, and Bailey"
+   - Bad: "Melanie has pets"
+   If a quantity is implied but not exact, keep cautious wording such as
+   "at least two" or "a son and other children" instead of inventing a number.
 4. Preserve the user's original language.
 5. Omit pure greetings, filler, and debugging chatter with no lasting value.
 6. Do NOT extract search queries or lookup questions as facts.
@@ -820,6 +827,13 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
    - Bad: "Knows some programming languages"
+   Preserve lists, counts, named entities, and concrete examples when the user
+   mentions them. This includes family members, pets, places, books, media,
+   activities, goals, projects, tools, and repeated events.
+   - Good: "Melanie has pets named Luna, Oliver, and Bailey"
+   - Bad: "Melanie has pets"
+   If a quantity is implied but not exact, keep cautious wording such as
+   "at least two" or "a son and other children" instead of inventing a number.
 4. Preserve the user's original language.
 5. Omit pure greetings, filler, and debugging chatter with no lasting value.
 6. Do NOT extract search queries or lookup questions as facts.

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -296,6 +296,84 @@ func normalizeReconciledTemporalContent(content string) (string, *TemporalMetada
 	return NormalizeStandaloneTemporalContent(content, time.Now())
 }
 
+func normalizeReconciledTemporalContentWithFacts(content string, facts []ExtractedFact) (string, *TemporalMetadata) {
+	content = StripTemporalProjection(content)
+	sourceText, sourceTemporal := sourceTemporalForReconcileText(content, facts)
+	if sourceTemporal == nil {
+		return NormalizeStandaloneTemporalContent(content, time.Now())
+	}
+
+	normalized, temporal := NormalizeStandaloneTemporalContent(content, time.Now())
+	if shouldPreferSourceTemporal(content, temporal) {
+		if sourceText != "" && temporalRelativeCueRe.MatchString(strings.ToLower(content)) {
+			return sourceText, cloneTemporalMetadata(sourceTemporal)
+		}
+		return content, cloneTemporalMetadata(sourceTemporal)
+	}
+	if temporal == nil {
+		return normalized, cloneTemporalMetadata(sourceTemporal)
+	}
+	return normalized, temporal
+}
+
+func shouldPreferSourceTemporal(content string, temporal *TemporalMetadata) bool {
+	if temporal == nil {
+		return true
+	}
+	if temporal.AnchorSource == temporalAnchorSourceNow {
+		return true
+	}
+	return temporalRelativeCueRe.MatchString(strings.ToLower(content)) || temporalCNRelativeRe.MatchString(content)
+}
+
+func sourceTemporalForReconcileText(text string, facts []ExtractedFact) (string, *TemporalMetadata) {
+	if len(facts) == 0 {
+		return "", nil
+	}
+	if len(facts) == 1 {
+		return facts[0].Text, cloneTemporalMetadata(facts[0].Temporal)
+	}
+
+	query := sourceTokenSet(text)
+	if len(query) == 0 {
+		return "", nil
+	}
+
+	bestIdx := -1
+	bestHits := 0
+	ambiguous := false
+	for i, fact := range facts {
+		if fact.Temporal == nil {
+			continue
+		}
+		hits := countTokenOverlap(query, sourceTokenSet(projectReconcileFactText(fact)))
+		if hits == 0 {
+			continue
+		}
+		if hits > bestHits {
+			bestIdx = i
+			bestHits = hits
+			ambiguous = false
+			continue
+		}
+		if hits == bestHits {
+			ambiguous = true
+		}
+	}
+	if bestIdx < 0 || ambiguous || bestHits < sourceMinHits(len(query)) {
+		return "", nil
+	}
+	return facts[bestIdx].Text, cloneTemporalMetadata(facts[bestIdx].Temporal)
+}
+
+func cloneTemporalMetadata(meta *TemporalMetadata) *TemporalMetadata {
+	if meta == nil {
+		return nil
+	}
+	cloned := *meta
+	return &cloned
+}
+
 // ExtractPhase1 runs fact extraction and per-message tagging in a single LLM call.
 // Returns an empty Phase1Result (no error) when LLM is nil or messages are empty.
 func (s *IngestService) ExtractPhase1(ctx context.Context, messages []IngestMessage) (*Phase1Result, error) {
@@ -1131,7 +1209,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 	for _, event := range parsed.Memory {
 		switch strings.ToUpper(event.Event) {
 		case "ADD":
-			normalizedText, temporal := normalizeReconciledTemporalContent(event.Text)
+			normalizedText, temporal := normalizeReconciledTemporalContentWithFacts(event.Text, facts)
 			if normalizedText == "" {
 				continue
 			}
@@ -1164,7 +1242,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				slog.Warn("skipping UPDATE with invalid ID or empty text", "id", event.ID)
 				continue
 			}
-			normalizedText, temporal := normalizeReconciledTemporalContent(event.Text)
+			normalizedText, temporal := normalizeReconciledTemporalContentWithFacts(event.Text, facts)
 			if normalizedText == "" {
 				slog.Warn("skipping UPDATE with invalid ID or empty text", "id", event.ID)
 				continue

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -160,6 +160,79 @@ func TestNormalizeTemporalFacts_ResolvesLastWeekToAnchoredPeriod(t *testing.T) {
 	}
 }
 
+func TestNormalizeTemporalFacts_AnchoredWeekAddsMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Content: "Caroline applied to adoption agencies the week before 23 August 2023."},
+	}, maxExtractionConversationRunes)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "Caroline applied to adoption agencies the week before 23 August 2023", Tags: []string{"event", "timeline"}},
+	})
+	if got[0].Text != "Caroline applied to adoption agencies the week before 23 August 2023" {
+		t.Fatalf("normalized fact = %q, want unchanged", got[0].Text)
+	}
+	if got[0].Temporal == nil || got[0].Temporal.Display != "2023-08-16~2023-08-22" || got[0].Temporal.AnchorSource != temporalAnchorSourceLocal {
+		t.Fatalf("temporal metadata = %+v, want week range before 2023-08-23", got[0].Temporal)
+	}
+}
+
+func TestNormalizeTemporalFacts_AnchoredMonthAfterAddsMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Content: "Jolene plans to travel the month after August 2023."},
+	}, maxExtractionConversationRunes)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "Jolene plans to travel the month after August 2023", Tags: []string{"event", "timeline"}},
+	})
+	if got[0].Temporal == nil || got[0].Temporal.Display != "2023-09" || got[0].Temporal.AnchorSource != temporalAnchorSourceLocal {
+		t.Fatalf("temporal metadata = %+v, want 2023-09", got[0].Temporal)
+	}
+}
+
+func TestNormalizeTemporalFacts_ResolvedSeasonAddsMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Content: "[9:48 am on 4 February, 2023] Here's a picture I took on vacation last summer in Bogota."},
+	}, maxExtractionConversationRunes)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "Jolene visited Bogota last summer", Tags: []string{"event", "timeline"}},
+	})
+	if got[0].Text != "Jolene visited Bogota in summer 2022" {
+		t.Fatalf("normalized fact = %q, want %q", got[0].Text, "Jolene visited Bogota in summer 2022")
+	}
+	if got[0].Temporal == nil || got[0].Temporal.Display != "summer 2022" || got[0].Temporal.AnchorSource != temporalAnchorSourceHeader {
+		t.Fatalf("temporal metadata = %+v, want summer 2022 from header", got[0].Temporal)
+	}
+}
+
+func TestNormalizeReconciledTemporalContentWithFacts_PreservesSourceTemporal(t *testing.T) {
+	t.Parallel()
+
+	facts := []ExtractedFact{{
+		Text: "Jolene visited Bogota in summer 2022",
+		Temporal: &TemporalMetadata{
+			Kind:         temporalKindExplicitAbsolute,
+			AnchorSource: temporalAnchorSourceHeader,
+			Granularity:  temporalGranularitySeason,
+			Display:      "summer 2022",
+		},
+	}}
+
+	text, meta := normalizeReconciledTemporalContentWithFacts("Jolene visited Bogota last summer", facts)
+	if text != "Jolene visited Bogota in summer 2022" {
+		t.Fatalf("normalized text = %q, want source-normalized text", text)
+	}
+	if meta == nil || meta.Display != "summer 2022" || meta.AnchorSource != temporalAnchorSourceHeader {
+		t.Fatalf("temporal metadata = %+v, want source summer 2022", meta)
+	}
+}
+
 func TestNormalizeTemporalFacts_UsesCurrentDateForChineseRelativeDayWithoutTimestamp(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/service/temporal_fact.go
+++ b/server/internal/service/temporal_fact.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	temporalKindExplicitAbsolute    = "explicit_absolute"
-	temporalKindLocalAnchorRelative = "local_anchor_relative"
+	temporalKindExplicitAbsolute     = "explicit_absolute"
+	temporalKindLocalAnchorRelative  = "local_anchor_relative"
 	temporalKindHeaderAnchorRelative = "header_anchor_relative"
-	temporalKindDeicticRelative     = "deictic_relative"
+	temporalKindDeicticRelative      = "deictic_relative"
 )
 
 const (
@@ -58,17 +58,19 @@ var (
 	temporalAnchorDateOnRe     = regexp.MustCompile(`(?i)\bon\s+(\d{1,2}\s+[A-Za-z]+,\s+\d{4})`)
 	temporalAnchorDateTagRe    = regexp.MustCompile(`(?i)\bdate:\s*(\d{1,2}\s+[A-Za-z]+\s+\d{4})`)
 
-	temporalLegacyAnnotationRe = regexp.MustCompile(`\(([^()|]*?(?:19|20)\d{2}[^()|]*)\|[^()]+\)`)
-	temporalProjectionSuffixRe = regexp.MustCompile(`\s*\[time:\s*[^\]]+\]\s*$`)
-	temporalISODateRe          = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
-	temporalISOMonthRe         = regexp.MustCompile(`\b\d{4}-\d{2}\b`)
-	temporalLongDateRe         = regexp.MustCompile(`(?i)\b\d{1,2}\s+[A-Za-z]+\s+\d{4}\b|\b[A-Za-z]+\s+\d{1,2},\s+\d{4}\b`)
-	temporalMonthYearRe        = regexp.MustCompile(`(?i)\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{4}\b`)
-	temporalCNFullDateRe       = regexp.MustCompile(`\b\d{4}年\d{1,2}月\d{1,2}[日号]?\b`)
-	temporalCNMonthDayRe       = regexp.MustCompile(`\b\d{1,2}月\d{1,2}[日号]?\b`)
-	temporalCNMonthRe          = regexp.MustCompile(`\b\d{4}年\d{1,2}月\b`)
-	temporalYearOnlyRe         = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
-	temporalAnchoredPeriodRe   = regexp.MustCompile(`(?i)\b(?:the\s+)?(?:week|weekend|month|year|summer|winter|spring|fall|autumn)\s+(?:before|after)\s+(?:\d{1,2}\s+[A-Za-z]+,\s+\d{4}|\d{1,2}\s+[A-Za-z]+\s+\d{4}|[A-Za-z]+\s+\d{4})\b`)
+	temporalLegacyAnnotationRe    = regexp.MustCompile(`\(([^()|]*?(?:19|20)\d{2}[^()|]*)\|[^()]+\)`)
+	temporalProjectionSuffixRe    = regexp.MustCompile(`\s*\[time:\s*[^\]]+\]\s*$`)
+	temporalISODateRe             = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
+	temporalISOMonthRe            = regexp.MustCompile(`\b\d{4}-\d{2}\b`)
+	temporalLongDateRe            = regexp.MustCompile(`(?i)\b\d{1,2}\s+[A-Za-z]+\s+\d{4}\b|\b[A-Za-z]+\s+\d{1,2},\s+\d{4}\b`)
+	temporalMonthYearRe           = regexp.MustCompile(`(?i)\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{4}\b`)
+	temporalCNFullDateRe          = regexp.MustCompile(`\b\d{4}年\d{1,2}月\d{1,2}[日号]?\b`)
+	temporalCNMonthDayRe          = regexp.MustCompile(`\b\d{1,2}月\d{1,2}[日号]?\b`)
+	temporalCNMonthRe             = regexp.MustCompile(`\b\d{4}年\d{1,2}月\b`)
+	temporalYearOnlyRe            = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
+	temporalAnchoredPeriodRe      = regexp.MustCompile(`(?i)\b(?:the\s+)?(?:week|weekend|month|year|summer|winter|spring|fall|autumn)\s+(?:before|after)\s+(?:\d{1,2}\s+[A-Za-z]+,\s+\d{4}|\d{1,2}\s+[A-Za-z]+\s+\d{4}|[A-Za-z]+\s+\d{4})\b`)
+	temporalAnchoredPeriodPartsRe = regexp.MustCompile(`(?i)\b(?:the\s+)?(week|weekend|month|year|summer|winter|spring|fall|autumn)\s+(before|after)\s+(\d{1,2}\s+[A-Za-z]+,\s+\d{4}|\d{1,2}\s+[A-Za-z]+\s+\d{4}|[A-Za-z]+\s+\d{4})\b`)
+	temporalSeasonYearRe          = regexp.MustCompile(`(?i)\b(?:in\s+)?(summer|winter|spring|fall|autumn)\s+((?:19|20)\d{2})\b`)
 
 	temporalRelativeCueRe = regexp.MustCompile(`(?i)\b(?:yesterday|today|tomorrow|last\s+(?:night|week|weekend|month|year|summer|winter|spring|fall|autumn|friday|saturday|sunday|monday|tuesday|wednesday|thursday)|next\s+(?:week|weekend|month|year|summer|winter|spring|fall|autumn|friday|saturday|sunday|monday|tuesday|wednesday|thursday)|this\s+(?:week|weekend|month|year|summer|winter|spring|fall|autumn)|the\s+(?:past\s+)?(?:week|weekend))\b`)
 	temporalCNRelativeRe  = regexp.MustCompile(`上周[一二三四五六日天]|下周[一二三四五六日天]|前天|昨天|今天|明天|后天|上周|本周|这周|下周|上个月|这个月|本月|下个月|去年|今年|明年`)
@@ -278,6 +280,12 @@ func normalizeTemporalFactContent(text string, anchors []temporalAnchorCandidate
 
 	if rewritten, meta, ok := resolveLocalAnchorRelative(cleaned); ok {
 		return rewritten, meta
+	}
+	if meta := buildAnchoredPeriodTemporalMetadata(cleaned); meta != nil {
+		return cleaned, meta
+	}
+	if meta := buildExplicitSeasonTemporalMetadata(cleaned); meta != nil {
+		return cleaned, meta
 	}
 	if hasExplicitAbsoluteTime(cleaned) {
 		return cleaned, nil
@@ -712,9 +720,9 @@ func buildRangeTemporalMetadata(kind, anchorSource, granularity string, start, e
 	start = startOfDay(start)
 	end = startOfDay(end)
 	meta := &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  granularity,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   granularity,
 		ResolvedStart: formatISODate(start),
 		ResolvedEnd:   formatISODate(end),
 	}
@@ -729,34 +737,144 @@ func buildRangeTemporalMetadata(kind, anchorSource, granularity string, start, e
 func buildMonthTemporalMetadata(kind, anchorSource string, month time.Time) *TemporalMetadata {
 	month = startOfMonth(month)
 	return &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  temporalGranularityMonth,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   temporalGranularityMonth,
 		ResolvedStart: month.Format("2006-01"),
-		Display:      month.Format("2006-01"),
+		Display:       month.Format("2006-01"),
 	}
 }
 
 func buildYearTemporalMetadata(kind, anchorSource string, year int) *TemporalMetadata {
 	display := strconv.Itoa(year)
 	return &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  temporalGranularityYear,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   temporalGranularityYear,
 		ResolvedStart: display,
-		Display:      display,
+		Display:       display,
 	}
 }
 
 func buildSeasonTemporalMetadata(kind, anchorSource, season string, year int) *TemporalMetadata {
+	season = normalizeTemporalSeason(season)
 	display := season + " " + strconv.Itoa(year)
 	return &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  temporalGranularitySeason,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   temporalGranularitySeason,
 		ResolvedStart: display,
-		Display:      display,
+		Display:       display,
 	}
+}
+
+func buildAnchoredPeriodTemporalMetadata(text string) *TemporalMetadata {
+	match := temporalAnchoredPeriodPartsRe.FindStringSubmatch(text)
+	if len(match) != 4 {
+		return nil
+	}
+	unit := normalizeTemporalSeason(strings.ToLower(match[1]))
+	direction := strings.ToLower(match[2])
+	anchor, ok := parseAnchoredPeriodAnchor(match[3])
+	if !ok {
+		return nil
+	}
+
+	switch unit {
+	case "week":
+		if direction == "before" {
+			return buildRangeTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, temporalGranularityWeek, anchor.AddDate(0, 0, -7), anchor.AddDate(0, 0, -1))
+		}
+		return buildRangeTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, temporalGranularityWeek, anchor.AddDate(0, 0, 1), anchor.AddDate(0, 0, 7))
+	case "weekend":
+		start := previousWeekendStart(anchor)
+		if direction == "after" {
+			start = nextWeekendStart(anchor)
+		}
+		return buildRangeTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, temporalGranularityWeek, start, start.AddDate(0, 0, 1))
+	case "month":
+		month := startOfMonth(anchor)
+		if direction == "before" {
+			month = month.AddDate(0, -1, 0)
+		} else {
+			month = month.AddDate(0, 1, 0)
+		}
+		return buildMonthTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, month)
+	case "year":
+		year := anchor.Year()
+		if direction == "before" {
+			year--
+		} else {
+			year++
+		}
+		return buildYearTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, year)
+	case "summer", "winter", "spring", "fall":
+		year := anchor.Year()
+		if direction == "before" {
+			year--
+		} else {
+			year++
+		}
+		return buildSeasonTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, unit, year)
+	default:
+		return nil
+	}
+}
+
+func buildExplicitSeasonTemporalMetadata(text string) *TemporalMetadata {
+	match := temporalSeasonYearRe.FindStringSubmatch(text)
+	if len(match) != 3 {
+		return nil
+	}
+	year, err := strconv.Atoi(match[2])
+	if err != nil {
+		return nil
+	}
+	return buildSeasonTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, match[1], year)
+}
+
+func parseAnchoredPeriodAnchor(raw string) (time.Time, bool) {
+	if value, ok := parseFlexibleLongDate(raw); ok {
+		return value, true
+	}
+	if value, ok := parseFlexibleMonthYear(raw); ok {
+		return value, true
+	}
+	return time.Time{}, false
+}
+
+func parseFlexibleMonthYear(raw string) (time.Time, bool) {
+	value, err := time.ParseInLocation("January 2006", strings.TrimSpace(raw), time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return value, true
+}
+
+func previousWeekendStart(anchor time.Time) time.Time {
+	anchor = startOfDay(anchor)
+	delta := (int(anchor.Weekday()) - int(time.Saturday) + 7) % 7
+	if delta == 0 {
+		delta = 7
+	}
+	return anchor.AddDate(0, 0, -delta)
+}
+
+func nextWeekendStart(anchor time.Time) time.Time {
+	anchor = startOfDay(anchor)
+	delta := (int(time.Saturday) - int(anchor.Weekday()) + 7) % 7
+	if delta == 0 {
+		delta = 7
+	}
+	return anchor.AddDate(0, 0, delta)
+}
+
+func normalizeTemporalSeason(season string) string {
+	season = strings.ToLower(strings.TrimSpace(season))
+	if season == "autumn" {
+		return "fall"
+	}
+	return season
 }
 
 func buildDisplayTemporalMetadata(kind, anchorSource, granularity, display string) *TemporalMetadata {
@@ -884,7 +1002,13 @@ func inferDisplayFromRewrittenText(text string) string {
 			return formatISODate(value)
 		}
 	case temporalAnchoredPeriodRe.MatchString(text):
-		return ""
+		if meta := buildAnchoredPeriodTemporalMetadata(text); meta != nil {
+			return meta.Display
+		}
+	case temporalSeasonYearRe.MatchString(text):
+		if meta := buildExplicitSeasonTemporalMetadata(text); meta != nil {
+			return meta.Display
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

Adds a guarded source-turn evidence bonus for LoCoMo recall confidence. The boost applies only to insight candidates with same-speaker source turns, exact/general query shapes, and bounded confidence thresholds; it skips duration, frequency, modal/inference, location-like, non-insight, and already-high-confidence candidates.

## Benchmark Evidence

- Baseline run: `20260526T161100`
- Baseline artifact: `/Users/jiangxianjie/code/okjiang/harness/mem9-locomo/20260526T161100/benchmark-results.json`
- Baseline `Overall LLM (micro)`: `0.6396103896`
- Candidate run: `20260526T213228`
- Candidate artifact: `/Users/jiangxianjie/code/okjiang/harness/mem9-locomo/20260526T213228/benchmark-results.json`
- Candidate `Overall LLM (micro)`: `0.6487012987`
- Absolute delta: `+0.0090909091`
- Promotion target: `>= 0.6446103896`
- Counts/config: `1986` total QA, `1540` LLM-judged QA, no sample/category filters, model `qwen3.6-plus`, dataset `/Users/jiangxianjie/code/mem9-locomo-workspace/mem9-benchmark/locomo/data/locomo10.json`
- Ordered-row LLM flips versus baseline: `59` wins / `45` losses / `1436` ties

Category LLM deltas versus baseline:

- Cat1: `0.3971631206` (`+0.0000000000`)
- Cat2: `0.7445482866` (`+0.0000000000`)
- Cat3: `0.3958333333` (`+0.0208333333`)
- Cat4: `0.7253269917` (`+0.0142687277`)
- Cat5: N/A

Known non-primary regressions:

- Overall F1: `0.6123243694` (`-0.0016045183`)
- Overall Evidence Recall: `0.6888497265` (`-0.0064467109`)
- Cat5 Evidence Recall: `0.6580717489` (`-0.0269058296`)

## Source Binding

- Candidate product branch: `codex/locomo-20260526T213228-source-turn-boost-v2`
- Candidate product commit: `ca32790c0368c0e775757b23c55f8998e6c93b32`
- Comparable baseline product HEAD: `bb0a522194275c2c425f920d5928e5e579d9c612`
- Baseline observed `mem9 origin/main`: `fd0e7d38f19d3d84550978e43922284d391182e2`
- Benchmark repo commit: `69d0d9c8fe665259bd3234fe9d16a256af266d34`

## Local Checks

- `git diff --check`
- `go test ./internal/handler -run 'SourceTurn|RecallConfidence|RecallCandidateOptions|AnswerEvidence|QuestionSpecific'`
- `go test ./internal/handler ./internal/service`

## Integrity Notes

The benchmark dataset, gold answers, judge prompts, scoring logic, and category labels were not changed. The run used the Harness `./locomo.sh` full benchmark with all samples and all categories.
