### PR TITLE
Add agent upgrade compatibility workflow

### DIFF
--- a/.github/workflows/agent-compat.yml
+++ b/.github/workflows/agent-compat.yml
@@ -16,19 +16,24 @@ on:
           - opencode
           - codex
           - dify
-      agent_ref:
-        description: Optional agent repo ref, tag, SHA, or path:<absolute-path> override
+      plugin_ref:
+        description: Optional mem9 plugin ref/version/source override
+        required: false
+        default: ""
+        type: string
+      host_ref:
+        description: Optional host agent/CLI version, tag, SHA, or path:<absolute-path> override
         required: false
         default: ""
         type: string
       lane:
         description: Compatibility lane
         required: true
-        default: contract
+        default: plugin-contract
         type: choice
         options:
-          - contract
-          - hosted-smoke
+          - plugin-contract
+          - host-smoke
           - full
       host_channel:
         description: Host channel, mainly for OpenClaw
@@ -39,7 +44,7 @@ on:
           - stable
           - next
       plugin_source:
-        description: OpenClaw plugin source: manifest, local, npm:<version>, or path:<path>
+        description: Plugin source: manifest, local, npm:<version>, path:<path>, github:<repo>@<ref>
         required: true
         default: manifest
         type: string
@@ -63,6 +68,10 @@ jobs:
       COMPAT_OPENCLAW_NEXT_VERSION: ${{ vars.COMPAT_OPENCLAW_NEXT_VERSION }}
       COMPAT_OPENCLAW_MODEL_PRIMARY: ${{ vars.COMPAT_OPENCLAW_MODEL_PRIMARY }}
       COMPAT_OPENCLAW_MODEL_SECONDARY: ${{ vars.COMPAT_OPENCLAW_MODEL_SECONDARY }}
+      COMPAT_HERMES_HOST_REF: ${{ vars.COMPAT_HERMES_HOST_REF }}
+      COMPAT_CLAUDE_HOST_REF: ${{ vars.COMPAT_CLAUDE_HOST_REF }}
+      COMPAT_OPENCODE_HOST_REF: ${{ vars.COMPAT_OPENCODE_HOST_REF }}
+      COMPAT_CODEX_HOST_REF: ${{ vars.COMPAT_CODEX_HOST_REF }}
 
     steps:
       - name: Checkout mem9
@@ -98,8 +107,12 @@ jobs:
             --plugin-source "${{ inputs.plugin_source }}"
           )
 
-          if [ -n "${{ inputs.agent_ref }}" ]; then
-            args+=(--agent-ref "${{ inputs.agent_ref }}")
+          if [ -n "${{ inputs.plugin_ref }}" ]; then
+            args+=(--plugin-ref "${{ inputs.plugin_ref }}")
+          fi
+
+          if [ -n "${{ inputs.host_ref }}" ]; then
+            args+=(--host-ref "${{ inputs.host_ref }}")
           fi
 
           python3 "${args[@]}"

--- a/.github/workflows/agent-compat.yml
+++ b/.github/workflows/agent-compat.yml
@@ -1,0 +1,114 @@
+name: Agent compatibility
+
+on:
+  workflow_dispatch:
+    inputs:
+      agent:
+        description: Agent to test
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - openclaw
+          - hermes
+          - claude
+          - opencode
+          - codex
+          - dify
+      agent_ref:
+        description: Optional agent repo ref, tag, SHA, or path:<absolute-path> override
+        required: false
+        default: ""
+        type: string
+      lane:
+        description: Compatibility lane
+        required: true
+        default: contract
+        type: choice
+        options:
+          - contract
+          - hosted-smoke
+          - full
+      host_channel:
+        description: Host channel, mainly for OpenClaw
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - next
+      plugin_source:
+        description: OpenClaw plugin source: manifest, local, npm:<version>, or path:<path>
+        required: true
+        default: manifest
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  agent-compat:
+    name: ${{ inputs.agent }} / ${{ inputs.lane }} / ${{ inputs.host_channel }}
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ inputs.host_channel == 'next' }}
+
+    env:
+      MNEMO_BASE_URL: ${{ secrets.MNEMO_BASE_URL }}
+      CLAUDE_CODE_TOKEN: ${{ secrets.CLAUDE_CODE_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      COMPAT_OPENCLAW_STABLE_BIN: ${{ vars.COMPAT_OPENCLAW_STABLE_BIN }}
+      COMPAT_OPENCLAW_NEXT_BIN: ${{ vars.COMPAT_OPENCLAW_NEXT_BIN }}
+      COMPAT_OPENCLAW_STABLE_VERSION: ${{ vars.COMPAT_OPENCLAW_STABLE_VERSION }}
+      COMPAT_OPENCLAW_NEXT_VERSION: ${{ vars.COMPAT_OPENCLAW_NEXT_VERSION }}
+      COMPAT_OPENCLAW_MODEL_PRIMARY: ${{ vars.COMPAT_OPENCLAW_MODEL_PRIMARY }}
+      COMPAT_OPENCLAW_MODEL_SECONDARY: ${{ vars.COMPAT_OPENCLAW_MODEL_SECONDARY }}
+
+    steps:
+      - name: Checkout mem9
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Go
+        if: ${{ inputs.agent == 'all' }}
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: server/go.mod
+          cache-dependency-path: server/go.sum
+
+      - name: Run agent compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          args=(
+            compat
+            agent "${{ inputs.agent }}"
+            --lane "${{ inputs.lane }}"
+            --host-channel "${{ inputs.host_channel }}"
+            --plugin-source "${{ inputs.plugin_source }}"
+          )
+
+          if [ -n "${{ inputs.agent_ref }}" ]; then
+            args+=(--agent-ref "${{ inputs.agent_ref }}")
+          fi
+
+          python3 "${args[@]}"
+
+      - name: Upload compatibility artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-compat-${{ inputs.agent }}-${{ inputs.lane }}-${{ inputs.host_channel }}
+          path: compat/artifacts/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/compat-framework-checks.yml
+++ b/.github/workflows/compat-framework-checks.yml
@@ -1,0 +1,43 @@
+name: Compat framework checks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/compat-framework-checks.yml"
+      - ".github/workflows/agent-compat.yml"
+      - "compat/**"
+      - "openclaw-plugin/**"
+      - "benchmark/**"
+      - "e2e/**"
+      - "Makefile"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/compat-framework-checks.yml"
+      - ".github/workflows/agent-compat.yml"
+      - "compat/**"
+      - "openclaw-plugin/**"
+      - "benchmark/**"
+      - "e2e/**"
+      - "Makefile"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compat-framework:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run compat harness tests
+        run: make compat-test

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ benchmark/MR-NIAH/.cache/
 # Claude Code and experiment outputs
 .claude/
 .playwright-mcp/
+
+# compat harness outputs
+compat/artifacts/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 IMG ?= $(REGISTRY)/mnemo-server:$(COMMIT)
 
-.PHONY: build vet clean run dev test test-cover test-integration docker
+.PHONY: build vet clean run dev test test-cover test-integration docker compat-test
 
 build:
 	mkdir -p $(MAKEFILE_DIR)/server/bin
@@ -36,3 +36,6 @@ dev:
 
 docker: build-linux
 	docker build --platform=linux/amd64 -q -f ./server/Dockerfile -t $(IMG) .
+
+compat-test:
+	python3 -m unittest compat.tests.test_compat

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,0 +1,109 @@
+# compat
+
+Atomic compatibility harness for mem9 integrations.
+
+## Repo-local entrypoint
+
+Because this repository needs both a `compat/` directory and a runnable entrypoint,
+the checked-in command is:
+
+```bash
+python3 compat run openclaw.install
+python3 compat run hermes.contract --agent-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
+python3 compat run dify.contract --agent-ref path:/Users/sx/github/mem9/mem9-dify-plugin
+python3 compat agent hermes --lane contract --agent-ref main
+python3 compat agent openclaw --lane hosted-smoke --host-channel next
+python3 compat suite openclaw-upgrade --host-channel stable --model-profile primary
+python3 compat matrix pr-core
+```
+
+## What is implemented in v1
+
+- A manifest-driven runner at [`manifest.yaml`](./manifest.yaml)
+- Atomic OpenClaw modules:
+  - `openclaw.install`
+  - `openclaw.setup`
+  - `openclaw.recall`
+  - `openclaw.ingest`
+  - `openclaw.compact`
+  - `openclaw.restart`
+  - `openclaw.failsoft`
+- Declarative suites:
+  - `openclaw-smoke`
+  - `openclaw-upgrade`
+  - `openclaw-plugin-release`
+- Matrix orchestration for `pr-core`, `nightly-full`, and `release-gate`
+- A local recorder proxy that forwards to `mnemo-server` and records plugin traffic
+- Agent lanes for `contract`, `hosted-smoke`, and `full`
+- External checkout support for:
+  - `mem9-ai/mem9-hermes-plugin`
+  - `mem9-ai/mem9-dify-plugin`
+
+## Agent upgrade checks
+
+The repo-owned GitHub Action is `.github/workflows/agent-compat.yml`.
+It is manual-first (`workflow_dispatch`) so an agent upgrade can be checked
+against a specific branch, tag, or SHA before release:
+
+```text
+agent=hermes
+agent_ref=<branch-or-tag-or-sha>
+lane=contract
+```
+
+For local development, pass `path:<absolute-path>` to use a sibling checkout:
+
+```bash
+python3 compat agent hermes --lane contract --agent-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
+python3 compat agent dify --lane contract --agent-ref path:/Users/sx/github/mem9/mem9-dify-plugin
+```
+
+When `agent_ref` is omitted, the harness uses `agents.<name>.default_ref` from
+`manifest.yaml`. Stable failures are blocking. `next` host-channel failures are
+configured as alert-style checks in the workflow.
+
+## Required environment
+
+OpenClaw live modules need a reachable mem9 API:
+
+```bash
+export MNEMO_BASE_URL="http://127.0.0.1:8080"
+```
+
+Agent-driving modules also need a model key that OpenClaw can use:
+
+```bash
+export CLAUDE_CODE_TOKEN="..."
+# or
+export ANTHROPIC_API_KEY="..."
+```
+
+Optional host overrides:
+
+```bash
+export COMPAT_OPENCLAW_STABLE_BIN="/path/to/openclaw-stable"
+export COMPAT_OPENCLAW_NEXT_BIN="/path/to/openclaw-next"
+export COMPAT_OPENCLAW_MODEL_PRIMARY="anthropic/claude-sonnet-4-6"
+export COMPAT_OPENCLAW_MODEL_SECONDARY="anthropic/claude-3-5-haiku-latest"
+```
+
+Optional external repo path overrides:
+
+```bash
+export COMPAT_HERMES_REPO_PATH="/Users/sx/github/mem9/mem9-hermes-plugin"
+export COMPAT_DIFY_REPO_PATH="/Users/sx/github/mem9/mem9-dify-plugin"
+```
+
+## Artifacts
+
+By default, every run writes under:
+
+```text
+compat/artifacts/<run-id>/<module>/
+```
+
+Each module writes:
+
+- `result.json`
+- `details.json`
+- module-specific logs such as `gateway.log`, `agent.stdout.json`, `agent.stderr.txt`

--- a/compat/README.md
+++ b/compat/README.md
@@ -9,10 +9,12 @@ the checked-in command is:
 
 ```bash
 python3 compat run openclaw.install
-python3 compat run hermes.contract --agent-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
-python3 compat run dify.contract --agent-ref path:/Users/sx/github/mem9/mem9-dify-plugin
-python3 compat agent hermes --lane contract --agent-ref main
-python3 compat agent openclaw --lane hosted-smoke --host-channel next
+python3 compat run hermes.contract --plugin-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
+python3 compat run dify.contract --plugin-ref path:/Users/sx/github/mem9/mem9-dify-plugin
+python3 compat agent hermes --lane plugin-contract --plugin-ref main
+python3 compat agent openclaw --lane host-smoke --host-ref 2026.5.28
+python3 compat agent opencode --lane host-smoke --host-ref 1.15.13
+python3 compat agent codex --lane host-smoke --host-ref 0.135.0
 python3 compat suite openclaw-upgrade --host-channel stable --model-profile primary
 python3 compat matrix pr-core
 ```
@@ -34,10 +36,16 @@ python3 compat matrix pr-core
   - `openclaw-plugin-release`
 - Matrix orchestration for `pr-core`, `nightly-full`, and `release-gate`
 - A local recorder proxy that forwards to `mnemo-server` and records plugin traffic
-- Agent lanes for `contract`, `hosted-smoke`, and `full`
+- Agent lanes for `plugin-contract`, `host-smoke`, and `full`
 - External checkout support for:
   - `mem9-ai/mem9-hermes-plugin`
   - `mem9-ai/mem9-dify-plugin`
+- Host upgrade smoke support for:
+  - OpenClaw via `openclaw@<host_ref>`
+  - Hermes via `NousResearch/hermes-agent@<host_ref>` checkout plus provider smoke
+  - Claude Code via `@anthropic-ai/claude-code@<host_ref>`
+  - OpenCode via `opencode-ai@<host_ref>`
+  - Codex via `@openai/codex@<host_ref>`
 
 ## Agent upgrade checks
 
@@ -47,20 +55,31 @@ against a specific branch, tag, or SHA before release:
 
 ```text
 agent=hermes
-agent_ref=<branch-or-tag-or-sha>
-lane=contract
+plugin_ref=<branch-or-tag-or-sha>
+lane=plugin-contract
 ```
 
 For local development, pass `path:<absolute-path>` to use a sibling checkout:
 
 ```bash
-python3 compat agent hermes --lane contract --agent-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
-python3 compat agent dify --lane contract --agent-ref path:/Users/sx/github/mem9/mem9-dify-plugin
+python3 compat agent hermes --lane plugin-contract --plugin-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
+python3 compat agent dify --lane plugin-contract --plugin-ref path:/Users/sx/github/mem9/mem9-dify-plugin
 ```
 
-When `agent_ref` is omitted, the harness uses `agents.<name>.default_ref` from
-`manifest.yaml`. Stable failures are blocking. `next` host-channel failures are
-configured as alert-style checks in the workflow.
+Use `plugin_ref` for plugin upgrades and `host_ref` for host upgrades. When a
+ref is omitted, the harness uses the manifest defaults. Stable failures are
+blocking. `next` host-channel failures are configured as alert-style checks in
+the workflow.
+
+Examples:
+
+```bash
+python3 compat agent hermes --lane plugin-contract --plugin-ref release-candidate
+python3 compat agent claude --lane host-smoke --host-ref 2.1.159
+python3 compat agent opencode --lane host-smoke --host-ref 1.15.13 --plugin-source local
+python3 compat agent codex --lane host-smoke --host-ref 0.135.0
+python3 compat agent openclaw --lane host-smoke --host-ref 2026.5.28
+```
 
 ## Required environment
 

--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -1,0 +1,1 @@
+"""Compatibility test harness for mem9 integrations."""

--- a/compat/__main__.py
+++ b/compat/__main__.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from compat.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/compat/bin/compat
+++ b/compat/bin/compat
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec python3 "$ROOT/compat" "$@"

--- a/compat/cli.py
+++ b/compat/cli.py
@@ -20,7 +20,9 @@ def build_parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--host-channel", default="stable")
     run_parser.add_argument("--model-profile", default="primary")
     run_parser.add_argument("--plugin-source", default="local")
-    run_parser.add_argument("--agent-ref", default=None)
+    run_parser.add_argument("--plugin-ref", default=None)
+    run_parser.add_argument("--host-ref", default=None)
+    run_parser.add_argument("--agent-ref", default=None, help=argparse.SUPPRESS)
     run_parser.add_argument("--manifest", default=None)
     run_parser.add_argument("--artifacts-root", default=None)
 
@@ -30,23 +32,33 @@ def build_parser() -> argparse.ArgumentParser:
     suite_parser.add_argument("--host-channel", default="stable")
     suite_parser.add_argument("--model-profile", default="primary")
     suite_parser.add_argument("--plugin-source", default="local")
-    suite_parser.add_argument("--agent-ref", default=None)
+    suite_parser.add_argument("--plugin-ref", default=None)
+    suite_parser.add_argument("--host-ref", default=None)
+    suite_parser.add_argument("--agent-ref", default=None, help=argparse.SUPPRESS)
     suite_parser.add_argument("--manifest", default=None)
     suite_parser.add_argument("--artifacts-root", default=None)
 
     agent_parser = subparsers.add_parser("agent", help="Run one agent for a compatibility lane")
     agent_parser.add_argument("agent", choices=["openclaw", "hermes", "claude", "opencode", "codex", "dify", "all"])
-    agent_parser.add_argument("--lane", default="contract", choices=["contract", "hosted-smoke", "full"])
+    agent_parser.add_argument(
+        "--lane",
+        default="plugin-contract",
+        choices=["plugin-contract", "host-smoke", "full", "contract", "hosted-smoke"],
+    )
     agent_parser.add_argument("--host-channel", default="stable")
     agent_parser.add_argument("--model-profile", default="primary")
     agent_parser.add_argument("--plugin-source", default="manifest")
-    agent_parser.add_argument("--agent-ref", default=None)
+    agent_parser.add_argument("--plugin-ref", default=None)
+    agent_parser.add_argument("--host-ref", default=None)
+    agent_parser.add_argument("--agent-ref", default=None, help=argparse.SUPPRESS)
     agent_parser.add_argument("--manifest", default=None)
     agent_parser.add_argument("--artifacts-root", default=None)
 
     matrix_parser = subparsers.add_parser("matrix", help="Run a compat matrix lane")
     matrix_parser.add_argument("lane")
-    matrix_parser.add_argument("--agent-ref", default=None)
+    matrix_parser.add_argument("--plugin-ref", default=None)
+    matrix_parser.add_argument("--host-ref", default=None)
+    matrix_parser.add_argument("--agent-ref", default=None, help=argparse.SUPPRESS)
     matrix_parser.add_argument("--manifest", default=None)
     matrix_parser.add_argument("--artifacts-root", default=None)
 
@@ -64,6 +76,19 @@ def main(argv: list[str] | None = None) -> int:
 
         manifest = load_manifest(args.manifest)
 
+    def compat_plugin_ref() -> str | None:
+        return args.plugin_ref or args.agent_ref
+
+    def compat_host_ref() -> str | None:
+        return args.host_ref
+
+    def compat_lane(value: str) -> str:
+        if value == "contract":
+            return "plugin-contract"
+        if value == "hosted-smoke":
+            return "host-smoke"
+        return value
+
     if args.command == "run":
         result = run_module(
             repo_root=repo_root,
@@ -73,7 +98,8 @@ def main(argv: list[str] | None = None) -> int:
             host_channel=args.host_channel,
             model_profile=args.model_profile,
             plugin_source=args.plugin_source,
-            agent_ref=args.agent_ref,
+            plugin_ref=compat_plugin_ref(),
+            host_ref=compat_host_ref(),
             artifacts_root=args.artifacts_root,
         )
         print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
@@ -88,7 +114,8 @@ def main(argv: list[str] | None = None) -> int:
             host_channel=args.host_channel,
             model_profile=args.model_profile,
             plugin_source=args.plugin_source,
-            agent_ref=args.agent_ref,
+            plugin_ref=compat_plugin_ref(),
+            host_ref=compat_host_ref(),
             artifacts_root=args.artifacts_root,
         )
         print(json.dumps(summary, ensure_ascii=False, indent=2))
@@ -99,11 +126,12 @@ def main(argv: list[str] | None = None) -> int:
             repo_root=repo_root,
             manifest=manifest,
             agent=args.agent,
-            lane=args.lane,
+            lane=compat_lane(args.lane),
             host_channel=args.host_channel,
             model_profile=args.model_profile,
             plugin_source=args.plugin_source,
-            agent_ref=args.agent_ref,
+            plugin_ref=compat_plugin_ref(),
+            host_ref=compat_host_ref(),
             artifacts_root=args.artifacts_root,
         )
         print(json.dumps(summary, ensure_ascii=False, indent=2))
