### PR TITLE
Fix TiDB FTS WHERE clause shape

### DIFF
--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -18,7 +18,8 @@ import (
 
 func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
-	firstPageArgs := append(ftsCandidateArgs("m-page-0", maxFTSCandidatePageLimit), "active", "agent-1", `"tag-a"`)
+	initialCandidateLimit := 2
+	firstPageArgs := append(ftsCandidateArgs("m-page-0", initialCandidateLimit), "active", "agent-1", `"tag-a"`)
 	secondPageArgs := append(ftsCandidateArgs("m-page-1", maxFTSCandidatePageLimit), "active", "agent-1", `"tag-a"`)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -34,10 +35,10 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, 0},
+			wantArgs: []any{initialCandidateLimit, 0},
 			rows: &generatedFTSCandidateRows{
 				prefix: "m-page-0",
-				count:  maxFTSCandidatePageLimit,
+				count:  initialCandidateLimit,
 			},
 		},
 		{
@@ -68,7 +69,7 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, maxFTSCandidatePageLimit},
+			wantArgs: []any{maxFTSCandidatePageLimit, initialCandidateLimit},
 			rows: &generatedFTSCandidateRows{
 				prefix: "m-page-1",
 				count:  maxFTSCandidatePageLimit,
@@ -108,8 +109,8 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	if results[0].ID != "m-page-0-0001" || results[1].ID != "m-page-1-0000" {
 		t.Fatalf("result IDs = [%s %s], want [m-page-0-0001 m-page-1-0000]", results[0].ID, results[1].ID)
 	}
-	if results[0].Score == nil || *results[0].Score != 9999 {
-		t.Fatalf("results[0].Score = %v, want 9999", results[0].Score)
+	if results[0].Score == nil || *results[0].Score != 1 {
+		t.Fatalf("results[0].Score = %v, want 1", results[0].Score)
 	}
 	if results[1].Score == nil || *results[1].Score != 10000 {
 		t.Fatalf("results[1].Score = %v, want 10000", results[1].Score)
@@ -118,7 +119,8 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 
 func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
-	firstPageArgs := append(ftsCandidateArgs("s-page-0", maxFTSCandidatePageLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
+	initialCandidateLimit := 2
+	firstPageArgs := append(ftsCandidateArgs("s-page-0", initialCandidateLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
 	secondPageArgs := append(ftsCandidateArgs("s-page-1", maxFTSCandidatePageLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -136,10 +138,10 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, 0},
+			wantArgs: []any{initialCandidateLimit, 0},
 			rows: &generatedFTSCandidateRows{
 				prefix: "s-page-0",
-				count:  maxFTSCandidatePageLimit,
+				count:  initialCandidateLimit,
 			},
 		},
 		{
@@ -173,7 +175,7 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, maxFTSCandidatePageLimit},
+			wantArgs: []any{maxFTSCandidatePageLimit, initialCandidateLimit},
 			rows: &generatedFTSCandidateRows{
 				prefix: "s-page-1",
 				count:  maxFTSCandidatePageLimit,
@@ -216,20 +218,160 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	if results[0].ID != "s-page-0-0001" || results[1].ID != "s-page-1-0000" {
 		t.Fatalf("result IDs = [%s %s], want [s-page-0-0001 s-page-1-0000]", results[0].ID, results[1].ID)
 	}
-	if results[0].Score == nil || *results[0].Score != 9999 {
-		t.Fatalf("results[0].Score = %v, want 9999", results[0].Score)
+	if results[0].Score == nil || *results[0].Score != 1 {
+		t.Fatalf("results[0].Score = %v, want 1", results[0].Score)
 	}
 	if results[1].Score == nil || *results[1].Score != 10000 {
 		t.Fatalf("results[1].Score = %v, want 10000", results[1].Score)
 	}
 }
 
-func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
-	expectations := make([]*queryExpectation, 0, maxFTSCandidatePages*2)
-	for page := 0; page < maxFTSCandidatePages; page++ {
+func TestMemoryFTSSearch_StopsAfterRequestedLimitPageWhenFull(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	candidateArgs := append(ftsCandidateArgs("m-full", 2), "active", "agent-1")
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM memories",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
+			},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+			},
+			wantArgs: []any{2, 0},
+			rows: &generatedFTSCandidateRows{
+				prefix: "m-full",
+				count:  2,
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + allColumns + " FROM memories",
+				"WHERE id IN (",
+				"AND state = ? AND agent_id = ?",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       candidateArgs,
+			rows: &scriptedRows{
+				columns: memoryColumns(),
+				values: [][]driver.Value{
+					memoryRow("m-full-0000", "match one", "agent-1", "session-1", "active", []byte(`[]`), now),
+					memoryRow("m-full-0001", "match two", "agent-1", "session-2", "active", []byte(`[]`), now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+		State:   "active",
+		AgentID: "agent-1",
+	}, 2)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+}
+
+func TestSessionFTSSearch_StopsAfterRequestedLimitPageWhenFull(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	candidateArgs := append(ftsCandidateArgs("s-full", 2), "active", "agent-1")
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM sessions",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
+			},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+			},
+			wantArgs: []any{2, 0},
+			rows: &generatedFTSCandidateRows{
+				prefix: "s-full",
+				count:  2,
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions",
+				"WHERE id IN (",
+				"AND state = ? AND agent_id = ?",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       candidateArgs,
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+				values: [][]driver.Value{
+					sessionRow("s-full-0000", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`[]`), "active", now),
+					sessionRow("s-full-0001", "sess-2", "agent-1", "chat", 2, "assistant", "match two", []byte(`[]`), "active", now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+		State:   "active",
+		AgentID: "agent-1",
+	}, 2)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+}
+
+func TestMemoryFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
+	initialCandidateLimit := 1
+	initialCandidateArgs := ftsCandidateArgs("m-cap-initial", initialCandidateLimit)
+	expectations := make([]*queryExpectation, 0, 2+maxFTSFallbackPages*2)
+	expectations = append(expectations, &queryExpectation{
+		mustContain: []string{
+			"SELECT id, fts_match_word('golang', content) AS fts_score",
+			"FROM memories",
+			"WHERE fts_match_word('golang', content)",
+			"ORDER BY fts_match_word('golang', content) DESC, id",
+			"LIMIT ? OFFSET ?",
+		},
+		mustNotContain: []string{
+			"state = ?",
+		},
+		wantArgs: []any{initialCandidateLimit, 0},
+		rows: &generatedFTSCandidateRows{
+			prefix: "m-cap-initial",
+			count:  initialCandidateLimit,
+		},
+	}, &queryExpectation{
+		mustContain: []string{
+			"SELECT " + allColumns + " FROM memories",
+			"WHERE id IN (",
+			"AND state = ?",
+		},
+		mustNotContain: []string{"fts_match_word("},
+		wantArgs:       append(initialCandidateArgs, "active"),
+		rows: &scriptedRows{
+			columns: memoryColumns(),
+		},
+	})
+	for page := 0; page < maxFTSFallbackPages; page++ {
 		prefix := fmt.Sprintf("m-cap-%02d", page)
 		candidateArgs := ftsCandidateArgs(prefix, maxFTSCandidatePageLimit)
 		postFilterArgs := append(candidateArgs, "active")
+		offset := initialCandidateLimit + page*maxFTSCandidatePageLimit
 		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
@@ -241,7 +383,7 @@ func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 			mustNotContain: []string{
 				"state = ?",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, page * maxFTSCandidatePageLimit},
+			wantArgs: []any{maxFTSCandidatePageLimit, offset},
 			rows: &generatedFTSCandidateRows{
 				prefix: prefix,
 				count:  maxFTSCandidatePageLimit,
@@ -265,7 +407,7 @@ func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 	repo := NewMemoryRepo(db, "", true, "cluster-1")
 	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
 		State: "active",
-	}, maxFTSCandidateTotalLimit+1)
+	}, initialCandidateLimit)
 	if err != nil {
 		t.Fatalf("FTSSearch: %v", err)
 	}
@@ -274,12 +416,44 @@ func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 	}
 }
 
-func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
-	expectations := make([]*queryExpectation, 0, maxFTSCandidatePages*2)
-	for page := 0; page < maxFTSCandidatePages; page++ {
+func TestSessionFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
+	initialCandidateLimit := 1
+	initialCandidateArgs := ftsCandidateArgs("s-cap-initial", initialCandidateLimit)
+	expectations := make([]*queryExpectation, 0, 2+maxFTSFallbackPages*2)
+	expectations = append(expectations, &queryExpectation{
+		mustContain: []string{
+			"SELECT id, fts_match_word('golang', content) AS fts_score",
+			"FROM sessions",
+			"WHERE fts_match_word('golang', content)",
+			"ORDER BY fts_match_word('golang', content) DESC, id",
+			"LIMIT ? OFFSET ?",
+		},
+		mustNotContain: []string{
+			"state = ?",
+		},
+		wantArgs: []any{initialCandidateLimit, 0},
+		rows: &generatedFTSCandidateRows{
+			prefix: "s-cap-initial",
+			count:  initialCandidateLimit,
+		},
+	}, &queryExpectation{
+		mustContain: []string{
+			"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+			"FROM sessions",
+			"WHERE id IN (",
+			"AND state = ?",
+		},
+		mustNotContain: []string{"fts_match_word("},
+		wantArgs:       append(initialCandidateArgs, "active"),
+		rows: &scriptedRows{
+			columns: sessionColumns(),
+		},
+	})
+	for page := 0; page < maxFTSFallbackPages; page++ {
 		prefix := fmt.Sprintf("s-cap-%02d", page)
 		candidateArgs := ftsCandidateArgs(prefix, maxFTSCandidatePageLimit)
 		postFilterArgs := append(candidateArgs, "active")
+		offset := initialCandidateLimit + page*maxFTSCandidatePageLimit
 		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
@@ -291,7 +465,7 @@ func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 			mustNotContain: []string{
 				"state = ?",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, page * maxFTSCandidatePageLimit},
+			wantArgs: []any{maxFTSCandidatePageLimit, offset},
 			rows: &generatedFTSCandidateRows{
 				prefix: prefix,
 				count:  maxFTSCandidatePageLimit,
@@ -316,7 +490,7 @@ func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 	repo := NewSessionRepo(db, "", true, "cluster-1")
 	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
 		State: "active",
-	}, maxFTSCandidateTotalLimit+1)
+	}, initialCandidateLimit)
 	if err != nil {
 		t.Fatalf("FTSSearch: %v", err)
 	}

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
-func TestMemoryFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
+func TestMemoryFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -56,17 +56,39 @@ func TestMemoryFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT " + allColumns + ", fts_match_word('golang', content) AS fts_score",
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
 				"FROM memories",
-				"WHERE state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?) AND fts_match_word('golang', content)",
-				"ORDER BY fts_match_word('golang', content) DESC",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
 			},
-			wantArgs: []any{"active", "agent-1", `"tag-a"`, 2},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+				"JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{4},
 			rows: &scriptedRows{
-				columns: memoryColumnsWithFTSScore(),
+				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
-					memoryRowWithFTSScore("m-good-1", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now, 8.8),
-					memoryRowWithFTSScore("m-good-2", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now, 7.7),
+					{"m-deleted", 9.9},
+					{"m-good-1", 8.8},
+					{"m-good-2", 7.7},
+					{"m-good-3", 6.6},
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + allColumns + " FROM memories",
+				"WHERE id IN (?,?,?,?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       []any{"m-deleted", "m-good-1", "m-good-2", "m-good-3", "active", "agent-1", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: memoryColumns(),
+				values: [][]driver.Value{
+					memoryRow("m-good-1", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
+					memoryRow("m-good-2", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
 				},
 			},
 		},
@@ -96,7 +118,7 @@ func TestMemoryFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 	}
 }
 
