### PR TITLE
[codex] Speed up Space Chain recall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ make build
 make vet
 make test
 make test-integration
+MNEMO_DSN="user:pass@tcp(host:4000)/db?parseTime=true" make dev
 
 # Single Go test
 cd server && go test -race -count=1 -run TestFunctionName ./internal/service/
@@ -62,6 +63,8 @@ cd cli && go build -o mnemo .
 
 # Run server locally
 cd server && MNEMO_DSN="user:pass@tcp(host:4000)/db?parseTime=true" go run ./cmd/mnemo-server
+# Run server locally with auto-restart on server code changes
+MNEMO_DSN="user:pass@tcp(host:4000)/db?parseTime=true" make dev
 ```
 
 ## Global conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,9 @@ mysql -h <host> -P <port> -u <user> -p < schema.sql
 # Run
 export MNEMO_DSN="user:pass@tcp(host:port)/mnemos?parseTime=true"
 go run ./cmd/mnemo-server
+
+# Or run from the repository root with auto-restart on server code changes
+MNEMO_DSN="user:pass@tcp(host:port)/mnemos?parseTime=true" make dev
 ```
 
 ### Claude Code Plugin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 IMG ?= $(REGISTRY)/mnemo-server:$(COMMIT)
 
-.PHONY: build vet clean run test test-cover test-integration docker
+.PHONY: build vet clean run dev test test-cover test-integration docker
 
 build:
 	mkdir -p $(MAKEFILE_DIR)/server/bin
@@ -30,6 +30,9 @@ clean:
 
 run: build
 	cd server && MNEMO_DSN="$(MNEMO_DSN)" ./bin/mnemo-server
+
+dev:
+	cd server && bash ./scripts/dev-watch.sh
 
 docker: build-linux
 	docker build --platform=linux/amd64 -q -f ./server/Dockerfile -t $(IMG) .

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ cd server
 MNEMO_DSN="user:pass@tcp(host:4000)/mnemos?parseTime=true" ./bin/mnemo-server
 ```
 
+For local development with automatic rebuild and restart on server source changes:
+
+```bash
+MNEMO_DSN="user:pass@tcp(host:4000)/mnemos?parseTime=true" make dev
+```
+
 For PostgreSQL or db9 deployments, export `MNEMO_DB_BACKEND=postgres` or `MNEMO_DB_BACKEND=db9` before launching the server.
 
 ### Docker

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -10,6 +10,7 @@ Go REST API server for mem9. This area owns HTTP routing, services, tenant provi
 
 ```bash
 make build
+make dev
 make vet
 make test
 make test-integration

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -7,6 +7,8 @@ import (
 	"sort"
 	"strings"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
@@ -152,50 +154,45 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 		perNodeFilter.Limit = requestLimit
 	}
 