@@ -114,7 +142,8 @@ def main(argv: list[str] | None = None) -> int:
             repo_root=repo_root,
             manifest=manifest,
             lane_name=args.lane,
-            agent_ref=args.agent_ref,
+            plugin_ref=args.plugin_ref or args.agent_ref,
+            host_ref=args.host_ref,
             artifacts_root=args.artifacts_root,
         )
         print(json.dumps(summary, ensure_ascii=False, indent=2))

--- a/compat/cli.py
+++ b/compat/cli.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .runtime import load_default_manifest, run_agent_lane, run_matrix, run_module, run_suite
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="mem9 compatibility test harness")
+    parser.add_argument("--manifest", default=None, help="Path to compat manifest (defaults to compat/manifest.yaml)")
+    parser.add_argument("--artifacts-root", default=None, help="Override artifacts root directory")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="Run a single compat module")
+    run_parser.add_argument("module")
+    run_parser.add_argument("--lane", default="ad-hoc")
+    run_parser.add_argument("--host-channel", default="stable")
+    run_parser.add_argument("--model-profile", default="primary")
+    run_parser.add_argument("--plugin-source", default="local")
+    run_parser.add_argument("--agent-ref", default=None)
+    run_parser.add_argument("--manifest", default=None)
+    run_parser.add_argument("--artifacts-root", default=None)
+
+    suite_parser = subparsers.add_parser("suite", help="Run a compat suite")
+    suite_parser.add_argument("suite")
+    suite_parser.add_argument("--lane", default="ad-hoc")
+    suite_parser.add_argument("--host-channel", default="stable")
+    suite_parser.add_argument("--model-profile", default="primary")
+    suite_parser.add_argument("--plugin-source", default="local")
+    suite_parser.add_argument("--agent-ref", default=None)
+    suite_parser.add_argument("--manifest", default=None)
+    suite_parser.add_argument("--artifacts-root", default=None)
+
+    agent_parser = subparsers.add_parser("agent", help="Run one agent for a compatibility lane")
+    agent_parser.add_argument("agent", choices=["openclaw", "hermes", "claude", "opencode", "codex", "dify", "all"])
+    agent_parser.add_argument("--lane", default="contract", choices=["contract", "hosted-smoke", "full"])
+    agent_parser.add_argument("--host-channel", default="stable")
+    agent_parser.add_argument("--model-profile", default="primary")
+    agent_parser.add_argument("--plugin-source", default="manifest")
+    agent_parser.add_argument("--agent-ref", default=None)
+    agent_parser.add_argument("--manifest", default=None)
+    agent_parser.add_argument("--artifacts-root", default=None)
+
+    matrix_parser = subparsers.add_parser("matrix", help="Run a compat matrix lane")
+    matrix_parser.add_argument("lane")
+    matrix_parser.add_argument("--agent-ref", default=None)
+    matrix_parser.add_argument("--manifest", default=None)
+    matrix_parser.add_argument("--artifacts-root", default=None)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    repo_root = Path(__file__).resolve().parents[1]
+    manifest = load_default_manifest(repo_root)
+    if args.manifest:
+        from .manifest import load_manifest
+
+        manifest = load_manifest(args.manifest)
+
+    if args.command == "run":
+        result = run_module(
+            repo_root=repo_root,
+            manifest=manifest,
+            module_name=args.module,
+            lane=args.lane,
+            host_channel=args.host_channel,
+            model_profile=args.model_profile,
+            plugin_source=args.plugin_source,
+            agent_ref=args.agent_ref,
+            artifacts_root=args.artifacts_root,
+        )
+        print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+        return 0 if result.status == "passed" else 1
+
+    if args.command == "suite":
+        summary = run_suite(
+            repo_root=repo_root,
+            manifest=manifest,
+            suite_name=args.suite,
+            lane=args.lane,
+            host_channel=args.host_channel,
+            model_profile=args.model_profile,
+            plugin_source=args.plugin_source,
+            agent_ref=args.agent_ref,
+            artifacts_root=args.artifacts_root,
+        )
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0 if summary["status"] == "passed" else 1
+
+    if args.command == "agent":
+        summary = run_agent_lane(
+            repo_root=repo_root,
+            manifest=manifest,
+            agent=args.agent,
+            lane=args.lane,
+            host_channel=args.host_channel,
+            model_profile=args.model_profile,
+            plugin_source=args.plugin_source,
+            agent_ref=args.agent_ref,
+            artifacts_root=args.artifacts_root,
+        )
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0 if summary["status"] == "passed" else 1
+
+    if args.command == "matrix":
+        summary = run_matrix(
+            repo_root=repo_root,
+            manifest=manifest,
+            lane_name=args.lane,
+            agent_ref=args.agent_ref,
+            artifacts_root=args.artifacts_root,
+        )
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+        return 0 if summary["status"] == "passed" else 1
+
+    parser.error(f"unknown command: {args.command}")
+    return 2

--- a/compat/external.py
+++ b/compat/external.py
@@ -42,9 +42,19 @@ def _agent_config(manifest: dict[str, Any], agent: str) -> dict[str, Any]:
     return cfg
 
 