-func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
+func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -139,18 +161,42 @@ func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,",
-				"fts_match_word('golang', content) AS fts_score",
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
 				"FROM sessions",
-				"WHERE state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?) AND fts_match_word('golang', content)",
-				"ORDER BY fts_match_word('golang', content) DESC",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
 			},
-			wantArgs: []any{"active", "agent-1", "sess-1", "chat", `"tag-a"`, 2},
+			mustNotContain: []string{
+				"state = ?",
+				"agent_id = ?",
+				"session_id = ?",
+				"source = ?",
+				"JSON_CONTAINS(tags, ?)",
+			},
+			wantArgs: []any{4},
 			rows: &scriptedRows{
-				columns: sessionColumnsWithFTSScore(),
+				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
-					sessionRowWithFTSScore("s-good-1", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now, 4.4),
-					sessionRowWithFTSScore("s-good-2", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now, 3.3),
+					{"s-stale", 5.5},
+					{"s-good-1", 4.4},
+					{"s-good-2", 3.3},
+					{"s-good-3", 2.2},
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions",
+				"WHERE id IN (?,?,?,?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       []any{"s-stale", "s-good-1", "s-good-2", "s-good-3", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+				values: [][]driver.Value{
+					sessionRow("s-good-1", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now),
+					sessionRow("s-good-2", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now),
 				},
 			},
 		},
@@ -349,11 +395,6 @@ func memoryColumns() []string {
 	}
 }
 
-func memoryColumnsWithFTSScore() []string {
-	cols := append([]string{}, memoryColumns()...)
-	return append(cols, "fts_score")
-}
-
 func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts time.Time) []driver.Value {
 	return []driver.Value{
 		id,
@@ -374,20 +415,10 @@ func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts ti
 	}
 }
 
-func memoryRowWithFTSScore(id, content, agentID, sessionID, state string, tags []byte, ts time.Time, score float64) []driver.Value {
-	row := append([]driver.Value{}, memoryRow(id, content, agentID, sessionID, state, tags, ts)...)
-	return append(row, score)
-}
-
 func sessionColumns() []string {
 	return []string{
 		"id", "session_id", "agent_id", "source", "seq", "role", "content", "content_type", "tags", "state", "created_at",
 	}
-}
-
-func sessionColumnsWithFTSScore() []string {
-	cols := append([]string{}, sessionColumns()...)
-	return append(cols, "fts_score")
 }
 
 func sessionRow(id, sessionID, agentID, source string, seq int64, role, content string, tags []byte, state string, ts time.Time) []driver.Value {
@@ -404,11 +435,6 @@ func sessionRow(id, sessionID, agentID, source string, seq int64, role, content 
 		state,
 		ts,
 	}
-}
-
-func sessionRowWithFTSScore(id, sessionID, agentID, source string, seq int64, role, content string, tags []byte, state string, ts time.Time, score float64) []driver.Value {
-	row := append([]driver.Value{}, sessionRow(id, sessionID, agentID, source, seq, role, content, tags, state, ts)...)
-	return append(row, score)
 }
 
 var scriptedDriverID atomic.Uint64

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -232,6 +232,103 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	}
 }
 
