### PR TITLE
[codex] support memory list server sorting

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -688,6 +688,12 @@
           },
           {
             "$ref": "#/components/parameters/SessionID"
+          },
+          {
+            "$ref": "#/components/parameters/SortBy"
+          },
+          {
+            "$ref": "#/components/parameters/SortDir"
           }
         ],
         "responses": {
@@ -1251,6 +1257,36 @@
         "description": "Session identifier filter.",
         "schema": {
           "type": "string"
+        }
+      },
+      "SortBy": {
+        "name": "sort_by",
+        "in": "query",
+        "required": false,
+        "description": "Sort field used when listing memories.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "content",
+            "memory_type",
+            "tags",
+            "updated_at"
+          ],
+          "default": "updated_at"
+        }
+      },
+      "SortDir": {
+        "name": "sort_dir",
+        "in": "query",
+        "required": false,
+        "description": "Sort direction used when listing memories.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
         }
       },
       "ScanAll": {

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -151,6 +151,8 @@ type MemoryFilter struct {
 	MemoryType string
 	AgentID    string
 	SessionID  string
+	SortBy     string
+	SortDir    string
 	Limit      int
 	Offset     int
 	ScanAll    bool

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -376,7 +376,7 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 	}
 
 	totalBeforePage := len(uniqueChainMemories(visited))
-	memories := finalizeChainMemories(visited, requestLimit, requestOffset, queryMode)
+	memories := finalizeChainMemories(visited, filter, requestLimit, requestOffset, queryMode)
 	slog.InfoContext(ctx, "space chain recall",
 		"chain_id", auth.Chain.ChainID,
 		"visited_node_count", visitedNodes,
@@ -610,9 +610,13 @@ func chainRankScore(mem domain.Memory) float64 {
 	return 0
 }
 
-func finalizeChainMemories(memories []domain.Memory, limit, offset int, queryMode bool) []domain.Memory {
+func finalizeChainMemories(memories []domain.Memory, filter domain.MemoryFilter, limit, offset int, queryMode bool) []domain.Memory {
 	memories = uniqueChainMemories(memories)
-	if queryMode {
+	if strings.TrimSpace(filter.SortBy) != "" {
+		sort.SliceStable(memories, func(i, j int) bool {
+			return compareChainMemoryForSort(memories[i], memories[j], filter)
+		})
+	} else if queryMode {
 		sort.SliceStable(memories, func(i, j int) bool {
 			leftConfidence := chainStopConfidence(memories[i])
 			rightConfidence := chainStopConfidence(memories[j])
@@ -645,6 +649,41 @@ func finalizeChainMemories(memories []domain.Memory, limit, offset int, queryMod
 		end = len(memories)
 	}
 	return memories[offset:end]
+}
+
+func compareChainMemoryForSort(left, right domain.Memory, filter domain.MemoryFilter) bool {
+	desc := !strings.EqualFold(strings.TrimSpace(filter.SortDir), "asc")
+	less := false
+	greater := false
+	switch strings.TrimSpace(filter.SortBy) {
+	case "content":
+		cmp := strings.Compare(strings.ToLower(left.Content), strings.ToLower(right.Content))
+		less = cmp < 0
+		greater = cmp > 0
+	case "memory_type":
+		cmp := strings.Compare(string(left.MemoryType), string(right.MemoryType))
+		less = cmp < 0
+		greater = cmp > 0
+	case "tags":
+		cmp := strings.Compare(strings.ToLower(strings.Join(left.Tags, ",")), strings.ToLower(strings.Join(right.Tags, ",")))
+		less = cmp < 0
+		greater = cmp > 0
+	case "updated_at":
+		fallthrough
+	default:
+		less = left.UpdatedAt.Before(right.UpdatedAt)
+		greater = left.UpdatedAt.After(right.UpdatedAt)
+	}
+	if less || greater {
+		if desc {
+			return greater
+		}
+		return less
+	}
+	if left.ChainSource != nil && right.ChainSource != nil && left.ChainSource.NodePosition != right.ChainSource.NodePosition {
+		return left.ChainSource.NodePosition < right.ChainSource.NodePosition
+	}
+	return left.ID < right.ID
 }
 
 func uniqueChainMemories(memories []domain.Memory) []domain.Memory {

--- a/server/internal/handler/chain_runtime_test.go
+++ b/server/internal/handler/chain_runtime_test.go
@@ -151,7 +151,7 @@ func TestFinalizeChainMemories_QueryModeSortsAndClipsByConfidence(t *testing.T) 
 		{ID: "low-confidence-high-score", Score: &lowScore, Confidence: &lowConfidence, UpdatedAt: now},
 		{ID: "mid-confidence", Score: &midScore, Confidence: &midConfidence, UpdatedAt: now.Add(-time.Minute)},
 		{ID: "high-confidence", Score: &highScore, Confidence: &highConfidence, UpdatedAt: now.Add(-2 * time.Minute)},
-	}, 2, 0, true)
+	}, domain.MemoryFilter{}, 2, 0, true)
 
 	if len(got) != 2 {
 		t.Fatalf("memories = %d, want 2", len(got))

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -694,6 +694,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		MemoryType: q.Get("memory_type"),
 		AgentID:    q.Get("agent_id"),
 		SessionID:  q.Get("session_id"),
+		SortBy:     q.Get("sort_by"),
+		SortDir:    q.Get("sort_dir"),
 		Limit:      limit,
 		Offset:     offset,
 		ScanAll:    parseBoolQuery(q.Get("scanAll")),

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -233,7 +233,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 
 	nextParam := len(args) + 1
 	dataQuery := "SELECT " + allColumns + " FROM memories WHERE " +
-		where + fmt.Sprintf(" ORDER BY updated_at DESC LIMIT $%d OFFSET $%d", nextParam, nextParam+1)
+		where + fmt.Sprintf(" ORDER BY %s LIMIT $%d OFFSET $%d", memoryListOrderBy(f), nextParam, nextParam+1)
 	dataArgs := make([]any, len(args), len(args)+2)
 	copy(dataArgs, args)
 	dataArgs = append(dataArgs, limit, offset)
@@ -254,6 +254,27 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 		memories = append(memories, *m)
 	}
 	return memories, total, rows.Err()
+}
+
+func memoryListOrderBy(f domain.MemoryFilter) string {
+	column := "updated_at"
+	switch strings.TrimSpace(f.SortBy) {
+	case "content":
+		column = "content"
+	case "memory_type":
+		column = "memory_type"
+	case "tags":
+		column = "tags"
+	case "updated_at", "":
+		column = "updated_at"
+	}
+
+	direction := "DESC"
+	if strings.EqualFold(strings.TrimSpace(f.SortDir), "asc") {
+		direction = "ASC"
+	}
+
+	return column + " " + direction + ", id " + direction
 }
 
 func (r *MemoryRepo) Count(ctx context.Context) (int, error) {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -269,7 +269,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	}
 
 	dataQuery := "SELECT " + allColumns + " FROM memories WHERE " +
-		where + " ORDER BY updated_at DESC LIMIT ? OFFSET ?"
+		where + " ORDER BY " + memoryListOrderBy(f) + " LIMIT ? OFFSET ?"
 	// Copy args to avoid mutating the original slice (append may reuse underlying array).
 	dataArgs := make([]any, len(args), len(args)+2)
 	copy(dataArgs, args)
@@ -291,6 +291,27 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 		memories = append(memories, *m)
 	}
 	return memories, total, rows.Err()
+}
+
+func memoryListOrderBy(f domain.MemoryFilter) string {
+	column := "updated_at"
+	switch strings.TrimSpace(f.SortBy) {
+	case "content":
+		column = "content"
+	case "memory_type":
+		column = "memory_type"
+	case "tags":
+		column = "tags"
+	case "updated_at", "":
+		column = "updated_at"
+	}
+
+	direction := "DESC"
+	if strings.EqualFold(strings.TrimSpace(f.SortDir), "asc") {
+		direction = "ASC"
+	}
+
+	return column + " " + direction + ", id " + direction
 }
 
 func (r *MemoryRepo) Count(ctx context.Context) (int, error) {


### PR DESCRIPTION
## Summary

- Add `sort_by` and `sort_dir` query parameters to the v1alpha2 memory list API contract.
- Parse and carry memory list sort settings through the handler and domain filter.
- Apply whitelisted server-side ordering in TiDB and Postgres memory list queries before pagination.
- Sort aggregated Space Chain memory list results when an explicit sort is requested.

## Why

The console memory table now sends table header sort choices to the server. This change makes sorting apply across all matching records before `LIMIT/OFFSET`, instead of only reordering the current page.

## Validation

- `jq empty docs/api/openapi.json`
- `go test ./internal/handler ./internal/repository/tidb ./internal/repository/postgres`