-def _repo_ref(agent_cfg: dict[str, Any], agent_ref: str | None) -> str:
-    ref = agent_ref or agent_cfg.get("default_ref") or "main"
-    return str(ref)
+def _repo_ref(agent_cfg: dict[str, Any], plugin_ref: str | None) -> tuple[str, str | None]:
+    plugin_cfg = agent_cfg.get("plugin")
+    default_ref = ""
+    if isinstance(plugin_cfg, dict):
+        default_ref = str(plugin_cfg.get("default_ref", "") or "")
+    ref = plugin_ref or default_ref or agent_cfg.get("default_ref") or "main"
+    if isinstance(ref, str) and ref.startswith("github:"):
+        spec = ref.split(":", 1)[1]
+        if "@" not in spec:
+            raise CompatFailure("setup_failure", "github plugin_ref must look like github:<owner>/<repo>@<ref>")
+        repo, parsed_ref = spec.rsplit("@", 1)
+        return parsed_ref, repo
+    return str(ref), None
 
 
 def _external_repo_path(
@@ -52,9 +62,9 @@ def _external_repo_path(
     module_dir: Path,
     agent: str,
     agent_cfg: dict[str, Any],
-    agent_ref: str | None,
+    plugin_ref: str | None,
 ) -> tuple[Path, dict[str, Any]]:
-    ref = _repo_ref(agent_cfg, agent_ref)
+    ref, repo_override = _repo_ref(agent_cfg, plugin_ref)
     if ref.startswith("path:"):
         repo_path = Path(ref.split(":", 1)[1]).expanduser().resolve()
         if not repo_path.exists():
@@ -68,7 +78,7 @@ def _external_repo_path(
             raise CompatFailure("setup_failure", f"{path_env} points at missing path: {repo_path}")
         return repo_path, {"source": "env_path", "path": str(repo_path), "ref": ref, "path_env": path_env}
 
-    repo = agent_cfg.get("repo")
+    repo = repo_override or agent_cfg.get("repo")
     if not isinstance(repo, str) or not repo:
         raise CompatFailure("setup_failure", f"missing repo for external agent {agent}")
 
@@ -200,6 +210,54 @@ def _run_hermes_hosted(repo_dir: Path, module_dir: Path) -> dict[str, Any]:
     return {"hosted": json.loads(proc.stdout.splitlines()[-1])}
 
 
+def _run_hermes_host_smoke(
+    *,
+    manifest: dict[str, Any],
+    repo_dir: Path,
+    module_dir: Path,
+    host_ref: str | None,
+) -> dict[str, Any]:
+    agent_cfg = _agent_config(manifest, "hermes")
+    host_cfg = agent_cfg.get("host")
+    if not isinstance(host_cfg, dict):
+        raise CompatFailure("setup_failure", "missing Hermes host config")
+
+    host_repo = str(host_cfg.get("repo", "") or "")
+    if not host_repo:
+        raise CompatFailure("setup_failure", "missing Hermes host repo")
+    ref = host_ref or str(host_cfg.get("default_ref", "") or "main")
+    repo_url = host_repo if host_repo.startswith(("http://", "https://", "git@")) else f"https://github.com/{host_repo}.git"
+    checkout_dir = module_dir / "checkout" / "hermes-host"
+    checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    init = _run(["git", "init", str(checkout_dir)], cwd=module_dir, module_dir=module_dir, stem="host-git-init")
+    if init.returncode != 0:
+        raise CompatFailure("setup_failure", init.stderr.strip() or "Hermes host git init failed")
+    fetch = _run(
+        ["git", "fetch", "--depth", "1", repo_url, ref],
+        cwd=checkout_dir,
+        module_dir=module_dir,
+        stem="host-git-fetch",
+        timeout=300,
+    )
+    if fetch.returncode != 0:
+        raise CompatFailure("setup_failure", fetch.stderr.strip() or f"Hermes host git fetch failed for {host_repo}@{ref}")
+    checkout = _run(["git", "checkout", "--detach", "FETCH_HEAD"], cwd=checkout_dir, module_dir=module_dir, stem="host-git-checkout")
+    if checkout.returncode != 0:
+        raise CompatFailure("setup_failure", checkout.stderr.strip() or "Hermes host git checkout failed")
+    rev = _run(["git", "rev-parse", "HEAD"], cwd=checkout_dir, module_dir=module_dir, stem="host-git-rev-parse")
+    host_details = {
+        "source": "git",
+        "repo": host_repo,
+        "repo_url": repo_url,
+        "ref": ref,
+        "sha": rev.stdout.strip() if rev.returncode == 0 else "",
+        "path": str(checkout_dir),
+    }
+    hosted = _run_hermes_hosted(repo_dir, module_dir)
+    return {"host": host_details, **hosted}
+
+
 def _run_dify_script(repo_dir: Path, module_dir: Path, *, hosted: bool) -> dict[str, Any]:
     if hosted and not os.getenv("MNEMO_BASE_URL", "").rstrip("/"):
         raise CompatFailure("setup_failure", "MNEMO_BASE_URL is required for dify.hosted-contract")
@@ -322,7 +380,8 @@ def run_external_module(
     module_name: str,
     module_cfg: dict[str, Any],
     module_dir: Path,
-    agent_ref: str | None,
+    plugin_ref: str | None,
+    host_ref: str | None = None,
 ) -> dict[str, Any]:
     agent = str(module_cfg.get("agent", ""))
     agent_cfg = _agent_config(manifest, agent)
@@ -330,7 +389,7 @@ def run_external_module(
         module_dir=module_dir,
         agent=agent,
         agent_cfg=agent_cfg,
-        agent_ref=agent_ref,
+        plugin_ref=plugin_ref,
     )
 
     kind = str(module_cfg.get("kind", ""))
@@ -342,6 +401,15 @@ def run_external_module(
         details.update(_run_hermes_pytest(repo_dir, module_dir))
     elif kind == "hermes-hosted":
         details.update(_run_hermes_hosted(repo_dir, module_dir))
+    elif kind == "hermes-host-smoke":
+        details.update(
+            _run_hermes_host_smoke(
+                manifest=manifest,
+                repo_dir=repo_dir,
+                module_dir=module_dir,
+                host_ref=host_ref,
+            )
+        )
     elif kind == "dify-contract":
         details.update(_run_dify_script(repo_dir, module_dir, hosted=False))
     elif kind == "dify-hosted":

--- a/compat/external.py
+++ b/compat/external.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import textwrap
+import uuid
+from pathlib import Path
+from typing import Any
+
+from .openclaw import CompatFailure
+
+
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    module_dir: Path,
+    stem: str,
+    env: dict[str, str] | None = None,
+    timeout: int = 300,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        argv,
+        cwd=str(cwd),
+        env=env or os.environ.copy(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    (module_dir / f"{stem}.stdout.txt").write_text(proc.stdout, encoding="utf-8")
+    (module_dir / f"{stem}.stderr.txt").write_text(proc.stderr, encoding="utf-8")
+    return proc
+
+
+def _agent_config(manifest: dict[str, Any], agent: str) -> dict[str, Any]:
+    cfg = manifest.get("agents", {}).get(agent)
+    if not isinstance(cfg, dict):
+        raise CompatFailure("setup_failure", f"missing agent config: {agent}")
+    return cfg
+
+
+def _repo_ref(agent_cfg: dict[str, Any], agent_ref: str | None) -> str:
+    ref = agent_ref or agent_cfg.get("default_ref") or "main"
+    return str(ref)
+
+
+def _external_repo_path(
+    *,
+    module_dir: Path,
+    agent: str,
+    agent_cfg: dict[str, Any],
+    agent_ref: str | None,
+) -> tuple[Path, dict[str, Any]]:
+    ref = _repo_ref(agent_cfg, agent_ref)
+    if ref.startswith("path:"):
+        repo_path = Path(ref.split(":", 1)[1]).expanduser().resolve()
+        if not repo_path.exists():
+            raise CompatFailure("setup_failure", f"external repo path does not exist: {repo_path}")
+        return repo_path, {"source": "path", "path": str(repo_path), "ref": ref}
+
+    path_env = agent_cfg.get("path_env")
+    if isinstance(path_env, str) and os.getenv(path_env):
+        repo_path = Path(os.environ[path_env]).expanduser().resolve()
+        if not repo_path.exists():
+            raise CompatFailure("setup_failure", f"{path_env} points at missing path: {repo_path}")
+        return repo_path, {"source": "env_path", "path": str(repo_path), "ref": ref, "path_env": path_env}
+
+    repo = agent_cfg.get("repo")
+    if not isinstance(repo, str) or not repo:
+        raise CompatFailure("setup_failure", f"missing repo for external agent {agent}")
+
+    repo_url = repo if repo.startswith(("http://", "https://", "git@")) else f"https://github.com/{repo}.git"
+    checkout_dir = module_dir / "checkout" / agent
+    checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+    init = _run(["git", "init", str(checkout_dir)], cwd=module_dir, module_dir=module_dir, stem="git-init")
+    if init.returncode != 0:
+        raise CompatFailure("setup_failure", init.stderr.strip() or "git init failed")
+    fetch = _run(
+        ["git", "fetch", "--depth", "1", repo_url, ref],
+        cwd=checkout_dir,
+        module_dir=module_dir,
+        stem="git-fetch",
+        timeout=300,
+    )
+    if fetch.returncode != 0:
+        raise CompatFailure("setup_failure", fetch.stderr.strip() or f"git fetch failed for {repo}@{ref}")
+    checkout = _run(["git", "checkout", "--detach", "FETCH_HEAD"], cwd=checkout_dir, module_dir=module_dir, stem="git-checkout")
+    if checkout.returncode != 0:
+        raise CompatFailure("setup_failure", checkout.stderr.strip() or "git checkout failed")
+    rev = _run(["git", "rev-parse", "HEAD"], cwd=checkout_dir, module_dir=module_dir, stem="git-rev-parse")
+    sha = rev.stdout.strip() if rev.returncode == 0 else ""
+    return checkout_dir, {"source": "git", "repo": repo, "repo_url": repo_url, "ref": ref, "sha": sha}
+
+
+def _install_python_deps(repo_dir: Path, module_dir: Path, deps: list[str]) -> Path:
+    venv_dir = module_dir / ".venv"
+    create = _run(["python3", "-m", "venv", str(venv_dir)], cwd=repo_dir, module_dir=module_dir, stem="venv-create")
+    if create.returncode != 0:
+        raise CompatFailure("setup_failure", create.stderr.strip() or "python venv creation failed")
+    python = venv_dir / "bin" / "python"
+    if not deps:
+        return python
+    proc = _run(
+        [str(python), "-m", "pip", "install", "--disable-pip-version-check", *deps],
+        cwd=repo_dir,
+        module_dir=module_dir,
+        stem="pip-install",
+        timeout=600,
+    )
+    if proc.returncode != 0:
+        raise CompatFailure("setup_failure", proc.stderr.strip() or "pip install failed")
+    return python
+
+
+def _run_hermes_pytest(repo_dir: Path, module_dir: Path) -> dict[str, Any]:
+    python = _install_python_deps(repo_dir, module_dir, ["pytest", "httpx"])
+    proc = _run([str(python), "-m", "pytest", "-q", "tests/test_mem9.py"], cwd=repo_dir, module_dir=module_dir, stem="pytest")
+    if proc.returncode != 0:
+        raise CompatFailure("host_contract_break", proc.stderr.strip() or proc.stdout.strip() or "Hermes pytest failed")
+    return {"pytest": {"returncode": proc.returncode}}
+
+
+def _write_script(module_dir: Path, name: str, source: str) -> Path:
+    path = module_dir / name
+    path.write_text(textwrap.dedent(source), encoding="utf-8")
+    return path
+
+
+def _run_hermes_hosted(repo_dir: Path, module_dir: Path) -> dict[str, Any]:
+    base_url = os.getenv("MNEMO_BASE_URL", "").rstrip("/")
+    if not base_url:
+        raise CompatFailure("setup_failure", "MNEMO_BASE_URL is required for hermes.hosted-contract")
+    python = _install_python_deps(repo_dir, module_dir, ["httpx"])
+    script = _write_script(
+        module_dir,
+        "hermes_hosted_contract.py",
+        """
+        import importlib.util
+        import json
+        import os
+        import sys
+        import types
+        from pathlib import Path
+
+        repo = Path(sys.argv[1])
+        home = Path(os.environ["HERMES_HOME"])
+        home.mkdir(parents=True, exist_ok=True)
+
+        agent_pkg = types.ModuleType("agent")
+        memory_provider_mod = types.ModuleType("agent.memory_provider")
+        class MemoryProvider: pass
+        memory_provider_mod.MemoryProvider = MemoryProvider
+        agent_pkg.memory_provider = memory_provider_mod
+
+        tools_pkg = types.ModuleType("tools")
+        registry_mod = types.ModuleType("tools.registry")
+        registry_mod.tool_error = lambda message: json.dumps({"error": message})
+        tools_pkg.registry = registry_mod
+
+        hermes_constants_mod = types.ModuleType("hermes_constants")
+        hermes_constants_mod.get_hermes_home = lambda: home
+
+        sys.modules["agent"] = agent_pkg
+        sys.modules["agent.memory_provider"] = memory_provider_mod
+        sys.modules["tools"] = tools_pkg
+        sys.modules["tools.registry"] = registry_mod
+        sys.modules["hermes_constants"] = hermes_constants_mod
+
+        spec = importlib.util.spec_from_file_location("mem9_hermes", repo / "__init__.py")
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+
+        base_url = os.environ["MNEMO_BASE_URL"].rstrip("/")
+        tenant = module._Mem9Client.autoprovision(base_url)["id"]
+        os.environ["MEM9_API_URL"] = base_url
+        os.environ["MEM9_API_KEY"] = tenant
+        os.environ["MEM9_AGENT_ID"] = "compat-hermes"
+
+        provider = module.Mem9MemoryProvider()
+        provider.initialize("compat-hermes-session", user_id="compat-hermes-user")
+        assert provider.is_available()
+        provider.prefetch("compat hermes hosted recall")
+        provider.sync_turn("Remember compat Hermes hosted smoke.", "Acknowledged.")
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=10)
+        provider._client.search("compat hermes hosted recall", limit=1)
+        print(json.dumps({"tenant": tenant, "ok": True}))
+        """,
+    )
+    env = os.environ.copy()
+    env["MNEMO_BASE_URL"] = base_url
+    env["HERMES_HOME"] = str(module_dir / "hermes-home")
+    proc = _run([str(python), str(script), str(repo_dir)], cwd=repo_dir, module_dir=module_dir, stem="hermes-hosted", env=env)
+    if proc.returncode != 0:
+        raise CompatFailure("host_contract_break", proc.stderr.strip() or proc.stdout.strip() or "Hermes hosted contract failed")
+    return {"hosted": json.loads(proc.stdout.splitlines()[-1])}
+
+
+def _run_dify_script(repo_dir: Path, module_dir: Path, *, hosted: bool) -> dict[str, Any]:
+    if hosted and not os.getenv("MNEMO_BASE_URL", "").rstrip("/"):
+        raise CompatFailure("setup_failure", "MNEMO_BASE_URL is required for dify.hosted-contract")
+    python = _install_python_deps(repo_dir, module_dir, ["requests"])
+    script = _write_script(
+        module_dir,
+        "dify_contract.py",
+        """
+        import json
+        import os
+        import sys
+        import types
+        import urllib.request
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import Mock, patch
+
+        repo = Path(sys.argv[1])
+        hosted = sys.argv[2] == "hosted"
+        sys.path.insert(0, str(repo))
+
+        dify_plugin = types.ModuleType("dify_plugin")
+        entities = types.ModuleType("dify_plugin.entities")
+        tool_entities = types.ModuleType("dify_plugin.entities.tool")
+        errors = types.ModuleType("dify_plugin.errors")
+        tool_errors = types.ModuleType("dify_plugin.errors.tool")
+
+        class ToolInvokeMessage(dict): pass
+        class Tool:
+            def create_json_message(self, payload):
+                return payload
+        class ToolProvider: pass
+        class ToolProviderCredentialValidationError(Exception): pass
+
+        dify_plugin.Tool = Tool
+        dify_plugin.ToolProvider = ToolProvider
+        tool_entities.ToolInvokeMessage = ToolInvokeMessage
+        tool_errors.ToolProviderCredentialValidationError = ToolProviderCredentialValidationError
+        sys.modules["dify_plugin"] = dify_plugin
+        sys.modules["dify_plugin.entities"] = entities
+        sys.modules["dify_plugin.entities.tool"] = tool_entities
+        sys.modules["dify_plugin.errors"] = errors
+        sys.modules["dify_plugin.errors.tool"] = tool_errors
+
+        from provider.mem9 import Mem9Provider
+        from tools.memory_search import MemorySearchTool
+        from tools.memory_store import MemoryStoreTool
+
+        class Response:
+            def __init__(self, status_code=200, payload=None, text=""):
+                self.status_code = status_code
+                self._payload = payload or {}
+                self.text = text
+            def json(self):
+                return self._payload
+
+        def invoke(tool, credentials, params):
+            tool.runtime = SimpleNamespace(credentials=credentials)
+            return list(tool._invoke(params))[0]
+
+        if hosted:
+            base_url = os.environ["MNEMO_BASE_URL"].rstrip("/")
+            with urllib.request.urlopen(urllib.request.Request(f"{base_url}/v1alpha1/mem9s", data=b"{}", method="POST"), timeout=20) as resp:
+                tenant = json.loads(resp.read().decode("utf-8"))["id"]
+            credentials = {"auth_mode": "single_space", "mem9_base_url": base_url, "mem9_api_key": tenant, "mem9_agent_id": "compat-dify"}
+            Mem9Provider()._validate_credentials(credentials)
+            store = invoke(MemoryStoreTool(), credentials, {"content": "Dify hosted compat memory", "session_id": "compat-dify-session"})
+            assert store["ok"] is True
+            search = invoke(MemorySearchTool(), credentials, {"query": "Dify hosted compat memory", "session_id": "compat-dify-session", "scanAll": True})
+            assert search["ok"] is True
+            print(json.dumps({"ok": True, "hosted": True, "tenant": tenant}))
+            raise SystemExit(0)
+
+        credentials = {"auth_mode": "single_space", "mem9_base_url": "https://mem9.test", "mem9_api_key": "tenant-1", "mem9_agent_id": "compat-dify"}
+
+        with patch("provider.mem9.requests.get", return_value=Response(payload={"memories": [], "total": 0})) as get:
+            Mem9Provider()._validate_credentials(credentials)
+            assert get.call_args.kwargs["headers"]["X-API-Key"] == "tenant-1"
+
+        missing = invoke(MemorySearchTool(), {"auth_mode": "multi_space", "mem9_base_url": "https://mem9.test"}, {"query": "x"})
+        assert missing["ok"] is False and "Multi-space" in missing["error"]
+
+        with patch("tools.memory_search.requests.get", return_value=Response(payload={"memories": [{"content": "fact", "confidence": 90, "score": 0.8}], "total": 1})) as get:
+            result = invoke(MemorySearchTool(), credentials, {"query": "fact", "limit": 2, "session_id": "session-1", "scanAll": "true"})
+            assert result["ok"] is True
+            kwargs = get.call_args.kwargs
+            assert kwargs["headers"]["X-Mnemo-Agent-Id"] == "compat-dify"
+            assert kwargs["params"]["limit"] == "6"
+            assert kwargs["params"]["session_id"] == "session-1"
+            assert kwargs["params"]["scanAll"] == "true"
+
+        with patch("tools.memory_store.requests.post", return_value=Response(payload={"status": "accepted"})) as post:
+            result = invoke(MemoryStoreTool(), credentials, {"content": "remember this", "session_id": "session-2"})
+            assert result["ok"] is True
+            kwargs = post.call_args.kwargs
+            assert kwargs["headers"]["X-API-Key"] == "tenant-1"
+            assert kwargs["json"]["messages"] == [{"role": "user", "content": "remember this"}]
+            assert kwargs["json"]["agent_id"] == "compat-dify"
+            assert kwargs["json"]["mode"] == "smart"
+            assert kwargs["json"]["session_id"] == "session-2"
+
+        print(json.dumps({"ok": True, "hosted": False}))
+        """,
+    )
+    proc = _run(
+        [str(python), str(script), str(repo_dir), "hosted" if hosted else "contract"],
+        cwd=repo_dir,
+        module_dir=module_dir,
+        stem="dify-hosted" if hosted else "dify-contract",
+        env=os.environ.copy(),
+    )
+    if proc.returncode != 0:
+        raise CompatFailure("host_contract_break", proc.stderr.strip() or proc.stdout.strip() or "Dify contract failed")
+    return {"dify": json.loads(proc.stdout.splitlines()[-1])}
+
+
+def run_external_module(
+    *,
+    manifest: dict[str, Any],
+    module_name: str,
+    module_cfg: dict[str, Any],
+    module_dir: Path,
+    agent_ref: str | None,
+) -> dict[str, Any]:
+    agent = str(module_cfg.get("agent", ""))
+    agent_cfg = _agent_config(manifest, agent)
+    repo_dir, checkout = _external_repo_path(
+        module_dir=module_dir,
+        agent=agent,
+        agent_cfg=agent_cfg,
+        agent_ref=agent_ref,
+    )
+
+    kind = str(module_cfg.get("kind", ""))
+    details: dict[str, Any] = {
+        "checkout": checkout,
+        "repo_dir": str(repo_dir),
+    }
+    if kind == "hermes-pytest":
+        details.update(_run_hermes_pytest(repo_dir, module_dir))
+    elif kind == "hermes-hosted":
+        details.update(_run_hermes_hosted(repo_dir, module_dir))
+    elif kind == "dify-contract":
+        details.update(_run_dify_script(repo_dir, module_dir, hosted=False))
+    elif kind == "dify-hosted":
+        details.update(_run_dify_script(repo_dir, module_dir, hosted=True))
+    else:
+        raise CompatFailure("setup_failure", f"unsupported external module kind: {kind} for {module_name}")
+    details["external_run_id"] = str(uuid.uuid4())
+    return details

--- a/compat/host_smoke.py
+++ b/compat/host_smoke.py
@@ -1,0 +1,538 @@
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any
+
+from .openclaw import CompatFailure
+
+
+class _FakeMem9Handler(http.server.BaseHTTPRequestHandler):
+    records: list[dict[str, Any]] = []
+
+    def do_POST(self) -> None:  # noqa: N802
+        payload = self._read_json()
+        self._record(payload)
+        if self.path == "/v1alpha1/mem9s":
+            self._write_json(201, {"id": "compat-host-smoke-key"})
+            return
+        if self.path == "/v1alpha2/mem9s/memories":
+            self._write_json(202, {"status": "accepted", "ok": True})
+            return
+        self._write_json(404, {"error": "not found"})
+
+    def do_GET(self) -> None:  # noqa: N802
+        self._record(None)
+        if self.path.startswith("/v1alpha2/mem9s/memories"):
+            self._write_json(
+                200,
+                {
+                    "memories": [
+                        {
+                            "id": "compat-memory",
+                            "content": "host smoke memory response",
+                            "score": 0.9,
+                        }
+                    ],
+                    "total": 1,
+                },
+            )
+            return
+        self._write_json(404, {"error": "not found"})
+
+    def log_message(self, _format: str, *_args: Any) -> None:
+        return
+
+    def _read_json(self) -> Any:
+        length = int(self.headers.get("Content-Length", "0"))
+        if length <= 0:
+            return None
+        raw = self.rfile.read(length).decode("utf-8")
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw
+
+    def _record(self, body: Any) -> None:
+        self.__class__.records.append(
+            {
+                "method": self.command,
+                "path": self.path,
+                "headers": {
+                    "X-API-Key": self.headers.get("X-API-Key", ""),
+                    "X-Mnemo-Agent-Id": self.headers.get("X-Mnemo-Agent-Id", ""),
+                    "Content-Type": self.headers.get("Content-Type", ""),
+                },
+                "body": body,
+            }
+        )
+
+    def _write_json(self, status: int, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class FakeMem9Server:
+    def __init__(self) -> None:
+        _FakeMem9Handler.records = []
+        self.server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _FakeMem9Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_port}"
+
+    @property
+    def records(self) -> list[dict[str, Any]]:
+        return list(_FakeMem9Handler.records)
+
+    def __enter__(self) -> "FakeMem9Server":
+        self.thread.start()
+        return self
+
+    def __exit__(self, _exc_type: object, _exc: object, _tb: object) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+def _run(
+    argv: list[str],
+    *,
+    cwd: Path,
+    module_dir: Path,
+    stem: str,
+    env: dict[str, str] | None = None,
+    timeout: int = 300,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(
+        argv,
+        cwd=str(cwd),
+        env=env or os.environ.copy(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    (module_dir / f"{stem}.stdout.txt").write_text(proc.stdout, encoding="utf-8")
+    (module_dir / f"{stem}.stderr.txt").write_text(proc.stderr, encoding="utf-8")
+    if proc.returncode != 0:
+        raise CompatFailure(
+            "host_contract_break",
+            proc.stderr.strip() or proc.stdout.strip() or f"{stem} failed",
+        )
+    return proc
+
+
+def _agent_config(manifest: dict[str, Any], agent: str) -> dict[str, Any]:
+    cfg = manifest.get("agents", {}).get(agent)
+    if not isinstance(cfg, dict):
+        raise CompatFailure("setup_failure", f"missing agent config: {agent}")
+    return cfg
+
+
+def _install_npm_host(
+    *,
+    manifest: dict[str, Any],
+    agent: str,
+    host_ref: str | None,
+    module_dir: Path,
+) -> tuple[Path, dict[str, Any]]:
+    cfg = _agent_config(manifest, agent)
+    host_cfg = cfg.get("host")
+    if not isinstance(host_cfg, dict):
+        raise CompatFailure("setup_failure", f"missing host config for {agent}")
+
+    binary = str(host_cfg.get("binary", agent))
+    if host_ref and host_ref.startswith("path:"):
+        executable = Path(host_ref.split(":", 1)[1]).expanduser().resolve()
+        if not executable.exists():
+            raise CompatFailure("install_failure", f"host executable does not exist: {executable}")
+        return executable, {"source": "path", "path": str(executable), "ref": host_ref}
+
+    package = str(host_cfg.get("package", "") or "")
+    if not package:
+        raise CompatFailure("setup_failure", f"missing npm host package for {agent}")
+    ref = host_ref or str(host_cfg.get("default_ref", "") or "latest")
+    package_spec = package if ref in {"", "latest"} else f"{package}@{ref}"
+    if ref == "latest":
+        package_spec = f"{package}@latest"
+
+    prefix = module_dir / "host-npm"
+    prefix.mkdir(parents=True, exist_ok=True)
+    _run(
+        ["npm", "install", "--prefix", str(prefix), "--no-audit", "--no-fund", package_spec],
+        cwd=module_dir,
+        module_dir=module_dir,
+        stem="host-npm-install",
+        timeout=600,
+    )
+    executable = prefix / "node_modules" / ".bin" / binary
+    if not executable.exists():
+        raise CompatFailure("install_failure", f"host binary was not installed: {executable}")
+    return executable, {"source": "npm", "package": package, "ref": ref, "package_spec": package_spec}
+
+
+def _version(executable: Path, module_dir: Path, env: dict[str, str] | None = None) -> str:
+    proc = _run(
+        [str(executable), "--version"],
+        cwd=module_dir,
+        module_dir=module_dir,
+        stem="host-version",
+        env=env,
+        timeout=60,
+    )
+    return "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_transcript(path: Path) -> None:
+    lines = [
+        {"type": "event_msg", "payload": {"type": "user_message", "message": "remember host smoke"}},
+        {"type": "event_msg", "payload": {"type": "agent_message", "message": "stored host smoke"}},
+        {"role": "user", "content": "remember host smoke"},
+        {"role": "assistant", "content": "stored host smoke"},
+    ]
+    path.write_text("\n".join(json.dumps(item) for item in lines) + "\n", encoding="utf-8")
+
+
+def _run_claude_host_smoke(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    module_dir: Path,
+    host_ref: str | None,
+) -> dict[str, Any]:
+    executable, host_details = _install_npm_host(
+        manifest=manifest,
+        agent="claude",
+        host_ref=host_ref,
+        module_dir=module_dir,
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(module_dir / "home")
+    env["CLAUDE_PLUGIN_DATA"] = str(module_dir / "claude-plugin-data")
+    env["MEM9_DEBUG"] = "1"
+    (module_dir / "home").mkdir(parents=True, exist_ok=True)
+    (module_dir / "claude-plugin-data").mkdir(parents=True, exist_ok=True)
+
+    version_text = _version(executable, module_dir, env)
+    _run(
+        [str(executable), "plugin", "validate", str(repo_root / "claude-plugin")],
+        cwd=repo_root,
+        module_dir=module_dir,
+        stem="claude-plugin-validate",
+        env=env,
+        timeout=120,
+    )
+
+    transcript = module_dir / "claude-transcript.jsonl"
+    _write_transcript(transcript)
+    with FakeMem9Server() as server:
+        env.update(
+            {
+                "MEM9_API_URL": server.base_url,
+                "MEM9_API_KEY": "compat-host-smoke-key",
+                "MEM9_AGENT_ID": "claude-code-main",
+                "MEM9_WRITER_ID": "claude-code",
+            }
+        )
+        hooks = repo_root / "claude-plugin" / "hooks"
+        for name, payload in [
+            ("session-start", {"source": "startup"}),
+            ("user-prompt-submit", {"prompt": "please recall host smoke"}),
+            ("stop", {"session_id": "claude-host-smoke", "transcript_path": str(transcript)}),
+            ("pre-compact", {"session_id": "claude-host-smoke", "transcript_path": str(transcript)}),
+            ("session-end", {"session_id": "claude-host-smoke", "transcript_path": str(transcript)}),
+        ]:
+            proc = subprocess.run(
+                ["bash", str(hooks / f"{name}.sh")],
+                cwd=str(repo_root),
+                env=env,
+                input=json.dumps(payload),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+            (module_dir / f"claude-{name}.stdout.txt").write_text(proc.stdout, encoding="utf-8")
+            (module_dir / f"claude-{name}.stderr.txt").write_text(proc.stderr, encoding="utf-8")
+            if proc.returncode != 0:
+                raise CompatFailure("host_contract_break", f"Claude hook {name} failed: {proc.stderr.strip()}")
+
+        records = server.records
+    if not any(record["method"] == "GET" and record["path"].startswith("/v1alpha2/mem9s/memories") for record in records):
+        raise CompatFailure("recall_failure", "Claude host smoke did not observe recall GET")
+    if not any(record["method"] == "POST" and record["path"] == "/v1alpha2/mem9s/memories" for record in records):
+        raise CompatFailure("ingest_failure", "Claude host smoke did not observe ingest POST")
+    return {"host": host_details, "version_text": version_text, "records": records}
+
+
+def _resolve_opencode_plugin_source(repo_root: Path, plugin_source: str, plugin_ref: str | None) -> str:
+    if plugin_source == "manifest":
+        plugin_source = "local"
+    if plugin_source == "local":
+        return str(repo_root / "opencode-plugin")
+    if plugin_source.startswith("npm:"):
+        version = plugin_source.split(":", 1)[1] or "latest"
+        return f"@mem9/opencode@{version}"
+    if plugin_source.startswith("path:"):
+        return plugin_source.split(":", 1)[1]
+    if plugin_source.startswith("github:"):
+        return f"git+https://github.com/{plugin_source.split(':', 1)[1]}"
+    if plugin_ref:
+        return plugin_ref
+    return plugin_source
+
+
+def _run_opencode_host_smoke(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    module_dir: Path,
+    plugin_source: str,
+    plugin_ref: str | None,
+    host_ref: str | None,
+) -> dict[str, Any]:
+    executable, host_details = _install_npm_host(
+        manifest=manifest,
+        agent="opencode",
+        host_ref=host_ref,
+        module_dir=module_dir,
+    )
+    env = os.environ.copy()
+    env["HOME"] = str(module_dir / "home")
+    env["XDG_CONFIG_HOME"] = str(module_dir / "config")
+    env["XDG_DATA_HOME"] = str(module_dir / "data")
+    env["XDG_CACHE_HOME"] = str(module_dir / "cache")
+    for key in ["HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME"]:
+        Path(env[key]).mkdir(parents=True, exist_ok=True)
+
+    version_text = _version(executable, module_dir, env)
+    resolved_plugin = _resolve_opencode_plugin_source(repo_root, plugin_source, plugin_ref)
+    _run(
+        [str(executable), "plugin", "--global", "--force", resolved_plugin],
+        cwd=repo_root,
+        module_dir=module_dir,
+        stem="opencode-plugin-install",
+        env=env,
+        timeout=300,
+    )
+    config_path = Path(env["XDG_CONFIG_HOME"]) / "opencode" / "opencode.json"
+    tui_path = Path(env["XDG_CONFIG_HOME"]) / "opencode" / "tui.json"
+    if not config_path.exists() or not tui_path.exists():
+        raise CompatFailure("host_contract_break", "OpenCode plugin install did not write both server and TUI config")
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    tui = json.loads(tui_path.read_text(encoding="utf-8"))
+    _write_json(module_dir / "opencode-config.json", config)
+    _write_json(module_dir / "opencode-tui.json", tui)
+    config_text = json.dumps({"opencode": config, "tui": tui})
+    if "mem9" not in config_text and "@mem9/opencode" not in config_text and "opencode-plugin" not in config_text:
+        raise CompatFailure("host_contract_break", "OpenCode config does not reference mem9 plugin")
+    return {
+        "host": host_details,
+        "version_text": version_text,
+        "plugin_install_source": resolved_plugin,
+        "config_paths": [str(config_path), str(tui_path)],
+    }
+
+
+def _run_codex_host_smoke(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    module_dir: Path,
+    host_ref: str | None,
+) -> dict[str, Any]:
+    executable, host_details = _install_npm_host(
+        manifest=manifest,
+        agent="codex",
+        host_ref=host_ref,
+        module_dir=module_dir,
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{executable.parent}:{env.get('PATH', '')}"
+    env["CODEX_HOME"] = str(module_dir / "codex-home")
+    env["MEM9_HOME"] = str(module_dir / "mem9-home")
+    env["MEM9_API_KEY"] = "compat-host-smoke-key"
+    Path(env["CODEX_HOME"]).mkdir(parents=True, exist_ok=True)
+    Path(env["MEM9_HOME"]).mkdir(parents=True, exist_ok=True)
+    manifest_path = repo_root / "codex-plugin" / ".codex-plugin" / "plugin.json"
+    plugin_version = "local"
+    if manifest_path.exists():
+        plugin_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        plugin_version = str(plugin_manifest.get("version") or "local")
+    (Path(env["CODEX_HOME"]) / "plugins" / "cache" / "mem9-ai" / "mem9" / plugin_version).mkdir(
+        parents=True,
+        exist_ok=True,
+    )
+
+    version_text = _version(executable, module_dir, env)
+    _run(
+        [str(executable), "plugin", "marketplace", "--help"],
+        cwd=repo_root,
+        module_dir=module_dir,
+        stem="codex-plugin-marketplace-help",
+        env=env,
+        timeout=60,
+    )
+
+    setup = repo_root / "codex-plugin" / "skills" / "setup" / "scripts" / "setup.mjs"
+    with FakeMem9Server() as server:
+        _run(
+            [
+                "node",
+                str(setup),
+                "profile",
+                "save-key",
+                "--profile",
+                "default",
+                "--label",
+                "Compat",
+                "--base-url",
+                server.base_url,
+                "--api-key-env",
+                "MEM9_API_KEY",
+                "--cwd",
+                str(repo_root),
+            ],
+            cwd=repo_root,
+            module_dir=module_dir,
+            stem="codex-profile-save-key",
+            env=env,
+        )
+        _run(
+            [
+                "node",
+                str(setup),
+                "scope",
+                "apply",
+                "--scope",
+                "user",
+                "--profile",
+                "default",
+                "--default-timeout-ms",
+                "8000",
+                "--search-timeout-ms",
+                "15000",
+                "--recall-min-prompt-length",
+                "5",
+                "--cwd",
+                str(repo_root),
+            ],
+            cwd=repo_root,
+            module_dir=module_dir,
+            stem="codex-scope-apply",
+            env=env,
+        )
+        inspect = _run(
+            ["node", str(setup), "inspect", "--cwd", str(repo_root)],
+            cwd=repo_root,
+            module_dir=module_dir,
+            stem="codex-inspect",
+            env=env,
+        )
+        hook_feature = "hooks"
+        config_toml = Path(env["CODEX_HOME"]) / "config.toml"
+        if config_toml.exists() and "codex_hooks = true" in config_toml.read_text(encoding="utf-8"):
+            hook_feature = "codex_hooks"
+
+        transcript = module_dir / "codex-transcript.jsonl"
+        _write_transcript(transcript)
+        for name, payload in [
+            ("session-start", {"cwd": str(repo_root)}),
+            ("user-prompt-submit", {"cwd": str(repo_root), "prompt": "please recall host smoke"}),
+            (
+                "stop",
+                {
+                    "cwd": str(repo_root),
+                    "session_id": "codex-host-smoke",
+                    "transcript_path": str(transcript),
+                },
+            ),
+        ]:
+            proc = subprocess.run(
+                ["node", str(repo_root / "codex-plugin" / "hooks" / f"{name}.mjs")],
+                cwd=str(repo_root),
+                env=env,
+                input=json.dumps(payload),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+            (module_dir / f"codex-{name}.stdout.txt").write_text(proc.stdout, encoding="utf-8")
+            (module_dir / f"codex-{name}.stderr.txt").write_text(proc.stderr, encoding="utf-8")
+            if proc.returncode != 0:
+                raise CompatFailure("host_contract_break", f"Codex hook {name} failed: {proc.stderr.strip()}")
+
+        records = server.records
+
+    if not any(record["method"] == "GET" and record["path"].startswith("/v1alpha2/mem9s/memories") for record in records):
+        raise CompatFailure("recall_failure", "Codex host smoke did not observe recall GET")
+    if not any(record["method"] == "POST" and record["path"] == "/v1alpha2/mem9s/memories" for record in records):
+        raise CompatFailure("ingest_failure", "Codex host smoke did not observe ingest POST")
+    return {
+        "host": host_details,
+        "version_text": version_text,
+        "hook_feature": hook_feature,
+        "inspect": json.loads(inspect.stdout),
+        "records": records,
+    }
+
+
+def run_host_smoke_module(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    module_name: str,
+    module_cfg: dict[str, Any],
+    module_dir: Path,
+    plugin_source: str,
+    plugin_ref: str | None,
+    host_ref: str | None,
+) -> dict[str, Any]:
+    if shutil.which("npm") is None:
+        raise CompatFailure("install_failure", "npm is required for host smoke modules")
+
+    agent = str(module_cfg.get("agent", ""))
+    if agent == "claude":
+        return _run_claude_host_smoke(
+            repo_root=repo_root,
+            manifest=manifest,
+            module_dir=module_dir,
+            host_ref=host_ref,
+        )
+    if agent == "opencode":
+        return _run_opencode_host_smoke(
+            repo_root=repo_root,
+            manifest=manifest,
+            module_dir=module_dir,
+            plugin_source=plugin_source,
+            plugin_ref=plugin_ref,
+            host_ref=host_ref,
+        )
+    if agent == "codex":
+        return _run_codex_host_smoke(
+            repo_root=repo_root,
+            manifest=manifest,
+            module_dir=module_dir,
+            host_ref=host_ref,
+        )
+    raise CompatFailure("setup_failure", f"unsupported host smoke module {module_name} for agent {agent}")

--- a/compat/manifest.py
+++ b/compat/manifest.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+
+_VAR_RE = re.compile(r"\$\{([A-Z0-9_]+)(:-([^}]*))?\}")
+
+
+def _expand_env(text: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        default = match.group(3)
+        value = os.getenv(name)
+        if value:
+            return value
+        if default is not None:
+            return default
+        return ""
+
+    return _VAR_RE.sub(repl, text)
+
+
+def load_manifest(path: str | Path) -> dict[str, Any]:
+    manifest_path = Path(path)
+    expanded = _expand_env(manifest_path.read_text(encoding="utf-8"))
+    data = json.loads(expanded)
+    if not isinstance(data, dict):
+        raise ValueError(f"manifest must decode to an object: {manifest_path}")
+    return data
+
+
+def resolve_path(value: str) -> str:
+    return str(Path(value).expanduser())

--- a/compat/manifest.yaml
+++ b/compat/manifest.yaml
@@ -4,31 +4,89 @@
       "repo": "mem9-ai/mem9",
       "path": "openclaw-plugin",
       "default_ref": "main",
+      "plugin": {
+        "repo": "mem9-ai/mem9",
+        "path": "openclaw-plugin",
+        "default_ref": "main",
+        "package": "@mem9/mem9"
+      },
+      "host": {
+        "package": "openclaw",
+        "binary": "openclaw",
+        "default_ref": "${COMPAT_OPENCLAW_STABLE_VERSION:-latest}"
+      },
       "channels": ["stable", "next"]
     },
     "hermes": {
       "repo": "mem9-ai/mem9-hermes-plugin",
       "default_ref": "main",
+      "plugin": {
+        "repo": "mem9-ai/mem9-hermes-plugin",
+        "default_ref": "main"
+      },
+      "host": {
+        "repo": "NousResearch/hermes-agent",
+        "default_ref": "${COMPAT_HERMES_HOST_REF:-main}",
+        "failure_policy": "block"
+      },
       "path_env": "COMPAT_HERMES_REPO_PATH"
     },
     "claude": {
       "repo": "mem9-ai/mem9",
       "path": "claude-plugin",
-      "default_ref": "main"
+      "default_ref": "main",
+      "plugin": {
+        "repo": "mem9-ai/mem9",
+        "path": "claude-plugin",
+        "default_ref": "main"
+      },
+      "host": {
+        "package": "@anthropic-ai/claude-code",
+        "binary": "claude",
+        "default_ref": "${COMPAT_CLAUDE_HOST_REF:-latest}",
+        "failure_policy": "block"
+      }
     },
     "opencode": {
       "repo": "mem9-ai/mem9",
       "path": "opencode-plugin",
-      "default_ref": "main"
+      "default_ref": "main",
+      "plugin": {
+        "repo": "mem9-ai/mem9",
+        "path": "opencode-plugin",
+        "default_ref": "main",
+        "package": "@mem9/opencode"
+      },
+      "host": {
+        "package": "opencode-ai",
+        "binary": "opencode",
+        "default_ref": "${COMPAT_OPENCODE_HOST_REF:-latest}",
+        "failure_policy": "block"
+      }
     },
     "codex": {
       "repo": "mem9-ai/mem9",
       "path": "codex-plugin",
-      "default_ref": "main"
+      "default_ref": "main",
+      "plugin": {
+        "repo": "mem9-ai/mem9",
+        "path": "codex-plugin",
+        "default_ref": "main"
+      },
+      "host": {
+        "package": "@openai/codex",
+        "binary": "codex",
+        "default_ref": "${COMPAT_CODEX_HOST_REF:-latest}",
+        "failure_policy": "block"
+      }
     },
     "dify": {
       "repo": "mem9-ai/mem9-dify-plugin",
       "default_ref": "main",
+      "plugin": {
+        "repo": "mem9-ai/mem9-dify-plugin",
+        "default_ref": "main"
+      },
       "path_env": "COMPAT_DIFY_REPO_PATH"
     }
   },
@@ -36,11 +94,15 @@
     "openclaw": {
       "stable": {
         "executable": "${COMPAT_OPENCLAW_STABLE_BIN:-openclaw}",
+        "package": "openclaw",
+        "binary": "openclaw",
         "version_hint": "${COMPAT_OPENCLAW_STABLE_VERSION:-stable}",
         "failure_policy": "block"
       },
       "next": {
         "executable": "${COMPAT_OPENCLAW_NEXT_BIN:-openclaw}",
+        "package": "openclaw",
+        "binary": "openclaw",
         "version_hint": "${COMPAT_OPENCLAW_NEXT_VERSION:-next}",
         "failure_policy": "alert"
       }
@@ -82,6 +144,11 @@
       "kind": "hermes-hosted",
       "failure_class": "host_contract_break"
     },
+    "hermes.host-smoke": {
+      "agent": "hermes",
+      "kind": "hermes-host-smoke",
+      "failure_class": "host_contract_break"
+    },
     "dify.contract": {
       "agent": "dify",
       "kind": "dify-contract",
@@ -98,17 +165,32 @@
       "failure_class": "host_contract_break",
       "argv": ["bash", "-lc", "cd opencode-plugin && npm install --no-audit --no-fund && npm run typecheck && npm test"]
     },
+    "opencode.host-smoke": {
+      "agent": "opencode",
+      "kind": "host-smoke",
+      "failure_class": "host_contract_break"
+    },
     "claude.contract": {
       "agent": "claude",
       "kind": "command",
       "failure_class": "host_contract_break",
       "argv": ["bash", "-lc", "cd claude-plugin && bash -n hooks/common.sh hooks/pre-compact.sh hooks/session-end.sh hooks/session-start.sh hooks/stop.sh hooks/user-prompt-submit.sh && node --check hooks/lib/hook-json.mjs && node --check hooks/lib/memories-formatter.mjs && node --check hooks/lib/transcript-parser.mjs"]
     },
+    "claude.host-smoke": {
+      "agent": "claude",
+      "kind": "host-smoke",
+      "failure_class": "host_contract_break"
+    },
     "codex.contract": {
       "agent": "codex",
       "kind": "command",
       "failure_class": "host_contract_break",
       "argv": ["bash", "-lc", "cd codex-plugin && npm install --no-audit --no-fund && npm run typecheck && npm test"]
+    },
+    "codex.host-smoke": {
+      "agent": "codex",
+      "kind": "host-smoke",
+      "failure_class": "host_contract_break"
     }
   },
   "suites": {
@@ -126,7 +208,7 @@
     }
   },
   "agent_lanes": {
-    "contract": {
+    "plugin-contract": {
       "openclaw": [
         { "name": "openclaw-unit-tests", "kind": "module", "module": "openclaw.unit-tests" }
       ],
@@ -146,24 +228,24 @@
         { "name": "dify-contract", "kind": "module", "module": "dify.contract" }
       ]
     },
-    "hosted-smoke": {
+    "host-smoke": {
       "openclaw": [
         { "name": "openclaw-smoke", "kind": "suite", "suite": "openclaw-smoke", "plugin_source": "local" }
       ],
       "hermes": [
-        { "name": "hermes-hosted-contract", "kind": "module", "module": "hermes.hosted-contract" }
+        { "name": "hermes-host-smoke", "kind": "module", "module": "hermes.host-smoke" }
       ],
       "claude": [
-        { "name": "claude-contract", "kind": "module", "module": "claude.contract" }
+        { "name": "claude-host-smoke", "kind": "module", "module": "claude.host-smoke" }
       ],
       "opencode": [
-        { "name": "opencode-contract", "kind": "module", "module": "opencode.contract" }
+        { "name": "opencode-host-smoke", "kind": "module", "module": "opencode.host-smoke" }
       ],
       "codex": [
-        { "name": "codex-contract", "kind": "module", "module": "codex.contract" }
+        { "name": "codex-host-smoke", "kind": "module", "module": "codex.host-smoke" }
       ],
       "dify": [
-        { "name": "dify-hosted-contract", "kind": "module", "module": "dify.hosted-contract" }
+        { "name": "dify-contract", "kind": "module", "module": "dify.contract" }
       ]
     },
     "full": {
@@ -172,16 +254,19 @@
       ],
       "hermes": [
         { "name": "hermes-pytest", "kind": "module", "module": "hermes.contract" },
-        { "name": "hermes-hosted-contract", "kind": "module", "module": "hermes.hosted-contract" }
+        { "name": "hermes-host-smoke", "kind": "module", "module": "hermes.host-smoke" }
       ],
       "claude": [
-        { "name": "claude-contract", "kind": "module", "module": "claude.contract" }
+        { "name": "claude-contract", "kind": "module", "module": "claude.contract" },
+        { "name": "claude-host-smoke", "kind": "module", "module": "claude.host-smoke" }
       ],
       "opencode": [
-        { "name": "opencode-contract", "kind": "module", "module": "opencode.contract" }
+        { "name": "opencode-contract", "kind": "module", "module": "opencode.contract" },
+        { "name": "opencode-host-smoke", "kind": "module", "module": "opencode.host-smoke" }
       ],
       "codex": [
-        { "name": "codex-contract", "kind": "module", "module": "codex.contract" }
+        { "name": "codex-contract", "kind": "module", "module": "codex.contract" },
+        { "name": "codex-host-smoke", "kind": "module", "module": "codex.host-smoke" }
       ],
       "dify": [
         { "name": "dify-contract", "kind": "module", "module": "dify.contract" },
@@ -193,12 +278,12 @@
     "pr-core": {
       "tasks": [
         { "name": "compat-harness", "kind": "command", "argv": ["make", "compat-test"] },
-        { "name": "openclaw-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent openclaw --lane contract"] },
-        { "name": "hermes-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent hermes --lane contract"] },
-        { "name": "dify-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent dify --lane contract"] },
-        { "name": "opencode-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent opencode --lane contract"] },
-        { "name": "claude-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent claude --lane contract"] },
-        { "name": "codex-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent codex --lane contract"] }
+        { "name": "openclaw-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent openclaw --lane plugin-contract"] },
+        { "name": "hermes-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent hermes --lane plugin-contract"] },
+        { "name": "dify-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent dify --lane plugin-contract"] },
+        { "name": "opencode-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent opencode --lane plugin-contract"] },
+        { "name": "claude-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent claude --lane plugin-contract"] },
+        { "name": "codex-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent codex --lane plugin-contract"] }
       ]
     },
     "nightly-full": {

--- a/compat/manifest.yaml
+++ b/compat/manifest.yaml
@@ -1,0 +1,226 @@
+{
+  "agents": {
+    "openclaw": {
+      "repo": "mem9-ai/mem9",
+      "path": "openclaw-plugin",
+      "default_ref": "main",
+      "channels": ["stable", "next"]
+    },
+    "hermes": {
+      "repo": "mem9-ai/mem9-hermes-plugin",
+      "default_ref": "main",
+      "path_env": "COMPAT_HERMES_REPO_PATH"
+    },
+    "claude": {
+      "repo": "mem9-ai/mem9",
+      "path": "claude-plugin",
+      "default_ref": "main"
+    },
+    "opencode": {
+      "repo": "mem9-ai/mem9",
+      "path": "opencode-plugin",
+      "default_ref": "main"
+    },
+    "codex": {
+      "repo": "mem9-ai/mem9",
+      "path": "codex-plugin",
+      "default_ref": "main"
+    },
+    "dify": {
+      "repo": "mem9-ai/mem9-dify-plugin",
+      "default_ref": "main",
+      "path_env": "COMPAT_DIFY_REPO_PATH"
+    }
+  },
+  "hosts": {
+    "openclaw": {
+      "stable": {
+        "executable": "${COMPAT_OPENCLAW_STABLE_BIN:-openclaw}",
+        "version_hint": "${COMPAT_OPENCLAW_STABLE_VERSION:-stable}",
+        "failure_policy": "block"
+      },
+      "next": {
+        "executable": "${COMPAT_OPENCLAW_NEXT_BIN:-openclaw}",
+        "version_hint": "${COMPAT_OPENCLAW_NEXT_VERSION:-next}",
+        "failure_policy": "alert"
+      }
+    }
+  },
+  "models": {
+    "primary": {
+      "openclaw_model": "${COMPAT_OPENCLAW_MODEL_PRIMARY:-anthropic/claude-sonnet-4-6}",
+      "api_key_env": "CLAUDE_CODE_TOKEN",
+      "fallback_api_key_env": "ANTHROPIC_API_KEY"
+    },
+    "secondary": {
+      "openclaw_model": "${COMPAT_OPENCLAW_MODEL_SECONDARY:-anthropic/claude-3-5-haiku-latest}",
+      "api_key_env": "CLAUDE_CODE_TOKEN",
+      "fallback_api_key_env": "ANTHROPIC_API_KEY"
+    }
+  },
+  "modules": {
+    "openclaw.install": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.setup": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.recall": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.ingest": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.compact": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.restart": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.failsoft": { "agent": "openclaw", "kind": "openclaw" },
+    "openclaw.unit-tests": {
+      "agent": "openclaw",
+      "kind": "command",
+      "failure_class": "host_contract_break",
+      "argv": ["bash", "-lc", "cd openclaw-plugin && npm install --no-audit --no-fund && npm run typecheck && npm test"]
+    },
+    "hermes.contract": {
+      "agent": "hermes",
+      "kind": "hermes-pytest",
+      "failure_class": "host_contract_break"
+    },
+    "hermes.hosted-contract": {
+      "agent": "hermes",
+      "kind": "hermes-hosted",
+      "failure_class": "host_contract_break"
+    },
+    "dify.contract": {
+      "agent": "dify",
+      "kind": "dify-contract",
+      "failure_class": "host_contract_break"
+    },
+    "dify.hosted-contract": {
+      "agent": "dify",
+      "kind": "dify-hosted",
+      "failure_class": "host_contract_break"
+    },
+    "opencode.contract": {
+      "agent": "opencode",
+      "kind": "command",
+      "failure_class": "host_contract_break",
+      "argv": ["bash", "-lc", "cd opencode-plugin && npm install --no-audit --no-fund && npm run typecheck && npm test"]
+    },
+    "claude.contract": {
+      "agent": "claude",
+      "kind": "command",
+      "failure_class": "host_contract_break",
+      "argv": ["bash", "-lc", "cd claude-plugin && bash -n hooks/common.sh hooks/pre-compact.sh hooks/session-end.sh hooks/session-start.sh hooks/stop.sh hooks/user-prompt-submit.sh && node --check hooks/lib/hook-json.mjs && node --check hooks/lib/memories-formatter.mjs && node --check hooks/lib/transcript-parser.mjs"]
+    },
+    "codex.contract": {
+      "agent": "codex",
+      "kind": "command",
+      "failure_class": "host_contract_break",
+      "argv": ["bash", "-lc", "cd codex-plugin && npm install --no-audit --no-fund && npm run typecheck && npm test"]
+    }
+  },
+  "suites": {
+    "openclaw-smoke": {
+      "shared_state": false,
+      "modules": ["openclaw.install", "openclaw.setup", "openclaw.recall", "openclaw.ingest"]
+    },
+    "openclaw-upgrade": {
+      "shared_state": false,
+      "modules": ["openclaw.install", "openclaw.setup", "openclaw.recall", "openclaw.compact", "openclaw.restart"]
+    },
+    "openclaw-plugin-release": {
+      "shared_state": false,
+      "modules": ["openclaw.install", "openclaw.setup", "openclaw.recall", "openclaw.compact", "openclaw.restart", "openclaw.failsoft"]
+    }
+  },
+  "agent_lanes": {
+    "contract": {
+      "openclaw": [
+        { "name": "openclaw-unit-tests", "kind": "module", "module": "openclaw.unit-tests" }
+      ],
+      "hermes": [
+        { "name": "hermes-pytest", "kind": "module", "module": "hermes.contract" }
+      ],
+      "claude": [
+        { "name": "claude-contract", "kind": "module", "module": "claude.contract" }
+      ],
+      "opencode": [
+        { "name": "opencode-contract", "kind": "module", "module": "opencode.contract" }
+      ],
+      "codex": [
+        { "name": "codex-contract", "kind": "module", "module": "codex.contract" }
+      ],
+      "dify": [
+        { "name": "dify-contract", "kind": "module", "module": "dify.contract" }
+      ]
+    },
+    "hosted-smoke": {
+      "openclaw": [
+        { "name": "openclaw-smoke", "kind": "suite", "suite": "openclaw-smoke", "plugin_source": "local" }
+      ],
+      "hermes": [
+        { "name": "hermes-hosted-contract", "kind": "module", "module": "hermes.hosted-contract" }
+      ],
+      "claude": [
+        { "name": "claude-contract", "kind": "module", "module": "claude.contract" }
+      ],
+      "opencode": [
+        { "name": "opencode-contract", "kind": "module", "module": "opencode.contract" }
+      ],
+      "codex": [
+        { "name": "codex-contract", "kind": "module", "module": "codex.contract" }
+      ],
+      "dify": [
+        { "name": "dify-hosted-contract", "kind": "module", "module": "dify.hosted-contract" }
+      ]
+    },
+    "full": {
+      "openclaw": [
+        { "name": "openclaw-upgrade", "kind": "suite", "suite": "openclaw-upgrade", "plugin_source": "local" }
+      ],
+      "hermes": [
+        { "name": "hermes-pytest", "kind": "module", "module": "hermes.contract" },
+        { "name": "hermes-hosted-contract", "kind": "module", "module": "hermes.hosted-contract" }
+      ],
+      "claude": [
+        { "name": "claude-contract", "kind": "module", "module": "claude.contract" }
+      ],
+      "opencode": [
+        { "name": "opencode-contract", "kind": "module", "module": "opencode.contract" }
+      ],
+      "codex": [
+        { "name": "codex-contract", "kind": "module", "module": "codex.contract" }
+      ],
+      "dify": [
+        { "name": "dify-contract", "kind": "module", "module": "dify.contract" },
+        { "name": "dify-hosted-contract", "kind": "module", "module": "dify.hosted-contract" }
+      ]
+    }
+  },
+  "matrices": {
+    "pr-core": {
+      "tasks": [
+        { "name": "compat-harness", "kind": "command", "argv": ["make", "compat-test"] },
+        { "name": "openclaw-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent openclaw --lane contract"] },
+        { "name": "hermes-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent hermes --lane contract"] },
+        { "name": "dify-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent dify --lane contract"] },
+        { "name": "opencode-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent opencode --lane contract"] },
+        { "name": "claude-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent claude --lane contract"] },
+        { "name": "codex-contract", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent codex --lane contract"] }
+      ]
+    },
+    "nightly-full": {
+      "tasks": [
+        { "name": "agent-full", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent all --lane full --host-channel stable --plugin-source local"] },
+        { "name": "openclaw-next-upgrade", "kind": "suite", "suite": "openclaw-upgrade", "host_channel": "next", "model_profile": "secondary", "plugin_source": "local" }
+      ]
+    },
+    "release-gate": {
+      "tasks": [
+        { "name": "existing-tenant-compat", "kind": "command", "argv": ["bash", "-lc", "MNEMO_BASE=${MNEMO_BASE_URL:?missing} MNEMO_EXISTING_TENANT_ID=${MNEMO_EXISTING_TENANT_ID:?missing} POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-existing-tenant.sh"] },
+        { "name": "agent-full", "kind": "command", "argv": ["bash", "-lc", "python3 compat agent all --lane full --host-channel stable --plugin-source local"] }
+      ]
+    }
+  },
+  "thresholds": {
+    "benchmark_accuracy_drop_absolute": 0.03,
+    "benchmark_accuracy_drop_relative": 0.10
+  },
+  "gate_policy": {
+    "stable_failure": "block",
+    "next_failure": "alert",
+    "benchmark_drift": "alert"
+  }
+}