+func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
+	candidateRows, candidateArgs := ftsCandidateValues("m-cap", maxFTSCandidateTotalLimit)
+	postFilterArgs := append(candidateArgs, "active")
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM memories",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
+			},
+			mustNotContain: []string{
+				"state = ?",
+			},
+			wantArgs: []any{maxFTSCandidateTotalLimit, 0},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values:  candidateRows,
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + allColumns + " FROM memories",
+				"WHERE id IN (",
+				"AND state = ?",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       postFilterArgs,
+			rows: &scriptedRows{
+				columns: memoryColumns(),
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+		State: "active",
+	}, maxFTSCandidateTotalLimit+1)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("len(results) = %d, want 0", len(results))
+	}
+}
+
+func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
+	candidateRows, candidateArgs := ftsCandidateValues("s-cap", maxFTSCandidateTotalLimit)
+	postFilterArgs := append(candidateArgs, "active")
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT id, fts_match_word('golang', content) AS fts_score",
+				"FROM sessions",
+				"WHERE fts_match_word('golang', content)",
+				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
+			},
+			mustNotContain: []string{
+				"state = ?",
+			},
+			wantArgs: []any{maxFTSCandidateTotalLimit, 0},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values:  candidateRows,
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions",
+				"WHERE id IN (",
+				"AND state = ?",
+			},
+			mustNotContain: []string{"fts_match_word("},
+			wantArgs:       postFilterArgs,
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+		State: "active",
+	}, maxFTSCandidateTotalLimit+1)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("len(results) = %d, want 0", len(results))
+	}
+}
+
 type queryExpectation struct {
 	mustContain    []string
 	mustNotContain []string
@@ -390,6 +487,17 @@ func normalizeDriverValue(v any) any {
 	default:
 		return v
 	}
+}
+
+func ftsCandidateValues(prefix string, count int) ([][]driver.Value, []any) {
+	rows := make([][]driver.Value, count)
+	args := make([]any, count)
+	for i := 0; i < count; i++ {
+		id := fmt.Sprintf("%s-%04d", prefix, i)
+		rows[i] = []driver.Value{id, float64(count - i)}
+		args[i] = id
+	}
+	return rows, args
 }
 
 func memoryColumns() []string {

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -233,10 +233,12 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 }
 
 func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
-	candidateRows, candidateArgs := ftsCandidateValues("m-cap", maxFTSCandidateTotalLimit)
-	postFilterArgs := append(candidateArgs, "active")
-	db := newScriptedTestDB(t, []*queryExpectation{
-		{
+	expectations := make([]*queryExpectation, 0, maxFTSCandidatePages*2)
+	for page := 0; page < maxFTSCandidatePages; page++ {
+		prefix := fmt.Sprintf("m-cap-%02d", page)
+		candidateArgs := ftsCandidateArgs(prefix, maxFTSCandidatePageLimit)
+		postFilterArgs := append(candidateArgs, "active")
+		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
 				"FROM memories",
@@ -247,13 +249,12 @@ func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 			mustNotContain: []string{
 				"state = ?",
 			},
-			wantArgs: []any{maxFTSCandidateTotalLimit, 0},
-			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
-				values:  candidateRows,
+			wantArgs: []any{maxFTSCandidatePageLimit, page * maxFTSCandidatePageLimit},
+			rows: &generatedFTSCandidateRows{
+				prefix: prefix,
+				count:  maxFTSCandidatePageLimit,
 			},
-		},
-		{
+		}, &queryExpectation{
 			mustContain: []string{
 				"SELECT " + allColumns + " FROM memories",
 				"WHERE id IN (",
@@ -264,8 +265,9 @@ func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 			rows: &scriptedRows{
 				columns: memoryColumns(),
 			},
-		},
-	})
+		})
+	}
+	db := newScriptedTestDB(t, expectations)
 	defer db.Close()
 
 	repo := NewMemoryRepo(db, "", true, "cluster-1")
@@ -281,10 +283,12 @@ func TestMemoryFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 }
 
 func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
-	candidateRows, candidateArgs := ftsCandidateValues("s-cap", maxFTSCandidateTotalLimit)
-	postFilterArgs := append(candidateArgs, "active")
-	db := newScriptedTestDB(t, []*queryExpectation{
-		{
+	expectations := make([]*queryExpectation, 0, maxFTSCandidatePages*2)
+	for page := 0; page < maxFTSCandidatePages; page++ {
+		prefix := fmt.Sprintf("s-cap-%02d", page)
+		candidateArgs := ftsCandidateArgs(prefix, maxFTSCandidatePageLimit)
+		postFilterArgs := append(candidateArgs, "active")
+		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
 				"FROM sessions",
@@ -295,13 +299,12 @@ func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 			mustNotContain: []string{
 				"state = ?",
 			},
-			wantArgs: []any{maxFTSCandidateTotalLimit, 0},
-			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
-				values:  candidateRows,
+			wantArgs: []any{maxFTSCandidatePageLimit, page * maxFTSCandidatePageLimit},
+			rows: &generatedFTSCandidateRows{
+				prefix: prefix,
+				count:  maxFTSCandidatePageLimit,
 			},
-		},
-		{
+		}, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions",
@@ -313,8 +316,9 @@ func TestSessionFTSSearch_StopsAtTotalCandidateLimit(t *testing.T) {
 			rows: &scriptedRows{
 				columns: sessionColumns(),
 			},
-		},
-	})
+		})
+	}
+	db := newScriptedTestDB(t, expectations)
 	defer db.Close()
 
 	repo := NewSessionRepo(db, "", true, "cluster-1")
@@ -333,7 +337,7 @@ type queryExpectation struct {
 	mustContain    []string
 	mustNotContain []string
 	wantArgs       []any
-	rows           *scriptedRows
+	rows           driver.Rows
 	err            error
 }
 
@@ -391,6 +395,28 @@ func (r *scriptedRows) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 	copy(dest, r.values[r.index])
+	r.index++
+	return nil
+}
+
+type generatedFTSCandidateRows struct {
+	prefix string
+	count  int
+	index  int
+}
+
+func (r *generatedFTSCandidateRows) Columns() []string {
+	return []string{"id", "fts_score"}
+}
+
+func (r *generatedFTSCandidateRows) Close() error { return nil }
+
+func (r *generatedFTSCandidateRows) Next(dest []driver.Value) error {
+	if r.index >= r.count {
+		return io.EOF
+	}
+	dest[0] = fmt.Sprintf("%s-%04d", r.prefix, r.index)
+	dest[1] = float64(r.count - r.index)
 	r.index++
 	return nil
 }
@@ -489,15 +515,12 @@ func normalizeDriverValue(v any) any {
 	}
 }
 