-	for _, node := range auth.Chain.Nodes {
-		nodeAuth := chainNodeAuth(auth, node)
-		svc := s.resolveServices(nodeAuth)
-		visitedNodes++
-
-		var (
-			memories []domain.Memory
-			err      error
-		)
-		switch {
-		case perNodeFilter.Query != "" && perNodeFilter.MemoryType == "":
-			memories, _, err = s.defaultConfidenceRecallSearch(ctx, nodeAuth, svc, perNodeFilter)
-		case perNodeFilter.Query != "" && (perNodeFilter.MemoryType == string(domain.TypeSession) ||
-			perNodeFilter.MemoryType == string(domain.TypePinned) ||
-			perNodeFilter.MemoryType == string(domain.TypeInsight)):
-			memories, _, err = s.singlePoolConfidenceRecallSearch(ctx, nodeAuth, svc, perNodeFilter)
-		case perNodeFilter.MemoryType == string(domain.TypeSession):
-			memories, _, err = svc.session.List(ctx, perNodeFilter)
-		case perNodeFilter.MemoryType != string(domain.TypeSession):
-			memories, _, err = svc.memory.Search(ctx, perNodeFilter)
-		}
+	if scanAll {
+		results, err := s.listChainMemoriesScanAll(ctx, auth, perNodeFilter, profile, queryMode)
 		if err != nil {
 			return nil, 0, err
 		}
-		applyChainSource(memories, chainSource(auth, node))
-		visited = append(visited, memories...)
-
-		if queryMode {
-			nodeTopScore := topChainScore(memories)
-			if nodeTopScore > topScore {
-				topScore = nodeTopScore
+		visitedNodes = len(results)
+		for _, result := range results {
+			visited = append(visited, result.memories...)
+			topScore, stopConfidence, stopEligible, stopBlockedReason = updateChainRecallStats(
+				topScore,
+				stopConfidence,
+				stopEligible,
+				stopBlockedReason,
+				result,
+				queryMode,
+			)
+			if queryMode && result.decision.stop {
+				stopReason = "scan_all"
 			}
-			decision := chainRecallStopDecision(profile, memories, s.chainRecallStopScore)
-			if decision.confidence > stopConfidence {
-				stopConfidence = decision.confidence
+		}
+	} else {
+		for _, node := range auth.Chain.Nodes {
+			result, err := s.listChainNodeMemories(ctx, auth, node, perNodeFilter, profile, queryMode)
+			if err != nil {
+				return nil, 0, err
 			}
-			stopEligible = decision.eligible
-			stopBlockedReason = decision.blockedReason
-			if decision.stop && !scanAll {
+			visitedNodes++
+			visited = append(visited, result.memories...)
+			topScore, stopConfidence, stopEligible, stopBlockedReason = updateChainRecallStats(
+				topScore,
+				stopConfidence,
+				stopEligible,
+				stopBlockedReason,
+				result,
+				queryMode,
+			)
+			if queryMode && result.decision.stop {
 				stopReason = "threshold_hit"
 				break
-			}
-			if decision.stop && scanAll {
-				stopReason = "scan_all"
 			}
 		}
 	}
@@ -215,6 +212,100 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 		"returned", len(memories),
 	)
 	return memories, totalBeforePage, nil
+}
+
+type chainNodeMemoryResult struct {
+	memories []domain.Memory
+	topScore float64
+	decision chainRecallStopStatus
+}
+
+func (s *Server) listChainMemoriesScanAll(
+	ctx context.Context,
+	auth *domain.AuthInfo,
+	filter domain.MemoryFilter,
+	profile recallQueryProfile,
+	queryMode bool,
+) ([]chainNodeMemoryResult, error) {
+	results := make([]chainNodeMemoryResult, len(auth.Chain.Nodes))
+	group, groupCtx := errgroup.WithContext(ctx)
+	for i, node := range auth.Chain.Nodes {
+		i, node := i, node
+		group.Go(func() error {
+			result, err := s.listChainNodeMemories(groupCtx, auth, node, filter, profile, queryMode)
+			if err != nil {
+				return err
+			}
+			results[i] = result
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *Server) listChainNodeMemories(
+	ctx context.Context,
+	auth *domain.AuthInfo,
+	node domain.ChainAuthNode,
+	filter domain.MemoryFilter,
+	profile recallQueryProfile,
+	queryMode bool,
+) (chainNodeMemoryResult, error) {
+	nodeAuth := chainNodeAuth(auth, node)
+	svc := s.resolveServices(nodeAuth)
+
+	var (
+		memories []domain.Memory
+		err      error
+	)
+	switch {
+	case filter.Query != "" && filter.MemoryType == "":
+		memories, _, err = s.defaultConfidenceRecallSearch(ctx, nodeAuth, svc, filter)
+	case filter.Query != "" && (filter.MemoryType == string(domain.TypeSession) ||
+		filter.MemoryType == string(domain.TypePinned) ||
+		filter.MemoryType == string(domain.TypeInsight)):
+		memories, _, err = s.singlePoolConfidenceRecallSearch(ctx, nodeAuth, svc, filter)
+	case filter.MemoryType == string(domain.TypeSession):
+		memories, _, err = svc.session.List(ctx, filter)
+	case filter.MemoryType != string(domain.TypeSession):
+		memories, _, err = svc.memory.Search(ctx, filter)
+	}
+	if err != nil {
+		return chainNodeMemoryResult{}, err
+	}
+	applyChainSource(memories, chainSource(auth, node))
+
+	result := chainNodeMemoryResult{memories: memories}
+	if queryMode {
+		result.topScore = topChainScore(memories)
+		result.decision = chainRecallStopDecision(profile, memories, s.chainRecallStopScore)
+	}
+	return result, nil
+}
+
+func updateChainRecallStats(
+	topScore float64,
+	stopConfidence int,
+	stopEligible bool,
+	stopBlockedReason string,
+	result chainNodeMemoryResult,
+	queryMode bool,
+) (float64, int, bool, string) {
+	if !queryMode {
+		return topScore, stopConfidence, stopEligible, stopBlockedReason
+	}
+	if result.topScore > topScore {
+		topScore = result.topScore
+	}
+	if result.decision.confidence > stopConfidence {
+		stopConfidence = result.decision.confidence
+	}
+	stopEligible = result.decision.eligible
+	stopBlockedReason = result.decision.blockedReason
+	return topScore, stopConfidence, stopEligible, stopBlockedReason
 }
 
 type chainRecallStopStatus struct {

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1773,12 +1775,12 @@ func TestListMemories_ChainStopsAfterHighConfidenceByDefault(t *testing.T) {
 
 func TestListMemories_ChainScanAllContinuesPastHighConfidence(t *testing.T) {
 	now := time.Now()
-	calls := 0
+	var calls atomic.Int32
 	sessionRepo := &testSessionRepo{
 		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
-			calls++
+			call := calls.Add(1)
 			id := "session-memory-a"
-			if calls > 1 {
+			if call > 1 {
 				id = "session-memory-b"
 			}
 			return []domain.Memory{
@@ -1797,8 +1799,56 @@ func TestListMemories_ChainScanAllContinuesPastHighConfidence(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
 	}
-	if calls != 2 {
-		t.Fatalf("node searches = %d, want 2", calls)
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("node searches = %d, want 2", got)
+	}
+}
+
+func TestListMemories_ChainScanAllSearchesNodesConcurrently(t *testing.T) {
+	now := time.Now()
+	var calls atomic.Int32
+	started := make(chan int32, 2)
+	release := make(chan struct{})
+	sessionRepo := &testSessionRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			call := calls.Add(1)
+			started <- call
+			<-release
+			return []domain.Memory{
+				{ID: fmt.Sprintf("session-memory-%d", call), Content: "Bosn's timezone is Asia/Shanghai.", MemoryType: domain.TypeSession, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+
+	req := makeChainRequestWithNodes(t, http.MethodGet, "/memories?q=what%20timezone%20does%20Bosn%20use&memory_type=session&limit=10&scanAll=true", nil, 2)
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.listMemories(rr, req)
+	}()
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			close(release)
+			t.Fatalf("node search %d did not start before the first searches were released", i+1)
+		}
+	}
+	close(release)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("scanAll request did not finish after releasing node searches")
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("node searches = %d, want 2", got)
 	}
 }
 

--- a/server/internal/middleware/auth.go
+++ b/server/internal/middleware/auth.go
@@ -8,9 +8,11 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/encrypt"
@@ -70,6 +72,124 @@ func classifyConnError(blacklist map[string]struct{}, clusterID string, err erro
 		return "cluster_quota_exhausted"
 	}
 	return "connection_error"
+}
+
+type authResolutionError struct {
+	status  int
+	message string
+	err     error
+}
+
+func (e *authResolutionError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if e.err != nil {
+		return e.err.Error()
+	}
+	return e.message
+}
+
+func (e *authResolutionError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+func resolveSpaceChainAuthNodes(
+	ctx context.Context,
+	chainID string,
+	nodes []domain.SpaceChainNode,
+	tenantRepo repository.TenantRepo,
+	pool tenantDBGetter,
+	enc encrypt.Encryptor,
+	clusterBlacklist map[string]struct{},
+) ([]domain.ChainAuthNode, time.Duration, error) {
+	resolved := make([]domain.ChainAuthNode, len(nodes))
+	var totalPoolNanos atomic.Int64
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	for i, node := range nodes {
+		i, node := i, node
+		group.Go(func() error {
+			t, err := tenantRepo.GetByID(groupCtx, node.TenantID)
+			if err != nil || t == nil || t.DeletedAt != nil || t.Status != domain.TenantActive {
+				slog.ErrorContext(groupCtx, "space chain node tenant unavailable",
+					"chain_id", chainID,
+					"node_position", node.Position,
+					"tenant_id", node.TenantID,
+					"err", err)
+				return &authResolutionError{
+					status:  http.StatusServiceUnavailable,
+					message: "chain node tenant unavailable",
+					err:     err,
+				}
+			}
+
+			decryptedPassword, err := enc.Decrypt(groupCtx, t.DBPassword)
+			if err != nil {
+				return &authResolutionError{
+					status:  http.StatusInternalServerError,
+					message: "failed to decrypt tenant credentials",
+					err:     err,
+				}
+			}
+			t.DBPassword = decryptedPassword
+
+			poolStart := time.Now()
+			db, err := pool.Get(groupCtx, t.ID, t.DSNForBackend(pool.Backend()))
+			poolDuration := time.Since(poolStart)
+			totalPoolNanos.Add(int64(poolDuration))
+			if err != nil {
+				slog.ErrorContext(groupCtx, "cannot connect to space chain node database",
+					"chain_id", chainID,
+					"node_position", node.Position,
+					"tenant_id", t.ID,
+					"cluster_id", t.ClusterID,
+					"duration_ms", poolDuration.Milliseconds(),
+					"classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err),
+					"err", err)
+				switch {
+				case errors.Is(err, domain.ErrSchemaIncompatible):
+					return &authResolutionError{
+						status:  http.StatusConflict,
+						message: err.Error(),
+						err:     err,
+					}
+				case isBlacklistedSpendLimitError(clusterBlacklist, t.ClusterID, err):
+					return &authResolutionError{
+						status:  http.StatusTooManyRequests,
+						message: "cluster quota exhausted",
+						err:     err,
+					}
+				default:
+					return &authResolutionError{
+						status:  http.StatusServiceUnavailable,
+						message: "chain node tenant unavailable",
+						err:     err,
+					}
+				}
+			}
+
+			resolved[i] = domain.ChainAuthNode{
+				SpaceChainNode: node,
+				TenantDB:       db,
+				ClusterID:      t.ClusterID,
+			}
+			return nil
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, time.Duration(totalPoolNanos.Load()), err
+	}
+	return resolved, time.Duration(totalPoolNanos.Load()), nil
+}
+
+func isBlacklistedSpendLimitError(blacklist map[string]struct{}, clusterID string, err error) bool {
+	_, blocked := blacklist[clusterID]
+	return blocked && isSpendLimitError(err)
 }
 
 // ResolveTenant is middleware that extracts {tenantID} from the URL path,
@@ -259,56 +379,25 @@ func ResolveApiKey(
 					info.AgentName = agentID
 				}
 
-				var totalPoolDuration time.Duration
-				for _, node := range chain.Nodes {
-					t, err := tenantRepo.GetByID(r.Context(), node.TenantID)
-					if err != nil || t.DeletedAt != nil || t.Status != domain.TenantActive {
-						slog.ErrorContext(r.Context(), "space chain node tenant unavailable",
-							"chain_id", chain.ID,
-							"node_position", node.Position,
-							"tenant_id", node.TenantID,
-							"err", err)
+				nodes, totalPoolDuration, err := resolveSpaceChainAuthNodes(
+					r.Context(),
+					chain.ID,
+					chain.Nodes,
+					tenantRepo,
+					pool,
+					enc,
+					clusterBlacklist,
+				)
+				if err != nil {
+					var authErr *authResolutionError
+					if errors.As(err, &authErr) {
+						writeError(w, authErr.status, authErr.message)
+					} else {
 						writeError(w, http.StatusServiceUnavailable, "chain node tenant unavailable")
-						return
 					}
-
-					decryptedPassword, err := enc.Decrypt(r.Context(), t.DBPassword)
-					if err != nil {
-						writeError(w, http.StatusInternalServerError, "failed to decrypt tenant credentials")
-						return
-					}
-					t.DBPassword = decryptedPassword
-
-					poolStart := time.Now()
-					db, err := pool.Get(r.Context(), t.ID, t.DSNForBackend(pool.Backend()))
-					poolDuration := time.Since(poolStart)
-					totalPoolDuration += poolDuration
-					if err != nil {
-						slog.ErrorContext(r.Context(), "cannot connect to space chain node database",
-							"chain_id", chain.ID,
-							"node_position", node.Position,
-							"tenant_id", t.ID,
-							"cluster_id", t.ClusterID,
-							"duration_ms", poolDuration.Milliseconds(),
-							"classified_reason", classifyConnError(clusterBlacklist, t.ClusterID, err),
-							"err", err)
-						if errors.Is(err, domain.ErrSchemaIncompatible) {
-							writeError(w, http.StatusConflict, err.Error())
-							return
-						}
-						if _, blocked := clusterBlacklist[t.ClusterID]; blocked && isSpendLimitError(err) {
-							writeError(w, http.StatusTooManyRequests, "cluster quota exhausted")
-							return
-						}
-						writeError(w, http.StatusServiceUnavailable, "chain node tenant unavailable")
-						return
-					}
-					info.Chain.Nodes = append(info.Chain.Nodes, domain.ChainAuthNode{
-						SpaceChainNode: node,
-						TenantDB:       db,
-						ClusterID:      t.ClusterID,
-					})
+					return
 				}
+				info.Chain.Nodes = nodes
 
 				slog.InfoContext(r.Context(), "tenant auth resolved",
 					"auth_mode", "space_chain_key",

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -379,6 +379,93 @@ func TestResolveApiKey_PreservesAPIKeySubject(t *testing.T) {
 	}
 }
 
+func TestResolveApiKey_SpaceChainResolvesNodesConcurrently(t *testing.T) {
+	db := sql.OpenDB(pingOKConnector{})
+	defer db.Close()
+	release := make(chan struct{})
+	pool := &blockingChainPool{
+		db:      db,
+		started: make(chan string, 2),
+		release: release,
+	}
+	enc := encrypt.NewPlainEncryptor()
+	repo := stubTenantRepo{
+		tenants: map[string]*domain.Tenant{
+			"tenant-1": {
+				ID:       "tenant-1",
+				Status:   domain.TenantActive,
+				DBHost:   "127.0.0.1",
+				DBPort:   4000,
+				DBUser:   "user",
+				DBName:   "db1",
+				Provider: "tidb",
+			},
+			"tenant-2": {
+				ID:       "tenant-2",
+				Status:   domain.TenantActive,
+				DBHost:   "127.0.0.1",
+				DBPort:   4000,
+				DBUser:   "user",
+				DBName:   "db2",
+				Provider: "tidb",
+			},
+		},
+	}
+	chains := &stubSpaceChainRepo{
+		chain: &domain.SpaceChain{
+			ID: "chain-1",
+			Nodes: []domain.SpaceChainNode{
+				{ID: "node-1", ChainID: "chain-1", TenantID: "tenant-1", Position: 0},
+				{ID: "node-2", ChainID: "chain-1", TenantID: "tenant-2", Position: 1},
+			},
+		},
+	}
+
+	mw := ResolveApiKey(repo, pool, enc, nil, WithSpaceChainRepo(chains))
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		info := AuthFromContext(r.Context())
+		if info == nil || info.Chain == nil {
+			t.Fatal("chain auth info missing from context")
+		}
+		if len(info.Chain.Nodes) != 2 {
+			t.Fatalf("resolved nodes = %d, want 2", len(info.Chain.Nodes))
+		}
+		if info.Chain.Nodes[0].TenantID != "tenant-1" || info.Chain.Nodes[1].TenantID != "tenant-2" {
+			t.Fatalf("resolved node order = [%s %s], want [tenant-1 tenant-2]",
+				info.Chain.Nodes[0].TenantID,
+				info.Chain.Nodes[1].TenantID)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set(APIKeyHeader, domain.ChainKeyPrefix+"test")
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	var closeRelease sync.Once
+	defer closeRelease.Do(func() { close(release) })
+	go func() {
+		handler.ServeHTTP(rr, req)
+		close(done)
+	}()
+
+	first := waitForStartedTenant(t, pool.started)
+	second := waitForStartedTenant(t, pool.started)
+	if first == second {
+		t.Fatalf("pool.Get started tenant %q twice, want two distinct chain nodes", first)
+	}
+
+	closeRelease.Do(func() { close(release) })
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("request did not complete after releasing pool.Get calls")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d; body = %s", rr.Code, http.StatusNoContent, rr.Body.String())
+	}
+}
+
 func TestResolveApiKey_MD5Encryptor_DecryptsPassword(t *testing.T) {
 	pool := tenant.NewPool(tenant.PoolConfig{Backend: "tidb"})
 	defer pool.Close()
@@ -607,6 +694,107 @@ func (s stubPool) Get(_ context.Context, _ string, _ string) (*sql.DB, error) {
 }
 
 func (s stubPool) Backend() string { return "tidb" }
+
+type blockingChainPool struct {
+	db      *sql.DB
+	started chan string
+	release <-chan struct{}
+}
+
+func (p *blockingChainPool) Get(ctx context.Context, tenantID string, _ string) (*sql.DB, error) {
+	select {
+	case p.started <- tenantID:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-p.release:
+		return p.db, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *blockingChainPool) Backend() string { return "tidb" }
+
+func waitForStartedTenant(t *testing.T, started <-chan string) string {
+	t.Helper()
+	select {
+	case tenantID := <-started:
+		return tenantID
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("timed out waiting for concurrent chain node pool.Get")
+		return ""
+	}
+}
+
+type stubSpaceChainRepo struct {
+	chain *domain.SpaceChain
+	err   error
+}
+
+func (r *stubSpaceChainRepo) Create(context.Context, *domain.SpaceChain, *domain.SpaceChainBinding) error {
+	return nil
+}
+
+func (r *stubSpaceChainRepo) GetByID(context.Context, string) (*domain.SpaceChain, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.chain, nil
+}
+
+func (r *stubSpaceChainRepo) GetByKey(context.Context, string) (*domain.SpaceChain, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.chain, nil
+}
+
+func (r *stubSpaceChainRepo) GetByKeyIncludingDisabled(context.Context, string) (*domain.SpaceChain, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.chain, nil
+}
+
+func (r *stubSpaceChainRepo) Update(context.Context, *domain.SpaceChain) error { return nil }
+
+func (r *stubSpaceChainRepo) SoftDelete(context.Context, string, string) error { return nil }
+
+func (r *stubSpaceChainRepo) CreateBinding(context.Context, *domain.SpaceChainBinding) error {
+	return nil
+}
+
+func (r *stubSpaceChainRepo) ListBindings(context.Context, string) ([]domain.SpaceChainBinding, error) {
+	return nil, nil
+}
+
+func (r *stubSpaceChainRepo) DisableBinding(context.Context, string, string, string) error {
+	return nil
+}
+
+func (r *stubSpaceChainRepo) ListNodes(context.Context, string) ([]domain.SpaceChainNode, error) {
+	if r.chain == nil {
+		return nil, nil
+	}
+	return r.chain.Nodes, nil
+}
+
+func (r *stubSpaceChainRepo) ReplaceNodes(_ context.Context, _ string, nodes []domain.SpaceChainNode) error {
+	if r.chain != nil {
+		r.chain.Nodes = append([]domain.SpaceChainNode(nil), nodes...)
+	}
+	return nil
+}
+
+func (r *stubSpaceChainRepo) RemoveNodeByExternalSpaceID(context.Context, string) error {
+	return nil
+}
+
+func (r *stubSpaceChainRepo) KeyStatus(context.Context, string) (domain.KeyStatus, error) {
+	return "", nil
+}
 
 var spendLimitErr = errors.New("Error 1105 (HY000): Due to the usage quota being exhausted, access to the cluster has been restricted.")
 

--- a/server/scripts/dev-watch.sh
+++ b/server/scripts/dev-watch.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SERVER_DIR/.." && pwd)"
+BIN="${MNEMO_DEV_BIN:-$SERVER_DIR/bin/mnemo-server}"
+BUILD_TARGET="${MNEMO_DEV_BUILD_TARGET:-build}"
+WATCH_INTERVAL="${MNEMO_DEV_WATCH_INTERVAL:-1}"
+
+server_pid=""
+
+fingerprint() {
+  (
+    cd "$SERVER_DIR"
+    find . \
+      \( -path './bin' -o -path './coverage' -o -path './.tmp' -o -path './uploads' \) -prune -o \
+      \( -name '*.go' -o -name 'go.mod' -o -name 'go.sum' -o -name 'schema*.sql' \) -type f -print |
+      LC_ALL=C sort |
+      while IFS= read -r file; do
+        cksum "$file"
+      done
+  )
+}
+
+server_running() {
+  [[ -n "$server_pid" ]] && kill -0 "$server_pid" 2>/dev/null
+}
+
+stop_server() {
+  if ! server_running; then
+    server_pid=""
+    return
+  fi
+  echo "[dev] stopping mnemo-server pid=$server_pid"
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+  server_pid=""
+}
+
+build_server() {
+  echo "[dev] building via make $BUILD_TARGET"
+  make -C "$REPO_ROOT" "$BUILD_TARGET"
+}
+
+start_server() {
+  echo "[dev] starting $BIN"
+  (
+    cd "$SERVER_DIR"
+    "$BIN"
+  ) &
+  server_pid="$!"
+  echo "[dev] mnemo-server pid=$server_pid"
+}
+
+restart_server() {
+  if ! build_server; then
+    echo "[dev] build failed; keeping current server process"
+    return
+  fi
+  stop_server
+  start_server
+}
+
+cleanup() {
+  stop_server
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 0' INT TERM
+
+echo "[dev] watching server source for changes"
+echo "[dev] set MNEMO_DEV_WATCH_INTERVAL to change the ${WATCH_INTERVAL}s poll interval"
+
+last_fingerprint="$(fingerprint)"
+restart_server
+
+while true; do
+  sleep "$WATCH_INTERVAL"
+
+  if [[ -n "$server_pid" ]] && ! server_running; then
+    wait "$server_pid" 2>/dev/null || true
+    echo "[dev] mnemo-server exited; waiting for source changes before restarting"
+    server_pid=""
+  fi
+
+  next_fingerprint="$(fingerprint)"
+  if [[ "$next_fingerprint" != "$last_fingerprint" ]]; then
+    echo "[dev] change detected"
+    last_fingerprint="$next_fingerprint"
+    restart_server
+  fi
+done

--- a/site/src/content/docs.ts
+++ b/site/src/content/docs.ts
@@ -47,6 +47,229 @@ export interface DocsPageCopy {
   sections: DocsSection[];
 }
 
+const spaceChainDocsSections: Record<DocsLocale, DocsSection> = {
+  en: {
+    id: 'space-chains',
+    label: '10',
+    title: 'Space Chains',
+    intro: 'Space Chain lets one recall key search several mem9 spaces in a deliberate order.',
+    paragraphs: [
+      'Use Space Chain when one agent should search layered knowledge sources without merging all data into one space. A common pattern is personal memory first, then team knowledge, then company knowledge.',
+      'Each node in the chain points to a normal mem9 space. The chain key is a separate key: clients call the same memory recall API with the chain key, and mem9 decides which spaces to visit.',
+    ],
+    bullets: [
+      'Keep different ownership boundaries while still offering one recall endpoint.',
+      'Put the most specific or most trusted space first.',
+      'Reuse existing spaces without copying their memories into a new store.',
+      'Rotate or disable Space Chain keys without changing the underlying space keys.',
+    ],
+    subsections: [
+      {
+        title: 'How recall works',
+        paragraphs: [
+          'By default, recall visits nodes from top to bottom. If an early node returns a high-confidence match, mem9 can stop there and avoid searching later, broader spaces.',
+          'When Force scanAll is enabled, mem9 searches every node and globally reranks the combined results. This is useful when you want the broadest answer or you are comparing knowledge across all spaces.',
+        ],
+      },
+      {
+        title: 'Creating and importing chains',
+        bullets: [
+          'Create Space Chain starts a new ordered chain and gives you a chain key.',
+          'Import key adds an existing chain key to the console so you can manage or test a chain you already created.',
+          'Add nodes from existing spaces, then save the node order before relying on recall behavior.',
+          'Use the Recall test area to compare normal ordered recall with Force scanAll.',
+        ],
+      },
+      {
+        title: 'What to watch for',
+        bullets: [
+          'A chain node must be a normal mem9 space, not another Space Chain.',
+          'A node without a usable space key cannot participate in runtime recall.',
+          'If an imported space was created with an incompatible backend schema, recall may ask you to refresh or recreate that space before it can be searched.',
+        ],
+      },
+    ],
+  },
+  zh: {
+    id: 'space-chains',
+    label: '10',
+    title: 'Space Chain',
+    intro: 'Space Chain 让一个 recall key 按顺序搜索多个 mem9 space。',
+    paragraphs: [
+      '当一个 Agent 需要按层级检索多份知识，但你又不想把所有数据混进同一个 space 时，就适合使用 Space Chain。常见顺序是：个人记忆、团队知识、公司知识。',
+      '链上的每个节点都指向一个普通 mem9 space。chain key 是单独的 key：客户端继续调用同一套 memory recall API，只是把 `X-API-Key` 换成 chain key，由 mem9 决定要访问哪些 space。',
+    ],
+    bullets: [
+      '保留不同 space 的数据边界，同时提供一个统一 recall 入口。',
+      '把最具体、最可信的 space 放在前面。',
+      '复用已有 space，不需要把记忆复制到新的存储里。',
+      '可以单独轮换或禁用 Space Chain key，不影响底层 space key。',
+    ],
+    subsections: [
+      {
+        title: '召回时如何工作',
+        paragraphs: [
+          '默认情况下，recall 会从上到下访问节点。如果靠前节点已经返回高 confidence 结果，mem9 可以提前停止，避免继续搜索后面更宽泛的 space。',
+          '开启 Force scanAll 时，mem9 会搜索所有节点，并把所有结果合并后做全局 rerank。它适合需要最大覆盖面，或想比较全部 space 知识的场景。',
+        ],
+      },
+      {
+        title: '创建和导入 chain',
+        bullets: [
+          'Create Space Chain 会创建一条新的有序 chain，并返回一个 chain key。',
+          'Import key 可以把已有 chain key 加到 Console 中，用来管理或测试已经存在的 chain。',
+          '从已有 space 添加节点后，需要保存节点顺序，再依赖这个顺序做 recall。',
+          '使用 Recall test 区域对比普通顺序 recall 和 Force scanAll 的差异。',
+        ],
+      },
+      {
+        title: '需要注意什么',
+        bullets: [
+          'chain node 必须是普通 mem9 space，不能是另一个 Space Chain。',
+          '没有可用 space key 的节点无法参与 runtime recall。',
+          '如果导入的 space 使用了与当前后端不兼容的 schema，recall 可能会提示你刷新或重建该 space 后再搜索。',
+        ],
+      },
+    ],
+  },
+  ja: {
+    id: 'space-chains',
+    label: '10',
+    title: 'Space Chains',
+    intro: 'Space Chain は、1 つの recall key で複数の mem9 space を順番に検索する仕組みです。',
+    paragraphs: [
+      'すべてのデータを 1 つの space に混ぜずに、個人、チーム、会社のような層ごとの知識を検索したい場合に使います。',
+      '各 node は通常の mem9 space を指します。client は同じ memory recall API を chain key で呼び出し、mem9 が訪問する space を決めます。',
+    ],
+    bullets: [
+      'データ境界を保ったまま、1 つの recall endpoint を提供できます。',
+      'より具体的、または信頼度の高い space を先頭に置きます。',
+      '既存 space をコピーせずに再利用できます。',
+      '基盤の space key を変えずに chain key を rotate / disable できます。',
+    ],
+    subsections: [
+      {
+        title: 'Recall の動き',
+        paragraphs: [
+          '通常は node を上から順番に検索します。早い node で高 confidence の結果が見つかると、後続の広い space を検索せずに止められます。',
+          'Force scanAll を有効にすると、すべての node を検索し、結果をまとめて global rerank します。',
+        ],
+      },
+      {
+        title: '作成と import',
+        bullets: [
+          'Create Space Chain は新しい chain と chain key を作成します。',
+          'Import key は既存の chain key を Console に追加し、管理やテストに使います。',
+          '既存 space から node を追加したら、recall 前に node order を保存してください。',
+          'Recall test で通常の順次 recall と Force scanAll を比較できます。',
+        ],
+      },
+    ],
+  },
+  ko: {
+    id: 'space-chains',
+    label: '10',
+    title: 'Space Chains',
+    intro: 'Space Chain 은 하나의 recall key 로 여러 mem9 space 를 정해진 순서대로 검색합니다.',
+    paragraphs: [
+      '모든 데이터를 한 space 로 합치지 않고 개인, 팀, 회사 지식처럼 계층화된 지식을 검색하고 싶을 때 사용합니다.',
+      '각 node 는 일반 mem9 space 를 가리킵니다. client 는 같은 memory recall API 를 chain key 로 호출하고, mem9 가 어떤 space 를 방문할지 결정합니다.',
+    ],
+    bullets: [
+      '데이터 경계를 유지하면서 하나의 recall endpoint 를 제공할 수 있습니다.',
+      '가장 구체적이거나 신뢰할 수 있는 space 를 앞에 둡니다.',
+      '기존 space 의 memory 를 복사하지 않고 재사용합니다.',
+      '하위 space key 를 바꾸지 않고 Space Chain key 를 교체하거나 비활성화할 수 있습니다.',
+    ],
+    subsections: [
+      {
+        title: 'Recall 방식',
+        paragraphs: [
+          '기본 recall 은 node 를 위에서 아래로 검색합니다. 앞쪽 node 에서 confidence 가 높은 결과가 나오면 뒤쪽의 더 넓은 space 검색을 멈출 수 있습니다.',
+          'Force scanAll 을 켜면 모든 node 를 검색하고 합쳐진 결과를 전역으로 rerank 합니다.',
+        ],
+      },
+      {
+        title: '생성과 import',
+        bullets: [
+          'Create Space Chain 은 새 chain 과 chain key 를 만듭니다.',
+          'Import key 는 기존 chain key 를 Console 에 추가해 관리하거나 테스트할 수 있게 합니다.',
+          '기존 space 에서 node 를 추가한 뒤 recall 에 의존하기 전에 node order 를 저장하세요.',
+          'Recall test 에서 일반 순차 recall 과 Force scanAll 을 비교할 수 있습니다.',
+        ],
+      },
+    ],
+  },
+  id: {
+    id: 'space-chains',
+    label: '10',
+    title: 'Space Chains',
+    intro: 'Space Chain membuat satu recall key dapat mencari beberapa mem9 space dalam urutan yang disengaja.',
+    paragraphs: [
+      'Gunakan saat agent perlu mencari knowledge berlapis tanpa mencampur semua data ke satu space, misalnya personal memory, team knowledge, lalu company knowledge.',
+      'Setiap node menunjuk ke mem9 space biasa. Client tetap memanggil memory recall API yang sama dengan chain key, lalu mem9 menentukan space yang dikunjungi.',
+    ],
+    bullets: [
+      'Menjaga batas data antar space sambil menyediakan satu endpoint recall.',
+      'Letakkan space paling spesifik atau paling tepercaya di awal.',
+      'Gunakan ulang space yang sudah ada tanpa menyalin memory.',
+      'Rotasi atau nonaktifkan Space Chain key tanpa mengubah space key di bawahnya.',
+    ],
+    subsections: [
+      {
+        title: 'Cara recall bekerja',
+        paragraphs: [
+          'Secara default, recall mengunjungi node dari atas ke bawah. Jika node awal memberi hasil high-confidence, mem9 dapat berhenti sebelum mencari space yang lebih luas.',
+          'Saat Force scanAll aktif, mem9 mencari semua node lalu melakukan global rerank pada hasil gabungan.',
+        ],
+      },
+      {
+        title: 'Membuat dan import chain',
+        bullets: [
+          'Create Space Chain membuat chain baru dan chain key.',
+          'Import key menambahkan chain key yang sudah ada ke Console untuk dikelola atau diuji.',
+          'Tambahkan node dari space yang sudah ada, lalu simpan urutan node sebelum mengandalkan recall.',
+          'Gunakan Recall test untuk membandingkan recall berurutan dengan Force scanAll.',
+        ],
+      },
+    ],
+  },
+  th: {
+    id: 'space-chains',
+    label: '10',
+    title: 'Space Chains',
+    intro: 'Space Chain ทำให้ recall key เดียวค้นหา mem9 space หลายชุดตามลำดับที่กำหนดได้',
+    paragraphs: [
+      'เหมาะเมื่อ agent ต้องค้นหา knowledge หลายชั้นโดยไม่รวมข้อมูลทั้งหมดไว้ใน space เดียว เช่น personal memory, team knowledge และ company knowledge',
+      'แต่ละ node ชี้ไปยัง mem9 space ปกติ client ยังเรียก memory recall API เดิมด้วย chain key แล้ว mem9 จะตัดสินใจว่าจะค้นหา space ใดบ้าง',
+    ],
+    bullets: [
+      'คงขอบเขตข้อมูลของแต่ละ space แต่มี recall endpoint เดียว',
+      'วาง space ที่เฉพาะเจาะจงหรือเชื่อถือได้ที่สุดไว้ก่อน',
+      'ใช้ space เดิมซ้ำโดยไม่ต้องคัดลอก memory',
+      'หมุนเวียนหรือปิด Space Chain key ได้โดยไม่กระทบ space key ด้านล่าง',
+    ],
+    subsections: [
+      {
+        title: 'Recall ทำงานอย่างไร',
+        paragraphs: [
+          'ค่าเริ่มต้นจะค้นหา node จากบนลงล่าง หาก node แรก ๆ ให้ผลลัพธ์ confidence สูง mem9 สามารถหยุดก่อนค้นหา space ที่กว้างกว่าได้',
+          'เมื่อเปิด Force scanAll mem9 จะค้นหาทุก node แล้ว rerank ผลลัพธ์รวมทั้งหมด',
+        ],
+      },
+      {
+        title: 'สร้างและ import chain',
+        bullets: [
+          'Create Space Chain สร้าง chain ใหม่และ chain key',
+          'Import key เพิ่ม chain key ที่มีอยู่เข้า Console เพื่อจัดการหรือทดสอบ',
+          'เพิ่ม node จาก space เดิม แล้วบันทึกลำดับ node ก่อนใช้งาน recall จริง',
+          'ใช้ Recall test เพื่อเปรียบเทียบ recall ตามลำดับกับ Force scanAll',
+        ],
+      },
+    ],
+  },
+};
+
 export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
   en: {
     meta: {
@@ -83,6 +306,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'official-install-flow',
           'what-you-get-after-setup',
           'your-memory-dashboard',
+          'space-chains',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -306,9 +530,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      spaceChainDocsSections.en,
       {
         id: 'daily-usage-expectations',
-        label: '10',
+        label: '11',
         title: 'Daily Usage Expectations',
         paragraphs: [
           'The most immediate day-to-day change is that users stop repeating the same project background, preferences, and working agreements every session.',
@@ -334,7 +559,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '11',
+        label: '12',
         title: 'Reconnect, New Machine, and API Key Care',
         subsections: [
           {
@@ -362,7 +587,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '12',
+        label: '13',
         title: 'Uninstall Behavior',
         intro: 'Uninstalling mem9 affects the local machine setup, not the remote cloud data.',
         subsections: [
@@ -390,7 +615,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '13',
+        label: '14',
         title: 'Security and Trust',
         paragraphs: [
           'mem9 positions itself as a production-ready memory layer, not an opaque black box. The product story emphasizes clear data handling boundaries and production-grade cloud infrastructure.',
@@ -417,7 +642,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '14',
+        label: '15',
         title: 'Product Expectations and Limits',
         subsections: [
           {
@@ -439,7 +664,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '15',
+        label: '16',
         title: 'Recommended Path and Official Links',
         intro: 'For a new user, the cleanest sequence looks like this.',
         bullets: [
@@ -507,6 +732,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'official-install-flow',
           'what-you-get-after-setup',
           'your-memory-dashboard',
+          'space-chains',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -735,9 +961,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      spaceChainDocsSections.zh,
       {
         id: 'daily-usage-expectations',
-        label: '10',
+        label: '11',
         title: '日常使用时，mem9 会怎样改变体验',
         paragraphs: [
           '最直接的变化通常是：你不需要每次重新解释项目背景，长期知识不会只留在某次聊天里，而且你还能明确要求“把这件事记下来”。',
@@ -763,7 +990,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '11',
+        label: '12',
         title: '恢复、重连和 API key 保管',
         subsections: [
           {
@@ -791,7 +1018,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '12',
+        label: '13',
         title: '卸载时，会发生什么，不会发生什么',
         intro: '卸载影响的是本地配置，不会直接删除远端云数据。',
         subsections: [
@@ -819,7 +1046,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '13',
+        label: '14',
         title: '安全和信任基础',
         paragraphs: [
           'mem9 对自己的定位是面向生产场景的长期记忆层，而不是一个不可控黑盒。官方叙述强调的是清晰的数据处理边界，以及生产级云基础设施。',
@@ -846,7 +1073,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '14',
+        label: '15',
         title: '真实使用时，应该有什么预期',
         subsections: [
           {
@@ -868,7 +1095,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '15',
+        label: '16',
         title: '给新用户的推荐顺序和官方入口',
         intro: '如果你第一次使用 mem9，推荐路径可以很简单。',
         bullets: [
@@ -936,6 +1163,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'official-install-flow',
           'what-you-get-after-setup',
           'your-memory-dashboard',
+          'space-chains',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -1158,9 +1386,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      spaceChainDocsSections.ja,
       {
         id: 'daily-usage-expectations',
-        label: '10',
+        label: '11',
         title: '日常利用で mem9 が変えること',
         paragraphs: [
           'もっとも直接的な変化は、毎回同じプロジェクト背景や作業ルールを説明し直さなくてよくなることです。',
@@ -1186,7 +1415,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '11',
+        label: '12',
         title: 'reconnect・復元・API key の管理',
         subsections: [
           {
@@ -1214,7 +1443,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '12',
+        label: '13',
         title: 'uninstall で起きること / 起きないこと',
         intro: 'uninstall はローカル設定に影響しますが、クラウド上のデータは直接削除しません。',
         subsections: [
@@ -1242,7 +1471,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '13',
+        label: '14',
         title: 'セキュリティと信頼の基盤',
         paragraphs: [
           'mem9 は、制御不能なブラックボックスではなく、本番運用を前提とした長期記憶レイヤーとして位置づけられています。説明の中心は、明確なデータ処理境界と本番級クラウド基盤です。',
@@ -1269,7 +1498,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '14',
+        label: '15',
         title: '実運用での期待値',
         subsections: [
           {
@@ -1291,7 +1520,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '15',
+        label: '16',
         title: '新規ユーザー向けおすすめ順序と公式入口',
         intro: '初めて mem9 を使うなら、次の流れがもっともシンプルです。',
         bullets: [
@@ -1359,6 +1588,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'official-install-flow',
           'what-you-get-after-setup',
           'your-memory-dashboard',
+          'space-chains',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -1581,9 +1811,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      spaceChainDocsSections.ko,
       {
         id: 'daily-usage-expectations',
-        label: '10',
+        label: '11',
         title: '일상 사용에서 어떻게 달라지는가',
         paragraphs: [
           '가장 즉각적인 변화는 프로젝트 배경, 선호, 작업 규칙을 매번 다시 설명하지 않아도 된다는 점입니다.',
@@ -1609,7 +1840,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '11',
+        label: '12',
         title: '복구, reconnect, API key 관리',
         subsections: [
           {
@@ -1637,7 +1868,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '12',
+        label: '13',
         title: '제거 시 일어나는 일과 일어나지 않는 일',
         intro: 'uninstall은 로컬 설정에 영향을 주지만 원격 클라우드 데이터는 직접 삭제하지 않습니다.',
         subsections: [
@@ -1665,7 +1896,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '13',
+        label: '14',
         title: '보안과 신뢰의 기반',
         paragraphs: [
           'mem9는 통제 불가능한 블랙박스가 아니라, 프로덕션 장기 메모리 레이어로 자리매김합니다. 공식 설명의 중심은 명확한 데이터 처리 경계와 프로덕션급 클라우드 인프라입니다.',
@@ -1692,7 +1923,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '14',
+        label: '15',
         title: '실사용에서의 기대치와 한계',
         subsections: [
           {
@@ -1714,7 +1945,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '15',
+        label: '16',
         title: '신규 사용자를 위한 추천 순서와 공식 링크',
         intro: '처음 mem9를 사용하는 사용자에게는 다음 순서가 가장 단순합니다.',
         bullets: [
@@ -1782,6 +2013,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'official-install-flow',
           'what-you-get-after-setup',
           'your-memory-dashboard',
+          'space-chains',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -2010,9 +2242,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      spaceChainDocsSections.id,
       {
         id: 'daily-usage-expectations',
-        label: '10',
+        label: '11',
         title: 'Bagaimana mem9 mengubah pengalaman harian',
         paragraphs: [
           'Perubahan paling langsung biasanya adalah Anda tidak perlu lagi menjelaskan ulang latar belakang proyek, preferensi, dan aturan kerja di setiap sesi.',
@@ -2038,7 +2271,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '11',
+        label: '12',
         title: 'Reconnect, pemulihan, dan penyimpanan API key',
         subsections: [
           {
@@ -2066,7 +2299,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '12',
+        label: '13',
         title: 'Apa yang terjadi dan tidak terjadi saat uninstall',
         intro: 'Uninstall memengaruhi konfigurasi lokal, bukan menghapus data cloud dari jarak jauh.',
         subsections: [
@@ -2094,7 +2327,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '13',
+        label: '14',
         title: 'Fondasi keamanan dan kepercayaan',
         paragraphs: [
           'mem9 memosisikan diri sebagai lapisan memori jangka panjang untuk penggunaan produksi, bukan kotak hitam yang tidak terkontrol. Narasi resminya menekankan batas penanganan data yang jelas dan infrastruktur cloud kelas produksi.',
@@ -2121,7 +2354,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '14',
+        label: '15',
         title: 'Ekspektasi nyata dan batasan produk',
         subsections: [
           {
@@ -2143,7 +2376,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '15',
+        label: '16',
         title: 'Urutan yang direkomendasikan dan tautan resmi',
         intro: 'Untuk pengguna baru, urutan paling sederhana biasanya seperti ini.',
         bullets: [
@@ -2211,6 +2444,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'official-install-flow',
           'what-you-get-after-setup',
           'your-memory-dashboard',
+          'space-chains',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -2439,9 +2673,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      spaceChainDocsSections.th,
       {
         id: 'daily-usage-expectations',
-        label: '10',
+        label: '11',
         title: 'mem9 เปลี่ยนประสบการณ์การใช้งานประจำวันอย่างไร',
         paragraphs: [
           'ความเปลี่ยนแปลงที่ชัดที่สุดคือคุณไม่ต้องอธิบายพื้นหลังโปรเจกต์ ความชอบ และกติกาการทำงานซ้ำในทุก session',
@@ -2467,7 +2702,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '11',
+        label: '12',
         title: 'Reconnect การกู้คืน และการเก็บ API key',
         subsections: [
           {
@@ -2495,7 +2730,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '12',
+        label: '13',
         title: 'สิ่งที่จะเกิดขึ้นและไม่เกิดขึ้นเมื่อ uninstall',
         intro: 'การ uninstall มีผลกับการตั้งค่าในเครื่อง แต่ไม่ได้ลบข้อมูลคลาวด์จากระยะไกลโดยตรง',
         subsections: [
@@ -2523,7 +2758,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '13',
+        label: '14',
         title: 'พื้นฐานด้านความปลอดภัยและความน่าเชื่อถือ',
         paragraphs: [
           'mem9 วางตำแหน่งตัวเองเป็นเลเยอร์หน่วยความจำระยะยาวสำหรับงาน production ไม่ใช่กล่องดำที่ควบคุมไม่ได้ เรื่องราวทางการจึงเน้นขอบเขตการจัดการข้อมูลที่ชัดเจนและโครงสร้างพื้นฐานคลาวด์ระดับ production',
@@ -2550,7 +2785,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '14',
+        label: '15',
         title: 'ความคาดหวังจริงและขอบเขตของผลิตภัณฑ์',
         subsections: [
           {
@@ -2572,7 +2807,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '15',
+        label: '16',
         title: 'ลำดับที่แนะนำและลิงก์ทางการ',
         intro: 'สำหรับผู้ใช้ใหม่ ลำดับที่เรียบง่ายที่สุดมักเป็นดังนี้',
         bullets: [

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -377,7 +377,11 @@ const stableOnboardingCommand =
 const provisionKeyCode = 'curl -sX POST https://api.mem9.ai/v1alpha1/mem9s';
 const exportApiEnvCode = `export API_KEY="your-api-key"
 export API="https://api.mem9.ai/v1alpha2/mem9s"`;
+const exportChainApiEnvCode = `export CHAIN_API_KEY="your-chain-api-key"
+export API="https://api.mem9.ai/v1alpha2/mem9s"
+export CHAIN_API="https://api.mem9.ai/v1alpha2/space-chains"`;
 const healthCheckCode = 'curl -s https://api.mem9.ai/healthz';
+const versionCheckCode = 'curl -s https://api.mem9.ai/versionz';
 const createMemoryCode = `curl -sX POST "$API/memories" \\
   -H "Content-Type: application/json" \\
   -H "X-API-Key: $API_KEY" \\
@@ -393,6 +397,10 @@ const updateMemoryCode = `curl -sX PUT "$API/memories/{id}" \\
   -H "If-Match: 3" \\
   -d '{"content":"Project uses PostgreSQL 16","tags":["tech","database"]}'`;
 const deleteMemoryCode = 'curl -sX DELETE -H "X-API-Key: $API_KEY" "$API/memories/{id}"';
+const batchDeleteMemoryCode = `curl -sX POST "$API/memories/batch-delete" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $API_KEY" \\
+  -d '{"ids":["memory-id-1","memory-id-2"]}'`;
 const importMemoryFileCode = `curl -sX POST "$API/imports" \\
   -H "X-API-Key: $API_KEY" \\
   -F "file=@memory.json" \\
@@ -408,6 +416,36 @@ const listImportsCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/imports"';
 const getImportCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/imports/{id}"';
 const sessionMessagesCode =
   'curl -s -H "X-API-Key: $API_KEY" "$API/session-messages?session_id=ses-001&session_id=ses-002&limit_per_session=20"';
+const keyStatusCode = 'curl -s -H "X-API-Key: $API_KEY" https://api.mem9.ai/v1alpha2/status';
+const chainKeyStatusCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" https://api.mem9.ai/v1alpha2/status';
+const createSpaceChainCode = `curl -sX POST https://api.mem9.ai/v1alpha2/space-chains \\
+  -H "Content-Type: application/json" \\
+  -d '{"name":"Team Knowledge Chain","description":"Ordered recall across team spaces"}'`;
+const getSpaceChainByKeyCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$CHAIN_API/by-key"';
+const getSpaceChainCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$CHAIN_API/{chain_id}"';
+const updateSpaceChainCode = `curl -sX PATCH "$CHAIN_API/{chain_id}" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{"name":"Team Knowledge Chain","description":"Updated description"}'`;
+const deleteSpaceChainCode = `curl -sX DELETE "$CHAIN_API/{chain_id}" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{"deleted_by_user_id":"user-123"}'`;
+const listSpaceChainNodesCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$CHAIN_API/{chain_id}/nodes"';
+const replaceSpaceChainNodesCode = `curl -sX PUT "$CHAIN_API/{chain_id}/nodes" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{"nodes":[{"tenant_id":"space_key_a","display_name":"Team"},{"tenant_id":"space_key_b","display_name":"Company"}]}'`;
+const listSpaceChainBindingsCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$CHAIN_API/{chain_id}/bindings"';
+const createSpaceChainBindingCode = `curl -sX POST "$CHAIN_API/{chain_id}/bindings" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{}'`;
+const disableSpaceChainBindingCode = `curl -sX PATCH "$CHAIN_API/{chain_id}/bindings/{binding_id}" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{"disabled":true,"disabled_by_user_id":"user-123"}'`;
+const recallSpaceChainCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$API/memories?q=postgres&scanAll=true&limit=10"';
 
 const faqCopyByLocale: Record<SiteLocale, SiteFaqCopy> = {
   en: {
@@ -872,6 +910,15 @@ const hostedMultipartHeaders: SiteApiFieldCopy[] = [
   { name: 'X-Mnemo-Agent-Id', description: 'Optional agent identity header for attribution.' },
 ];
 
+const chainManagementHeaders: SiteApiFieldCopy[] = [
+  { name: 'X-API-Key', description: 'Active Space Chain API key for this chain.', required: true },
+];
+
+const chainJSONWriteHeaders: SiteApiFieldCopy[] = [
+  { name: 'X-API-Key', description: 'Active Space Chain API key for this chain.', required: true },
+  { name: 'Content-Type', description: 'Set to `application/json` for JSON request bodies.', required: true },
+];
+
 const memoryCreateBodyFields: SiteApiFieldCopy[] = [
   { name: 'content', description: 'Plain memory content for direct writes.' },
   { name: 'messages', description: 'Conversation messages for ingest-based writes.' },
@@ -893,12 +940,21 @@ const memoryListQueryParams: SiteApiFieldCopy[] = [
   { name: 'session_id', description: 'Filter by session id.' },
   { name: 'limit', description: 'Page size. The handler caps large values.' },
   { name: 'offset', description: 'Offset for pagination.' },
+  {
+    name: 'scanAll',
+    description:
+      'Space Chain keys only. When true, recall searches every node and globally reranks the merged facts.',
+  },
 ];
 
 const memoryUpdateBodyFields: SiteApiFieldCopy[] = [
   { name: 'content', description: 'Updated memory content.' },
   { name: 'tags', description: 'Updated tag array.' },
   { name: 'metadata', description: 'Updated JSON metadata payload.' },
+];
+
+const batchDeleteBodyFields: SiteApiFieldCopy[] = [
+  { name: 'ids', description: 'Array of memory ids to delete.', required: true },
 ];
 
 const importBodyFields: SiteApiFieldCopy[] = [
@@ -919,6 +975,15 @@ const provisionResponseFields: SiteApiFieldCopy[] = [
 
 const healthResponseFields: SiteApiFieldCopy[] = [
   { name: 'status', description: 'Health status string. Hosted service returns `ok`.', required: true },
+];
+
+const versionResponseFields: SiteApiFieldCopy[] = [
+  { name: 'go_version', description: 'Go runtime version used by the server.', required: true },
+  { name: 'started_at', description: 'Server start timestamp.', required: true },
+];
+
+const keyStatusResponseFields: SiteApiFieldCopy[] = [
+  { name: 'status', description: '`active` when the key can be used, otherwise `inactive`.', required: true },
 ];
 
 const memoryListResponseFields: SiteApiFieldCopy[] = [
@@ -965,6 +1030,241 @@ const sessionMessagesResponseFields: SiteApiFieldCopy[] = [
   { name: 'messages', description: 'Array of captured session message rows.', required: true },
   { name: 'limit_per_session', description: 'Applied per-session limit.', required: true },
 ];
+
+const spaceChainCreateBodyFields: SiteApiFieldCopy[] = [
+  { name: 'name', description: 'Human-readable Space Chain name.', required: true },
+  { name: 'project_id', description: 'Optional project id for control-plane ownership.' },
+  { name: 'description', description: 'Optional Space Chain description.' },
+  { name: 'created_by_user_id', description: 'Optional user id for audit attribution.' },
+];
+
+const spaceChainCreateResponseFields: SiteApiFieldCopy[] = [
+  { name: 'chain', description: 'Created Space Chain object.', required: true },
+  { name: 'chain_api_key', description: 'New plaintext Space Chain API key. Store it now.', required: true },
+  { name: 'binding_id', description: 'Identifier of the initial key binding.', required: true },
+  { name: 'key_prefix', description: 'Space Chain key prefix, currently `chain_`.', required: true },
+  { name: 'key_preview', description: 'Short masked preview of the new key.', required: true },
+];
+
+const spaceChainObjectResponseFields: SiteApiFieldCopy[] = [
+  { name: 'id', description: 'Space Chain id.', required: true },
+  { name: 'project_id', description: 'Owning project id when present.' },
+  { name: 'name', description: 'Space Chain name.', required: true },
+  { name: 'description', description: 'Space Chain description.' },
+  { name: 'bindings', description: 'Key bindings when included.' },
+  { name: 'nodes', description: 'Ordered node list when included.' },
+  { name: 'created_at', description: 'Creation timestamp.', required: true },
+  { name: 'updated_at', description: 'Last update timestamp.', required: true },
+];
+
+const spaceChainUpdateBodyFields: SiteApiFieldCopy[] = [
+  { name: 'name', description: 'Updated Space Chain name.', required: true },
+  { name: 'description', description: 'Updated description.' },
+];
+
+const spaceChainDeleteBodyFields: SiteApiFieldCopy[] = [
+  { name: 'deleted_by_user_id', description: 'Optional user id for audit attribution.' },
+];
+
+const spaceChainNodesBodyFields: SiteApiFieldCopy[] = [
+  { name: 'nodes', description: 'Ordered array of Space Chain node inputs.', required: true },
+  { name: 'nodes[].tenant_id', description: 'Space API key / tenant id for the node.', required: true },
+  { name: 'nodes[].external_space_id', description: 'Optional console Space id for display and sync.' },
+  { name: 'nodes[].display_name', description: 'Optional display name for the node.' },
+];
+
+const spaceChainNodesResponseFields: SiteApiFieldCopy[] = [
+  { name: 'nodes', description: 'Ordered node list. Positions are zero-based.', required: true },
+];
+
+const spaceChainBindingsResponseFields: SiteApiFieldCopy[] = [
+  { name: 'bindings', description: 'Array of Space Chain API key bindings.', required: true },
+];
+
+const spaceChainBindingBodyFields: SiteApiFieldCopy[] = [
+  { name: 'chain_api_key', description: 'Optional caller-supplied key. Omit to generate one.' },
+  { name: 'created_by_user_id', description: 'Optional user id for audit attribution.' },
+];
+
+const spaceChainBindingResponseFields: SiteApiFieldCopy[] = [
+  { name: 'id', description: 'Binding id.', required: true },
+  { name: 'chain_id', description: 'Space Chain id.', required: true },
+  { name: 'chain_api_key', description: 'Plaintext key for newly created bindings.', required: true },
+  { name: 'disabled', description: 'Whether this key binding is disabled.', required: true },
+  { name: 'created_at', description: 'Creation timestamp.', required: true },
+];
+
+const spaceChainDisableBindingBodyFields: SiteApiFieldCopy[] = [
+  { name: 'disabled', description: 'Must be `true`.', required: true },
+  { name: 'disabled_by_user_id', description: 'Optional user id for audit attribution.' },
+];
+
+const spaceChainRuntimeResponseFields: SiteApiFieldCopy[] = [
+  { name: 'memories', description: 'Merged memories from the visited Space Chain nodes.', required: true },
+  { name: 'total', description: 'Matched rows before pagination after chain-level de-duplication.', required: true },
+  { name: 'limit', description: 'Applied page size.', required: true },
+  { name: 'offset', description: 'Applied page offset.', required: true },
+];
+
+const keyStatusEndpointGroup: SiteApiEndpointGroupCopy = {
+  id: 'key-status',
+  title: 'Key Status',
+  description: 'Validate whether a Space key or Space Chain key is currently usable before making runtime calls.',
+  endpoints: [
+    {
+      method: 'GET',
+      path: '/v1alpha2/status',
+      summary: 'Check API key status.',
+      description:
+        'Send either a normal mem9 Space key or a Space Chain key in `X-API-Key`. The response is `active` or `inactive`; unknown keys return `404`.',
+      headers: [{ name: 'X-API-Key', description: 'Space API key or Space Chain API key.', required: true }],
+      responseFields: keyStatusResponseFields,
+      examples: [
+        { label: 'Check Space key', code: keyStatusCode },
+        { label: 'Check Space Chain key', code: chainKeyStatusCode },
+      ],
+    },
+  ],
+};
+
+const batchDeleteMemoryEndpoint: SiteApiEndpointCopy = {
+  method: 'POST',
+  path: '/v1alpha2/mem9s/memories/batch-delete',
+  summary: 'Delete multiple memories.',
+  description:
+    'Deletes the provided memory ids in one request. When authenticated with a Space Chain key, the handler resolves each id to the node that owns it.',
+  headers: hostedJSONWriteHeaders,
+  bodyFields: batchDeleteBodyFields,
+  examples: [{ label: 'Batch delete memories', code: batchDeleteMemoryCode }],
+};
+
+const spaceChainEndpointGroup: SiteApiEndpointGroupCopy = {
+  id: 'space-chains',
+  title: 'Space Chains',
+  description:
+    'Create and manage ordered chains of Spaces. Runtime memory endpoints accept a Space Chain key and search the chain in node order, or all nodes when `scanAll=true`.',
+  endpoints: [
+    {
+      method: 'POST',
+      path: '/v1alpha2/space-chains',
+      summary: 'Create a Space Chain.',
+      description:
+        'Creates a Space Chain and returns its first plaintext chain key once. Store `chain_api_key` securely; later list responses only expose masked or bound key records.',
+      headers: [{ name: 'Content-Type', description: 'Set to `application/json` for JSON request bodies.', required: true }],
+      bodyFields: spaceChainCreateBodyFields,
+      responseFields: spaceChainCreateResponseFields,
+      examples: [
+        { label: 'Create Space Chain', code: createSpaceChainCode },
+        { label: 'Export Space Chain env vars', code: exportChainApiEnvCode },
+      ],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/by-key',
+      summary: 'Read the Space Chain for a key.',
+      description: 'Looks up the active Space Chain associated with the `X-API-Key` chain key.',
+      headers: chainManagementHeaders,
+      responseFields: spaceChainObjectResponseFields,
+      examples: [{ label: 'Get by key', code: getSpaceChainByKeyCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/{chain_id}',
+      summary: 'Read one Space Chain.',
+      description: 'Returns chain metadata, nodes, and bindings for a chain key authorized to manage this Space Chain.',
+      headers: chainManagementHeaders,
+      responseFields: spaceChainObjectResponseFields,
+      examples: [{ label: 'Get Space Chain', code: getSpaceChainCode }],
+    },
+    {
+      method: 'PATCH',
+      path: '/v1alpha2/space-chains/{chain_id}',
+      summary: 'Update Space Chain details.',
+      description: 'Updates the display name and description for a Space Chain.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: spaceChainUpdateBodyFields,
+      responseFields: spaceChainObjectResponseFields,
+      examples: [{ label: 'Update Space Chain', code: updateSpaceChainCode }],
+    },
+    {
+      method: 'DELETE',
+      path: '/v1alpha2/space-chains/{chain_id}',
+      summary: 'Delete a Space Chain.',
+      description: 'Soft-deletes the Space Chain. A successful delete returns `204 No Content`.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: spaceChainDeleteBodyFields,
+      examples: [{ label: 'Delete Space Chain', code: deleteSpaceChainCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/{chain_id}/nodes',
+      summary: 'List Space Chain nodes.',
+      description: 'Returns the ordered node list. Node positions are zero-based and define sequential recall order.',
+      headers: chainManagementHeaders,
+      responseFields: spaceChainNodesResponseFields,
+      examples: [{ label: 'List nodes', code: listSpaceChainNodesCode }],
+    },
+    {
+      method: 'PUT',
+      path: '/v1alpha2/space-chains/{chain_id}/nodes',
+      summary: 'Replace Space Chain nodes.',
+      description:
+        'Replaces the entire ordered node list. Each node must reference a normal Space key / tenant id, not another Space Chain key.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: spaceChainNodesBodyFields,
+      responseFields: spaceChainNodesResponseFields,
+      examples: [{ label: 'Replace nodes', code: replaceSpaceChainNodesCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/{chain_id}/bindings',
+      summary: 'List Space Chain key bindings.',
+      description: 'Returns all key bindings visible to the management key for this Space Chain.',
+      headers: chainManagementHeaders,
+      responseFields: spaceChainBindingsResponseFields,
+      examples: [{ label: 'List bindings', code: listSpaceChainBindingsCode }],
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/space-chains/{chain_id}/bindings',
+      summary: 'Create a Space Chain key binding.',
+      description: 'Creates another chain key. Omit `chain_api_key` to let mem9 generate a key.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: spaceChainBindingBodyFields,
+      responseFields: spaceChainBindingResponseFields,
+      examples: [{ label: 'Create binding', code: createSpaceChainBindingCode }],
+    },
+    {
+      method: 'PATCH',
+      path: '/v1alpha2/space-chains/{chain_id}/bindings/{binding_id}',
+      summary: 'Disable a Space Chain key binding.',
+      description: 'Disables an active binding. The API rejects disabling the last active key for a chain.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: spaceChainDisableBindingBodyFields,
+      examples: [{ label: 'Disable binding', code: disableSpaceChainBindingCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/mem9s/memories',
+      summary: 'Recall across a Space Chain.',
+      description:
+        'Use the normal memory search endpoint with a Space Chain key. By default recall visits nodes in order and stops early on high confidence; pass `scanAll=true` to search every node and globally rerank.',
+      headers: chainManagementHeaders,
+      queryParams: memoryListQueryParams,
+      responseFields: spaceChainRuntimeResponseFields,
+      examples: [{ label: 'Recall with scanAll', code: recallSpaceChainCode }],
+    },
+  ],
+};
+
+const versionEndpoint: SiteApiEndpointCopy = {
+  method: 'GET',
+  path: '/versionz',
+  summary: 'Check server version metadata.',
+  description: 'Returns runtime metadata that is useful for support and deployment verification.',
+  responseFields: versionResponseFields,
+  examples: [{ label: 'Version check', code: versionCheckCode }],
+};
 
 const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   en: {
@@ -1038,6 +1338,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1096,6 +1398,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: 'Delete memory', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -1169,6 +1472,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: 'Health check', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],
@@ -1247,6 +1551,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1302,6 +1608,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: '删除记忆', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -1372,6 +1679,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: '健康检查', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],
@@ -1449,6 +1757,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1504,6 +1814,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: '刪除記憶', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -1574,6 +1885,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: '健康檢查', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],
@@ -1651,6 +1963,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1706,6 +2020,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: 'Memory を削除', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -1776,6 +2091,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: 'Health check', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],
@@ -1853,6 +2169,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1908,6 +2226,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: 'Memory 삭제', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -1978,6 +2297,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: 'Health check', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],
@@ -2055,6 +2375,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -2110,6 +2432,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: 'Hapus memory', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -2180,6 +2503,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: 'Health check', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],
@@ -2257,6 +2581,8 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           },
         ],
       },
+      keyStatusEndpointGroup,
+      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -2312,6 +2638,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedReadHeaders,
             examples: [{ label: 'ลบ memory', code: deleteMemoryCode }],
           },
+          batchDeleteMemoryEndpoint,
         ],
       },
       {
@@ -2382,6 +2709,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             responseFields: healthResponseFields,
             examples: [{ label: 'Health check', code: healthCheckCode }],
           },
+          versionEndpoint,
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- Parallelize Space Chain scanAll recall across runtime nodes and preserve global rerank behavior.
- Parallelize Space Chain auth node DB resolution so cold requests do not spend time opening node connections serially.
- Add a development watcher via make dev for automatic mnemo-server rebuild/restart.

## Validation
- go test ./internal/handler/
- go test -race -count=1 ./internal/handler/
- go test ./internal/middleware/
- go test -race -count=1 ./internal/middleware/ ./internal/handler/
- git diff --check

## Notes
Chrome/local runtime verification showed Force scanAll recall around 3.7s on the warmed path after the auth fix.