--- a/compat/openclaw.py
+++ b/compat/openclaw.py
@@ -368,6 +368,7 @@ def prepare_openclaw_environment(
     host_channel: str,
     model_profile_name: str,
     plugin_source: str,
+    host_ref: str | None = None,
     failure_class: str = "setup_failure",
     default_timeout_ms: int = 8000,
     search_timeout_ms: int = 15000,
@@ -392,8 +393,33 @@ def prepare_openclaw_environment(
     home_dir = module_dir / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
 
+    executable = str(host_cfg.get("executable", "openclaw"))
+    if host_ref:
+        if host_ref.startswith("path:"):
+            executable = host_ref.split(":", 1)[1]
+        else:
+            package_name = str(host_cfg.get("package", "openclaw") or "openclaw")
+            host_prefix = module_dir / "host-npm"
+            host_prefix.mkdir(parents=True, exist_ok=True)
+            package_spec = f"{package_name}@{host_ref}"
+            proc = subprocess.run(
+                ["npm", "install", "--prefix", str(host_prefix), "--no-audit", "--no-fund", package_spec],
+                cwd=str(repo_root),
+                env=os.environ.copy(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=600,
+                check=False,
+            )
+            (module_dir / "host-npm-install.stdout.txt").write_text(proc.stdout, encoding="utf-8")
+            (module_dir / "host-npm-install.stderr.txt").write_text(proc.stderr, encoding="utf-8")
+            if proc.returncode != 0:
+                raise CompatFailure("install_failure", proc.stderr.strip() or f"failed to install {package_spec}")
+            executable = str(host_prefix / "node_modules" / ".bin" / str(host_cfg.get("binary", "openclaw")))
+
     host = OpenClawHost(
-        executable=str(host_cfg.get("executable", "openclaw")),
+        executable=executable,
         home_dir=home_dir,
         repo_root=repo_root,
         module_dir=module_dir,
@@ -475,6 +501,7 @@ def run_openclaw_module(
     host_channel: str,
     model_profile_name: str,
     plugin_source: str,
+    host_ref: str | None = None,
 ) -> dict[str, Any]:
     env = prepare_openclaw_environment(
         repo_root=repo_root,
@@ -484,6 +511,7 @@ def run_openclaw_module(
         host_channel=host_channel,
         model_profile_name=model_profile_name,
         plugin_source=plugin_source,
+        host_ref=host_ref,
     )
     try:
         write_json(module_dir / "probe.json", env.probe_info)
@@ -655,6 +683,7 @@ def run_openclaw_module(
                 host_channel=host_channel,
                 model_profile_name=model_profile_name,
                 plugin_source=plugin_source,
+                host_ref=host_ref,
                 search_timeout_ms=50,
             )
             env.proxy.set_fault(

--- a/compat/openclaw.py
+++ b/compat/openclaw.py
@@ -1,0 +1,691 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+from .manifest import resolve_path
+from .proxy import FaultRule, RequestRecorderProxy, find_free_port
+
+
+class CompatFailure(RuntimeError):
+    def __init__(self, failure_class: str, message: str):
+        super().__init__(message)
+        self.failure_class = failure_class
+
+
+def _parse_version(text: str) -> tuple[int, int, int] | None:
+    match = re.search(r"(\d+)\.(\d+)(?:\.(\d+))?", text)
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3) or 0))
+
+
+def _supports_conversation_access(version_text: str) -> bool:
+    version = _parse_version(version_text)
+    if version is None:
+        return False
+    major, minor, patch = version
+    if major >= 2026:
+        return (major, minor, patch) >= (2026, 4, 22)
+    return (major, minor, patch) >= (4, 23, 0)
+
+
+@dataclass
+class CommandCapture:
+    argv: list[str]
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class OpenClawHost:
+    def __init__(
+        self,
+        *,
+        executable: str,
+        home_dir: Path,
+        repo_root: Path,
+        module_dir: Path,
+        gateway_token: str,
+        model_profile: dict[str, Any] | None,
+    ):
+        self.executable = resolve_path(executable)
+        self.home_dir = home_dir
+        self.repo_root = repo_root
+        self.module_dir = module_dir
+        self.gateway_token = gateway_token
+        self.model_profile = model_profile or {}
+
+    def env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env["HOME"] = str(self.home_dir)
+        api_key_env = self.model_profile.get("api_key_env")
+        fallback_env = self.model_profile.get("fallback_api_key_env")
+        resolved_key = ""
+        if isinstance(api_key_env, str):
+            resolved_key = os.getenv(api_key_env, "")
+        if not resolved_key and isinstance(fallback_env, str):
+            resolved_key = os.getenv(fallback_env, "")
+        if resolved_key:
+            env["ANTHROPIC_API_KEY"] = resolved_key
+        return env
+
+    def version_text(self) -> str:
+        capture = self.run_raw(["--version"], timeout=30)
+        text = "\n".join(part for part in (capture.stdout, capture.stderr) if part).strip()
+        if not text:
+            raise CompatFailure("install_failure", "openclaw --version returned no output")
+        return text
+
+    def supports_conversation_access(self) -> bool:
+        return _supports_conversation_access(self.version_text())
+
+    def run_raw(
+        self,
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        timeout: int = 120,
+        check: bool = True,
+    ) -> CommandCapture:
+        argv = [self.executable, *args]
+        proc = subprocess.run(
+            argv,
+            cwd=str(cwd or self.repo_root),
+            env=self.env(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        capture = CommandCapture(argv=argv, returncode=proc.returncode, stdout=proc.stdout, stderr=proc.stderr)
+        if check and proc.returncode != 0:
+            raise CompatFailure(
+                "host_contract_break",
+                f"command failed ({proc.returncode}): {' '.join(argv)}\n{proc.stderr.strip()}".strip(),
+            )
+        return capture
+
+    def config_set(self, profile: str, *parts: str, strict_json: bool = False) -> None:
+        args = ["--profile", profile, "config", "set"]
+        if strict_json:
+            args.append("--strict-json")
+        args.extend(parts)
+        self.run_raw(args)
+
+    def config_get(self, profile: str) -> dict[str, Any]:
+        capture = self.run_raw(["--profile", profile, "config", "get"])
+        try:
+            parsed = json.loads(capture.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise CompatFailure("host_contract_break", f"openclaw config get returned invalid JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise CompatFailure("host_contract_break", "openclaw config get did not return an object")
+        return parsed
+
+    def configure_profile(
+        self,
+        *,
+        profile: str,
+        plugin_source: str,
+        plugin_name: str,
+        plugin_dir: Path,
+        api_url: str,
+        api_key: str,
+        model_id: str | None,
+        debug: bool = True,
+        default_timeout_ms: int = 8000,
+        search_timeout_ms: int = 15000,
+    ) -> None:
+        self.config_set(profile, "gateway.mode", "local")
+        self.config_set(profile, "gateway.auth.token", self.gateway_token)
+        self.config_set(profile, "gateway.remote.token", self.gateway_token)
+
+        if model_id:
+            self.config_set(profile, "agents.defaults.model.primary", model_id)
+
+        if plugin_source == "local":
+            plugins_json = json.dumps(
+                {"allow": [plugin_name], "load": {"paths": [str(plugin_dir.resolve())]}},
+                separators=(",", ":"),
+            )
+            self.config_set(profile, "plugins", plugins_json, strict_json=True)
+        elif plugin_source.startswith("path:"):
+            path_value = Path(plugin_source.split(":", 1)[1]).expanduser().resolve()
+            plugins_json = json.dumps(
+                {"allow": [plugin_name], "load": {"paths": [str(path_value)]}},
+                separators=(",", ":"),
+            )
+            self.config_set(profile, "plugins", plugins_json, strict_json=True)
+        elif plugin_source.startswith("npm:"):
+            version = plugin_source.split(":", 1)[1]
+            package_ref = "@mem9/mem9" if not version else f"@mem9/mem9@{version}"
+            self.run_raw(["--profile", profile, "plugins", "install", package_ref], timeout=300)
+            self.config_set(profile, "plugins.allow", json.dumps([plugin_name]), strict_json=True)
+        else:
+            raise CompatFailure("install_failure", f"unsupported plugin source: {plugin_source}")
+
+        self.config_set(profile, "plugins.slots.memory", plugin_name)
+        self.config_set(profile, f"plugins.entries.{plugin_name}.enabled", "true")
+        if self.supports_conversation_access():
+            self.config_set(profile, f"plugins.entries.{plugin_name}.hooks.allowConversationAccess", "true")
+        self.config_set(profile, f"plugins.entries.{plugin_name}.config.apiUrl", api_url)
+        self.config_set(profile, f"plugins.entries.{plugin_name}.config.apiKey", api_key)
+        self.config_set(profile, f"plugins.entries.{plugin_name}.config.tenantID", api_key)
+        self.config_set(profile, f"plugins.entries.{plugin_name}.config.debug", "true" if debug else "false")
+        self.config_set(
+            profile,
+            f"plugins.entries.{plugin_name}.config.defaultTimeoutMs",
+            str(default_timeout_ms),
+        )
+        self.config_set(
+            profile,
+            f"plugins.entries.{plugin_name}.config.searchTimeoutMs",
+            str(search_timeout_ms),
+        )
+        self.run_raw(
+            ["--profile", profile, "config", "set", "plugins.entries.memory-core.enabled", "false"],
+            check=False,
+        )
+        self.run_raw(
+            ["--profile", profile, "config", "set", "plugins.entries.memory-lancedb.enabled", "false"],
+            check=False,
+        )
+
+    def start_gateway(self, *, profile: str, port: int, log_path: Path) -> tuple[subprocess.Popen[str], TextIO]:
+        argv = [
+            self.executable,
+            "--profile",
+            profile,
+            "gateway",
+            "run",
+            "--port",
+            str(port),
+            "--force",
+        ]
+        handle = log_path.open("w", encoding="utf-8")
+        proc = subprocess.Popen(
+            argv,
+            cwd=str(self.repo_root),
+            env=self.env(),
+            stdout=handle,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        return proc, handle
+
+    def wait_for_gateway(self, *, port: int, timeout_seconds: float = 20.0) -> None:
+        deadline = time.time() + timeout_seconds
+        url = f"http://127.0.0.1:{port}/health"
+        last_error = ""
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(url, timeout=2) as response:
+                    if response.getcode() == 200:
+                        return
+            except Exception as exc:  # noqa: BLE001
+                last_error = str(exc)
+                time.sleep(0.25)
+        raise CompatFailure("host_contract_break", f"gateway health check failed: {last_error}")
+
+    def run_agent(
+        self,
+        *,
+        profile: str,
+        message: str,
+        session_id: str,
+        output_dir: Path,
+        timeout_seconds: int = 120,
+    ) -> CommandCapture:
+        capture = self.run_raw(
+            [
+                "--profile",
+                profile,
+                "agent",
+                "--agent",
+                "main",
+                "--session-id",
+                session_id,
+                "--message",
+                message,
+                "--json",
+            ],
+            timeout=timeout_seconds,
+            check=False,
+        )
+        (output_dir / "agent.stdout.json").write_text(capture.stdout, encoding="utf-8")
+        (output_dir / "agent.stderr.txt").write_text(capture.stderr, encoding="utf-8")
+        return capture
+
+
+def http_json(
+    *,
+    method: str,
+    url: str,
+    body: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 30,
+) -> tuple[int, dict[str, Any] | list[Any] | None, str]:
+    payload = None
+    request_headers = {"Content-Type": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    if body is not None:
+        payload = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(url, data=payload, headers=request_headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            text = response.read().decode("utf-8", errors="replace")
+            status = response.getcode()
+    except urllib.error.HTTPError as exc:
+        text = exc.read().decode("utf-8", errors="replace")
+        status = exc.code
+    try:
+        decoded = json.loads(text) if text else None
+    except json.JSONDecodeError:
+        decoded = None
+    return status, decoded, text
+
+
+def provision_tenant(base_url: str) -> str:
+    status, decoded, text = http_json(method="POST", url=f"{base_url.rstrip('/')}/v1alpha1/mem9s", body={})
+    if status not in (200, 201) or not isinstance(decoded, dict) or not isinstance(decoded.get("id"), str):
+        raise CompatFailure("setup_failure", f"failed to provision tenant: status={status} body={text}")
+    return decoded["id"]
+
+
+def seed_memory(*, base_url: str, api_key: str, content: str, tags: list[str]) -> None:
+    status, _decoded, text = http_json(
+        method="POST",
+        url=f"{base_url.rstrip('/')}/v1alpha2/mem9s/memories",
+        body={"content": content, "tags": tags},
+        headers={"X-API-Key": api_key, "X-Mnemo-Agent-Id": "compat-openclaw"},
+    )
+    if status not in (200, 202):
+        raise CompatFailure("setup_failure", f"failed to seed memory: status={status} body={text}")
+
+
+def probe_seed_visible(*, base_url: str, api_key: str, query: str, timeout_seconds: float = 15.0) -> None:
+    deadline = time.time() + timeout_seconds
+    url = f"{base_url.rstrip('/')}/v1alpha2/mem9s/memories?q={urllib.parse.quote(query)}&limit=10"
+    while time.time() < deadline:
+        status, decoded, _text = http_json(
+            method="GET",
+            url=url,
+            headers={"X-API-Key": api_key, "X-Mnemo-Agent-Id": "compat-openclaw"},
+        )
+        if status == 200 and isinstance(decoded, dict):
+            memories = decoded.get("memories")
+            if isinstance(memories, list) and memories:
+                return
+        time.sleep(0.5)
+    raise CompatFailure("setup_failure", f"seed memory did not materialize for query={query!r}")
+
+
+@dataclass
+class OpenClawPreparedEnv:
+    host: OpenClawHost
+    target_base_url: str
+    proxy: RequestRecorderProxy
+    proxy_base_url: str
+    tenant_id: str
+    profile: str
+    gateway_port: int
+    gateway_process: subprocess.Popen[str] | None
+    gateway_log_handle: TextIO | None
+    module_dir: Path
+    gateway_log: Path
+    probe_info: dict[str, Any]
+
+    def cleanup(self) -> None:
+        if self.gateway_process is not None:
+            self.gateway_process.terminate()
+            try:
+                self.gateway_process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.gateway_process.kill()
+        if self.gateway_log_handle is not None:
+            self.gateway_log_handle.close()
+        self.proxy.stop()
+
+
+def prepare_openclaw_environment(
+    *,
+    repo_root: Path,
+    module_dir: Path,
+    manifest: dict[str, Any],
+    module_name: str,
+    host_channel: str,
+    model_profile_name: str,
+    plugin_source: str,
+    failure_class: str = "setup_failure",
+    default_timeout_ms: int = 8000,
+    search_timeout_ms: int = 15000,
+) -> OpenClawPreparedEnv:
+    hosts = manifest.get("hosts", {})
+    openclaw_hosts = hosts.get("openclaw", {})
+    host_cfg = openclaw_hosts.get(host_channel)
+    if not isinstance(host_cfg, dict):
+        raise CompatFailure("install_failure", f"missing host config for openclaw.{host_channel}")
+
+    model_cfg = manifest.get("models", {}).get(model_profile_name, {})
+    if not isinstance(model_cfg, dict):
+        raise CompatFailure("setup_failure", f"missing model profile: {model_profile_name}")
+
+    target_base_url = os.getenv("MNEMO_BASE_URL", "").rstrip("/")
+    if not target_base_url:
+        raise CompatFailure(
+            failure_class,
+            "MNEMO_BASE_URL is required for compat OpenClaw modules; point it at the target mnemo-server",
+        )
+
+    home_dir = module_dir / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+
+    host = OpenClawHost(
+        executable=str(host_cfg.get("executable", "openclaw")),
+        home_dir=home_dir,
+        repo_root=repo_root,
+        module_dir=module_dir,
+        gateway_token="compat-openclaw-token",
+        model_profile=model_cfg,
+    )
+
+    proxy = RequestRecorderProxy(target_base_url=target_base_url)
+    proxy.start()
+
+    tenant_id = provision_tenant(target_base_url)
+    profile = f"compat-{module_name.replace('.', '-')}-{host_channel}"
+    plugin_dir = repo_root / "openclaw-plugin"
+    gateway_port = find_free_port()
+
+    model_id = model_cfg.get("openclaw_model")
+    if not isinstance(model_id, str):
+        model_id = None
+
+    host.configure_profile(
+        profile=profile,
+        plugin_source=plugin_source,
+        plugin_name="mem9",
+        plugin_dir=plugin_dir,
+        api_url=proxy.base_url,
+        api_key=tenant_id,
+        model_id=model_id,
+        default_timeout_ms=default_timeout_ms,
+        search_timeout_ms=search_timeout_ms,
+    )
+
+    config = host.config_get(profile)
+    version_text = host.version_text()
+    supports_conversation = _supports_conversation_access(version_text)
+    probe_info = {
+        "version_text": version_text,
+        "supports_allow_conversation_access": supports_conversation,
+        "profile_dir": str(home_dir / f".openclaw-{profile}"),
+        "workspace_dir": str(home_dir / ".openclaw" / f"workspace-{profile}"),
+        "config_snapshot": config,
+    }
+    gateway_log = module_dir / "gateway.log"
+
+    return OpenClawPreparedEnv(
+        host=host,
+        target_base_url=target_base_url,
+        proxy=proxy,
+        proxy_base_url=proxy.base_url,
+        tenant_id=tenant_id,
+        profile=profile,
+        gateway_port=gateway_port,
+        gateway_process=None,
+        gateway_log_handle=None,
+        module_dir=module_dir,
+        gateway_log=gateway_log,
+        probe_info=probe_info,
+    )
+
+
+def start_gateway(env: OpenClawPreparedEnv) -> None:
+    env.gateway_process, env.gateway_log_handle = env.host.start_gateway(
+        profile=env.profile,
+        port=env.gateway_port,
+        log_path=env.gateway_log,
+    )
+    env.host.wait_for_gateway(port=env.gateway_port)
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def run_openclaw_module(
+    *,
+    repo_root: Path,
+    module_dir: Path,
+    manifest: dict[str, Any],
+    module_name: str,
+    host_channel: str,
+    model_profile_name: str,
+    plugin_source: str,
+) -> dict[str, Any]:
+    env = prepare_openclaw_environment(
+        repo_root=repo_root,
+        module_dir=module_dir,
+        manifest=manifest,
+        module_name=module_name,
+        host_channel=host_channel,
+        model_profile_name=model_profile_name,
+        plugin_source=plugin_source,
+    )
+    try:
+        write_json(module_dir / "probe.json", env.probe_info)
+
+        if module_name == "openclaw.install":
+            return {"probe": env.probe_info}
+
+        if module_name == "openclaw.setup":
+            start_gateway(env)
+            config = env.host.config_get(env.profile)
+            if not isinstance(config.get("plugins"), dict):
+                raise CompatFailure("setup_failure", "plugins config missing after setup")
+            return {"probe": env.probe_info, "config": config}
+
+        if module_name == "openclaw.recall":
+            start_gateway(env)
+            seed_memory(
+                base_url=env.target_base_url,
+                api_key=env.tenant_id,
+                content="upgrade sentinel for recall verification",
+                tags=["compat", "recall"],
+            )
+            probe_seed_visible(
+                base_url=env.target_base_url,
+                api_key=env.tenant_id,
+                query="upgrade sentinel",
+            )
+            capture = env.host.run_agent(
+                profile=env.profile,
+                session_id="compat-recall",
+                message="Please recall the upgrade sentinel",
+                output_dir=module_dir,
+            )
+            env.proxy.wait_for(
+                lambda records: any(
+                    rec.method == "GET"
+                    and rec.path == "/v1alpha2/mem9s/memories"
+                    and "Please recall the upgrade sentinel" in "".join(rec.query.get("q", []))
+                    for rec in records
+                ),
+                10.0,
+            )
+            if not any(
+                rec.method == "GET"
+                and rec.path == "/v1alpha2/mem9s/memories"
+                and "Please recall the upgrade sentinel" in "".join(rec.query.get("q", []))
+                for rec in env.proxy.records
+            ):
+                raise CompatFailure("recall_failure", "mem9 recall request was not observed")
+            return {
+                "probe": env.probe_info,
+                "agent_returncode": capture.returncode,
+                "proxy_records": [record.__dict__ for record in env.proxy.records],
+            }
+
+        if module_name == "openclaw.ingest":
+            start_gateway(env)
+            capture = env.host.run_agent(
+                profile=env.profile,
+                session_id="compat-ingest",
+                message="Remember this upgrade checklist and keep it after the run.",
+                output_dir=module_dir,
+            )
+            env.proxy.wait_for(
+                lambda records: any(
+                    rec.method == "POST"
+                    and rec.path == "/v1alpha2/mem9s/memories"
+                    and isinstance(rec.body_json, dict)
+                    and isinstance(rec.body_json.get("messages"), list)
+                    for rec in records
+                ),
+                10.0,
+            )
+            if not any(
+                rec.method == "POST"
+                and rec.path == "/v1alpha2/mem9s/memories"
+                and isinstance(rec.body_json, dict)
+                and isinstance(rec.body_json.get("messages"), list)
+                for rec in env.proxy.records
+            ):
+                raise CompatFailure("ingest_failure", "agent_end ingest POST was not observed")
+            return {
+                "probe": env.probe_info,
+                "agent_returncode": capture.returncode,
+                "proxy_records": [record.__dict__ for record in env.proxy.records],
+            }
+
+        if module_name == "openclaw.compact":
+            start_gateway(env)
+            seed_memory(
+                base_url=env.target_base_url,
+                api_key=env.tenant_id,
+                content="compaction sentinel for recall verification",
+                tags=["compat", "compact"],
+            )
+            probe_seed_visible(
+                base_url=env.target_base_url,
+                api_key=env.tenant_id,
+                query="compaction sentinel",
+            )
+            env.host.run_agent(
+                profile=env.profile,
+                session_id="compat-compact",
+                message="/compact",
+                output_dir=module_dir / "compact-command",
+            )
+            env.proxy.clear()
+            env.host.run_agent(
+                profile=env.profile,
+                session_id="compat-compact",
+                message="Please recall the compaction sentinel",
+                output_dir=module_dir / "post-compact",
+            )
+            if not env.proxy.wait_for(
+                lambda records: any(
+                    rec.method == "GET"
+                    and rec.path == "/v1alpha2/mem9s/memories"
+                    and "Please recall the compaction sentinel" in "".join(rec.query.get("q", []))
+                    for rec in records
+                ),
+                10.0,
+            ):
+                raise CompatFailure("recall_failure", "recall after /compact was not observed")
+            return {"probe": env.probe_info, "proxy_records": [record.__dict__ for record in env.proxy.records]}
+
+        if module_name == "openclaw.restart":
+            start_gateway(env)
+            env.gateway_process.terminate()
+            env.gateway_process.wait(timeout=10)
+            env.gateway_process = None
+            env.proxy.clear()
+            start_gateway(env)
+            seed_memory(
+                base_url=env.target_base_url,
+                api_key=env.tenant_id,
+                content="restart sentinel for recall verification",
+                tags=["compat", "restart"],
+            )
+            probe_seed_visible(
+                base_url=env.target_base_url,
+                api_key=env.tenant_id,
+                query="restart sentinel",
+            )
+            env.host.run_agent(
+                profile=env.profile,
+                session_id="compat-restart",
+                message="Please recall the restart sentinel",
+                output_dir=module_dir,
+            )
+            if not env.proxy.wait_for(
+                lambda records: any(
+                    rec.method == "GET"
+                    and rec.path == "/v1alpha2/mem9s/memories"
+                    and "Please recall the restart sentinel" in "".join(rec.query.get("q", []))
+                    for rec in records
+                ),
+                10.0,
+            ):
+                raise CompatFailure("recall_failure", "recall after restart was not observed")
+            return {"probe": env.probe_info, "proxy_records": [record.__dict__ for record in env.proxy.records]}
+
+        if module_name == "openclaw.failsoft":
+            env.cleanup()
+            env = prepare_openclaw_environment(
+                repo_root=repo_root,
+                module_dir=module_dir,
+                manifest=manifest,
+                module_name=module_name,
+                host_channel=host_channel,
+                model_profile_name=model_profile_name,
+                plugin_source=plugin_source,
+                search_timeout_ms=50,
+            )
+            env.proxy.set_fault(
+                FaultRule(
+                    path_prefix="/v1alpha2/mem9s/memories",
+                    method="GET",
+                    delay_seconds=0.2,
+                )
+            )
+            start_gateway(env)
+            capture = env.host.run_agent(
+                profile=env.profile,
+                session_id="compat-failsoft",
+                message="Trigger a failsoft memory lookup",
+                output_dir=module_dir,
+            )
+            stderr_text = capture.stderr
+            stdout_text = capture.stdout
+            if capture.returncode != 0 and "[mem9]" not in stderr_text and "[mem9]" not in stdout_text:
+                raise CompatFailure(
+                    "host_contract_break",
+                    "agent failed without mem9 diagnostic after injected timeout",
+                )
+            if not env.proxy.records:
+                raise CompatFailure("recall_failure", "proxy did not observe the failsoft recall attempt")
+            return {
+                "probe": env.probe_info,
+                "agent_returncode": capture.returncode,
+                "proxy_records": [record.__dict__ for record in env.proxy.records],
+            }
+
+        raise CompatFailure("setup_failure", f"unsupported OpenClaw module: {module_name}")
+    finally:
+        env.cleanup()

--- a/compat/proxy.py
+++ b/compat/proxy.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+@dataclass
+class FaultRule:
+    path_prefix: str
+    method: str | None = None
+    delay_seconds: float = 0.0
+    response_status: int | None = None
+    response_body: dict[str, Any] | None = None
+
+    def matches(self, method: str, path: str) -> bool:
+        if self.method and self.method.upper() != method.upper():
+            return False
+        return path.startswith(self.path_prefix)
+
+
+@dataclass
+class RecordedRequest:
+    method: str
+    path: str
+    status: int
+    query: dict[str, list[str]]
+    headers: dict[str, str]
+    body_text: str
+    body_json: dict[str, Any] | list[Any] | None
+    timestamp: float = field(default_factory=time.time)
+
+
+class RequestRecorderProxy:
+    def __init__(self, *, target_base_url: str):
+        self.target_base_url = target_base_url.rstrip("/")
+        self._records: list[RecordedRequest] = []
+        self._lock = threading.Lock()
+        self._fault: FaultRule | None = None
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self.base_url = ""
+
+    @property
+    def records(self) -> list[RecordedRequest]:
+        with self._lock:
+            return list(self._records)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._records.clear()
+
+    def set_fault(self, fault: FaultRule | None) -> None:
+        self._fault = fault
+
+    def start(self) -> None:
+        proxy = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # noqa: N802
+                proxy._handle(self)
+
+            def do_POST(self) -> None:  # noqa: N802
+                proxy._handle(self)
+
+            def do_PUT(self) -> None:  # noqa: N802
+                proxy._handle(self)
+
+            def do_DELETE(self) -> None:  # noqa: N802
+                proxy._handle(self)
+
+            def log_message(self, _format: str, *_args: object) -> None:
+                return
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        port = self._server.server_port
+        self.base_url = f"http://127.0.0.1:{port}"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def wait_for(self, predicate, timeout_seconds: float) -> bool:
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            if predicate(self.records):
+                return True
+            time.sleep(0.1)
+        return predicate(self.records)
+
+    def _handle(self, handler: BaseHTTPRequestHandler) -> None:
+        body = b""
+        content_length = handler.headers.get("Content-Length")
+        if content_length:
+            body = handler.rfile.read(int(content_length))
+
+        parsed = urllib.parse.urlsplit(handler.path)
+        query = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+        body_text = body.decode("utf-8", errors="replace")
+        body_json: dict[str, Any] | list[Any] | None = None
+        if body_text:
+            try:
+                decoded = json.loads(body_text)
+                if isinstance(decoded, (dict, list)):
+                    body_json = decoded
+            except json.JSONDecodeError:
+                body_json = None
+
+        headers = {key: value for key, value in handler.headers.items()}
+        fault = self._fault
+        if fault and fault.matches(handler.command, parsed.path):
+            if fault.delay_seconds > 0:
+                time.sleep(fault.delay_seconds)
+            status = fault.response_status or 503
+            payload = fault.response_body or {"error": "compat proxy injected failure"}
+            encoded = json.dumps(payload).encode("utf-8")
+            self._record(
+                RecordedRequest(
+                    method=handler.command,
+                    path=parsed.path,
+                    status=status,
+                    query=query,
+                    headers=headers,
+                    body_text=body_text,
+                    body_json=body_json,
+                )
+            )
+            handler.send_response(status)
+            handler.send_header("Content-Type", "application/json")
+            handler.send_header("Content-Length", str(len(encoded)))
+            handler.end_headers()
+            handler.wfile.write(encoded)
+            return
+
+        target_url = f"{self.target_base_url}{handler.path}"
+        request = urllib.request.Request(
+            target_url,
+            data=body if body else None,
+            headers=headers,
+            method=handler.command,
+        )
+
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                payload = response.read()
+                status = response.getcode()
+                response_headers = response.headers
+        except urllib.error.HTTPError as exc:
+            payload = exc.read()
+            status = exc.code
+            response_headers = exc.headers
+        except urllib.error.URLError as exc:
+            encoded = json.dumps({"error": str(exc)}).encode("utf-8")
+            status = 502
+            payload = encoded
+            response_headers = {"Content-Type": "application/json"}
+
+        self._record(
+            RecordedRequest(
+                method=handler.command,
+                path=parsed.path,
+                status=status,
+                query=query,
+                headers=headers,
+                body_text=body_text,
+                body_json=body_json,
+            )
+        )
+        handler.send_response(status)
+        for key, value in response_headers.items():
+            if key.lower() == "transfer-encoding":
+                continue
+            handler.send_header(key, value)
+        handler.send_header("Content-Length", str(len(payload)))
+        handler.end_headers()
+        handler.wfile.write(payload)
+
+    def _record(self, record: RecordedRequest) -> None:
+        with self._lock:
+            self._records.append(record)
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])

--- a/compat/runtime.py
+++ b/compat/runtime.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .external import run_external_module
+from .manifest import load_manifest
+from .openclaw import CompatFailure, run_openclaw_module
+
+
+@dataclass
+class ResultRecord:
+    run_id: str
+    lane: str
+    agent: str
+    module: str
+    host_channel: str
+    host_version_detected: str
+    plugin_source: str
+    plugin_version: str
+    model_profile: str
+    status: str
+    failure_class: str
+    artifacts: list[str]
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _read_plugin_version(repo_root: Path, agent: str) -> str:
+    if agent == "openclaw":
+        package_path = repo_root / "openclaw-plugin" / "package.json"
+    elif agent == "opencode":
+        package_path = repo_root / "opencode-plugin" / "package.json"
+    elif agent == "codex":
+        package_path = repo_root / "codex-plugin" / "package.json"
+    else:
+        return ""
+
+    try:
+        payload = json.loads(package_path.read_text(encoding="utf-8"))
+    except Exception:
+        return ""
+    version = payload.get("version")
+    return version if isinstance(version, str) else ""
+
+
+def _host_version_from_details(details: dict[str, Any]) -> str:
+    probe = details.get("probe")
+    if isinstance(probe, dict):
+        version_text = probe.get("version_text")
+        if isinstance(version_text, str):
+            return version_text
+    return ""
+
+
+def _module_output_dir(
+    *,
+    repo_root: Path,
+    run_id: str,
+    module_name: str,
+    artifacts_root: str | None,
+) -> Path:
+    root = Path(artifacts_root) if artifacts_root else repo_root / "compat" / "artifacts"
+    module_dir = root / run_id / module_name
+    module_dir.mkdir(parents=True, exist_ok=True)
+    return module_dir
+
+
+def write_json(path: Path, payload: Any) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def run_module(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    module_name: str,
+    lane: str,
+    host_channel: str,
+    model_profile: str,
+    plugin_source: str,
+    agent_ref: str | None = None,
+    run_id: str | None = None,
+    artifacts_root: str | None = None,
+) -> ResultRecord:
+    modules = manifest.get("modules", {})
+    module_cfg = modules.get(module_name)
+    if not isinstance(module_cfg, dict):
+        raise ValueError(f"unknown module: {module_name}")
+
+    run_id = run_id or str(uuid.uuid4())
+    agent = str(module_cfg.get("agent", ""))
+    module_dir = _module_output_dir(
+        repo_root=repo_root,
+        run_id=run_id,
+        module_name=module_name,
+        artifacts_root=artifacts_root,
+    )
+
+    start = time.time()
+    details: dict[str, Any] = {}
+    status = "passed"
+    failure_class = ""
+
+    try:
+        kind = module_cfg.get("kind")
+        if kind == "openclaw":
+            details = run_openclaw_module(
+                repo_root=repo_root,
+                module_dir=module_dir,
+                manifest=manifest,
+                module_name=module_name,
+                host_channel=host_channel,
+                model_profile_name=model_profile,
+                plugin_source=plugin_source,
+            )
+        elif kind in {"hermes-pytest", "hermes-hosted", "dify-contract", "dify-hosted"}:
+            details = run_external_module(
+                manifest=manifest,
+                module_name=module_name,
+                module_cfg=module_cfg,
+                module_dir=module_dir,
+                agent_ref=agent_ref,
+            )
+        elif kind == "command":
+            argv = module_cfg.get("argv")
+            if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
+                raise CompatFailure("setup_failure", f"invalid argv for module {module_name}")
+            proc = subprocess.run(
+                argv,
+                cwd=str(repo_root),
+                env={
+                    **os.environ.copy(),
+                    "COMPAT_AGENT_REF": agent_ref or "",
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            (module_dir / "command.stdout.txt").write_text(proc.stdout, encoding="utf-8")
+            (module_dir / "command.stderr.txt").write_text(proc.stderr, encoding="utf-8")
+            details = {"argv": argv, "returncode": proc.returncode}
+            if proc.returncode != 0:
+                raise CompatFailure(str(module_cfg.get("failure_class", "host_contract_break")), proc.stderr.strip())
+        else:
+            raise CompatFailure("setup_failure", f"unsupported module kind for {module_name}: {kind}")
+    except CompatFailure as exc:
+        status = "failed"
+        failure_class = exc.failure_class
+        details.setdefault("error", str(exc))
+    except Exception as exc:  # noqa: BLE001
+        status = "failed"
+        failure_class = "env_flake"
+        details.setdefault("error", str(exc))
+
+    details["duration_seconds"] = round(time.time() - start, 3)
+    write_json(module_dir / "details.json", details)
+
+    result = ResultRecord(
+        run_id=run_id,
+        lane=lane,
+        agent=agent,
+        module=module_name,
+        host_channel=host_channel,
+        host_version_detected=_host_version_from_details(details),
+        plugin_source=plugin_source,
+        plugin_version=_read_plugin_version(repo_root, agent),
+        model_profile=model_profile,
+        status=status,
+        failure_class=failure_class,
+        artifacts=[str(module_dir)],
+        details=details,
+    )
+    write_json(module_dir / "result.json", result.to_dict())
+    return result
+
+
+def run_suite(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    suite_name: str,
+    lane: str,
+    host_channel: str,
+    model_profile: str,
+    plugin_source: str,
+    agent_ref: str | None = None,
+    artifacts_root: str | None = None,
+) -> dict[str, Any]:
+    suites = manifest.get("suites", {})
+    suite_cfg = suites.get(suite_name)
+    if not isinstance(suite_cfg, dict):
+        raise ValueError(f"unknown suite: {suite_name}")
+    run_id = str(uuid.uuid4())
+    results = []
+    for module_name in suite_cfg.get("modules", []):
+        if not isinstance(module_name, str):
+            raise ValueError(f"invalid module entry in suite {suite_name}: {module_name!r}")
+        result = run_module(
+            repo_root=repo_root,
+            manifest=manifest,
+            module_name=module_name,
+            lane=lane,
+            host_channel=host_channel,
+            model_profile=model_profile,
+            plugin_source=plugin_source,
+            agent_ref=agent_ref,
+            run_id=run_id,
+            artifacts_root=artifacts_root,
+        )
+        results.append(result.to_dict())
+        if result.status == "failed" and not bool(suite_cfg.get("continue_on_failure", False)):
+            break
+
+    summary = {
+        "run_id": run_id,
+        "suite": suite_name,
+        "lane": lane,
+        "host_channel": host_channel,
+        "model_profile": model_profile,
+        "plugin_source": plugin_source,
+        "agent_ref": agent_ref or "",
+        "results": results,
+        "status": "failed" if any(item["status"] == "failed" for item in results) else "passed",
+    }
+    suite_dir = _module_output_dir(
+        repo_root=repo_root,
+        run_id=run_id,
+        module_name=f"suite-{suite_name}",
+        artifacts_root=artifacts_root,
+    )
+    write_json(suite_dir / "summary.json", summary)
+    return summary
+
+
+def run_matrix(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    lane_name: str,
+    agent_ref: str | None = None,
+    artifacts_root: str | None = None,
+) -> dict[str, Any]:
+    matrices = manifest.get("matrices", {})
+    matrix_cfg = matrices.get(lane_name)
+    if not isinstance(matrix_cfg, dict):
+        raise ValueError(f"unknown matrix: {lane_name}")
+
+    run_id = str(uuid.uuid4())
+    task_results: list[dict[str, Any]] = []
+    for task in matrix_cfg.get("tasks", []):
+        if not isinstance(task, dict):
+            raise ValueError(f"invalid task in matrix {lane_name}: {task!r}")
+        kind = task.get("kind")
+        if kind == "suite":
+            summary = run_suite(
+                repo_root=repo_root,
+                manifest=manifest,
+                suite_name=str(task["suite"]),
+                lane=lane_name,
+                host_channel=str(task.get("host_channel", "stable")),
+                model_profile=str(task.get("model_profile", "primary")),
+                plugin_source=str(task.get("plugin_source", "local")),
+                agent_ref=agent_ref,
+                artifacts_root=artifacts_root,
+            )
+            task_results.append({"name": task.get("name", task["suite"]), "kind": "suite", "summary": summary})
+        elif kind == "command":
+            argv = task.get("argv")
+            if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
+                raise ValueError(f"invalid argv in matrix {lane_name}: {task!r}")
+            proc = subprocess.run(
+                argv,
+                cwd=str(repo_root),
+                env=os.environ.copy(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            task_dir = _module_output_dir(
+                repo_root=repo_root,
+                run_id=run_id,
+                module_name=str(task.get("name", "command")),
+                artifacts_root=artifacts_root,
+            )
+            (task_dir / "stdout.txt").write_text(proc.stdout, encoding="utf-8")
+            (task_dir / "stderr.txt").write_text(proc.stderr, encoding="utf-8")
+            task_results.append(
+                {
+                    "name": task.get("name", "command"),
+                    "kind": "command",
+                    "argv": argv,
+                    "returncode": proc.returncode,
+                    "status": "passed" if proc.returncode == 0 else "failed",
+                    "artifacts": [str(task_dir)],
+                }
+            )
+            if proc.returncode != 0:
+                break
+        else:
+            raise ValueError(f"unsupported matrix task kind: {kind}")
+
+    summary = {
+        "run_id": run_id,
+        "lane": lane_name,
+        "agent_ref": agent_ref or "",
+        "tasks": task_results,
+        "status": "failed" if any(task.get("status") == "failed" or task.get("summary", {}).get("status") == "failed" for task in task_results) else "passed",
+    }
+    matrix_dir = _module_output_dir(
+        repo_root=repo_root,
+        run_id=run_id,
+        module_name=f"matrix-{lane_name}",
+        artifacts_root=artifacts_root,
+    )
+    write_json(matrix_dir / "summary.json", summary)
+    return summary
+
+
+def _agent_lane_plan(manifest: dict[str, Any], lane: str, agent: str) -> list[dict[str, Any]]:
+    lanes = manifest.get("agent_lanes", {})
+    lane_cfg = lanes.get(lane)
+    if not isinstance(lane_cfg, dict):
+        raise ValueError(f"unknown agent lane: {lane}")
+    if agent == "all":
+        agents = ["openclaw", "hermes", "claude", "opencode", "codex", "dify"]
+        plan: list[dict[str, Any]] = []
+        for item_agent in agents:
+            plan.extend(_agent_lane_plan(manifest, lane, item_agent))
+        return plan
+    agent_cfg = lane_cfg.get(agent)
+    if not isinstance(agent_cfg, list):
+        raise ValueError(f"agent {agent!r} is not configured for lane {lane!r}")
+    return [item for item in agent_cfg if isinstance(item, dict)]
+
+
+def run_agent_lane(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    agent: str,
+    lane: str,
+    host_channel: str,
+    model_profile: str,
+    plugin_source: str,
+    agent_ref: str | None = None,
+    artifacts_root: str | None = None,
+) -> dict[str, Any]:
+    run_id = str(uuid.uuid4())
+    task_results: list[dict[str, Any]] = []
+    for task in _agent_lane_plan(manifest, lane, agent):
+        kind = task.get("kind")
+        resolved_plugin_source = str(task.get("plugin_source", plugin_source)) if plugin_source == "manifest" else plugin_source
+        if kind == "module":
+            result = run_module(
+                repo_root=repo_root,
+                manifest=manifest,
+                module_name=str(task["module"]),
+                lane=lane,
+                host_channel=str(task.get("host_channel", host_channel)),
+                model_profile=str(task.get("model_profile", model_profile)),
+                plugin_source=resolved_plugin_source,
+                agent_ref=agent_ref,
+                run_id=run_id,
+                artifacts_root=artifacts_root,
+            )
+            task_results.append({"name": task.get("name", task["module"]), "kind": "module", "result": result.to_dict()})
+            if result.status == "failed":
+                break
+        elif kind == "suite":
+            summary = run_suite(
+                repo_root=repo_root,
+                manifest=manifest,
+                suite_name=str(task["suite"]),
+                lane=lane,
+                host_channel=str(task.get("host_channel", host_channel)),
+                model_profile=str(task.get("model_profile", model_profile)),
+                plugin_source=resolved_plugin_source,
+                agent_ref=agent_ref,
+                artifacts_root=artifacts_root,
+            )
+            task_results.append({"name": task.get("name", task["suite"]), "kind": "suite", "summary": summary})
+            if summary["status"] == "failed":
+                break
+        else:
+            raise ValueError(f"unsupported agent lane task kind: {kind}")
+
+    status = "failed" if any(
+        task.get("result", {}).get("status") == "failed"
+        or task.get("summary", {}).get("status") == "failed"
+        for task in task_results
+    ) else "passed"
+    summary = {
+        "run_id": run_id,
+        "agent": agent,
+        "lane": lane,
+        "host_channel": host_channel,
+        "model_profile": model_profile,
+        "plugin_source": plugin_source,
+        "agent_ref": agent_ref or "",
+        "tasks": task_results,
+        "status": status,
+    }
+    agent_dir = _module_output_dir(
+        repo_root=repo_root,
+        run_id=run_id,
+        module_name=f"agent-{agent}-{lane}",
+        artifacts_root=artifacts_root,
+    )
+    write_json(agent_dir / "summary.json", summary)
+    return summary
+
+
+def load_default_manifest(repo_root: Path) -> dict[str, Any]:
+    return load_manifest(repo_root / "compat" / "manifest.yaml")

--- a/compat/runtime.py
+++ b/compat/runtime.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from .external import run_external_module
+from .host_smoke import run_host_smoke_module
 from .manifest import load_manifest
 from .openclaw import CompatFailure, run_openclaw_module
 
@@ -23,6 +24,8 @@ class ResultRecord:
     host_channel: str
     host_version_detected: str
     plugin_source: str
+    plugin_ref: str
+    host_ref: str
     plugin_version: str
     model_profile: str
     status: str
@@ -53,6 +56,9 @@ def _read_plugin_version(repo_root: Path, agent: str) -> str:
 
 
 def _host_version_from_details(details: dict[str, Any]) -> str:
+    version_text = details.get("version_text")
+    if isinstance(version_text, str):
+        return version_text
     probe = details.get("probe")
     if isinstance(probe, dict):
         version_text = probe.get("version_text")
@@ -78,6 +84,104 @@ def write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
+def _agent_config(manifest: dict[str, Any], agent: str) -> dict[str, Any]:
+    cfg = manifest.get("agents", {}).get(agent)
+    return cfg if isinstance(cfg, dict) else {}
+
+
+def _plugin_repo(agent_cfg: dict[str, Any]) -> str:
+    plugin_cfg = agent_cfg.get("plugin")
+    if isinstance(plugin_cfg, dict) and isinstance(plugin_cfg.get("repo"), str):
+        return str(plugin_cfg["repo"])
+    repo = agent_cfg.get("repo")
+    return str(repo) if isinstance(repo, str) else ""
+
+
+def _checkout_plugin_ref(
+    *,
+    repo_root: Path,
+    manifest: dict[str, Any],
+    agent: str,
+    plugin_ref: str,
+    module_dir: Path,
+) -> tuple[Path, dict[str, Any]]:
+    if plugin_ref.startswith("path:"):
+        path_value = Path(plugin_ref.split(":", 1)[1]).expanduser().resolve()
+        if not path_value.exists():
+            raise CompatFailure("setup_failure", f"plugin_ref path does not exist: {path_value}")
+        return path_value, {"source": "path", "path": str(path_value), "ref": plugin_ref}
+    if plugin_ref.startswith(("npm:", "pkg:")):
+        raise CompatFailure("setup_failure", f"plugin_ref {plugin_ref!r} is not supported for command contract modules")
+
+    agent_cfg = _agent_config(manifest, agent)
+    repo = _plugin_repo(agent_cfg)
+    ref = plugin_ref
+    if plugin_ref.startswith("github:"):
+        spec = plugin_ref.split(":", 1)[1]
+        if "@" not in spec:
+            raise CompatFailure("setup_failure", "github plugin_ref must look like github:<owner>/<repo>@<ref>")
+        repo, ref = spec.rsplit("@", 1)
+    if not repo:
+        return repo_root, {"source": "current_checkout", "ref": plugin_ref}
+
+    repo_url = repo if repo.startswith(("http://", "https://", "git@")) else f"https://github.com/{repo}.git"
+    checkout_dir = module_dir / "plugin-checkout" / agent
+    checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+    init = subprocess.run(
+        ["git", "init", str(checkout_dir)],
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    (module_dir / "plugin-git-init.stdout.txt").write_text(init.stdout, encoding="utf-8")
+    (module_dir / "plugin-git-init.stderr.txt").write_text(init.stderr, encoding="utf-8")
+    if init.returncode != 0:
+        raise CompatFailure("setup_failure", init.stderr.strip() or "plugin checkout git init failed")
+    fetch = subprocess.run(
+        ["git", "fetch", "--depth", "1", repo_url, ref],
+        cwd=str(checkout_dir),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    (module_dir / "plugin-git-fetch.stdout.txt").write_text(fetch.stdout, encoding="utf-8")
+    (module_dir / "plugin-git-fetch.stderr.txt").write_text(fetch.stderr, encoding="utf-8")
+    if fetch.returncode != 0:
+        raise CompatFailure("setup_failure", fetch.stderr.strip() or f"plugin checkout fetch failed for {repo}@{ref}")
+    checkout = subprocess.run(
+        ["git", "checkout", "--detach", "FETCH_HEAD"],
+        cwd=str(checkout_dir),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    (module_dir / "plugin-git-checkout.stdout.txt").write_text(checkout.stdout, encoding="utf-8")
+    (module_dir / "plugin-git-checkout.stderr.txt").write_text(checkout.stderr, encoding="utf-8")
+    if checkout.returncode != 0:
+        raise CompatFailure("setup_failure", checkout.stderr.strip() or "plugin checkout failed")
+    rev = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=str(checkout_dir),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    return checkout_dir, {
+        "source": "git",
+        "repo": repo,
+        "repo_url": repo_url,
+        "ref": ref,
+        "sha": rev.stdout.strip() if rev.returncode == 0 else "",
+        "path": str(checkout_dir),
+    }
+
+
 def run_module(
     *,
     repo_root: Path,
@@ -87,7 +191,8 @@ def run_module(
     host_channel: str,
     model_profile: str,
     plugin_source: str,
-    agent_ref: str | None = None,
+    plugin_ref: str | None = None,
+    host_ref: str | None = None,
     run_id: str | None = None,
     artifacts_root: str | None = None,
 ) -> ResultRecord:
@@ -121,25 +226,50 @@ def run_module(
                 host_channel=host_channel,
                 model_profile_name=model_profile,
                 plugin_source=plugin_source,
+                host_ref=host_ref,
             )
-        elif kind in {"hermes-pytest", "hermes-hosted", "dify-contract", "dify-hosted"}:
+        elif kind in {"hermes-pytest", "hermes-hosted", "hermes-host-smoke", "dify-contract", "dify-hosted"}:
             details = run_external_module(
                 manifest=manifest,
                 module_name=module_name,
                 module_cfg=module_cfg,
                 module_dir=module_dir,
-                agent_ref=agent_ref,
+                plugin_ref=plugin_ref,
+                host_ref=host_ref,
+            )
+        elif kind == "host-smoke":
+            details = run_host_smoke_module(
+                repo_root=repo_root,
+                manifest=manifest,
+                module_name=module_name,
+                module_cfg=module_cfg,
+                module_dir=module_dir,
+                plugin_source=plugin_source,
+                plugin_ref=plugin_ref,
+                host_ref=host_ref,
             )
         elif kind == "command":
             argv = module_cfg.get("argv")
             if not isinstance(argv, list) or not all(isinstance(item, str) for item in argv):
                 raise CompatFailure("setup_failure", f"invalid argv for module {module_name}")
+            command_cwd = repo_root
+            plugin_checkout: dict[str, Any] | None = None
+            if plugin_ref:
+                command_cwd, plugin_checkout = _checkout_plugin_ref(
+                    repo_root=repo_root,
+                    manifest=manifest,
+                    agent=agent,
+                    plugin_ref=plugin_ref,
+                    module_dir=module_dir,
+                )
             proc = subprocess.run(
                 argv,
-                cwd=str(repo_root),
+                cwd=str(command_cwd),
                 env={
                     **os.environ.copy(),
-                    "COMPAT_AGENT_REF": agent_ref or "",
+                    "COMPAT_PLUGIN_REF": plugin_ref or "",
+                    "COMPAT_HOST_REF": host_ref or "",
+                    "COMPAT_AGENT_REF": plugin_ref or "",
                 },
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -148,7 +278,9 @@ def run_module(
             )
             (module_dir / "command.stdout.txt").write_text(proc.stdout, encoding="utf-8")
             (module_dir / "command.stderr.txt").write_text(proc.stderr, encoding="utf-8")
-            details = {"argv": argv, "returncode": proc.returncode}
+            details = {"argv": argv, "returncode": proc.returncode, "cwd": str(command_cwd)}
+            if plugin_checkout is not None:
+                details["plugin_checkout"] = plugin_checkout
             if proc.returncode != 0:
                 raise CompatFailure(str(module_cfg.get("failure_class", "host_contract_break")), proc.stderr.strip())
         else:
@@ -173,6 +305,8 @@ def run_module(
         host_channel=host_channel,
         host_version_detected=_host_version_from_details(details),
         plugin_source=plugin_source,
+        plugin_ref=plugin_ref or "",
+        host_ref=host_ref or "",
         plugin_version=_read_plugin_version(repo_root, agent),
         model_profile=model_profile,
         status=status,
@@ -193,7 +327,8 @@ def run_suite(
     host_channel: str,
     model_profile: str,
     plugin_source: str,
-    agent_ref: str | None = None,
+    plugin_ref: str | None = None,
+    host_ref: str | None = None,
     artifacts_root: str | None = None,
 ) -> dict[str, Any]:
     suites = manifest.get("suites", {})
@@ -213,7 +348,8 @@ def run_suite(
             host_channel=host_channel,
             model_profile=model_profile,
             plugin_source=plugin_source,
-            agent_ref=agent_ref,
+            plugin_ref=plugin_ref,
+            host_ref=host_ref,
             run_id=run_id,
             artifacts_root=artifacts_root,
         )
@@ -228,7 +364,9 @@ def run_suite(
         "host_channel": host_channel,
         "model_profile": model_profile,
         "plugin_source": plugin_source,
-        "agent_ref": agent_ref or "",
+        "plugin_ref": plugin_ref or "",
+        "host_ref": host_ref or "",
+        "agent_ref": plugin_ref or "",
         "results": results,
         "status": "failed" if any(item["status"] == "failed" for item in results) else "passed",
     }
@@ -247,7 +385,8 @@ def run_matrix(
     repo_root: Path,
     manifest: dict[str, Any],
     lane_name: str,
-    agent_ref: str | None = None,
+    plugin_ref: str | None = None,
+    host_ref: str | None = None,
     artifacts_root: str | None = None,
 ) -> dict[str, Any]:
     matrices = manifest.get("matrices", {})
@@ -270,7 +409,8 @@ def run_matrix(
                 host_channel=str(task.get("host_channel", "stable")),
                 model_profile=str(task.get("model_profile", "primary")),
                 plugin_source=str(task.get("plugin_source", "local")),
-                agent_ref=agent_ref,
+                plugin_ref=plugin_ref,
+                host_ref=host_ref,
                 artifacts_root=artifacts_root,
             )
             task_results.append({"name": task.get("name", task["suite"]), "kind": "suite", "summary": summary})
@@ -313,7 +453,9 @@ def run_matrix(
     summary = {
         "run_id": run_id,
         "lane": lane_name,
-        "agent_ref": agent_ref or "",
+        "plugin_ref": plugin_ref or "",
+        "host_ref": host_ref or "",
+        "agent_ref": plugin_ref or "",
         "tasks": task_results,
         "status": "failed" if any(task.get("status") == "failed" or task.get("summary", {}).get("status") == "failed" for task in task_results) else "passed",
     }
@@ -353,7 +495,8 @@ def run_agent_lane(
     host_channel: str,
     model_profile: str,
     plugin_source: str,
-    agent_ref: str | None = None,
+    plugin_ref: str | None = None,
+    host_ref: str | None = None,
     artifacts_root: str | None = None,
 ) -> dict[str, Any]:
     run_id = str(uuid.uuid4())
@@ -370,7 +513,8 @@ def run_agent_lane(
                 host_channel=str(task.get("host_channel", host_channel)),
                 model_profile=str(task.get("model_profile", model_profile)),
                 plugin_source=resolved_plugin_source,
-                agent_ref=agent_ref,
+                plugin_ref=plugin_ref,
+                host_ref=host_ref,
                 run_id=run_id,
                 artifacts_root=artifacts_root,
             )
@@ -386,7 +530,8 @@ def run_agent_lane(
                 host_channel=str(task.get("host_channel", host_channel)),
                 model_profile=str(task.get("model_profile", model_profile)),
                 plugin_source=resolved_plugin_source,
-                agent_ref=agent_ref,
+                plugin_ref=plugin_ref,
+                host_ref=host_ref,
                 artifacts_root=artifacts_root,
             )
             task_results.append({"name": task.get("name", task["suite"]), "kind": "suite", "summary": summary})
@@ -407,7 +552,9 @@ def run_agent_lane(
         "host_channel": host_channel,
         "model_profile": model_profile,
         "plugin_source": plugin_source,
-        "agent_ref": agent_ref or "",
+        "plugin_ref": plugin_ref or "",
+        "host_ref": host_ref or "",
+        "agent_ref": plugin_ref or "",
         "tasks": task_results,
         "status": status,
     }

--- a/compat/tests/__init__.py
+++ b/compat/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the compat harness."""

--- a/compat/tests/test_compat.py
+++ b/compat/tests/test_compat.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import http.server
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import threading
+import unittest
+from pathlib import Path
+
+from compat.manifest import load_manifest
+from compat.runtime import run_module, run_suite
+
+
+class FakeMem9Handler(http.server.BaseHTTPRequestHandler):
+    memories = []
+    last_messages = []
+
+    def do_POST(self):  # noqa: N802
+        if self.path == "/v1alpha1/mem9s":
+            self._write_json(201, {"id": "tenant-123"})
+            return
+
+        if self.path == "/v1alpha2/mem9s/memories":
+            length = int(self.headers.get("Content-Length", "0"))
+            body = self.rfile.read(length).decode("utf-8")
+            payload = json.loads(body) if body else {}
+            if "content" in payload:
+                self.__class__.memories.append(payload["content"])
+            if "messages" in payload:
+                self.__class__.last_messages = payload["messages"]
+            self._write_json(202, {"status": "accepted"})
+            return
+
+        self._write_json(404, {"error": "not found"})
+
+    def do_GET(self):  # noqa: N802
+        if self.path.startswith("/v1alpha2/mem9s/memories"):
+            from urllib.parse import parse_qs, urlsplit
+
+            query = parse_qs(urlsplit(self.path).query)
+            q = "".join(query.get("q", []))
+            matches = [item for item in self.__class__.memories if q.lower() in item.lower()]
+            self._write_json(
+                200,
+                {
+                    "memories": [{"id": f"mem-{idx}", "content": item} for idx, item in enumerate(matches, start=1)],
+                    "total": len(matches),
+                },
+            )
+            return
+        if self.path == "/healthz":
+            self._write_json(200, {"status": "ok"})
+            return
+        self._write_json(404, {"error": "not found"})
+
+    def log_message(self, _format, *_args):
+        return
+
+    def _write_json(self, status: int, payload: dict):
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+def start_fake_mem9_server():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), FakeMem9Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+def write_fake_openclaw_script(path: Path) -> None:
+    path.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env python3
+            import json
+            import os
+            import sys
+            import threading
+            import time
+            import urllib.parse
+            import urllib.request
+            from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+            from pathlib import Path
+
+            HOME = Path(os.environ["HOME"])
+            LOG_PATH = os.environ.get("FAKE_OPENCLAW_LOG", "")
+            VERSION = os.environ.get("FAKE_OPENCLAW_VERSION", "2026.4.22")
+
+            def log(entry):
+                if not LOG_PATH:
+                    return
+                with open(LOG_PATH, "a", encoding="utf-8") as handle:
+                    handle.write(json.dumps(entry) + "\\n")
+
+            def profile_dir(profile):
+                return HOME / f".openclaw-{profile}"
+
+            def config_path(profile):
+                return profile_dir(profile) / "openclaw.json"
+
+            def load_config(profile):
+                path = config_path(profile)
+                if not path.exists():
+                    return {}
+                return json.loads(path.read_text(encoding="utf-8"))
+
+            def save_config(profile, data):
+                path = config_path(profile)
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(json.dumps(data), encoding="utf-8")
+
+            def set_nested(data, key, value):
+                current = data
+                parts = key.split(".")
+                for part in parts[:-1]:
+                    current = current.setdefault(part, {})
+                current[parts[-1]] = value
+
+            class HealthHandler(BaseHTTPRequestHandler):
+                def do_GET(self):
+                    if self.path == "/health":
+                        payload = b'{"status":"ok"}'
+                        self.send_response(200)
+                        self.send_header("Content-Type", "application/json")
+                        self.send_header("Content-Length", str(len(payload)))
+                        self.end_headers()
+                        self.wfile.write(payload)
+                    else:
+                        self.send_response(404)
+                        self.end_headers()
+
+                def log_message(self, _format, *_args):
+                    return
+
+            argv = sys.argv[1:]
+            log({"argv": argv})
+            if argv == ["--version"]:
+                print(VERSION)
+                raise SystemExit(0)
+
+            if len(argv) < 2 or argv[0] != "--profile":
+                print("missing profile", file=sys.stderr)
+                raise SystemExit(2)
+
+            profile = argv[1]
+            cmd = argv[2:]
+
+            if cmd[:2] == ["config", "set"]:
+                strict = False
+                parts = cmd[2:]
+                if parts and parts[0] == "--strict-json":
+                    strict = True
+                    parts = parts[1:]
+                key = parts[0]
+                raw_value = parts[1]
+                value = json.loads(raw_value) if strict else raw_value
+                cfg = load_config(profile)
+                set_nested(cfg, key, value)
+                save_config(profile, cfg)
+                raise SystemExit(0)
+
+            if cmd[:2] == ["config", "get"]:
+                print(json.dumps(load_config(profile)))
+                raise SystemExit(0)
+
+            if cmd[:2] == ["plugins", "install"]:
+                raise SystemExit(0)
+
+            if cmd[:2] == ["gateway", "run"]:
+                port = 0
+                if "--port" in cmd:
+                    port = int(cmd[cmd.index("--port") + 1])
+                server = ThreadingHTTPServer(("127.0.0.1", port), HealthHandler)
+                thread = threading.Thread(target=server.serve_forever, daemon=True)
+                thread.start()
+                try:
+                    while True:
+                        time.sleep(1)
+                except KeyboardInterrupt:
+                    pass
+                finally:
+                    server.shutdown()
+                    server.server_close()
+                raise SystemExit(0)
+
+            if cmd and cmd[0] == "agent":
+                cfg = load_config(profile)
+                mem9_cfg = cfg["plugins"]["entries"]["mem9"]["config"]
+                api_url = mem9_cfg["apiUrl"].rstrip("/")
+                session_id = cmd[cmd.index("--session-id") + 1]
+                message = cmd[cmd.index("--message") + 1]
+                query = urllib.parse.quote(message)
+                urllib.request.urlopen(
+                    urllib.request.Request(
+                        f"{api_url}/v1alpha2/mem9s/memories?q={query}&limit=10",
+                        headers={"X-API-Key": mem9_cfg["apiKey"], "X-Mnemo-Agent-Id": "fake-openclaw"},
+                        method="GET",
+                    ),
+                    timeout=5,
+                ).read()
+                if not message.startswith("/compact"):
+                    payload = json.dumps(
+                        {
+                            "session_id": session_id,
+                            "messages": [
+                                {"role": "user", "content": message},
+                                {"role": "assistant", "content": "stored from fake openclaw"},
+                            ],
+                        }
+                    ).encode("utf-8")
+                    urllib.request.urlopen(
+                        urllib.request.Request(
+                            f"{api_url}/v1alpha2/mem9s/memories",
+                            data=payload,
+                            headers={
+                                "Content-Type": "application/json",
+                                "X-API-Key": mem9_cfg["apiKey"],
+                                "X-Mnemo-Agent-Id": "fake-openclaw",
+                            },
+                            method="POST",
+                        ),
+                        timeout=5,
+                    ).read()
+                print(json.dumps({"result": {"payloads": [{"text": "ok"}]}}))
+                raise SystemExit(0)
+
+            print("unsupported fake openclaw command", file=sys.stderr)
+            raise SystemExit(3)
+            """
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+
+
+class CompatHarnessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeMem9Handler.memories = []
+        FakeMem9Handler.last_messages = []
+        self.server, self.thread = start_fake_mem9_server()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+        self.fake_openclaw = self.tmp_path / "fake-openclaw.py"
+        write_fake_openclaw_script(self.fake_openclaw)
+        self.log_path = self.tmp_path / "fake-openclaw.log"
+        self.repo_root = Path(__file__).resolve().parents[2]
+        self._old_env = {
+            key: os.environ.get(key)
+            for key in [
+                "MNEMO_BASE_URL",
+                "COMPAT_OPENCLAW_STABLE_BIN",
+                "FAKE_OPENCLAW_LOG",
+                "ANTHROPIC_API_KEY",
+            ]
+        }
+        os.environ["MNEMO_BASE_URL"] = f"http://127.0.0.1:{self.server.server_port}"
+        os.environ["COMPAT_OPENCLAW_STABLE_BIN"] = str(self.fake_openclaw)
+        os.environ["FAKE_OPENCLAW_LOG"] = str(self.log_path)
+        os.environ["ANTHROPIC_API_KEY"] = "test-key"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+        self.tmp.cleanup()
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    def test_manifest_loads(self) -> None:
+        manifest = load_manifest(self.repo_root / "compat" / "manifest.yaml")
+        self.assertIn("openclaw.install", manifest["modules"])
+        self.assertEqual(manifest["agents"]["hermes"]["repo"], "mem9-ai/mem9-hermes-plugin")
+        self.assertEqual(manifest["agents"]["dify"]["repo"], "mem9-ai/mem9-dify-plugin")
+        self.assertEqual(manifest["hosts"]["openclaw"]["stable"]["executable"], str(self.fake_openclaw))
+
+    def test_run_openclaw_install_module(self) -> None:
+        manifest = load_manifest(self.repo_root / "compat" / "manifest.yaml")
+        result = run_module(
+            repo_root=self.repo_root,
+            manifest=manifest,
+            module_name="openclaw.install",
+            lane="ad-hoc",
+            host_channel="stable",
+            model_profile="primary",
+            plugin_source="local",
+            artifacts_root=str(self.tmp_path / "artifacts"),
+        )
+        self.assertEqual(result.status, "passed")
+        self.assertIn("2026.4.22", result.host_version_detected)
+
+    def test_run_openclaw_suite(self) -> None:
+        manifest = load_manifest(self.repo_root / "compat" / "manifest.yaml")
+        summary = run_suite(
+            repo_root=self.repo_root,
+            manifest=manifest,
+            suite_name="openclaw-smoke",
+            lane="ad-hoc",
+            host_channel="stable",
+            model_profile="primary",
+            plugin_source="local",
+            artifacts_root=str(self.tmp_path / "artifacts"),
+        )
+        self.assertEqual(summary["status"], "passed")
+        self.assertTrue(any(item["module"] == "openclaw.recall" for item in summary["results"]))
+        self.assertTrue(FakeMem9Handler.last_messages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -69,6 +69,7 @@ export class ServerBackend implements MemoryBackend {
     const url = this.baseUrl + path;
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
+      "User-Agent": "mem9-opencode-plugin/0.1",
       "X-Mnemo-Agent-Id": this.agentName,
       "X-API-Key": this.apiKey,
     };
@@ -82,10 +83,18 @@ export class ServerBackend implements MemoryBackend {
     if (resp.status === 204) return undefined as T;
 
     const text = await resp.text();
-    const data = text ? (JSON.parse(text) as unknown) : undefined;
+    let data: unknown;
+    if (text) {
+      try {
+        data = JSON.parse(text) as unknown;
+      } catch {
+        data = undefined;
+      }
+    }
     if (!resp.ok) {
-      const message =
-        isRecord(data) && typeof data.error === "string" ? data.error : `HTTP ${resp.status}`;
+      const message = isRecord(data) && typeof data.error === "string"
+        ? data.error
+        : `HTTP ${resp.status}${text ? `: ${text.slice(0, 200)}` : ""}`;
       throw new Error(message);
     }
     return data as T;

--- a/opencode-plugin/src/server/tools.ts
+++ b/opencode-plugin/src/server/tools.ts
@@ -24,6 +24,10 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           .string()
           .optional()
           .describe("Which agent wrote this memory"),
+        memory_type: tool.schema
+          .string()
+          .optional()
+          .describe("Memory type to create, for example pinned"),
         tags: tool.schema
           .array(tool.schema.string())
           .max(20)
@@ -39,6 +43,7 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           const input: CreateMemoryInput = {
             content: args.content,
             source: args.source,
+            memory_type: args.memory_type,
             tags: args.tags,
             metadata: args.metadata as Record<string, unknown> | undefined,
           };

--- a/opencode-plugin/src/shared/types.ts
+++ b/opencode-plugin/src/shared/types.ts
@@ -51,6 +51,7 @@ export interface SearchResult {
 export interface CreateMemoryInput {
   content: string;
   source?: string;
+  memory_type?: string;
   tags?: string[];
   metadata?: Record<string, unknown>;
 }
@@ -58,6 +59,7 @@ export interface CreateMemoryInput {
 export interface UpdateMemoryInput {
   content?: string;
   source?: string;
+  memory_type?: string;
   tags?: string[];
   metadata?: Record<string, unknown>;
 }

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -70,6 +70,27 @@ test("ServerBackend reports non-JSON HTTP errors clearly", async () => {
   }
 });
 
+test("ServerBackend forwards memory_type in store body", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestBody: unknown;
+
+  globalThis.fetch = async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body));
+    return new Response(JSON.stringify({ id: "memory-1", content: "saved" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    await backend.store({ content: "saved", memory_type: "pinned" });
+    assert.deepEqual(requestBody, { content: "saved", memory_type: "pinned" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("ServerBackend uses searchTimeoutMs for search and defaultTimeoutMs for writes", async () => {
   const originalFetch = globalThis.fetch;
 

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -45,6 +45,26 @@ test("ServerBackend uses X-API-Key and v1alpha2 paths", async () => {
     await backend.search({ q: "hello" });
     assert.equal(requestURL.includes("/v1alpha2/mem9s/memories"), true);
     assert.equal(requestHeaders?.get("X-API-Key"), "mk_demo");
+    assert.equal(requestHeaders?.get("User-Agent"), "mem9-opencode-plugin/0.1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ServerBackend reports non-JSON HTTP errors clearly", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => new Response("<html>forbidden</html>", {
+    status: 403,
+    headers: { "Content-Type": "text/html" },
+  });
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    await assert.rejects(
+      () => backend.store({ content: "saved" }),
+      /HTTP 403: <html>forbidden<\/html>/,
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
## Summary

Adds a repo-owned compatibility harness and manual GitHub Action for upgrade checks across the mem9 agent stack:

- OpenClaw
- Hermes Agent
- Claude Code
- OpenCode
- Codex
- Dify

The latest workflow separates the two upgrade axes:

- `plugin_ref`: the mem9 plugin candidate ref/version/source
- `host_ref`: the host agent/CLI candidate version, tag, SHA, or `path:<bin>`

This lets us test plugin upgrades by themselves and host upgrades by themselves from GitHub Actions.

## What changed

- Added `compat/` with a manifest-driven runner:
  - `python3 compat run <module>`
  - `python3 compat suite <suite>`
  - `python3 compat matrix <lane>`
  - `python3 compat agent <agent|all> --lane <plugin-contract|host-smoke|full>`
- Added `compat/manifest.yaml` with plugin metadata, host metadata, default refs, stable/next channels, and lane plans for all six agents.
- Added OpenClaw live modules for install/setup/recall/ingest/compact/restart/failsoft, with `host_ref` support for `openclaw@<version>` or `path:<bin>`.
- Added external repo support for `mem9-ai/mem9-hermes-plugin` and `mem9-ai/mem9-dify-plugin` via `plugin_ref`.
- Added host-smoke coverage for:
  - Hermes host checkout plus provider HTTP contract smoke
  - Claude Code real CLI install/validate plus hook lifecycle HTTP shape
  - OpenCode real CLI install plus plugin config/TUI registration smoke
  - Codex real CLI install plus marketplace command, setup script, hook feature, recall/store hook smoke
- Added Dify contract coverage with a stubbed Dify runtime for auth mode, headers, `session_id`, `scanAll`, and store/search request shape.
- Added `.github/workflows/agent-compat.yml` for manual upgrade checks.
- Added `.github/workflows/compat-framework-checks.yml` and `make compat-test` for harness PR checks.
- Uploads `compat/artifacts/**` for per-agent logs and result JSON.

## How to run locally

Fast harness self-test:

```bash
make compat-test
```

Run plugin contract tests:

```bash
python3 compat agent openclaw --lane plugin-contract
python3 compat agent hermes --lane plugin-contract --plugin-ref path:/Users/sx/github/mem9/mem9-hermes-plugin
python3 compat agent dify --lane plugin-contract --plugin-ref path:/Users/sx/github/mem9/mem9-dify-plugin
python3 compat agent claude --lane plugin-contract
python3 compat agent opencode --lane plugin-contract
python3 compat agent codex --lane plugin-contract
```

Run host upgrade smoke tests:

```bash
python3 compat agent claude --lane host-smoke --host-ref 2.1.159
python3 compat agent opencode --lane host-smoke --host-ref 1.15.13 --plugin-source local
python3 compat agent codex --lane host-smoke --host-ref 0.135.0
python3 compat agent openclaw --lane host-smoke --host-ref 2026.5.28 --plugin-source local
python3 compat agent hermes --lane host-smoke --host-ref <hermes-agent-branch-or-tag>
```

Use local installed CLIs during development:

```bash
python3 compat agent claude --lane host-smoke --host-ref path:$(command -v claude)
python3 compat agent opencode --lane host-smoke --host-ref path:$(command -v opencode) --plugin-source local
python3 compat agent codex --lane host-smoke --host-ref path:$(command -v codex)
```

## GitHub Action usage

Manual workflow:

`Actions` -> `Agent compatibility` -> `Run workflow`

Inputs:

- `agent`: `openclaw`, `hermes`, `claude`, `opencode`, `codex`, `dify`, or `all`
- `lane`: `plugin-contract`, `host-smoke`, or `full`
- `plugin_ref`: optional plugin branch/tag/SHA/source override
- `host_ref`: optional host version/tag/SHA/source override
- `host_channel`: `stable` or `next`; `next` is non-blocking
- `plugin_source`: `manifest`, `local`, `npm:<version>`, `path:<path>`, or `github:<repo>@<ref>`

Plugin upgrade example:

```text
agent: opencode
lane: plugin-contract
plugin_ref: <plugin-branch-or-tag-or-sha>
host_ref: <empty>
host_channel: stable
plugin_source: manifest
```

Host upgrade example:

```text
agent: codex
lane: host-smoke
plugin_ref: <empty>
host_ref: 0.135.0
host_channel: stable
plugin_source: manifest
```

Full matrix example:

```text
agent: all
lane: full
host_channel: stable
plugin_source: local
```

## GitHub Action configuration

No secrets are required for:

- all `plugin-contract` lanes
- Claude Code `host-smoke`
- OpenCode `host-smoke`
- Codex `host-smoke`

Required for OpenClaw and Hermes hosted/host smoke lanes:

```text
MNEMO_BASE_URL=<hosted-dev-api-base-url>
```

OpenClaw also needs one model key:

```text
ANTHROPIC_API_KEY=<model-key>
# or
CLAUDE_CODE_TOKEN=<model-key>
```

Optional Action variables for default host refs:

```text
COMPAT_OPENCLAW_STABLE_VERSION=<openclaw-version>
COMPAT_OPENCLAW_NEXT_VERSION=<openclaw-next-version>
COMPAT_HERMES_HOST_REF=<hermes-agent-ref>
COMPAT_CLAUDE_HOST_REF=<claude-code-version>
COMPAT_OPENCODE_HOST_REF=<opencode-ai-version>
COMPAT_CODEX_HOST_REF=<codex-version>
```

## Verified locally

```bash
python3 -m py_compile compat/*.py && make compat-test
python3 compat agent claude --lane host-smoke --host-ref path:$(command -v claude)
python3 compat agent opencode --lane host-smoke --host-ref path:$(command -v opencode) --plugin-source local
python3 compat agent codex --lane host-smoke --host-ref path:$(command -v codex)
python3 compat agent claude --lane plugin-contract --plugin-ref path:/Users/sx/github/mem9/mem9
```

OpenClaw `host_ref path:<bin>` was also verified with the fake OpenClaw harness in `compat-test`. Live OpenClaw/Hermes hosted checks require `MNEMO_BASE_URL` and, for OpenClaw, a model key.