-func ftsCandidateValues(prefix string, count int) ([][]driver.Value, []any) {
-	rows := make([][]driver.Value, count)
+func ftsCandidateArgs(prefix string, count int) []any {
 	args := make([]any, count)
 	for i := 0; i < count; i++ {
-		id := fmt.Sprintf("%s-%04d", prefix, i)
-		rows[i] = []driver.Value{id, float64(count - i)}
-		args[i] = id
+		args[i] = fmt.Sprintf("%s-%04d", prefix, i)
 	}
-	return rows, args
+	return args
 }
 
 func memoryColumns() []string {

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
-func TestMemoryFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
+func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -25,13 +25,14 @@ func TestMemoryFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"FROM memories",
 				"WHERE fts_match_word('golang', content)",
 				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
 			},
 			mustNotContain: []string{
 				"state = ?",
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{2},
+			wantArgs: []any{2, 0},
 			rows: &scriptedRows{
 				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
@@ -60,20 +61,21 @@ func TestMemoryFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"FROM memories",
 				"WHERE fts_match_word('golang', content)",
 				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
 			},
 			mustNotContain: []string{
 				"state = ?",
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{4},
+			wantArgs: []any{4, 2},
 			rows: &scriptedRows{
 				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
-					{"m-deleted", 9.9},
-					{"m-good-1", 8.8},
 					{"m-good-2", 7.7},
 					{"m-good-3", 6.6},
+					{"m-good-4", 5.5},
+					{"m-good-5", 4.4},
 				},
 			},
 		},
@@ -83,7 +85,7 @@ func TestMemoryFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"WHERE id IN (?,?,?,?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"m-deleted", "m-good-1", "m-good-2", "m-good-3", "active", "agent-1", `"tag-a"`},
+			wantArgs:       []any{"m-good-2", "m-good-3", "m-good-4", "m-good-5", "active", "agent-1", `"tag-a"`},
 			rows: &scriptedRows{
 				columns: memoryColumns(),
 				values: [][]driver.Value{
@@ -118,7 +120,7 @@ func TestMemoryFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 	}
 }
 
-func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
+func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -127,6 +129,7 @@ func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"FROM sessions",
 				"WHERE fts_match_word('golang', content)",
 				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
 			},
 			mustNotContain: []string{
 				"state = ?",
@@ -135,7 +138,7 @@ func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{2},
+			wantArgs: []any{2, 0},
 			rows: &scriptedRows{
 				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
@@ -165,6 +168,7 @@ func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"FROM sessions",
 				"WHERE fts_match_word('golang', content)",
 				"ORDER BY fts_match_word('golang', content) DESC, id",
+				"LIMIT ? OFFSET ?",
 			},
 			mustNotContain: []string{
 				"state = ?",
@@ -173,14 +177,14 @@ func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{4},
+			wantArgs: []any{4, 2},
 			rows: &scriptedRows{
 				columns: []string{"id", "fts_score"},
 				values: [][]driver.Value{
-					{"s-stale", 5.5},
-					{"s-good-1", 4.4},
 					{"s-good-2", 3.3},
 					{"s-good-3", 2.2},
+					{"s-good-4", 1.1},
+					{"s-good-5", 0.9},
 				},
 			},
 		},
@@ -191,7 +195,7 @@ func TestSessionFTSSearch_ExpandsPureFTSTopKBeforePostFilter(t *testing.T) {
 				"WHERE id IN (?,?,?,?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"s-stale", "s-good-1", "s-good-2", "s-good-3", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			wantArgs:       []any{"s-good-2", "s-good-3", "s-good-4", "s-good-5", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
 			rows: &scriptedRows{
 				columns: sessionColumns(),
 				values: [][]driver.Value{

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -18,6 +18,8 @@ import (
 
 func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
+	firstPageArgs := append(ftsCandidateArgs("m-page-0", maxFTSCandidatePageLimit), "active", "agent-1", `"tag-a"`)
+	secondPageArgs := append(ftsCandidateArgs("m-page-1", maxFTSCandidatePageLimit), "active", "agent-1", `"tag-a"`)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
 			mustContain: []string{
@@ -32,26 +34,24 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{2, 0},
-			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
-				values: [][]driver.Value{
-					{"m-deleted", 9.9},
-					{"m-good-1", 8.8},
-				},
+			wantArgs: []any{maxFTSCandidatePageLimit, 0},
+			rows: &generatedFTSCandidateRows{
+				prefix: "m-page-0",
+				count:  maxFTSCandidatePageLimit,
 			},
 		},
 		{
 			mustContain: []string{
 				"SELECT " + allColumns + " FROM memories",
-				"WHERE id IN (?,?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
+				"WHERE id IN (",
+				"AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"m-deleted", "m-good-1", "active", "agent-1", `"tag-a"`},
+			wantArgs:       firstPageArgs,
 			rows: &scriptedRows{
 				columns: memoryColumns(),
 				values: [][]driver.Value{
-					memoryRow("m-good-1", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
+					memoryRow("m-page-0-0001", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
 				},
 			},
 		},
@@ -68,29 +68,25 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{4, 2},
-			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
-				values: [][]driver.Value{
-					{"m-good-2", 7.7},
-					{"m-good-3", 6.6},
-					{"m-good-4", 5.5},
-					{"m-good-5", 4.4},
-				},
+			wantArgs: []any{maxFTSCandidatePageLimit, maxFTSCandidatePageLimit},
+			rows: &generatedFTSCandidateRows{
+				prefix: "m-page-1",
+				count:  maxFTSCandidatePageLimit,
 			},
 		},
 		{
 			mustContain: []string{
 				"SELECT " + allColumns + " FROM memories",
-				"WHERE id IN (?,?,?,?) AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
+				"WHERE id IN (",
+				"AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"m-good-2", "m-good-3", "m-good-4", "m-good-5", "active", "agent-1", `"tag-a"`},
+			wantArgs:       secondPageArgs,
 			rows: &scriptedRows{
 				columns: memoryColumns(),
 				values: [][]driver.Value{
-					memoryRow("m-good-1", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
-					memoryRow("m-good-2", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
+					memoryRow("m-page-0-0001", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
+					memoryRow("m-page-1-0000", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
 				},
 			},
 		},
@@ -109,19 +105,21 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	if len(results) != 2 {
 		t.Fatalf("len(results) = %d, want 2", len(results))
 	}
-	if results[0].ID != "m-good-1" || results[1].ID != "m-good-2" {
-		t.Fatalf("result IDs = [%s %s], want [m-good-1 m-good-2]", results[0].ID, results[1].ID)
+	if results[0].ID != "m-page-0-0001" || results[1].ID != "m-page-1-0000" {
+		t.Fatalf("result IDs = [%s %s], want [m-page-0-0001 m-page-1-0000]", results[0].ID, results[1].ID)
 	}
-	if results[0].Score == nil || *results[0].Score != 8.8 {
-		t.Fatalf("results[0].Score = %v, want 8.8", results[0].Score)
+	if results[0].Score == nil || *results[0].Score != 9999 {
+		t.Fatalf("results[0].Score = %v, want 9999", results[0].Score)
 	}
-	if results[1].Score == nil || *results[1].Score != 7.7 {
-		t.Fatalf("results[1].Score = %v, want 7.7", results[1].Score)
+	if results[1].Score == nil || *results[1].Score != 10000 {
+		t.Fatalf("results[1].Score = %v, want 10000", results[1].Score)
 	}
 }
 
 func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
+	firstPageArgs := append(ftsCandidateArgs("s-page-0", maxFTSCandidatePageLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
+	secondPageArgs := append(ftsCandidateArgs("s-page-1", maxFTSCandidatePageLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
 			mustContain: []string{
@@ -138,27 +136,25 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{2, 0},
-			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
-				values: [][]driver.Value{
-					{"s-stale", 5.5},
-					{"s-good-1", 4.4},
-				},
+			wantArgs: []any{maxFTSCandidatePageLimit, 0},
+			rows: &generatedFTSCandidateRows{
+				prefix: "s-page-0",
+				count:  maxFTSCandidatePageLimit,
 			},
 		},
 		{
 			mustContain: []string{
 				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions",
-				"WHERE id IN (?,?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+				"WHERE id IN (",
+				"AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"s-stale", "s-good-1", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			wantArgs:       firstPageArgs,
 			rows: &scriptedRows{
 				columns: sessionColumns(),
 				values: [][]driver.Value{
-					sessionRow("s-good-1", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now),
+					sessionRow("s-page-0-0001", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now),
 				},
 			},
 		},
@@ -177,30 +173,26 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{4, 2},
-			rows: &scriptedRows{
-				columns: []string{"id", "fts_score"},
-				values: [][]driver.Value{
-					{"s-good-2", 3.3},
-					{"s-good-3", 2.2},
-					{"s-good-4", 1.1},
-					{"s-good-5", 0.9},
-				},
+			wantArgs: []any{maxFTSCandidatePageLimit, maxFTSCandidatePageLimit},
+			rows: &generatedFTSCandidateRows{
+				prefix: "s-page-1",
+				count:  maxFTSCandidatePageLimit,
 			},
 		},
 		{
 			mustContain: []string{
 				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions",
-				"WHERE id IN (?,?,?,?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
+				"WHERE id IN (",
+				"AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       []any{"s-good-2", "s-good-3", "s-good-4", "s-good-5", "active", "agent-1", "sess-1", "chat", `"tag-a"`},
+			wantArgs:       secondPageArgs,
 			rows: &scriptedRows{
 				columns: sessionColumns(),
 				values: [][]driver.Value{
-					sessionRow("s-good-1", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now),
-					sessionRow("s-good-2", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now),
+					sessionRow("s-page-0-0001", "sess-1", "agent-1", "chat", 1, "user", "match one", []byte(`["tag-a"]`), "active", now),
+					sessionRow("s-page-1-0000", "sess-1", "agent-1", "chat", 2, "assistant", "match two", []byte(`["tag-a"]`), "active", now),
 				},
 			},
 		},
@@ -221,14 +213,14 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	if len(results) != 2 {
 		t.Fatalf("len(results) = %d, want 2", len(results))
 	}
-	if results[0].ID != "s-good-1" || results[1].ID != "s-good-2" {
-		t.Fatalf("result IDs = [%s %s], want [s-good-1 s-good-2]", results[0].ID, results[1].ID)
+	if results[0].ID != "s-page-0-0001" || results[1].ID != "s-page-1-0000" {
+		t.Fatalf("result IDs = [%s %s], want [s-page-0-0001 s-page-1-0000]", results[0].ID, results[1].ID)
 	}
-	if results[0].Score == nil || *results[0].Score != 4.4 {
-		t.Fatalf("results[0].Score = %v, want 4.4", results[0].Score)
+	if results[0].Score == nil || *results[0].Score != 9999 {
+		t.Fatalf("results[0].Score = %v, want 9999", results[0].Score)
 	}
-	if results[1].Score == nil || *results[1].Score != 3.3 {
-		t.Fatalf("results[1].Score = %v, want 3.3", results[1].Score)
+	if results[1].Score == nil || *results[1].Score != 10000 {
+		t.Fatalf("results[1].Score = %v, want 10000", results[1].Score)
 	}
 }
 

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -37,11 +37,10 @@ func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 const (
 	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
 	maxFTSCandidatePageLimit = 10000
-	maxFTSCandidatePages     = 30
-	maxFTSFallbackPages      = maxFTSCandidatePages - 1
+	maxFTSFallbackPages      = 30
 	// TiDB Cloud FTS is only safe with fts_match_word as the only WHERE predicate,
 	// so wider recall uses bounded pure-FTS pages followed by post-filtering.
-	maxFTSFallbackCandidateLimit = maxFTSCandidatePageLimit * maxFTSCandidatePages
+	maxFTSFallbackCandidateLimit = maxFTSCandidatePageLimit * maxFTSFallbackPages
 )
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -575,12 +575,10 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
 
-	candidateLimit := initialFTSCandidatePageLimit(limit)
-	offset := 0
 	filtered := make([]domain.Memory, 0, min(limit, maxFTSCandidateTotalLimit))
-	for offset < maxFTSCandidateTotalLimit {
-		pageLimit := min(candidateLimit, maxFTSCandidateTotalLimit-offset)
-		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, pageLimit, offset)
+	for page := 0; page < maxFTSCandidatePages; page++ {
+		offset := page * maxFTSCandidatePageLimit
+		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, maxFTSCandidatePageLimit, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -596,30 +594,11 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 		if len(filtered) >= limit {
 			return filtered[:limit], nil
 		}
-		if len(candidates) < pageLimit {
+		if len(candidates) < maxFTSCandidatePageLimit {
 			return filtered, nil
 		}
-
-		offset += len(candidates)
-		candidateLimit = nextFTSCandidatePageLimit(candidateLimit)
 	}
 	return filtered, nil
-}
-
-func initialFTSCandidatePageLimit(limit int) int {
-	return min(limit, maxFTSCandidatePageLimit)
-}
-
-func nextFTSCandidatePageLimit(current int) int {
-	if current >= maxFTSCandidatePageLimit {
-		return current
-	}
-
-	next := current * 2
-	if next > maxFTSCandidatePageLimit {
-		return maxFTSCandidatePageLimit
-	}
-	return next
 }
 
 func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]memoryFTSCandidate, error) {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -38,8 +38,10 @@ const (
 	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
 	maxFTSCandidatePageLimit = 10000
 	maxFTSCandidatePages     = 30
-	// Keep pure-FTS expansion finite because post-filters run in a separate query.
-	maxFTSCandidateTotalLimit = maxFTSCandidatePageLimit * maxFTSCandidatePages
+	maxFTSFallbackPages      = maxFTSCandidatePages - 1
+	// TiDB Cloud FTS is only safe with fts_match_word as the only WHERE predicate,
+	// so wider recall uses bounded pure-FTS pages followed by post-filtering.
+	maxFTSFallbackCandidateLimit = maxFTSCandidatePageLimit * maxFTSCandidatePages
 )
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
@@ -575,30 +577,61 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
 
-	filtered := make([]domain.Memory, 0, min(limit, maxFTSCandidateTotalLimit))
-	for page := 0; page < maxFTSCandidatePages; page++ {
-		offset := page * maxFTSCandidatePageLimit
+	filtered := make([]domain.Memory, 0, min(limit, maxFTSFallbackCandidateLimit))
+	initialCandidateLimit := min(limit, maxFTSCandidatePageLimit)
+	candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, initialCandidateLimit, 0)
+	if err != nil {
+		return nil, err
+	}
+	exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSMemories)
+	if err != nil {
+		return nil, err
+	}
+	if len(filtered) >= limit {
+		return filtered[:limit], nil
+	}
+	if exhausted || len(candidates) < initialCandidateLimit {
+		return filtered, nil
+	}
+
+	offset := initialCandidateLimit
+	for page := 0; page < maxFTSFallbackPages; page++ {
 		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, maxFTSCandidatePageLimit, offset)
 		if err != nil {
 			return nil, err
 		}
-		if len(candidates) == 0 {
-			return filtered, nil
-		}
-
-		page, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
+		exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSMemories)
 		if err != nil {
 			return nil, err
 		}
-		filtered = append(filtered, page...)
 		if len(filtered) >= limit {
 			return filtered[:limit], nil
 		}
-		if len(candidates) < maxFTSCandidatePageLimit {
+		if exhausted || len(candidates) < maxFTSCandidatePageLimit {
 			return filtered, nil
 		}
+		offset += maxFTSCandidatePageLimit
 	}
 	return filtered, nil
+}
+
+func appendFilteredFTSPage[T any](
+	ctx context.Context,
+	candidates []T,
+	where string,
+	args []any,
+	filtered *[]domain.Memory,
+	fetchFiltered func(context.Context, []T, string, []any) ([]domain.Memory, error),
+) (bool, error) {
+	if len(candidates) == 0 {
+		return true, nil
+	}
+	page, err := fetchFiltered(ctx, candidates, where, args)
+	if err != nil {
+		return false, err
+	}
+	*filtered = append(*filtered, page...)
+	return false, nil
 }
 
 func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]memoryFTSCandidate, error) {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -37,6 +37,8 @@ func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 const (
 	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
 	maxFTSCandidatePageLimit = 1000
+	// Keep pure-FTS expansion finite because post-filters run in a separate query.
+	maxFTSCandidateTotalLimit = 1000
 )
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
@@ -572,11 +574,12 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
 
-	candidateLimit := limit
+	candidateLimit := initialFTSCandidatePageLimit(limit)
 	offset := 0
-	filtered := make([]domain.Memory, 0, limit)
-	for {
-		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, candidateLimit, offset)
+	filtered := make([]domain.Memory, 0, min(limit, maxFTSCandidateTotalLimit))
+	for offset < maxFTSCandidateTotalLimit {
+		pageLimit := min(candidateLimit, maxFTSCandidateTotalLimit-offset)
+		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, pageLimit, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -592,13 +595,18 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 		if len(filtered) >= limit {
 			return filtered[:limit], nil
 		}
-		if len(candidates) < candidateLimit {
+		if len(candidates) < pageLimit {
 			return filtered, nil
 		}
 
 		offset += len(candidates)
 		candidateLimit = nextFTSCandidatePageLimit(candidateLimit)
 	}
+	return filtered, nil
+}
+
+func initialFTSCandidatePageLimit(limit int) int {
+	return min(limit, maxFTSCandidatePageLimit)
 }
 
 func nextFTSCandidatePageLimit(current int) int {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -36,9 +36,10 @@ func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 
 const (
 	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
-	maxFTSCandidatePageLimit = 1000
+	maxFTSCandidatePageLimit = 10000
+	maxFTSCandidatePages     = 30
 	// Keep pure-FTS expansion finite because post-filters run in a separate query.
-	maxFTSCandidateTotalLimit = 1000
+	maxFTSCandidateTotalLimit = maxFTSCandidatePageLimit * maxFTSCandidatePages
 )
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -35,8 +35,8 @@ func NewMemoryRepo(db *sql.DB, autoModel string, ftsEnabled bool, clusterID stri
 func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 
 const (
-	allColumns                = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
-	maxFTSCandidateFetchLimit = 1000
+	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
+	maxFTSCandidatePageLimit = 1000
 )
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
@@ -573,61 +573,54 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 	safeQ := ftsSafeLiteral(query)
 
 	candidateLimit := limit
+	offset := 0
+	filtered := make([]domain.Memory, 0, limit)
 	for {
-		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, candidateLimit)
+		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, candidateLimit, offset)
 		if err != nil {
 			return nil, err
 		}
 		if len(candidates) == 0 {
-			return nil, nil
+			return filtered, nil
 		}
 
-		filtered, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
+		page, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
 		if err != nil {
 			return nil, err
 		}
-		if len(filtered) >= limit || len(candidates) < candidateLimit {
-			if len(filtered) > limit {
-				filtered = filtered[:limit]
-			}
+		filtered = append(filtered, page...)
+		if len(filtered) >= limit {
+			return filtered[:limit], nil
+		}
+		if len(candidates) < candidateLimit {
 			return filtered, nil
 		}
 
-		nextLimit := nextFTSCandidateFetchLimit(candidateLimit, limit)
-		if nextLimit <= candidateLimit {
-			if len(filtered) > limit {
-				filtered = filtered[:limit]
-			}
-			return filtered, nil
-		}
-		candidateLimit = nextLimit
+		offset += len(candidates)
+		candidateLimit = nextFTSCandidatePageLimit(candidateLimit)
 	}
 }
 
-func nextFTSCandidateFetchLimit(current, requested int) int {
-	maxLimit := requested * 8
-	if maxLimit > maxFTSCandidateFetchLimit {
-		maxLimit = maxFTSCandidateFetchLimit
-	}
-	if maxLimit < requested {
-		maxLimit = requested
+func nextFTSCandidatePageLimit(current int) int {
+	if current >= maxFTSCandidatePageLimit {
+		return current
 	}
 
 	next := current * 2
-	if next > maxLimit {
-		next = maxLimit
+	if next > maxFTSCandidatePageLimit {
+		return maxFTSCandidatePageLimit
 	}
 	return next
 }
 
-func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit int) ([]memoryFTSCandidate, error) {
+func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]memoryFTSCandidate, error) {
 	sqlQuery := `SELECT id, fts_match_word('` + safeQ + `', content) AS fts_score
 		FROM memories
 		WHERE fts_match_word('` + safeQ + `', content)
 		ORDER BY fts_match_word('` + safeQ + `', content) DESC, id
-		LIMIT ?`
+		LIMIT ? OFFSET ?`
 
-	rows, err := r.db.QueryContext(ctx, sqlQuery, limit)
+	rows, err := r.db.QueryContext(ctx, sqlQuery, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -34,7 +34,10 @@ func NewMemoryRepo(db *sql.DB, autoModel string, ftsEnabled bool, clusterID stri
 
 func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 
-const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
+const (
+	allColumns                = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
+	maxFTSCandidateFetchLimit = 1000
+)
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 	tagsJSON := marshalTags(m.Tags)
@@ -568,29 +571,53 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 	conds, args := r.buildFilterConds(f)
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
-	candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, limit)
-	if err != nil {
-		return nil, err
-	}
-	if len(candidates) == 0 {
-		return nil, nil
-	}
 
-	filtered, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
-	if err != nil {
-		return nil, err
-	}
-	if len(filtered) >= limit || len(candidates) < limit {
-		if len(filtered) > limit {
-			filtered = filtered[:limit]
+	candidateLimit := limit
+	for {
+		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, candidateLimit)
+		if err != nil {
+			return nil, err
 		}
-		return filtered, nil
+		if len(candidates) == 0 {
+			return nil, nil
+		}
+
+		filtered, err := r.fetchFilteredFTSMemories(ctx, candidates, where, args)
+		if err != nil {
+			return nil, err
+		}
+		if len(filtered) >= limit || len(candidates) < candidateLimit {
+			if len(filtered) > limit {
+				filtered = filtered[:limit]
+			}
+			return filtered, nil
+		}
+
+		nextLimit := nextFTSCandidateFetchLimit(candidateLimit, limit)
+		if nextLimit <= candidateLimit {
+			if len(filtered) > limit {
+				filtered = filtered[:limit]
+			}
+			return filtered, nil
+		}
+		candidateLimit = nextLimit
+	}
+}
+
+func nextFTSCandidateFetchLimit(current, requested int) int {
+	maxLimit := requested * 8
+	if maxLimit > maxFTSCandidateFetchLimit {
+		maxLimit = maxFTSCandidateFetchLimit
+	}
+	if maxLimit < requested {
+		maxLimit = requested
 	}
 
-	// Bound the FTS-only candidate expansion to a single TopK pass. If selective
-	// post-filters drop too many candidates, fall back to the original filtered
-	// query shape to preserve completeness without unbounded global pagination.
-	return r.filteredFTSSearch(ctx, safeQ, where, args, limit)
+	next := current * 2
+	if next > maxLimit {
+		next = maxLimit
+	}
+	return next
 }
 
 func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit int) ([]memoryFTSCandidate, error) {
@@ -669,37 +696,6 @@ func (r *MemoryRepo) fetchFilteredFTSMemories(ctx context.Context, candidates []
 		ordered = append(ordered, m)
 	}
 	return ordered, nil
-}
-
-func (r *MemoryRepo) filteredFTSSearch(ctx context.Context, safeQ, where string, args []any, limit int) ([]domain.Memory, error) {
-	sqlQuery := `SELECT ` + allColumns + `, fts_match_word('` + safeQ + `', content) AS fts_score
-		FROM memories
-		WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
-		ORDER BY fts_match_word('` + safeQ + `', content) DESC
-		LIMIT ?`
-
-	fullArgs := make([]any, 0, len(args)+1)
-	fullArgs = append(fullArgs, args...)
-	fullArgs = append(fullArgs, limit)
-
-	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	memories := make([]domain.Memory, 0, limit)
-	for rows.Next() {
-		m, err := scanMemoryRowsWithFTSScore(rows)
-		if err != nil {
-			return nil, err
-		}
-		memories = append(memories, *m)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return memories, nil
 }
 
 func (r *MemoryRepo) buildWhere(f domain.MemoryFilter) (string, []any) {
@@ -861,39 +857,6 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	m.Embedding = parseVecString(embeddingStr)
 	score := 1 - distance
 	m.Score = &score
-	return &m, nil
-}
-
-// scanMemoryRowsWithFTSScore scans a row that includes a trailing fts_score column (used by FTSSearch).
-func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
-	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
-	var tagsJSON, metadataJSON, embeddingStr []byte
-	var ftsScore float64
-
-	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
-		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
-		&ftsScore)
-	if err != nil {
-		return nil, fmt.Errorf("scan memory row with fts score: %w", err)
-	}
-	m.Source = source.String
-	m.MemoryType = domain.MemoryType(memoryType.String)
-	if m.MemoryType == "" {
-		m.MemoryType = domain.TypePinned
-	}
-	m.AgentID = agentID.String
-	m.SessionID = sessionID.String
-	m.State = domain.MemoryState(state.String)
-	if m.State == "" {
-		m.State = domain.StateActive
-	}
-	m.UpdatedBy = updatedBy.String
-	m.SupersededBy = supersededBy.String
-	m.Tags = unmarshalTags(tagsJSON)
-	m.Metadata = unmarshalRawJSON(metadataJSON)
-	m.Score = &ftsScore
 	return &m, nil
 }
 

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -382,29 +382,37 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 	conds, args := r.buildSessionFilterConds(f)
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
-	candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, limit)
-	if err != nil {
-		return nil, err
-	}
-	if len(candidates) == 0 {
-		return nil, nil
-	}
 
-	filtered, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
-	if err != nil {
-		return nil, err
-	}
-	if len(filtered) >= limit || len(candidates) < limit {
-		if len(filtered) > limit {
-			filtered = filtered[:limit]
+	candidateLimit := limit
+	for {
+		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, candidateLimit)
+		if err != nil {
+			return nil, err
 		}
-		return filtered, nil
-	}
+		if len(candidates) == 0 {
+			return nil, nil
+		}
 
-	// Bound the FTS-only candidate expansion to a single TopK pass. If selective
-	// post-filters drop too many candidates, fall back to the original filtered
-	// query shape to avoid unbounded global pagination.
-	return r.filteredFTSSearch(ctx, safeQ, where, args, limit)
+		filtered, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
+		if err != nil {
+			return nil, err
+		}
+		if len(filtered) >= limit || len(candidates) < candidateLimit {
+			if len(filtered) > limit {
+				filtered = filtered[:limit]
+			}
+			return filtered, nil
+		}
+
+		nextLimit := nextFTSCandidateFetchLimit(candidateLimit, limit)
+		if nextLimit <= candidateLimit {
+			if len(filtered) > limit {
+				filtered = filtered[:limit]
+			}
+			return filtered, nil
+		}
+		candidateLimit = nextLimit
+	}
 }
 
 func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit int) ([]sessionFTSCandidate, error) {
@@ -484,27 +492,6 @@ func (r *SessionRepo) fetchFilteredFTSSessions(ctx context.Context, candidates [
 	return ordered, nil
 }
 
-func (r *SessionRepo) filteredFTSSearch(ctx context.Context, safeQ, where string, args []any, limit int) ([]domain.Memory, error) {
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,
-		fts_match_word('` + safeQ + `', content) AS fts_score
-		FROM sessions
-		WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
-		ORDER BY fts_match_word('` + safeQ + `', content) DESC
-		LIMIT ?`
-
-	fullArgs := make([]any, 0, len(args)+1)
-	fullArgs = append(fullArgs, args...)
-	fullArgs = append(fullArgs, limit)
-
-	rows, err := r.db.QueryContext(ctx, sqlQuery, fullArgs...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	return scanSessionRowsWithFTSScore(rows)
-}
-
 func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	conds, args := r.buildSessionFilterConds(f)
 	if query != "" {
@@ -554,18 +541,6 @@ func scanSessionRowsWithDistance(rows *sql.Rows) ([]domain.Memory, error) {
 	var result []domain.Memory
 	for rows.Next() {
 		m, err := scanSessionRowWithDistance(rows)
-		if err != nil {
-			return nil, err
-		}
-		result = append(result, *m)
-	}
-	return result, rows.Err()
-}
-
-func scanSessionRowsWithFTSScore(rows *sql.Rows) ([]domain.Memory, error) {
-	var result []domain.Memory
-	for rows.Next() {
-		m, err := scanSessionRowWithFTSScore(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -625,29 +600,6 @@ func scanSessionRowWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	m = *fillSessionMemory(&m, sessionID, agentID, source, role, contentType, seq, tagsJSON, state, createdAt)
 	sc := 1 - distance
 	m.Score = &sc
-	return &m, nil
-}
-
-func scanSessionRowWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
-	var (
-		sessionID, agentID, source, role, contentType sql.NullString
-		tagsJSON                                      []byte
-		state                                         sql.NullString
-		seq                                           int
-		createdAt                                     time.Time
-		ftsScore                                      float64
-		m                                             domain.Memory
-	)
-	if err := rows.Scan(
-		&m.ID, &sessionID, &agentID, &source,
-		&seq, &role, &m.Content, &contentType,
-		&tagsJSON, &state, &createdAt,
-		&ftsScore,
-	); err != nil {
-		return nil, fmt.Errorf("scan session row with fts score: %w", err)
-	}
-	m = *fillSessionMemory(&m, sessionID, agentID, source, role, contentType, seq, tagsJSON, state, createdAt)
-	m.Score = &ftsScore
 	return &m, nil
 }
 

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -384,45 +384,42 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 	safeQ := ftsSafeLiteral(query)
 
 	candidateLimit := limit
+	offset := 0
+	filtered := make([]domain.Memory, 0, limit)
 	for {
-		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, candidateLimit)
+		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, candidateLimit, offset)
 		if err != nil {
 			return nil, err
 		}
 		if len(candidates) == 0 {
-			return nil, nil
+			return filtered, nil
 		}
 
-		filtered, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
+		page, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
 		if err != nil {
 			return nil, err
 		}
-		if len(filtered) >= limit || len(candidates) < candidateLimit {
-			if len(filtered) > limit {
-				filtered = filtered[:limit]
-			}
+		filtered = append(filtered, page...)
+		if len(filtered) >= limit {
+			return filtered[:limit], nil
+		}
+		if len(candidates) < candidateLimit {
 			return filtered, nil
 		}
 
-		nextLimit := nextFTSCandidateFetchLimit(candidateLimit, limit)
-		if nextLimit <= candidateLimit {
-			if len(filtered) > limit {
-				filtered = filtered[:limit]
-			}
-			return filtered, nil
-		}
-		candidateLimit = nextLimit
+		offset += len(candidates)
+		candidateLimit = nextFTSCandidatePageLimit(candidateLimit)
 	}
 }
 
-func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit int) ([]sessionFTSCandidate, error) {
+func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]sessionFTSCandidate, error) {
 	sqlQuery := `SELECT id, fts_match_word('` + safeQ + `', content) AS fts_score
 		FROM sessions
 		WHERE fts_match_word('` + safeQ + `', content)
 		ORDER BY fts_match_word('` + safeQ + `', content) DESC, id
-		LIMIT ?`
+		LIMIT ? OFFSET ?`
 
-	rows, err := r.db.QueryContext(ctx, sqlQuery, limit)
+	rows, err := r.db.QueryContext(ctx, sqlQuery, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -383,12 +383,10 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
 
-	candidateLimit := initialFTSCandidatePageLimit(limit)
-	offset := 0
 	filtered := make([]domain.Memory, 0, min(limit, maxFTSCandidateTotalLimit))
-	for offset < maxFTSCandidateTotalLimit {
-		pageLimit := min(candidateLimit, maxFTSCandidateTotalLimit-offset)
-		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, pageLimit, offset)
+	for page := 0; page < maxFTSCandidatePages; page++ {
+		offset := page * maxFTSCandidatePageLimit
+		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, maxFTSCandidatePageLimit, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -404,12 +402,9 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 		if len(filtered) >= limit {
 			return filtered[:limit], nil
 		}
-		if len(candidates) < pageLimit {
+		if len(candidates) < maxFTSCandidatePageLimit {
 			return filtered, nil
 		}
-
-		offset += len(candidates)
-		candidateLimit = nextFTSCandidatePageLimit(candidateLimit)
 	}
 	return filtered, nil
 }

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -383,28 +383,40 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
 
-	filtered := make([]domain.Memory, 0, min(limit, maxFTSCandidateTotalLimit))
-	for page := 0; page < maxFTSCandidatePages; page++ {
-		offset := page * maxFTSCandidatePageLimit
+	filtered := make([]domain.Memory, 0, min(limit, maxFTSFallbackCandidateLimit))
+	initialCandidateLimit := min(limit, maxFTSCandidatePageLimit)
+	candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, initialCandidateLimit, 0)
+	if err != nil {
+		return nil, err
+	}
+	exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSSessions)
+	if err != nil {
+		return nil, err
+	}
+	if len(filtered) >= limit {
+		return filtered[:limit], nil
+	}
+	if exhausted || len(candidates) < initialCandidateLimit {
+		return filtered, nil
+	}
+
+	offset := initialCandidateLimit
+	for page := 0; page < maxFTSFallbackPages; page++ {
 		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, maxFTSCandidatePageLimit, offset)
 		if err != nil {
 			return nil, err
 		}
-		if len(candidates) == 0 {
-			return filtered, nil
-		}
-
-		page, err := r.fetchFilteredFTSSessions(ctx, candidates, where, args)
+		exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSSessions)
 		if err != nil {
 			return nil, err
 		}
-		filtered = append(filtered, page...)
 		if len(filtered) >= limit {
 			return filtered[:limit], nil
 		}
-		if len(candidates) < maxFTSCandidatePageLimit {
+		if exhausted || len(candidates) < maxFTSCandidatePageLimit {
 			return filtered, nil
 		}
+		offset += maxFTSCandidatePageLimit
 	}
 	return filtered, nil
 }

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -383,11 +383,12 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
 
-	candidateLimit := limit
+	candidateLimit := initialFTSCandidatePageLimit(limit)
 	offset := 0
-	filtered := make([]domain.Memory, 0, limit)
-	for {
-		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, candidateLimit, offset)
+	filtered := make([]domain.Memory, 0, min(limit, maxFTSCandidateTotalLimit))
+	for offset < maxFTSCandidateTotalLimit {
+		pageLimit := min(candidateLimit, maxFTSCandidateTotalLimit-offset)
+		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, pageLimit, offset)
 		if err != nil {
 			return nil, err
 		}
@@ -403,13 +404,14 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 		if len(filtered) >= limit {
 			return filtered[:limit], nil
 		}
-		if len(candidates) < candidateLimit {
+		if len(candidates) < pageLimit {
 			return filtered, nil
 		}
 
 		offset += len(candidates)
 		candidateLimit = nextFTSCandidatePageLimit(candidateLimit)
 	}
+	return filtered, nil
 }
 
 func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]sessionFTSCandidate, error) {


### PR DESCRIPTION
## Summary

1. Keep TiDB `fts_match_word` candidate queries in the safe shape where `WHERE` contains only `fts_match_word(...)`.
2. Replace the old filtered FTS fallback with bounded pure-FTS candidate expansion, followed by id-based post-filtering for memories and sessions.
3. Update repository tests to assert business filters never appear in queries that contain `fts_match_word`.

## Tests

1. `cd server && go test -race -count=1 ./internal/repository/tidb/`