### PR TITLE
[codex] fix memory scan-all list sorting

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -282,6 +282,9 @@
             "$ref": "#/components/parameters/MemoryQuery"
           },
           {
+            "$ref": "#/components/parameters/MemorySearchMode"
+          },
+          {
             "$ref": "#/components/parameters/Limit"
           },
           {
@@ -304,6 +307,9 @@
           },
           {
             "$ref": "#/components/parameters/SessionID"
+          },
+          {
+            "$ref": "#/components/parameters/AppID"
           },
           {
             "$ref": "#/components/parameters/ScanAll"
@@ -562,6 +568,9 @@
             "$ref": "#/components/parameters/SessionIDRepeated"
           },
           {
+            "$ref": "#/components/parameters/AppID"
+          },
+          {
             "$ref": "#/components/parameters/LimitPerSession"
           }
         ],
@@ -666,6 +675,9 @@
             "$ref": "#/components/parameters/MemoryQuery"
           },
           {
+            "$ref": "#/components/parameters/MemorySearchMode"
+          },
+          {
             "$ref": "#/components/parameters/Limit"
           },
           {
@@ -688,6 +700,9 @@
           },
           {
             "$ref": "#/components/parameters/SessionID"
+          },
+          {
+            "$ref": "#/components/parameters/AppID"
           },
           {
             "$ref": "#/components/parameters/SortBy"
@@ -1088,6 +1103,9 @@
             "$ref": "#/components/parameters/SessionIDRepeated"
           },
           {
+            "$ref": "#/components/parameters/AppID"
+          },
+          {
             "$ref": "#/components/parameters/LimitPerSession"
           }
         ],
@@ -1181,6 +1199,18 @@
         "description": "Natural-language search query. When omitted, the endpoint lists memories by filters.",
         "schema": {
           "type": "string"
+        }
+      },
+      "MemorySearchMode": {
+        "name": "search_mode",
+        "in": "query",
+        "required": false,
+        "description": "Set to `keyword` to search memory content by direct substring match for list filtering. Omit for the default recall-style query behavior.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "keyword"
+          ]
         }
       },
       "Limit": {
@@ -1358,6 +1388,16 @@
         "schema": {
           "type": "string"
         }
+      },
+      "AppID": {
+        "name": "appId",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "description": "Optional application isolation filter. Omit appId to search across all appIds. Use appId=<value> for an exact appId, and appId=null or appId= to search only the default/global appId stored as an empty string."
       }
     },
     "headers": {
@@ -1734,6 +1774,12 @@
             "type": "string",
             "description": "Agent identity. Defaults from X-Mnemo-Agent-Id when omitted."
           },
+          "appId": {
+            "type": "string",
+            "nullable": true,
+            "maxLength": 100,
+            "description": "Optional application isolation id. Omitted, null, empty, or whitespace values are stored as the default/global appId; non-empty values are trimmed and stored exactly."
+          },
           "tags": {
             "type": "array",
             "items": {
@@ -1854,7 +1900,8 @@
             "type": "string",
             "description": "Optional session ID associated with session imports."
           }
-        }
+        },
+        "description": "Multipart upload for async file ingest. File size is limited to 50 MiB. For JSON memory/session import files, include top-level appId or per-memory appId fields to assign imported rows to an application isolation id."
       },
       "MemoryListResponse": {
         "type": "object",
@@ -1923,6 +1970,10 @@
           },
           "session_id": {
             "type": "string"
+          },
+          "appId": {
+            "type": "string",
+            "description": "Application isolation id. Empty string represents the default/global appId."
           },
           "updated_by": {
             "type": "string"
@@ -2055,6 +2106,10 @@
           },
           "agent_id": {
             "type": "string"
+          },
+          "appId": {
+            "type": "string",
+            "description": "Application isolation id. Empty string represents the default/global appId."
           },
           "source": {
             "type": "string"

--- a/docs/design/app-id-isolation-plan.md
+++ b/docs/design/app-id-isolation-plan.md
@@ -1,0 +1,84 @@
+# mem9 AppID Isolation Plan
+
+## Goal
+
+Add an optional `appId` isolation dimension under the same mem9 API key. `appId` does not change authentication, quota, tenant ownership, or metering. It only scopes memory/session writes and optional query filters.
+
+## Semantics
+
+- External API field: `appId`.
+- Internal database column: `app_id`.
+- Default/global appId is stored as `""`, not SQL `NULL`.
+- Write normalization:
+  - omitted, `null`, empty string, or whitespace-only `appId` writes `app_id = ""`;
+  - non-empty values are trimmed and limited to 100 characters.
+- Query semantics:
+  - omitted `appId`: search across all appIds;
+  - `appId=<value>`: exact appId search;
+  - `appId=null` or `appId=`: search only default/global (`app_id = ""`).
+- `app_id` is accepted as an input alias where compatibility is useful, but public docs use `appId`.
+
+## Server Changes
+
+- Add `AppID` to `domain.Memory`, `domain.Session`, create-memory request, ingest request, session-message response, and import JSON file structs.
+- Add `MemoryFilter.AppID *string`:
+  - `nil` means no appId filter;
+  - `ptr("")` means default/global only;
+  - `ptr("value")` means exact appId only.
+- Add `app_id VARCHAR(100) NOT NULL DEFAULT ''` to tenant `memories` and `sessions`.
+- Add app indexes on `memories.app_id` and `sessions.app_id`.
+- Change session dedup from `(session_id, content_hash)` to `(app_id, session_id, content_hash)`.
+- Ensure existing tenant schemas idempotently receive the new columns and indexes.
+- On first service resolution for an existing tenant, synchronously ensure the memory/session appId schema before repositories run queries or writes.
+- Scope reconciliation, near-duplicate search, existing-memory gathering, update/archive decisions, raw session saves, and session tag patching by appId.
+- Support appId in:
+  - `POST /memories` direct create;
+  - `POST /memories` smart/raw ingest;
+  - raw session persistence;
+  - JSON import files;
+  - `GET /memories`;
+  - `GET /session-messages`;
+  - both `v1alpha1` tenant routes and `v1alpha2` API-key routes.
+- Update `docs/api/openapi.json` and `site/src/content/site.ts`.
+
+## Import Format
+
+Multipart import task creation keeps the existing form fields. JSON file contents can carry appId:
+
+```json
+{
+  "appId": "docs",
+  "memories": [
+    { "content": "Project uses PostgreSQL 15" },
+    { "content": "CLI uses Go", "appId": "cli" }
+  ]
+}
+```
+
+```json
+{
+  "appId": "docs",
+  "session_id": "ses-001",
+  "messages": [
+    { "role": "user", "content": "We use PostgreSQL 15" }
+  ]
+}
+```
+
+## Validation
+
+- `go test ./internal/handler ./internal/service`
+- `go test ./internal/repository/tidb`
+- `cd site && npm run build`
+- Manual API checks:
+  - create memory with omitted/null/empty/specific appId;
+  - list memories with omitted, `appId=value`, `appId=null`, and `appId=`;
+  - ingest the same `session_id` under two appIds and verify session-message filtering does not mix rows;
+  - reconcile similar facts under different appIds and verify update/archive decisions do not cross app boundaries.
+
+## Out Of Scope
+
+- appId-based permissioning or quota.
+- appId editing after memory creation.
+- Persisted default appId preferences in clients.
+- Form-level appId for multipart import task metadata; JSON import payloads carry appId for this version.

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -264,7 +264,7 @@ func main() {
 		WithRuntimeUsage(runtimeUsageManager).
 		WithActivityTracker(activityTracker).
 		WithDisableSessionSave(cfg.DisableSessionSave)
-	router := srv.Router(tenantMW, rateMW, apiKeyMW)
+	router := srv.Router(tenantMW, rateMW, apiKeyMW, middleware.CORS(cfg.CORSAllowedOrigins))
 
 	httpSrv := &http.Server{
 		Addr:         ":" + cfg.Port,
@@ -284,6 +284,8 @@ func main() {
 		embedder,
 		llmClient,
 		cfg.EmbedAutoModel,
+		cfg.EmbedAutoDims,
+		cfg.EmbedDims,
 		cfg.FTSEnabled,
 		service.IngestMode(cfg.IngestMode),
 		logger,

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	DSN       string
 	RateLimit float64
 	RateBurst int
+	Env       string
 
 	// DBBackend selects the database driver: "tidb" (default), "postgres", or "db9".
 	DBBackend string
@@ -121,6 +122,8 @@ type Config struct {
 	AutoSpendLimitCooldown  time.Duration
 
 	UTMEnabled bool
+
+	CORSAllowedOrigins []string
 }
 
 func Load() (*Config, error) {
@@ -156,9 +159,11 @@ func Load() (*Config, error) {
 		}
 	}
 
+	env := strings.ToLower(strings.TrimSpace(envOr("MNEMO_ENV", envOr("APP_ENV", "development"))))
 	cfg := &Config{
 		Port:                        envOr("MNEMO_PORT", "8080"),
 		DSN:                         dsn,
+		Env:                         env,
 		DBBackend:                   envOr("MNEMO_DB_BACKEND", "tidb"),
 		RateLimit:                   envFloat("MNEMO_RATE_LIMIT", 100),
 		RateBurst:                   envInt("MNEMO_RATE_BURST", 200),
@@ -208,6 +213,7 @@ func Load() (*Config, error) {
 		AutoSpendLimitMax:           envInt("MNEMO_AUTO_SPEND_LIMIT_MAX", 10000),
 		AutoSpendLimitCooldown:      envDuration("MNEMO_AUTO_SPEND_LIMIT_COOLDOWN", 1*time.Hour),
 		UTMEnabled:                  envBool("MNEMO_UTM_ENABLED", false),
+		CORSAllowedOrigins:          parseCSV(envOr("MNEMO_CORS_ALLOWED_ORIGINS", defaultCORSAllowedOrigins(env))),
 	}
 	// Validate ingest mode.
 	switch cfg.IngestMode {
@@ -239,6 +245,27 @@ func Load() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func defaultCORSAllowedOrigins(env string) string {
+	switch env {
+	case "prod", "production":
+		return "https://mem9.ai"
+	default:
+		return "https://mem9.ai,http://localhost:4321,http://127.0.0.1:4321"
+	}
+}
+
+func parseCSV(value string) []string {
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func envOr(key, fallback string) string {

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -38,6 +38,7 @@ type Memory struct {
 
 	AgentID      string `json:"agent_id,omitempty"`
 	SessionID    string `json:"session_id,omitempty"`
+	AppID        string `json:"appId,omitempty"`
 	UpdatedBy    string `json:"updated_by,omitempty"`
 	SupersededBy string `json:"superseded_by,omitempty"`
 
@@ -151,6 +152,7 @@ type MemoryFilter struct {
 	MemoryType string
 	AgentID    string
 	SessionID  string
+	AppID      *string
 	SortBy     string
 	SortDir    string
 	Limit      int
@@ -257,6 +259,7 @@ type Session struct {
 	ID          string      `json:"id"`
 	SessionID   string      `json:"session_id,omitempty"`
 	AgentID     string      `json:"agent_id,omitempty"`
+	AppID       string      `json:"appId,omitempty"`
 	Source      string      `json:"source,omitempty"`
 	Seq         int         `json:"seq"`
 	Role        string      `json:"role"`

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -133,7 +133,7 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 					return
 				}
 			}
-			result, err := targetSvc.ingest.ReconcilePhase2(ctx, nodeAuth.AgentName, req.AgentID, req.SessionID, factsForTarget)
+			result, err := targetSvc.ingest.ReconcilePhase2(ctx, nodeAuth.AgentName, req.AgentID, req.AppID, req.SessionID, factsForTarget)
 			if err != nil {
 				if s.runtimeUsageEnabled() && lease != nil {
 					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
@@ -389,6 +389,52 @@ func (s *Server) listChainMemories(ctx context.Context, auth *domain.AuthInfo, f
 		"scan_all", scanAll,
 		"returned", len(memories),
 	)
+	return memories, totalBeforePage, nil
+}
+
+func (s *Server) listChainMemoriesContentKeyword(ctx context.Context, auth *domain.AuthInfo, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return nil, 0, &domain.ValidationError{Message: "Space Chain has no nodes."}
+	}
+	requestLimit := filter.Limit
+	requestOffset := filter.Offset
+	if requestLimit <= 0 {
+		requestLimit = 20
+	}
+
+	perNodeFilter := filter
+	perNodeFilter.Offset = 0
+	perNodeFilter.Limit = requestLimit + requestOffset
+	if perNodeFilter.Limit <= 0 {
+		perNodeFilter.Limit = requestLimit
+	}
+
+	results := make([][]domain.Memory, len(auth.Chain.Nodes))
+	group, groupCtx := errgroup.WithContext(ctx)
+	for i, node := range auth.Chain.Nodes {
+		i, node := i, node
+		group.Go(func() error {
+			nodeAuth := chainNodeAuth(auth, node)
+			svc := s.resolveServices(nodeAuth)
+			memories, _, err := s.listLocalMemoriesContentKeyword(groupCtx, svc, perNodeFilter)
+			if err != nil {
+				return err
+			}
+			applyChainSource(memories, chainSource(auth, node))
+			results[i] = memories
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, 0, err
+	}
+
+	combined := make([]domain.Memory, 0, perNodeFilter.Limit*len(auth.Chain.Nodes))
+	for _, page := range results {
+		combined = append(combined, page...)
+	}
+	totalBeforePage := len(uniqueChainMemories(combined))
+	memories := finalizeChainMemories(combined, filter, requestLimit, requestOffset, false)
 	return memories, totalBeforePage, nil
 }
 
@@ -706,7 +752,7 @@ func uniqueChainMemories(memories []domain.Memory) []domain.Memory {
 	return out
 }
 
-func (s *Server) listChainSessionMessages(ctx context.Context, auth *domain.AuthInfo, sessionIDs []string, limitPerSession int) ([]sessionMessageResponse, error) {
+func (s *Server) listChainSessionMessages(ctx context.Context, auth *domain.AuthInfo, sessionIDs []string, appID *string, limitPerSession int) ([]sessionMessageResponse, error) {
 	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
 		return nil, &domain.ValidationError{Message: "Space Chain has no nodes."}
 	}
@@ -714,7 +760,7 @@ func (s *Server) listChainSessionMessages(ctx context.Context, auth *domain.Auth
 	for _, node := range auth.Chain.Nodes {
 		nodeAuth := chainNodeAuth(auth, node)
 		svc := s.resolveServices(nodeAuth)
-		sessions, err := svc.session.ListBySessionIDs(ctx, sessionIDs, limitPerSession)
+		sessions, err := svc.session.ListBySessionIDs(ctx, sessionIDs, appID, limitPerSession)
 		if err != nil {
 			return nil, err
 		}
@@ -724,6 +770,7 @@ func (s *Server) listChainSessionMessages(ctx context.Context, auth *domain.Auth
 				ID:          sess.ID,
 				SessionID:   sess.SessionID,
 				AgentID:     sess.AgentID,
+				AppID:       sess.AppID,
 				Source:      sess.Source,
 				Seq:         sess.Seq,
 				Role:        sess.Role,

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -123,6 +123,7 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		if cached, ok := s.svcCache.Load(key); ok {
 			return cached.(resolvedSvc)
 		}
+		schemaReady := s.ensureTenantAppIDSchema(auth)
 		memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		svc := resolvedSvc{
@@ -130,22 +131,17 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 			ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 			session: service.NewSessionService(sessRepo, s.embedder, s.autoModel),
 		}
-		actual, loaded := s.svcCache.LoadOrStore(key, svc)
-		if !loaded {
-			go func() {
-				if err := s.tenant.EnsureSessionsTable(context.Background(), auth.TenantDB); err != nil {
-					s.logger.Warn("sessions table migration failed",
-						"cluster_id", auth.ClusterID,
-						"err", err) // no tenant field: TenantID is empty in this branch
-				}
-			}()
+		if !schemaReady {
+			return svc
 		}
+		actual, _ := s.svcCache.LoadOrStore(key, svc)
 		return actual.(resolvedSvc)
 	}
 	key := tenantSvcKey(fmt.Sprintf("%s-%p", auth.TenantID, auth.TenantDB))
 	if cached, ok := s.svcCache.Load(key); ok {
 		return cached.(resolvedSvc)
 	}
+	schemaReady := s.ensureTenantAppIDSchema(auth)
 	memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	svc := resolvedSvc{
@@ -153,18 +149,31 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
 		session: service.NewSessionService(sessRepo, s.embedder, s.autoModel),
 	}
-	actual, loaded := s.svcCache.LoadOrStore(key, svc)
-	if !loaded {
-		go func() {
-			if err := s.tenant.EnsureSessionsTable(context.Background(), auth.TenantDB); err != nil {
-				s.logger.Warn("sessions table migration failed",
-					"cluster_id", auth.ClusterID,
-					"tenant", auth.TenantID,
-					"err", err)
-			}
-		}()
+	if !schemaReady {
+		return svc
 	}
+	actual, _ := s.svcCache.LoadOrStore(key, svc)
 	return actual.(resolvedSvc)
+}
+
+func (s *Server) ensureTenantAppIDSchema(auth *domain.AuthInfo) bool {
+	if s.tenant == nil || auth == nil || auth.TenantDB == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := s.tenant.EnsureAppIDSchema(ctx, auth.TenantDB); err != nil {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn("app_id schema migration failed",
+			"cluster_id", auth.ClusterID,
+			"tenant", auth.TenantID,
+			"err", err)
+		return false
+	}
+	return true
 }
 
 // Router builds the chi router with all routes and middleware.
@@ -172,11 +181,13 @@ func (s *Server) Router(
 	tenantMW func(http.Handler) http.Handler,
 	rateLimitMW func(http.Handler) http.Handler,
 	apiKeyMW func(http.Handler) http.Handler,
+	corsMW func(http.Handler) http.Handler,
 ) http.Handler {
 	r := chi.NewRouter()
 
 	// Global middleware.
 	r.Use(chimw.Recoverer)
+	r.Use(corsMW)
 	r.Use(chimw.RequestID)
 	r.Use(reqid.NewContextMiddleware)
 	r.Use(requestLogger(s.logger))

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -726,6 +726,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	} else {
 		svc := s.resolveServices(auth)
 		switch {
+		case filter.Query != "" && filter.ScanAll:
+			memories, total, err = s.listLocalMemoriesScanAll(r.Context(), svc, filter)
 		case filter.Query != "" && filter.MemoryType == "":
 			memories, total, err = s.defaultConfidenceRecallSearch(r.Context(), auth, svc, filter)
 		case filter.Query != "" && (filter.MemoryType == string(domain.TypeSession) ||
@@ -789,6 +791,61 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 func parseBoolQuery(value string) bool {
 	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
 	return err == nil && parsed
+}
+
+func (s *Server) listLocalMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	switch strings.TrimSpace(filter.MemoryType) {
+	case string(domain.TypeSession):
+		return svc.session.List(ctx, filter)
+	case string(domain.TypePinned), string(domain.TypeInsight):
+		return svc.memory.List(ctx, filter)
+	case "":
+		return s.listLocalAllTypeMemoriesScanAll(ctx, svc, filter)
+	default:
+		return svc.memory.List(ctx, filter)
+	}
+}
+
+func (s *Server) listLocalAllTypeMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	memoryPages, err := collectLocalListPages(ctx, filter, svc.memory.List)
+	if err != nil {
+		return nil, 0, err
+	}
+	sessionPages, err := collectLocalListPages(ctx, filter, svc.session.List)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	combined := make([]domain.Memory, 0, len(memoryPages)+len(sessionPages))
+	combined = append(combined, memoryPages...)
+	combined = append(combined, sessionPages...)
+	combined = uniqueChainMemories(combined)
+
+	total := len(combined)
+	return finalizeChainMemories(combined, filter, filter.Limit, filter.Offset, false), total, nil
+}
+
+func collectLocalListPages(
+	ctx context.Context,
+	filter domain.MemoryFilter,
+	list func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error),
+) ([]domain.Memory, error) {
+	pageFilter := filter
+	pageFilter.Limit = 200
+	pageFilter.Offset = 0
+
+	var all []domain.Memory
+	for {
+		page, pageTotal, err := list(ctx, pageFilter)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, page...)
+		if len(page) == 0 || pageFilter.Offset+pageFilter.Limit >= pageTotal {
+			return all, nil
+		}
+		pageFilter.Offset += pageFilter.Limit
+	}
 }
 
 func normalizeRecallQuery(query string, now time.Time) string {

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,6 +30,8 @@ type createMemoryRequest struct {
 	Content            string                  `json:"content,omitempty"`
 	MemoryType         string                  `json:"memory_type,omitempty"`
 	AgentID            string                  `json:"agent_id,omitempty"`
+	AppID              string                  `json:"appId,omitempty"`
+	AppIDLegacy        string                  `json:"app_id,omitempty"`
 	Tags               []string                `json:"tags,omitempty"`
 	Metadata           json.RawMessage         `json:"metadata,omitempty"`
 	Messages           []service.IngestMessage `json:"messages,omitempty"`
@@ -70,6 +73,11 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	if agentID == "" {
 		agentID = auth.AgentName
 	}
+	appID, err := appIDFromCreateRequest(req)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
 
 	hasMessages := len(req.Messages) > 0
 	hasContent := strings.TrimSpace(req.Content) != ""
@@ -90,6 +98,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			Messages:           messages,
 			SessionID:          req.SessionID,
 			AgentID:            agentID,
+			AppID:              appID,
 			Mode:               req.Mode,
 			DisableSessionSave: s.disableSessionSave || req.DisableSessionSave,
 		}
@@ -261,7 +270,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			}()
 		}
 
-		mem, written, err := svc.memory.CreatePinned(r.Context(), agentID, content, tags, metadata)
+		mem, written, err := svc.memory.CreatePinned(r.Context(), agentID, appID, content, tags, metadata)
 		if err != nil {
 			if s.runtimeUsageEnabled() {
 				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
@@ -324,7 +333,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		routingTargets := chainRoutingTargets(chainAuth)
 		if len(routingTargets) > 0 && svc.ingest.HasLLM() {
-			result, err := s.createSmartContentWithRouting(r.Context(), chainAuth, svc, routingTargets, auth.AgentName, agentID, req.SessionID, content, tags, metadata)
+			result, err := s.createSmartContentWithRouting(r.Context(), chainAuth, svc, routingTargets, auth.AgentName, agentID, appID, req.SessionID, content, tags, metadata)
 			if err != nil {
 				if s.runtimeUsageEnabled() {
 					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
@@ -373,7 +382,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// s.persistContentSession(r.Context(), auth, svc, req.SessionID, agentID, content, metadata)
-		mem, written, err := svc.memory.Create(r.Context(), agentID, content, tags, metadata)
+		mem, written, err := svc.memory.Create(r.Context(), agentID, appID, content, tags, metadata)
 		if err != nil {
 			if s.runtimeUsageEnabled() {
 				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
@@ -419,10 +428,10 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		routingTargets := chainRoutingTargets(chainAuth)
-		go func(auth, chainAuth *domain.AuthInfo, lease *runtimeusage.OperationLease, agentName, actorAgentID, sessionID, content string, tags []string, metadata json.RawMessage, routingTargets []service.RoutingTarget) {
+		go func(auth, chainAuth *domain.AuthInfo, lease *runtimeusage.OperationLease, agentName, actorAgentID, appID, sessionID, content string, tags []string, metadata json.RawMessage, routingTargets []service.RoutingTarget) {
 			// s.persistContentSession(context.Background(), auth, svc, sessionID, actorAgentID, content, metadata)
 			if len(routingTargets) > 0 && svc.ingest.HasLLM() {
-				result, err := s.createSmartContentWithRouting(context.Background(), chainAuth, svc, routingTargets, agentName, actorAgentID, sessionID, content, tags, metadata)
+				result, err := s.createSmartContentWithRouting(context.Background(), chainAuth, svc, routingTargets, agentName, actorAgentID, appID, sessionID, content, tags, metadata)
 				if err != nil {
 					if s.runtimeUsageEnabled() {
 						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
@@ -460,7 +469,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				s.afterSuccessfulWrite(auth, svc, written)
 				return
 			}
-			mem, written, err := svc.memory.Create(context.Background(), actorAgentID, content, tags, metadata)
+			mem, written, err := svc.memory.Create(context.Background(), actorAgentID, appID, content, tags, metadata)
 			if err != nil {
 				if s.runtimeUsageEnabled() {
 					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
@@ -492,7 +501,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			s.afterSuccessfulWrite(auth, svc, int64(written))
-		}(auth, chainAuth, lease, auth.AgentName, agentID, req.SessionID, content, tags, metadata, routingTargets)
+		}(auth, chainAuth, lease, auth.AgentName, agentID, appID, req.SessionID, content, tags, metadata, routingTargets)
 
 		respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
 	}
@@ -572,7 +581,7 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 					continue
 				}
 				hash := service.SessionContentHash(req.SessionID, msg.Role, msg.Content, msg.Seq)
-				if err := svc.session.PatchTags(ctx, req.SessionID, hash, tags); err != nil {
+				if err := svc.session.PatchTags(ctx, req.AppID, req.SessionID, hash, tags); err != nil {
 					slog.Warn("session tag patch failed",
 						"cluster_id", auth.ClusterID, "session", req.SessionID, "err", err)
 				}
@@ -588,7 +597,7 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 			reconcileDuration = time.Since(reconcileStart)
 		}()
 		reconcileResult, reconcileErr = svc.ingest.ReconcilePhase2(
-			ctx, auth.AgentName, req.AgentID, req.SessionID, phase1.Facts)
+			ctx, auth.AgentName, req.AgentID, req.AppID, req.SessionID, phase1.Facts)
 	}()
 
 	wg.Wait()
@@ -620,7 +629,7 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 	return reconcileResult, nil
 }
 
-func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *domain.AuthInfo, svc resolvedSvc, routingTargets []service.RoutingTarget, agentName, agentID, sessionID, content string, tags []string, metadata json.RawMessage) (*service.IngestResult, error) {
+func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *domain.AuthInfo, svc resolvedSvc, routingTargets []service.RoutingTarget, agentName, agentID, appID, sessionID, content string, tags []string, metadata json.RawMessage) (*service.IngestResult, error) {
 	facts, err := svc.ingest.ExtractContentWithRouting(ctx, content, routingTargets)
 	if err != nil {
 		return nil, err
@@ -628,7 +637,7 @@ func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *d
 	if len(facts) == 0 {
 		return &service.IngestResult{Status: "complete"}, nil
 	}
-	result, err := svc.ingest.ReconcilePhase2(ctx, agentName, agentID, sessionID, facts)
+	result, err := svc.ingest.ReconcilePhase2(ctx, agentName, agentID, appID, sessionID, facts)
 	if err != nil {
 		return nil, err
 	}
@@ -649,7 +658,7 @@ func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *d
 		result.MemoriesChanged += patchWrites
 	}
 
-	routed := s.reconcileRoutedChainFacts(ctx, chainAuth, service.IngestRequest{AgentID: agentID, SessionID: sessionID}, facts)
+	routed := s.reconcileRoutedChainFacts(ctx, chainAuth, service.IngestRequest{AgentID: agentID, AppID: appID, SessionID: sessionID}, facts)
 	result.MemoriesChanged += routed.memoriesChanged
 	result.InsightIDs = append(result.InsightIDs, routed.insightIDs...)
 	result.Warnings += routed.warnings
@@ -670,7 +679,11 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
 	q := r.URL.Query()
 	rawQuery := q.Get("q")
-	query := normalizeRecallQuery(rawQuery, time.Now())
+	contentKeywordSearch := isContentKeywordSearch(q)
+	query := strings.TrimSpace(rawQuery)
+	if !contentKeywordSearch {
+		query = normalizeRecallQuery(rawQuery, time.Now())
+	}
 
 	limit, _ := strconv.Atoi(q.Get("limit"))
 	offset, _ := strconv.Atoi(q.Get("offset"))
@@ -679,6 +692,11 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if offset < 0 {
 		offset = 0
+	}
+	appIDFilter, err := parseAppIDFilter(q)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
 	}
 
 	var tags []string
@@ -694,6 +712,7 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		MemoryType: q.Get("memory_type"),
 		AgentID:    q.Get("agent_id"),
 		SessionID:  q.Get("session_id"),
+		AppID:      appIDFilter,
 		SortBy:     q.Get("sort_by"),
 		SortDir:    q.Get("sort_dir"),
 		Limit:      limit,
@@ -704,11 +723,11 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 
 	var memories []domain.Memory
 	var total int
-	var err error
 	var recallLease *runtimeusage.OperationLease
 	recallFinalized := false
+	recallSearch := filter.Query != "" && !contentKeywordSearch
 
-	if s.runtimeUsageEnabled() && filter.Query != "" {
+	if s.runtimeUsageEnabled() && recallSearch {
 		recallLease, err = s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
 		if err != nil {
 			s.handleRuntimeUsageError(w, err)
@@ -722,10 +741,16 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if auth.IsChain() {
-		memories, total, err = s.listChainMemories(r.Context(), auth, filter)
+		if filter.Query != "" && contentKeywordSearch {
+			memories, total, err = s.listChainMemoriesContentKeyword(r.Context(), auth, filter)
+		} else {
+			memories, total, err = s.listChainMemories(r.Context(), auth, filter)
+		}
 	} else {
 		svc := s.resolveServices(auth)
 		switch {
+		case filter.Query != "" && contentKeywordSearch:
+			memories, total, err = s.listLocalMemoriesContentKeyword(r.Context(), svc, filter)
 		case filter.Query != "" && filter.ScanAll:
 			memories, total, err = s.listLocalMemoriesScanAll(r.Context(), svc, filter)
 		case filter.Query != "" && filter.MemoryType == "":
@@ -753,12 +778,12 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	if memories == nil {
 		memories = []domain.Memory{}
 	}
-	if rawQuery != "" && classifyRecallQueryShape(rawQuery) == recallQueryShapeTime {
+	if !contentKeywordSearch && rawQuery != "" && classifyRecallQueryShape(rawQuery) == recallQueryShapeTime {
 		for i := range memories {
 			memories[i].Content = service.TemporalRecallProjection(memories[i].Content, memories[i].Metadata)
 		}
 	}
-	if filter.Query != "" {
+	if recallSearch {
 		if s.runtimeUsageEnabled() && recallLease != nil {
 			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
 				return s.runtimeUsage.AfterRecallSuccess(ctx, recallLease, runtimeusage.RecallResult{
@@ -788,9 +813,58 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func isContentKeywordSearch(q url.Values) bool {
+	mode := strings.TrimSpace(q.Get("search_mode"))
+	if mode == "" {
+		mode = strings.TrimSpace(q.Get("searchMode"))
+	}
+	return strings.EqualFold(mode, "keyword") || strings.EqualFold(mode, "content_keyword")
+}
+
 func parseBoolQuery(value string) bool {
 	parsed, err := strconv.ParseBool(strings.TrimSpace(value))
 	return err == nil && parsed
+}
+
+const maxAppIDLen = 100
+
+func appIDFromCreateRequest(req createMemoryRequest) (string, error) {
+	raw := req.AppID
+	if raw == "" {
+		raw = req.AppIDLegacy
+	}
+	return normalizeAppIDForWrite(raw)
+}
+
+func normalizeAppIDForWrite(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) > maxAppIDLen {
+		return "", &domain.ValidationError{Field: "appId", Message: "too long (max 100)"}
+	}
+	return value, nil
+}
+
+func parseAppIDFilter(q url.Values) (*string, error) {
+	rawValues, ok := q["appId"]
+	if !ok {
+		rawValues, ok = q["app_id"]
+	}
+	if !ok {
+		return nil, nil
+	}
+	raw := ""
+	if len(rawValues) > 0 {
+		raw = rawValues[len(rawValues)-1]
+	}
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.EqualFold(raw, "null") {
+		appID := ""
+		return &appID, nil
+	}
+	if len(raw) > maxAppIDLen {
+		return nil, &domain.ValidationError{Field: "appId", Message: "too long (max 100)"}
+	}
+	return &raw, nil
 }
 
 func (s *Server) listLocalMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
@@ -804,6 +878,38 @@ func (s *Server) listLocalMemoriesScanAll(ctx context.Context, svc resolvedSvc, 
 	default:
 		return svc.memory.List(ctx, filter)
 	}
+}
+
+func (s *Server) listLocalMemoriesContentKeyword(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	switch strings.TrimSpace(filter.MemoryType) {
+	case string(domain.TypeSession):
+		return svc.session.ContentKeywordSearch(ctx, filter)
+	case string(domain.TypePinned), string(domain.TypeInsight):
+		return svc.memory.ContentKeywordSearch(ctx, filter)
+	case "":
+		return s.listLocalAllTypeMemoriesContentKeyword(ctx, svc, filter)
+	default:
+		return svc.memory.ContentKeywordSearch(ctx, filter)
+	}
+}
+
+func (s *Server) listLocalAllTypeMemoriesContentKeyword(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	memoryPages, err := collectLocalListPages(ctx, filter, svc.memory.ContentKeywordSearch)
+	if err != nil {
+		return nil, 0, err
+	}
+	sessionPages, err := collectLocalListPages(ctx, filter, svc.session.ContentKeywordSearch)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	combined := make([]domain.Memory, 0, len(memoryPages)+len(sessionPages))
+	combined = append(combined, memoryPages...)
+	combined = append(combined, sessionPages...)
+	combined = uniqueChainMemories(combined)
+
+	total := len(combined)
+	return finalizeChainMemories(combined, filter, filter.Limit, filter.Offset, false), total, nil
 }
 
 func (s *Server) listLocalAllTypeMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
@@ -1479,6 +1585,7 @@ type sessionMessageResponse struct {
 	ID          string              `json:"id"`
 	SessionID   string              `json:"session_id,omitempty"`
 	AgentID     string              `json:"agent_id,omitempty"`
+	AppID       string              `json:"appId,omitempty"`
 	Source      string              `json:"source,omitempty"`
 	Seq         int                 `json:"seq"`
 	Role        string              `json:"role"`
@@ -1508,6 +1615,11 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 		})
 		return
 	}
+	appIDFilter, err := parseAppIDFilter(r.URL.Query())
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
 
 	limitPerSession := maxLimitPerSession
 	if raw := r.URL.Query().Get("limit_per_session"); raw != "" {
@@ -1524,7 +1636,7 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 	}
 
 	if auth.IsChain() {
-		messages, err := s.listChainSessionMessages(r.Context(), auth, sessionIDs, limitPerSession)
+		messages, err := s.listChainSessionMessages(r.Context(), auth, sessionIDs, appIDFilter, limitPerSession)
 		if err != nil {
 			s.handleError(r.Context(), w, err)
 			return
@@ -1537,7 +1649,7 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 	}
 
 	svc := s.resolveServices(auth)
-	sessions, err := svc.session.ListBySessionIDs(r.Context(), sessionIDs, limitPerSession)
+	sessions, err := svc.session.ListBySessionIDs(r.Context(), sessionIDs, appIDFilter, limitPerSession)
 	if err != nil {
 		s.handleError(r.Context(), w, err)
 		return
@@ -1551,6 +1663,7 @@ func (s *Server) handleListSessionMessages(w http.ResponseWriter, r *http.Reques
 			ID:          sess.ID,
 			SessionID:   sess.SessionID,
 			AgentID:     sess.AgentID,
+			AppID:       sess.AppID,
 			Source:      sess.Source,
 			Seq:         sess.Seq,
 			Role:        sess.Role,

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -35,6 +35,10 @@ type testMemoryRepo struct {
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordFilter    domain.MemoryFilter
+	listResults          []domain.Memory
+	listTotal            int
+	lastListFilter       domain.MemoryFilter
+	listCalls            int
 	softDeleteCalls      []string
 	softDeleteResult     int64
 	softDeleteErr        error
@@ -103,8 +107,12 @@ func (m *testMemoryRepo) ArchiveAndCreate(_ context.Context, _, _ string, mem *d
 	return nil
 }
 func (m *testMemoryRepo) SetState(context.Context, string, domain.MemoryState) error { return nil }
-func (m *testMemoryRepo) List(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
-	return nil, 0, nil
+func (m *testMemoryRepo) List(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listCalls++
+	m.lastListFilter = filter
+	return append([]domain.Memory(nil), m.listResults...), m.listTotal, nil
 }
 func (m *testMemoryRepo) Count(context.Context) (int, error) { return 0, nil }
 func (m *testMemoryRepo) BulkCreate(ctx context.Context, _ []*domain.Memory) error {
@@ -715,6 +723,75 @@ func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 		sessionRepo.lastListFilter.SessionID != "sess-1" ||
 		sessionRepo.lastListFilter.Source != "cli" ||
 		len(sessionRepo.lastListFilter.Tags) != 2 {
+		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
+	}
+}
+
+func TestListMemories_ScanAllListsAllLocalMemoryTypes(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "insight-1",
+				Content:    "HEARTBEAT insight",
+				MemoryType: domain.TypeInsight,
+				State:      domain.StateActive,
+				CreatedAt:  now.Add(-2 * time.Hour),
+				UpdatedAt:  now.Add(-2 * time.Hour),
+			},
+		},
+		listTotal: 1,
+	}
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "session-1",
+				Content:    "HEARTBEAT session",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+		listTotal: 1,
+	}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories?q=HEARTBEAT&limit=50&scanAll=true&sort_by=updated_at&sort_dir=desc", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 2 || resp.Limit != 50 || resp.Offset != 0 {
+		t.Fatalf("page = total:%d limit:%d offset:%d, want 2/50/0", resp.Total, resp.Limit, resp.Offset)
+	}
+	if len(resp.Memories) != 2 {
+		t.Fatalf("len(memories) = %d, want 2", len(resp.Memories))
+	}
+	if resp.Memories[0].ID != "session-1" || resp.Memories[1].ID != "insight-1" {
+		t.Fatalf("memory order = [%s %s], want [session-1 insight-1]", resp.Memories[0].ID, resp.Memories[1].ID)
+	}
+	if memRepo.listCalls != 1 || sessionRepo.listCalls != 1 {
+		t.Fatalf("list calls = memory:%d session:%d, want 1/1", memRepo.listCalls, sessionRepo.listCalls)
+	}
+	if memRepo.lastListFilter.Query != "HEARTBEAT" ||
+		!memRepo.lastListFilter.ScanAll ||
+		memRepo.lastListFilter.SortBy != "updated_at" ||
+		memRepo.lastListFilter.SortDir != "desc" ||
+		memRepo.lastListFilter.Limit != 200 {
+		t.Fatalf("memory list filter = %+v", memRepo.lastListFilter)
+	}
+	if sessionRepo.lastListFilter.Query != "HEARTBEAT" ||
+		!sessionRepo.lastListFilter.ScanAll ||
+		sessionRepo.lastListFilter.SortBy != "updated_at" ||
+		sessionRepo.lastListFilter.SortDir != "desc" ||
+		sessionRepo.lastListFilter.Limit != 200 {
 		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
 	}
 }

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"bytes"
 	"context"
+	"database/sql"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,7 +36,9 @@ type testMemoryRepo struct {
 	bulkCreateHook       func(context.Context)
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
+	lastKeywordQuery     string
 	lastKeywordFilter    domain.MemoryFilter
+	lastKeywordLimit     int
 	listResults          []domain.Memory
 	listTotal            int
 	lastListFilter       domain.MemoryFilter
@@ -135,7 +139,9 @@ func (m *testMemoryRepo) AutoVectorSearch(context.Context, string, domain.Memory
 
 func (m *testMemoryRepo) KeywordSearch(ctx context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	m.mu.Lock()
+	m.lastKeywordQuery = query
 	m.lastKeywordFilter = filter
+	m.lastKeywordLimit = limit
 	hook := m.keywordSearchHook
 	results := append([]domain.Memory(nil), m.keywordSearchResults...)
 	m.mu.Unlock()
@@ -153,7 +159,7 @@ func (m *testMemoryRepo) ListBootstrap(context.Context, int) ([]domain.Memory, e
 	return nil, nil
 }
 
-func (m *testMemoryRepo) NearDupSearch(context.Context, string) (string, float64, error) {
+func (m *testMemoryRepo) NearDupSearch(context.Context, string, domain.MemoryFilter) (string, float64, error) {
 	return "", 0, nil
 }
 
@@ -169,6 +175,7 @@ type testSessionRepo struct {
 	mu                   sync.Mutex
 	bulkCreateCalled     bool
 	patchTagsCalled      bool
+	patchedAppID         string
 	patchedHash          string
 	patchedSessionID     string
 	patchedTags          []string
@@ -177,6 +184,7 @@ type testSessionRepo struct {
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordFilter    domain.MemoryFilter
 	sessionListResults   []*domain.Session
+	lastSessionAppID     *string
 	lastSessionIDs       []string
 	lastSessionLimit     int
 	getResult            *domain.Memory
@@ -199,10 +207,11 @@ func (s *testSessionRepo) BulkCreate(_ context.Context, sessions []*domain.Sessi
 	return nil
 }
 
-func (s *testSessionRepo) PatchTags(_ context.Context, sessionID, hash string, tags []string) error {
+func (s *testSessionRepo) PatchTags(_ context.Context, appID, sessionID, hash string, tags []string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.patchTagsCalled = true
+	s.patchedAppID = appID
 	s.patchedSessionID = sessionID
 	s.patchedHash = hash
 	s.patchedTags = append([]string(nil), tags...)
@@ -274,7 +283,13 @@ func (s *testSessionRepo) KeywordSearch(ctx context.Context, query string, filte
 	return results, nil
 }
 func (s *testSessionRepo) FTSAvailable() bool { return false }
-func (s *testSessionRepo) ListBySessionIDs(_ context.Context, sessionIDs []string, limit int) ([]*domain.Session, error) {
+func (s *testSessionRepo) ListBySessionIDs(_ context.Context, sessionIDs []string, appID *string, limit int) ([]*domain.Session, error) {
+	if appID != nil {
+		v := *appID
+		s.lastSessionAppID = &v
+	} else {
+		s.lastSessionAppID = nil
+	}
 	s.lastSessionIDs = append([]string(nil), sessionIDs...)
 	s.lastSessionLimit = limit
 	return append([]*domain.Session(nil), s.sessionListResults...), nil
@@ -519,6 +534,48 @@ func ensureNoMeteringEvents(t *testing.T, writer *captureMeteringWriter, timeout
 	}
 }
 
+var handlerErrorDBRegisterOnce sync.Once
+
+func openHandlerErrorDB(t *testing.T) *sql.DB {
+	t.Helper()
+	handlerErrorDBRegisterOnce.Do(func() {
+		sql.Register("handler-error-db", handlerErrorDriver{})
+	})
+	db, err := sql.Open("handler-error-db", "")
+	if err != nil {
+		t.Fatalf("open handler error db: %v", err)
+	}
+	return db
+}
+
+type handlerErrorDriver struct{}
+
+func (handlerErrorDriver) Open(string) (driver.Conn, error) {
+	return handlerErrorConn{}, nil
+}
+
+type handlerErrorConn struct{}
+
+func (handlerErrorConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (handlerErrorConn) Close() error {
+	return nil
+}
+
+func (handlerErrorConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (handlerErrorConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return nil, errors.New("schema unavailable")
+}
+
+func (handlerErrorConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return nil, errors.New("schema unavailable")
+}
+
 // newTestServer creates a Server with pre-populated svcCache for testing.
 func newTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) *Server {
 	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default())
@@ -542,6 +599,35 @@ func storeTestTenantServices(srv *Server, tenantID string, memRepo *testMemoryRe
 		session: service.NewSessionService(&testSessionRepo{}, nil, ""),
 	}
 	srv.svcCache.Store(tenantSvcKey(fmt.Sprintf("%s-0x0", tenantID)), svc)
+}
+
+func TestResolveServicesDoesNotCacheAfterAppIDSchemaMigrationFailure(t *testing.T) {
+	db := openHandlerErrorDB(t)
+	defer db.Close()
+
+	tenantSvc := service.NewTenantService(nil, nil, nil, nil, "", 0, 0, false, nil)
+	srv := NewServer(tenantSvc, nil, "", nil, nil, "", false, service.ModeSmart, "tidb", slog.Default())
+	auth := &domain.AuthInfo{
+		TenantID: "tenant-a",
+		TenantDB: db,
+	}
+	key := tenantSvcKey(fmt.Sprintf("%s-%p", auth.TenantID, auth.TenantDB))
+
+	first := srv.resolveServices(auth)
+	if first.memory == nil || first.ingest == nil || first.session == nil {
+		t.Fatal("resolveServices returned incomplete services")
+	}
+	if _, ok := srv.svcCache.Load(key); ok {
+		t.Fatal("schema migration failure must not cache services")
+	}
+
+	second := srv.resolveServices(auth)
+	if _, ok := srv.svcCache.Load(key); ok {
+		t.Fatal("schema migration retry failure must not cache services")
+	}
+	if first.memory == second.memory {
+		t.Fatal("expected uncached resolveServices call to build a fresh service bundle")
+	}
 }
 
 func TestReconcileRoutedChainFactsRuntimeUsageUsesTargetSubjects(t *testing.T) {
@@ -793,6 +879,106 @@ func TestListMemories_ScanAllListsAllLocalMemoryTypes(t *testing.T) {
 		sessionRepo.lastListFilter.SortDir != "desc" ||
 		sessionRepo.lastListFilter.Limit != 200 {
 		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
+	}
+}
+
+func TestListMemories_ContentKeywordSearchBypassesRecall(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchResults: []domain.Memory{
+			{
+				ID:         "insight-zh",
+				Content:    "mem9小组负责本周的控制台验证",
+				MemoryType: domain.TypeInsight,
+				State:      domain.StateActive,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+	}
+	sessionRepo := &testSessionRepo{
+		keywordSearchHook: func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
+			t.Fatal("content keyword list search must not call session recall search")
+			return nil, nil
+		},
+	}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("mem9小组")+"&search_mode=keyword&limit=10&state=active&memory_type=insight", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 || len(resp.Memories) != 1 || resp.Memories[0].ID != "insight-zh" {
+		t.Fatalf("unexpected response: total=%d memories=%+v", resp.Total, resp.Memories)
+	}
+	if memRepo.lastKeywordQuery != "mem9小组" {
+		t.Fatalf("keyword query = %q, want mem9小组", memRepo.lastKeywordQuery)
+	}
+	if memRepo.lastKeywordFilter.State != "active" || memRepo.lastKeywordFilter.Query != "mem9小组" || memRepo.lastKeywordFilter.MemoryType != "insight" {
+		t.Fatalf("keyword filter = %+v", memRepo.lastKeywordFilter)
+	}
+	if memRepo.lastKeywordLimit != 30 {
+		t.Fatalf("keyword limit = %d, want 30", memRepo.lastKeywordLimit)
+	}
+	if sessionRepo.listCalls != 0 {
+		t.Fatalf("session list calls = %d, want 0", sessionRepo.listCalls)
+	}
+}
+
+func TestListMemories_ContentKeywordSearchAllTypesIncludesSessions(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchResults: []domain.Memory{
+			{
+				ID:         "insight-zh",
+				Content:    "mem9小组负责本周的控制台验证",
+				MemoryType: domain.TypeInsight,
+				State:      domain.StateActive,
+				CreatedAt:  now.Add(-time.Minute),
+				UpdatedAt:  now.Add(-time.Minute),
+			},
+		},
+	}
+	sessionRepo := &testSessionRepo{
+		keywordSearchResults: []domain.Memory{
+			{
+				ID:         "session-zh",
+				Content:    "mem9小组周会会记录原始 session",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+	}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("小组")+"&search_mode=keyword&limit=10&state=active&sort_by=updated_at&sort_dir=desc", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 2 || len(resp.Memories) != 2 {
+		t.Fatalf("unexpected response: total=%d memories=%+v", resp.Total, resp.Memories)
+	}
+	if resp.Memories[0].ID != "session-zh" || resp.Memories[1].ID != "insight-zh" {
+		t.Fatalf("unexpected order: %+v", resp.Memories)
+	}
+	if memRepo.lastKeywordFilter.Query != "小组" || sessionRepo.lastKeywordFilter.Query != "小组" {
+		t.Fatalf("keyword filters = memory:%+v session:%+v", memRepo.lastKeywordFilter, sessionRepo.lastKeywordFilter)
 	}
 }
 
@@ -2702,6 +2888,68 @@ func TestListMemories_DefaultRecall_PrefersSessionForExactQuery(t *testing.T) {
 	}
 	if resp.Memories[0].Confidence == nil || *resp.Memories[0].Confidence < defaultMixedMinConfidence {
 		t.Fatalf("expected confidence >= %d, got %+v", defaultMixedMinConfidence, resp.Memories[0].Confidence)
+	}
+}
+
+func TestListMemories_DefaultRecall_KeepsPinnedIdentifierSearchHits(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			switch filter.MemoryType {
+			case string(domain.TypePinned):
+				return []domain.Memory{
+					{
+						ID:         "p1",
+						Content:    "codex-appid-e2e-20260602154502 isolated app B memory",
+						MemoryType: domain.TypePinned,
+						UpdatedAt:  now,
+						State:      domain.StateActive,
+					},
+					{
+						ID:         "p2",
+						Content:    "codex-appid-e2e-20260602154502 isolated app A memory",
+						MemoryType: domain.TypePinned,
+						UpdatedAt:  now.Add(-time.Second),
+						State:      domain.StateActive,
+					},
+					{
+						ID:         "p3",
+						Content:    "codex-appid-e2e-20260602154502 global default memory",
+						MemoryType: domain.TypePinned,
+						UpdatedAt:  now.Add(-2 * time.Second),
+						State:      domain.StateActive,
+					},
+				}, nil
+			default:
+				return nil, nil
+			}
+		},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+
+	req := makeRequest(t, http.MethodGet, "/memories?q=codex-appid-e2e-20260602154502&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Memories) != 3 {
+		t.Fatalf("expected 3 memories, got %d", len(resp.Memories))
+	}
+	if resp.Memories[0].ID != "p1" {
+		t.Fatalf("expected pinned identifier hit, got %q", resp.Memories[0].ID)
+	}
+	for _, memory := range resp.Memories {
+		if memory.Confidence == nil || *memory.Confidence < defaultPinnedMinConfidence {
+			t.Fatalf("expected pinned confidence >= %d, got %+v for %s", defaultPinnedMinConfidence, memory.Confidence, memory.ID)
+		}
 	}
 }
 

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -208,7 +208,7 @@ func (s *Server) defaultConfidenceRecallSearch(
 	sessionCandidates = applyRecallConfidence(profile, sessionCandidates)
 
 	selectionStart := time.Now()
-	pinned, seen := selectPinnedRecallCandidates(profile.shape, budget, pinnedCandidates)
+	pinned, seen := selectPinnedRecallCandidates(profile, budget, pinnedCandidates)
 	mixed, cutoffReason, stats := selectMixedRecallCandidates(profile, budget-len(pinned), append(insightCandidates, sessionCandidates...), seen)
 	selectionDuration := time.Since(selectionStart)
 
@@ -344,10 +344,11 @@ func buildRecallConfidence(profile recallQueryProfile, candidate service.RecallC
 	if candidate.InVector && candidate.InKeyword {
 		agreementBonus = 0.10
 	}
-
 	confidenceRaw := 0.55*rrfNorm +
 		0.20*vecNorm +
 		agreementBonus +
+		literalContentEvidenceBonus(profile, candidate) +
+		keywordContentEvidenceBonus(profile, candidate) +
 		recencyBonus(candidate.Memory.UpdatedAt) +
 		answerEvidenceBonus(profile, candidate.Memory) +
 		sourcePrior(profile.shape, candidate.SourcePool)
@@ -355,8 +356,137 @@ func buildRecallConfidence(profile recallQueryProfile, candidate service.RecallC
 	return int(clampFloat64(confidenceRaw, 0, 1)*100 + 0.5)
 }
 
+func literalContentEvidenceBonus(profile recallQueryProfile, candidate service.RecallCandidate) float64 {
+	if !candidate.InKeyword {
+		return 0
+	}
+
+	query := strings.TrimSpace(profile.lower)
+	if query == "" {
+		return 0
+	}
+
+	content, _, _ := recallContentForScoring(candidate.Memory)
+	if !strings.Contains(strings.ToLower(content), query) {
+		return 0
+	}
+
+	if isRecallIdentifierLiteral(query) {
+		return 0.35
+	}
+	if len([]rune(query)) >= 8 && !strings.ContainsAny(query, " \t\r\n?？") {
+		return 0.22
+	}
+	return 0
+}
+
+func isRecallIdentifierLiteral(query string) bool {
+	if len([]rune(query)) < 8 {
+		return false
+	}
+
+	hasLetter := false
+	hasDigit := false
+	hasSeparator := false
+	for _, r := range query {
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		case r == '-' || r == '_' || r == ':' || r == '.' || r == '/':
+			hasSeparator = true
+		}
+	}
+	return hasLetter && hasDigit && hasSeparator
+}
+
+func keywordContentEvidenceBonus(profile recallQueryProfile, candidate service.RecallCandidate) float64 {
+	if !candidate.InKeyword || candidate.InVector || candidate.SourcePool != service.RecallSourceInsight {
+		return 0
+	}
+	if profile.shape != recallQueryShapeGeneral {
+		return 0
+	}
+
+	queryTokens := looseRecallQueryTokens(profile.lower)
+	if len(queryTokens) == 0 {
+		return 0
+	}
+	matchCount := recallExactTokenMatchCount(candidate.Memory, queryTokens)
+	if len(queryTokens) == 1 && matchCount == 1 {
+		return 0.22
+	}
+	if len(queryTokens) > 1 && matchCount >= 2 && matchCount*2 >= len(queryTokens) {
+		return 0.22
+	}
+	return 0
+}
+
+func looseRecallQueryTokens(query string) []string {
+	var tokens []string
+	seen := make(map[string]struct{})
+	var current strings.Builder
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		token := strings.ToLower(current.String())
+		current.Reset()
+		if len(token) < 2 || isRecallCoverageStopword(token) || isLooseRecallQueryStopword(token) {
+			return
+		}
+		if _, exists := seen[token]; exists {
+			return
+		}
+		seen[token] = struct{}{}
+		tokens = append(tokens, token)
+	}
+
+	for _, r := range query {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return tokens
+}
+
+func isLooseRecallQueryStopword(token string) bool {
+	switch token {
+	case "a", "an", "and", "are", "as", "at", "be", "by", "for", "from", "how", "if", "in", "is", "me", "not", "of", "on", "or", "say", "says", "said", "tell", "the", "to", "was", "were", "whether", "who", "whom", "whose", "why":
+		return true
+	default:
+		return false
+	}
+}
+
+func recallExactTokenMatchCount(memory domain.Memory, queryTokens []string) int {
+	if len(queryTokens) == 0 {
+		return 0
+	}
+	content, _, _ := recallContentForScoring(memory)
+	contentTokens := make(map[string]struct{})
+	for _, match := range recallCoverageEnglishTokenRe.FindAllString(strings.ToLower(content), -1) {
+		contentTokens[match] = struct{}{}
+	}
+	for _, match := range recallCoverageCJKTokenRe.FindAllString(content, -1) {
+		contentTokens[match] = struct{}{}
+	}
+
+	matches := 0
+	for _, token := range queryTokens {
+		if _, exists := contentTokens[token]; exists {
+			matches++
+		}
+	}
+	return matches
+}
+
 func selectPinnedRecallCandidates(
-	shape recallQueryShape,
+	profile recallQueryProfile,
 	budget int,
 	candidates []service.RecallCandidate,
 ) ([]domain.Memory, map[string]struct{}) {
@@ -364,7 +494,11 @@ func selectPinnedRecallCandidates(
 		return []domain.Memory{}, map[string]struct{}{}
 	}
 
-	selected, _ := selectTopRecallCandidates(shape, minInt(pinnedKeepMax(shape), budget), defaultPinnedMinConfidence, false, candidates, nil)
+	keepMax := pinnedKeepMax(profile.shape)
+	if isRecallIdentifierLiteral(profile.lower) {
+		keepMax = budget
+	}
+	selected, _ := selectTopRecallCandidates(profile.shape, minInt(keepMax, budget), defaultPinnedMinConfidence, false, candidates, nil)
 	seen := make(map[string]struct{}, len(selected))
 	for _, mem := range selected {
 		seen[recallMemoryKey(mem)] = struct{}{}

--- a/server/internal/handler/recall_test.go
+++ b/server/internal/handler/recall_test.go
@@ -207,6 +207,66 @@ func TestBuildRecallConfidence_TimeFutureIntentPrefersPlannedFutureEvidence(t *t
 	}
 }
 
+func TestBuildRecallConfidence_AllowsKeywordOnlyInsightHits(t *testing.T) {
+	profile := buildRecallQueryProfile("Bosn")
+	candidate := service.RecallCandidate{
+		Memory: domain.Memory{
+			ID:         "m1",
+			Content:    "Flame loves Bosn",
+			MemoryType: domain.TypeInsight,
+			UpdatedAt:  time.Now(),
+		},
+		SourcePool: service.RecallSourceInsight,
+		RRFScore:   1.0 / 61.0,
+		InKeyword:  true,
+	}
+
+	confidence := buildRecallConfidence(profile, candidate)
+	if confidence < defaultMixedMinConfidence {
+		t.Fatalf("keyword-only insight confidence = %d, want >= %d", confidence, defaultMixedMinConfidence)
+	}
+}
+
+func TestBuildRecallConfidence_AllowsKeywordOnlyInsightQuestionHits(t *testing.T) {
+	profile := buildRecallQueryProfile("Does Bosn love Flame?")
+	candidate := service.RecallCandidate{
+		Memory: domain.Memory{
+			ID:         "m1",
+			Content:    "Bosn loves Flame",
+			MemoryType: domain.TypeInsight,
+			UpdatedAt:  time.Now(),
+		},
+		SourcePool: service.RecallSourceInsight,
+		RRFScore:   1.0 / 61.0,
+		InKeyword:  true,
+	}
+
+	confidence := buildRecallConfidence(profile, candidate)
+	if confidence < defaultMixedMinConfidence {
+		t.Fatalf("keyword-only insight question confidence = %d, want >= %d", confidence, defaultMixedMinConfidence)
+	}
+}
+
+func TestBuildRecallConfidence_AllowsKeywordOnlyPinnedIdentifierHits(t *testing.T) {
+	profile := buildRecallQueryProfile("codex-appid-e2e-20260602154502")
+	candidate := service.RecallCandidate{
+		Memory: domain.Memory{
+			ID:         "p1",
+			Content:    "codex-appid-e2e-20260602154502 isolated app B memory",
+			MemoryType: domain.TypePinned,
+			UpdatedAt:  time.Now(),
+		},
+		SourcePool: service.RecallSourcePinned,
+		RRFScore:   1.0 / 61.0,
+		InKeyword:  true,
+	}
+
+	confidence := buildRecallConfidence(profile, candidate)
+	if confidence < defaultPinnedMinConfidence {
+		t.Fatalf("keyword-only pinned identifier confidence = %d, want >= %d", confidence, defaultPinnedMinConfidence)
+	}
+}
+
 func TestRecallCandidateOptions_EnumerationExpandsAdjacentTurns(t *testing.T) {
 	opts := recallCandidateOptions(recallQueryShapeEnumeration, true)
 

--- a/server/internal/handler/tenant_test.go
+++ b/server/internal/handler/tenant_test.go
@@ -285,6 +285,7 @@ func TestGetKeyStatus(t *testing.T) {
 						respondError(w, http.StatusTeapot, "apiKeyMW called")
 					})
 				},
+				func(h http.Handler) http.Handler { return h },
 			)
 
 			req := httptest.NewRequest(http.MethodGet, "/v1alpha2/status", nil)

--- a/server/internal/handler/version_test.go
+++ b/server/internal/handler/version_test.go
@@ -9,7 +9,12 @@ import (
 
 func TestVersionz_ReturnsStartedAt(t *testing.T) {
 	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
-	router := srv.Router(func(h http.Handler) http.Handler { return h }, func(h http.Handler) http.Handler { return h }, func(h http.Handler) http.Handler { return h })
+	router := srv.Router(
+		func(h http.Handler) http.Handler { return h },
+		func(h http.Handler) http.Handler { return h },
+		func(h http.Handler) http.Handler { return h },
+		func(h http.Handler) http.Handler { return h },
+	)
 
 	req := httptest.NewRequest(http.MethodGet, "/versionz", nil)
 	rr := httptest.NewRecorder()

--- a/server/internal/middleware/cors.go
+++ b/server/internal/middleware/cors.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+const corsMaxAge = "86400"
+
+// CORS returns middleware for browser clients. It handles preflight before auth
+// so API-key protected routes can be exercised from the public docs.
+func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
+	allowed := make(map[string]struct{}, len(allowedOrigins))
+	for _, origin := range allowedOrigins {
+		if origin != "" {
+			allowed[origin] = struct{}{}
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			w.Header().Add("Vary", "Origin")
+			w.Header().Add("Vary", "Access-Control-Request-Method")
+			w.Header().Add("Vary", "Access-Control-Request-Headers")
+
+			if _, ok := allowed[origin]; !ok {
+				if r.Method == http.MethodOptions {
+					http.Error(w, "CORS origin not allowed", http.StatusForbidden)
+					return
+				}
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key, X-Mnemo-Agent-Id, Authorization, If-Match")
+			w.Header().Set("Access-Control-Max-Age", corsMaxAge)
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server/internal/middleware/cors_test.go
+++ b/server/internal/middleware/cors_test.go
@@ -1,0 +1,77 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCORS_AllowsPreflightBeforeNext(t *testing.T) {
+	called := false
+	handler := CORS([]string{"https://mem9.ai", "http://localhost:4321"})(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set("Origin", "http://localhost:4321")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Headers", "X-API-Key")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if called {
+		t.Fatal("next handler must not run for allowed preflight")
+	}
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusNoContent)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:4321" {
+		t.Fatalf("allow origin = %q", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); got == "" {
+		t.Fatal("allow headers missing")
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(got, "If-Match") {
+		t.Fatalf("allow headers = %q, want If-Match", got)
+	}
+}
+
+func TestCORS_RejectsDisallowedPreflight(t *testing.T) {
+	handler := CORS([]string{"https://mem9.ai"})(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("next handler must not run for rejected preflight")
+	}))
+
+	req := httptest.NewRequest(http.MethodOptions, "/v1alpha2/mem9s/memories", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("disallowed origin should not be echoed, got %q", got)
+	}
+}
+
+func TestCORS_AddsHeadersForAllowedRequest(t *testing.T) {
+	handler := CORS([]string{"https://mem9.ai"})(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("Origin", "https://mem9.ai")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://mem9.ai" {
+		t.Fatalf("allow origin = %q", got)
+	}
+}

--- a/server/internal/repository/db9/memory.go
+++ b/server/internal/repository/db9/memory.go
@@ -39,7 +39,7 @@ func NewMemoryRepo(db *sql.DB, autoModel string, ftsEnabled bool, clusterID stri
 	}
 }
 
-const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
+const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
 
 // Create inserts a new memory. When autoModel is set, embedding column is omitted
 // (db9's GENERATED ALWAYS AS will auto-compute it).
@@ -56,10 +56,10 @@ func (r *DB9MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 		memoryType = string(domain.TypePinned)
 	}
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10, NOW(), NOW())`,
+		`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $11, NOW(), NOW())`,
 		m.ID, m.Content, nullString(m.Source),
-		tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+		tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 		m.Version, nullString(m.UpdatedBy),
 	)
 	if err != nil {
@@ -118,10 +118,10 @@ func (r *DB9MemoryRepo) BulkCreate(ctx context.Context, memories []*domain.Memor
 			memoryType = string(domain.TypePinned)
 		}
 		_, execErr := tx.ExecContext(ctx,
-			`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10, NOW(), NOW())`,
+			`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $11, NOW(), NOW())`,
 			m.ID, m.Content, nullString(m.Source),
-			tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+			tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 			m.Version, nullString(m.UpdatedBy),
 		)
 		if execErr != nil {
@@ -166,10 +166,10 @@ func (r *DB9MemoryRepo) ArchiveAndCreate(ctx context.Context, archiveID, superse
 	}
 
 	_, err = tx.ExecContext(ctx,
-		`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10, NOW(), NOW())`,
+		`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $11, NOW(), NOW())`,
 		newMem.ID, newMem.Content, nullString(newMem.Source),
-		tagsJSON, nullJSON(newMem.Metadata), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID),
+		tagsJSON, nullJSON(newMem.Metadata), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID), newMem.AppID,
 		newMem.Version, nullString(newMem.UpdatedBy),
 	)
 	if err != nil {
@@ -296,13 +296,13 @@ func (r *DB9MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Me
 // scanMemoryRowsWithDistance scans a row with distance score appended.
 func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON []byte
 	var embeddingStr sql.NullString
 	var distance float64
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
 		&distance)
 	if err != nil {
@@ -315,6 +315,7 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -332,13 +333,13 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 // scanMemoryRowsWithFTSScore scans a row with FTS score appended.
 func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON []byte
 	var embeddingStr sql.NullString
 	var ftsScore float64
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
 		&ftsScore)
 	if err != nil {
@@ -351,6 +352,7 @@ func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -414,26 +416,31 @@ func isDuplicateKey(err error) bool {
 	return strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key")
 }
 
-func (r *DB9MemoryRepo) NearDupSearch(ctx context.Context, queryText string) (string, float64, error) {
+func (r *DB9MemoryRepo) NearDupSearch(ctx context.Context, queryText string, f domain.MemoryFilter) (string, float64, error) {
 	if r.autoModel == "" {
 		return "", 0, nil
 	}
+	f.State = "active"
+	f.MemoryType = "insight,pinned"
+	conds, args := r.BuildFilterConds(f)
+	conds = append(conds, "embedding IS NOT NULL")
+	where := strings.Join(conds, " AND ")
+	queryParamIdx := len(args) + 1
 	var id string
 	var dist float64
-	err := r.db.QueryRowContext(ctx,
-		`WITH scored AS (
-			SELECT id, VEC_EMBED_COSINE_DISTANCE(embedding, $1) AS dist
+	query := fmt.Sprintf(`WITH scored AS (
+			SELECT id, VEC_EMBED_COSINE_DISTANCE(embedding, $%d) AS dist
 			FROM memories
-			WHERE state = 'active'
-			  AND memory_type IN ('insight', 'pinned')
-			  AND embedding IS NOT NULL
+			WHERE %s
 		)
 		SELECT id, dist
 		FROM scored
 		ORDER BY dist
-		LIMIT 1`,
-		queryText,
-	).Scan(&id, &dist)
+		LIMIT 1`, queryParamIdx, where)
+	fullArgs := make([]any, 0, len(args)+1)
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs, queryText)
+	err := r.db.QueryRowContext(ctx, query, fullArgs...).Scan(&id, &dist)
 	if err == sql.ErrNoRows {
 		return "", 0, nil
 	}

--- a/server/internal/repository/factory.go
+++ b/server/internal/repository/factory.go
@@ -108,7 +108,7 @@ func NewSessionRepo(backend string, db *sql.DB, autoModel string, ftsEnabled boo
 type stubSessionRepo struct{}
 
 func (stubSessionRepo) BulkCreate(_ context.Context, _ []*domain.Session) error { return nil }
-func (stubSessionRepo) PatchTags(_ context.Context, _, _ string, _ []string) error {
+func (stubSessionRepo) PatchTags(_ context.Context, _, _, _ string, _ []string) error {
 	return nil
 }
 func (stubSessionRepo) GetByID(_ context.Context, _ string) (*domain.Memory, error) {
@@ -136,6 +136,6 @@ func (stubSessionRepo) KeywordSearch(_ context.Context, _ string, _ domain.Memor
 	return nil, nil
 }
 func (stubSessionRepo) FTSAvailable() bool { return false }
-func (stubSessionRepo) ListBySessionIDs(_ context.Context, _ []string, _ int) ([]*domain.Session, error) {
+func (stubSessionRepo) ListBySessionIDs(_ context.Context, _ []string, _ *string, _ int) ([]*domain.Session, error) {
 	return nil, fmt.Errorf("session messages: %w", domain.ErrNotSupported)
 }

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -31,7 +31,7 @@ func NewMemoryRepo(db *sql.DB, ftsEnabled bool, clusterID string) *MemoryRepo {
 
 func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 
-const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
+const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 	tagsJSON := marshalTags(m.Tags)
@@ -40,10 +40,10 @@ func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 		memoryType = string(domain.TypePinned)
 	}
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $11, NOW(), NOW())`,
+		`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'active', $11, $12, NOW(), NOW())`,
 		m.ID, m.Content, nullString(m.Source),
-		tagsJSON, nullJSON(m.Metadata), vecToParam(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+		tagsJSON, nullJSON(m.Metadata), vecToParam(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 		m.Version, nullString(m.UpdatedBy),
 	)
 	if err != nil {
@@ -183,10 +183,10 @@ func (r *MemoryRepo) ArchiveAndCreate(ctx context.Context, archiveID, superseded
 	}
 
 	_, err = tx.ExecContext(ctx,
-		`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $11, NOW(), NOW())`,
+		`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'active', $11, $12, NOW(), NOW())`,
 		newMem.ID, newMem.Content, nullString(newMem.Source),
-		tagsJSON, nullJSON(newMem.Metadata), vecToParam(newMem.Embedding), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID),
+		tagsJSON, nullJSON(newMem.Metadata), vecToParam(newMem.Embedding), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID), newMem.AppID,
 		newMem.Version, nullString(newMem.UpdatedBy),
 	)
 	if err != nil {
@@ -328,10 +328,10 @@ func (r *MemoryRepo) BulkCreate(ctx context.Context, memories []*domain.Memory) 
 			memoryType = string(domain.TypePinned)
 		}
 		_, execErr := tx.ExecContext(ctx,
-			`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'active', $10, $11, NOW(), NOW())`,
+			`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'active', $11, $12, NOW(), NOW())`,
 			m.ID, m.Content, nullString(m.Source),
-			tagsJSON, nullJSON(m.Metadata), vecToParam(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+			tagsJSON, nullJSON(m.Metadata), vecToParam(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 			m.Version, nullString(m.UpdatedBy),
 		)
 		if execErr != nil {
@@ -514,6 +514,11 @@ func (r *MemoryRepo) BuildFilterConds(f domain.MemoryFilter) ([]string, []any) {
 		args = append(args, f.SessionID)
 		paramIdx++
 	}
+	if f.AppID != nil {
+		conds = append(conds, fmt.Sprintf("app_id = $%d", paramIdx))
+		args = append(args, *f.AppID)
+		paramIdx++
+	}
 	if f.Source != "" {
 		conds = append(conds, fmt.Sprintf("source = $%d", paramIdx))
 		args = append(args, f.Source)
@@ -538,12 +543,12 @@ func (r *MemoryRepo) BuildFilterConds(f domain.MemoryFilter) ([]string, []any) {
 
 func scanMemory(row *sql.Row) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON []byte
 	var embeddingStr sql.NullString
 
 	err := row.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy)
 	if err == sql.ErrNoRows {
 		return nil, domain.ErrNotFound
@@ -558,6 +563,7 @@ func scanMemory(row *sql.Row) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -571,12 +577,12 @@ func scanMemory(row *sql.Row) (*domain.Memory, error) {
 
 func scanMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON []byte
 	var embeddingStr sql.NullString
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy)
 	if err != nil {
 		return nil, fmt.Errorf("scan memory row: %w", err)
@@ -588,6 +594,7 @@ func scanMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -601,13 +608,13 @@ func scanMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
 
 func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON []byte
 	var embeddingStr sql.NullString
 	var distance float64
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
 		&distance)
 	if err != nil {
@@ -620,6 +627,7 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -635,13 +643,13 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 
 func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON []byte
 	var embeddingStr sql.NullString
 	var ftsScore float64
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
 		&ftsScore)
 	if err != nil {
@@ -654,6 +662,7 @@ func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -725,7 +734,7 @@ func isDuplicateKey(err error) bool {
 	return strings.Contains(err.Error(), "23505") || strings.Contains(err.Error(), "duplicate key")
 }
 
-func (r *MemoryRepo) NearDupSearch(_ context.Context, _ string) (string, float64, error) {
+func (r *MemoryRepo) NearDupSearch(_ context.Context, _ string, _ domain.MemoryFilter) (string, float64, error) {
 	return "", 0, nil
 }
 

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -42,7 +42,7 @@ type MemoryRepo interface {
 	// configured, or backend does not support auto-embedding).
 	// Postgres returns ("", 0, nil) — auto-embedding is not supported.
 	// DB9 implements real search when autoModel is configured; returns ("", 0, nil) otherwise.
-	NearDupSearch(ctx context.Context, queryText string) (id string, score float64, err error)
+	NearDupSearch(ctx context.Context, queryText string, f domain.MemoryFilter) (id string, score float64, err error)
 	// CountStats returns the total active memory count and the count created in the last 7 days.
 	CountStats(ctx context.Context) (total int64, last7d int64, err error)
 }
@@ -104,7 +104,7 @@ type UTMRepo interface {
 // BulkCreate silently skips MySQL 1146 (table not yet migrated) at DEBUG level.
 type SessionRepo interface {
 	BulkCreate(ctx context.Context, sessions []*domain.Session) error
-	PatchTags(ctx context.Context, sessionID, contentHash string, tags []string) error
+	PatchTags(ctx context.Context, appID, sessionID, contentHash string, tags []string) error
 	GetByID(ctx context.Context, id string) (*domain.Memory, error)
 	List(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, total int, err error)
 	SoftDelete(ctx context.Context, id, agentName string) (int64, error)
@@ -117,5 +117,5 @@ type SessionRepo interface {
 	// ListBySessionIDs returns raw session rows for the given session IDs, ordered by
 	// session_id ASC, created_at ASC, seq ASC, id ASC. At most limitPerSession rows are
 	// returned per session_id. Returns ErrNotSupported on non-TiDB backends.
-	ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error)
+	ListBySessionIDs(ctx context.Context, sessionIDs []string, appID *string, limitPerSession int) ([]*domain.Session, error)
 }

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -124,7 +124,7 @@ func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions",
 				"WHERE id IN (?,?) AND state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
 			},
@@ -139,7 +139,7 @@ func TestSessionFTSSearch_PostFiltersAfterFTSTopK(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,",
+				"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at,",
 				"fts_match_word('golang', content) AS fts_score",
 				"FROM sessions",
 				"WHERE state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?) AND fts_match_word('golang', content)",
@@ -345,7 +345,7 @@ func normalizeDriverValue(v any) any {
 func memoryColumns() []string {
 	return []string{
 		"id", "content", "source", "tags", "metadata", "embedding", "memory_type", "agent_id",
-		"session_id", "state", "version", "updated_by", "created_at", "updated_at", "superseded_by",
+		"session_id", "app_id", "state", "version", "updated_by", "created_at", "updated_at", "superseded_by",
 	}
 }
 
@@ -365,6 +365,7 @@ func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts ti
 		string(domain.TypeInsight),
 		agentID,
 		sessionID,
+		"",
 		state,
 		int64(1),
 		"tester",
@@ -381,7 +382,7 @@ func memoryRowWithFTSScore(id, content, agentID, sessionID, state string, tags [
 
 func sessionColumns() []string {
 	return []string{
-		"id", "session_id", "agent_id", "source", "seq", "role", "content", "content_type", "tags", "state", "created_at",
+		"id", "session_id", "agent_id", "app_id", "source", "seq", "role", "content", "content_type", "tags", "state", "created_at",
 	}
 }
 
@@ -395,6 +396,7 @@ func sessionRow(id, sessionID, agentID, source string, seq int64, role, content 
 		id,
 		sessionID,
 		agentID,
+		"",
 		source,
 		seq,
 		role,

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -34,7 +34,7 @@ func NewMemoryRepo(db *sql.DB, autoModel string, ftsEnabled bool, clusterID stri
 
 func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 
-const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at, superseded_by`
+const allColumns = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 	tagsJSON := marshalTags(m.Tags)
@@ -44,10 +44,10 @@ func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 	}
 	if r.autoModel != "" {
 		_, err := r.db.ExecContext(ctx,
-			`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
+			`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
 			m.ID, m.Content, nullString(m.Source),
-			tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+			tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 			m.Version, nullString(m.UpdatedBy),
 		)
 		if err != nil {
@@ -56,10 +56,10 @@ func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
 		return nil
 	}
 	_, err := r.db.ExecContext(ctx,
-		`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
+		`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
 		m.ID, m.Content, nullString(m.Source),
-		tagsJSON, nullJSON(m.Metadata), vecToString(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+		tagsJSON, nullJSON(m.Metadata), vecToString(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 		m.Version, nullString(m.UpdatedBy),
 	)
 	if err != nil {
@@ -211,18 +211,18 @@ func (r *MemoryRepo) ArchiveAndCreate(ctx context.Context, archiveID, superseded
 
 	if r.autoModel != "" {
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
+			`INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
 			newMem.ID, newMem.Content, nullString(newMem.Source),
-			tagsJSON, nullJSON(newMem.Metadata), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID),
+			tagsJSON, nullJSON(newMem.Metadata), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID), newMem.AppID,
 			newMem.Version, nullString(newMem.UpdatedBy),
 		)
 	} else {
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
+			`INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`,
 			newMem.ID, newMem.Content, nullString(newMem.Source),
-			tagsJSON, nullJSON(newMem.Metadata), vecToString(newMem.Embedding), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID),
+			tagsJSON, nullJSON(newMem.Metadata), vecToString(newMem.Embedding), memoryType, nullString(newMem.AgentID), nullString(newMem.SessionID), newMem.AppID,
 			newMem.Version, nullString(newMem.UpdatedBy),
 		)
 	}
@@ -360,11 +360,11 @@ func (r *MemoryRepo) BulkCreate(ctx context.Context, memories []*domain.Memory) 
 
 	var stmtSQL string
 	if r.autoModel != "" {
-		stmtSQL = `INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`
-	} else {
-		stmtSQL = `INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, state, version, updated_by, created_at, updated_at)
+		stmtSQL = `INSERT INTO memories (id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`
+	} else {
+		stmtSQL = `INSERT INTO memories (id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NOW(), NOW())`
 	}
 
 	stmt, err := tx.PrepareContext(ctx, stmtSQL)
@@ -383,13 +383,13 @@ func (r *MemoryRepo) BulkCreate(ctx context.Context, memories []*domain.Memory) 
 		if r.autoModel != "" {
 			_, execErr = stmt.ExecContext(ctx,
 				m.ID, m.Content, nullString(m.Source),
-				tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+				tagsJSON, nullJSON(m.Metadata), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 				m.Version, nullString(m.UpdatedBy),
 			)
 		} else {
 			_, execErr = stmt.ExecContext(ctx,
 				m.ID, m.Content, nullString(m.Source),
-				tagsJSON, nullJSON(m.Metadata), vecToString(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID),
+				tagsJSON, nullJSON(m.Metadata), vecToString(m.Embedding), memoryType, nullString(m.AgentID), nullString(m.SessionID), m.AppID,
 				m.Version, nullString(m.UpdatedBy),
 			)
 		}
@@ -748,6 +748,10 @@ func (r *MemoryRepo) buildFilterConds(f domain.MemoryFilter) ([]string, []any) {
 		conds = append(conds, "session_id = ?")
 		args = append(args, f.SessionID)
 	}
+	if f.AppID != nil {
+		conds = append(conds, "app_id = ?")
+		args = append(args, *f.AppID)
+	}
 	if f.Source != "" {
 		conds = append(conds, "source = ?")
 		args = append(args, f.Source)
@@ -769,11 +773,11 @@ func (r *MemoryRepo) buildFilterConds(f domain.MemoryFilter) ([]string, []any) {
 // scanMemory scans a single row into a Memory.
 func scanMemory(row *sql.Row) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON, embeddingStr []byte
 
 	err := row.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy)
 	if err == sql.ErrNoRows {
 		return nil, domain.ErrNotFound
@@ -788,6 +792,7 @@ func scanMemory(row *sql.Row) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -802,11 +807,11 @@ func scanMemory(row *sql.Row) (*domain.Memory, error) {
 // scanMemoryRows scans from *sql.Rows (used by List and KeywordSearch).
 func scanMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON, embeddingStr []byte
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy)
 	if err != nil {
 		return nil, fmt.Errorf("scan memory row: %w", err)
@@ -818,6 +823,7 @@ func scanMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -832,12 +838,12 @@ func scanMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
 // scanMemoryRowsWithDistance scans a row that includes a trailing distance column (used by VectorSearch).
 func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON, embeddingStr []byte
 	var distance float64
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
 		&distance)
 	if err != nil {
@@ -850,6 +856,7 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -867,12 +874,12 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 // scanMemoryRowsWithFTSScore scans a row that includes a trailing fts_score column (used by FTSSearch).
 func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	var m domain.Memory
-	var source, memoryType, agentID, sessionID, state, updatedBy, supersededBy sql.NullString
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
 	var tagsJSON, metadataJSON, embeddingStr []byte
 	var ftsScore float64
 
 	err := rows.Scan(&m.ID, &m.Content, &source,
-		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &state, &m.Version, &updatedBy,
+		&tagsJSON, &metadataJSON, &embeddingStr, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
 		&ftsScore)
 	if err != nil {
@@ -885,6 +892,7 @@ func scanMemoryRowsWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	}
 	m.AgentID = agentID.String
 	m.SessionID = sessionID.String
+	m.AppID = appID.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {
 		m.State = domain.StateActive
@@ -981,21 +989,29 @@ func vecToString(embedding []float32) any {
 	return sb.String()
 }
 
-func (r *MemoryRepo) NearDupSearch(ctx context.Context, queryText string) (string, float64, error) {
+func (r *MemoryRepo) NearDupSearch(ctx context.Context, queryText string, f domain.MemoryFilter) (string, float64, error) {
 	if r.autoModel == "" {
 		return "", 0, nil
 	}
+	f.State = "active"
+	f.MemoryType = "insight,pinned"
+	conds, args := r.buildFilterConds(f)
+	conds = append(conds, "embedding IS NOT NULL")
+	where := strings.Join(conds, " AND ")
+
 	var id string
 	var dist float64
+	fullArgs := make([]any, 0, len(args)+2)
+	fullArgs = append(fullArgs, queryText)
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs, queryText)
 	err := r.db.QueryRowContext(ctx,
 		`SELECT id, VEC_EMBED_COSINE_DISTANCE(embedding, ?) AS dist
 		 FROM memories
-		 WHERE state = 'active'
-		   AND memory_type IN ('insight', 'pinned')
-		   AND embedding IS NOT NULL
+		 WHERE `+where+`
 		 ORDER BY VEC_EMBED_COSINE_DISTANCE(embedding, ?)
 		 LIMIT 1`,
-		queryText, queryText,
+		fullArgs...,
 	).Scan(&id, &dist)
 	if err == sql.ErrNoRows {
 		return "", 0, nil

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -258,7 +258,7 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 	}
 
 	dataQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
-		FROM sessions WHERE ` + where + ` ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?`
+		FROM sessions WHERE ` + where + ` ORDER BY ` + sessionListOrderBy(f) + ` LIMIT ? OFFSET ?`
 	dataArgs := make([]any, len(args), len(args)+2)
 	copy(dataArgs, args)
 	dataArgs = append(dataArgs, limit, offset)
@@ -278,6 +278,25 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 		return nil, 0, err
 	}
 	return memories, total, nil
+}
+
+func sessionListOrderBy(f domain.MemoryFilter) string {
+	column := "updated_at"
+	switch strings.TrimSpace(f.SortBy) {
+	case "content":
+		column = "content"
+	case "tags":
+		column = "tags"
+	case "updated_at", "memory_type", "":
+		column = "updated_at"
+	}
+
+	direction := "DESC"
+	if strings.EqualFold(strings.TrimSpace(f.SortDir), "asc") {
+		direction = "ASC"
+	}
+
+	return column + " " + direction + ", id " + direction
 }
 
 func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -39,12 +39,12 @@ func (r *SessionRepo) BulkCreate(ctx context.Context, sessions []*domain.Session
 	var stmtSQL string
 	if r.autoModel != "" {
 		stmtSQL = `INSERT IGNORE INTO sessions
-			(id, session_id, agent_id, source, seq, role, content, content_type, content_hash, tags, state, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NOW(), NOW())`
+			(id, session_id, agent_id, app_id, source, seq, role, content, content_type, content_hash, tags, state, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NOW(), NOW())`
 	} else {
 		stmtSQL = `INSERT IGNORE INTO sessions
-			(id, session_id, agent_id, source, seq, role, content, content_type, content_hash, tags, embedding, state, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NOW(), NOW())`
+			(id, session_id, agent_id, app_id, source, seq, role, content, content_type, content_hash, tags, embedding, state, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', NOW(), NOW())`
 	}
 
 	tx, err := r.db.BeginTx(ctx, nil)
@@ -68,12 +68,12 @@ func (r *SessionRepo) BulkCreate(ctx context.Context, sessions []*domain.Session
 		var execErr error
 		if r.autoModel != "" {
 			_, execErr = stmt.ExecContext(ctx,
-				s.ID, nullString(s.SessionID), nullString(s.AgentID), nullString(s.Source),
+				s.ID, nullString(s.SessionID), nullString(s.AgentID), s.AppID, nullString(s.Source),
 				s.Seq, s.Role, s.Content, s.ContentType, s.ContentHash, tagsJSON,
 			)
 		} else {
 			_, execErr = stmt.ExecContext(ctx,
-				s.ID, nullString(s.SessionID), nullString(s.AgentID), nullString(s.Source),
+				s.ID, nullString(s.SessionID), nullString(s.AgentID), s.AppID, nullString(s.Source),
 				s.Seq, s.Role, s.Content, s.ContentType, s.ContentHash, tagsJSON,
 				vecToString(s.Embedding),
 			)
@@ -90,11 +90,11 @@ func (r *SessionRepo) BulkCreate(ctx context.Context, sessions []*domain.Session
 	return tx.Commit()
 }
 
-func (r *SessionRepo) PatchTags(ctx context.Context, sessionID, contentHash string, tags []string) error {
+func (r *SessionRepo) PatchTags(ctx context.Context, appID, sessionID, contentHash string, tags []string) error {
 	tagsJSON := marshalTags(tags)
 	_, err := r.db.ExecContext(ctx,
-		`UPDATE sessions SET tags = ? WHERE session_id = ? AND content_hash = ? AND JSON_LENGTH(COALESCE(tags, '[]')) = 0`,
-		tagsJSON, sessionID, contentHash,
+		`UPDATE sessions SET tags = ? WHERE app_id = ? AND session_id = ? AND content_hash = ? AND JSON_LENGTH(COALESCE(tags, '[]')) = 0`,
+		tagsJSON, appID, sessionID, contentHash,
 	)
 	if err != nil && internaltenant.IsTableNotFoundError(err) {
 		return nil
@@ -104,7 +104,7 @@ func (r *SessionRepo) PatchTags(ctx context.Context, sessionID, contentHash stri
 
 func (r *SessionRepo) GetByID(ctx context.Context, id string) (*domain.Memory, error) {
 	row := r.db.QueryRowContext(ctx,
-		`SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+		`SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at
 		 FROM sessions WHERE id = ? AND state = 'active'`,
 		id,
 	)
@@ -212,6 +212,10 @@ func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, 
 		conds = append(conds, "session_id = ?")
 		args = append(args, f.SessionID)
 	}
+	if f.AppID != nil {
+		conds = append(conds, "app_id = ?")
+		args = append(args, *f.AppID)
+	}
 	if f.Source != "" {
 		conds = append(conds, "source = ?")
 		args = append(args, f.Source)
@@ -257,7 +261,7 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 		offset = 0
 	}
 
-	dataQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+	dataQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at
 		FROM sessions WHERE ` + where + ` ORDER BY ` + sessionListOrderBy(f) + ` LIMIT ? OFFSET ?`
 	dataArgs := make([]any, len(args), len(args)+2)
 	copy(dataArgs, args)
@@ -304,7 +308,7 @@ func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f doma
 	conds = append(conds, "embedding IS NOT NULL")
 	where := strings.Join(conds, " AND ")
 
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,
+	sqlQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at,
 		VEC_EMBED_COSINE_DISTANCE(embedding, ?) AS distance
 		FROM sessions
 		WHERE ` + where + `
@@ -344,7 +348,7 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 	conds = append(conds, "embedding IS NOT NULL")
 	where := strings.Join(conds, " AND ")
 
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,
+	sqlQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at,
 		VEC_COSINE_DISTANCE(embedding, ?) AS distance
 		FROM sessions
 		WHERE ` + where + `
@@ -468,7 +472,7 @@ func (r *SessionRepo) fetchFilteredFTSSessions(ctx context.Context, candidates [
 	}
 	args = append(args, filterArgs...)
 
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+	sqlQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at
 		FROM sessions
 		WHERE id IN (` + strings.Join(placeholders, ",") + `) AND ` + where
 
@@ -504,7 +508,7 @@ func (r *SessionRepo) fetchFilteredFTSSessions(ctx context.Context, candidates [
 }
 
 func (r *SessionRepo) filteredFTSSearch(ctx context.Context, safeQ, where string, args []any, limit int) ([]domain.Memory, error) {
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at,
+	sqlQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at,
 		fts_match_word('` + safeQ + `', content) AS fts_score
 		FROM sessions
 		WHERE ` + where + ` AND fts_match_word('` + safeQ + `', content)
@@ -532,7 +536,7 @@ func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.
 	}
 	where := strings.Join(conds, " AND ")
 
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at
+	sqlQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at
 		FROM sessions
 		WHERE ` + where + `
 		ORDER BY created_at DESC
@@ -599,15 +603,15 @@ type sessionMemoryScanner interface {
 
 func scanSessionMemory(scanner sessionMemoryScanner) (*domain.Memory, error) {
 	var (
-		sessionID, agentID, source, role, contentType sql.NullString
-		tagsJSON                                      []byte
-		state                                         sql.NullString
-		seq                                           int
-		createdAt                                     time.Time
-		m                                             domain.Memory
+		sessionID, agentID, appID, source, role, contentType sql.NullString
+		tagsJSON                                             []byte
+		state                                                sql.NullString
+		seq                                                  int
+		createdAt                                            time.Time
+		m                                                    domain.Memory
 	)
 	if err := scanner.Scan(
-		&m.ID, &sessionID, &agentID, &source,
+		&m.ID, &sessionID, &agentID, &appID, &source,
 		&seq, &role, &m.Content, &contentType,
 		&tagsJSON, &state, &createdAt,
 	); err != nil {
@@ -616,7 +620,7 @@ func scanSessionMemory(scanner sessionMemoryScanner) (*domain.Memory, error) {
 		}
 		return nil, fmt.Errorf("scan session memory: %w", err)
 	}
-	return fillSessionMemory(&m, sessionID, agentID, source, role, contentType, seq, tagsJSON, state, createdAt), nil
+	return fillSessionMemory(&m, sessionID, agentID, appID, source, role, contentType, seq, tagsJSON, state, createdAt), nil
 }
 
 func scanSessionRowNoScore(rows *sql.Rows) (*domain.Memory, error) {
@@ -625,23 +629,23 @@ func scanSessionRowNoScore(rows *sql.Rows) (*domain.Memory, error) {
 
 func scanSessionRowWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	var (
-		sessionID, agentID, source, role, contentType sql.NullString
-		tagsJSON                                      []byte
-		state                                         sql.NullString
-		seq                                           int
-		createdAt                                     time.Time
-		distance                                      float64
-		m                                             domain.Memory
+		sessionID, agentID, appID, source, role, contentType sql.NullString
+		tagsJSON                                             []byte
+		state                                                sql.NullString
+		seq                                                  int
+		createdAt                                            time.Time
+		distance                                             float64
+		m                                                    domain.Memory
 	)
 	if err := rows.Scan(
-		&m.ID, &sessionID, &agentID, &source,
+		&m.ID, &sessionID, &agentID, &appID, &source,
 		&seq, &role, &m.Content, &contentType,
 		&tagsJSON, &state, &createdAt,
 		&distance,
 	); err != nil {
 		return nil, fmt.Errorf("scan session row with distance: %w", err)
 	}
-	m = *fillSessionMemory(&m, sessionID, agentID, source, role, contentType, seq, tagsJSON, state, createdAt)
+	m = *fillSessionMemory(&m, sessionID, agentID, appID, source, role, contentType, seq, tagsJSON, state, createdAt)
 	sc := 1 - distance
 	m.Score = &sc
 	return &m, nil
@@ -649,28 +653,28 @@ func scanSessionRowWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 
 func scanSessionRowWithFTSScore(rows *sql.Rows) (*domain.Memory, error) {
 	var (
-		sessionID, agentID, source, role, contentType sql.NullString
-		tagsJSON                                      []byte
-		state                                         sql.NullString
-		seq                                           int
-		createdAt                                     time.Time
-		ftsScore                                      float64
-		m                                             domain.Memory
+		sessionID, agentID, appID, source, role, contentType sql.NullString
+		tagsJSON                                             []byte
+		state                                                sql.NullString
+		seq                                                  int
+		createdAt                                            time.Time
+		ftsScore                                             float64
+		m                                                    domain.Memory
 	)
 	if err := rows.Scan(
-		&m.ID, &sessionID, &agentID, &source,
+		&m.ID, &sessionID, &agentID, &appID, &source,
 		&seq, &role, &m.Content, &contentType,
 		&tagsJSON, &state, &createdAt,
 		&ftsScore,
 	); err != nil {
 		return nil, fmt.Errorf("scan session row with fts score: %w", err)
 	}
-	m = *fillSessionMemory(&m, sessionID, agentID, source, role, contentType, seq, tagsJSON, state, createdAt)
+	m = *fillSessionMemory(&m, sessionID, agentID, appID, source, role, contentType, seq, tagsJSON, state, createdAt)
 	m.Score = &ftsScore
 	return &m, nil
 }
 
-func (r *SessionRepo) ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error) {
+func (r *SessionRepo) ListBySessionIDs(ctx context.Context, sessionIDs []string, appID *string, limitPerSession int) ([]*domain.Session, error) {
 	if len(sessionIDs) == 0 {
 		return nil, nil
 	}
@@ -678,22 +682,27 @@ func (r *SessionRepo) ListBySessionIDs(ctx context.Context, sessionIDs []string,
 	placeholders := strings.Repeat("?,", len(sessionIDs))
 	placeholders = placeholders[:len(placeholders)-1]
 
-	args := make([]any, 0, len(sessionIDs)+1)
+	args := make([]any, 0, len(sessionIDs)+2)
 	for _, id := range sessionIDs {
 		args = append(args, id)
 	}
+	appFilter := ""
+	if appID != nil {
+		appFilter = " AND app_id = ?"
+		args = append(args, *appID)
+	}
 	args = append(args, limitPerSession)
 
-	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type,
+	sqlQuery := `SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type,
 		content_hash, tags, state, created_at, updated_at
 		FROM (
 			SELECT *,
 				ROW_NUMBER() OVER (
-					PARTITION BY session_id
+					PARTITION BY app_id, session_id
 					ORDER BY created_at ASC, seq ASC, id ASC
 				) AS rn
 			FROM sessions
-			WHERE session_id IN (` + placeholders + `) AND state = 'active'
+			WHERE session_id IN (` + placeholders + `) AND state = 'active'` + appFilter + `
 		) t
 		WHERE rn <= ?
 		ORDER BY session_id ASC, created_at ASC, seq ASC, id ASC`
@@ -723,13 +732,13 @@ func scanSessionDomainRows(rows *sql.Rows) ([]*domain.Session, error) {
 
 func scanSessionDomainRow(rows *sql.Rows) (*domain.Session, error) {
 	var (
-		sessionID, agentID, source, role, contentType, contentHash sql.NullString
-		tagsJSON                                                   []byte
-		state                                                      sql.NullString
-		s                                                          domain.Session
+		sessionID, agentID, appID, source, role, contentType, contentHash sql.NullString
+		tagsJSON                                                          []byte
+		state                                                             sql.NullString
+		s                                                                 domain.Session
 	)
 	if err := rows.Scan(
-		&s.ID, &sessionID, &agentID, &source,
+		&s.ID, &sessionID, &agentID, &appID, &source,
 		&s.Seq, &role, &s.Content, &contentType,
 		&contentHash, &tagsJSON, &state,
 		&s.CreatedAt, &s.UpdatedAt,
@@ -738,6 +747,7 @@ func scanSessionDomainRow(rows *sql.Rows) (*domain.Session, error) {
 	}
 	s.SessionID = sessionID.String
 	s.AgentID = agentID.String
+	s.AppID = appID.String
 	s.Source = source.String
 	s.Role = role.String
 	s.ContentType = contentType.String
@@ -749,11 +759,12 @@ func scanSessionDomainRow(rows *sql.Rows) (*domain.Session, error) {
 	}
 	return &s, nil
 }
-func fillSessionMemory(m *domain.Memory, sessionID, agentID, source, role, contentType sql.NullString,
+func fillSessionMemory(m *domain.Memory, sessionID, agentID, appID, source, role, contentType sql.NullString,
 	seq int, tagsJSON []byte, state sql.NullString, createdAt time.Time) *domain.Memory {
 	m.MemoryType = domain.TypeSession
 	m.SessionID = sessionID.String
 	m.AgentID = agentID.String
+	m.AppID = appID.String
 	m.Source = source.String
 	m.State = domain.MemoryState(state.String)
 	if m.State == "" {

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -27,7 +27,7 @@ func TestSessionRepoListFiltersAndPaginates(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions WHERE state = ? AND agent_id = ? AND session_id = ? AND source = ? AND JSON_CONTAINS(tags, ?)",
 				"ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
 			},
@@ -77,7 +77,7 @@ func TestSessionRepoListSortsByContent(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions WHERE state = 'active'",
 				"ORDER BY content ASC, id ASC LIMIT ? OFFSET ?",
 			},
@@ -110,7 +110,7 @@ func TestSessionRepoGetByIDMissingTableReturnsNotFound(t *testing.T) {
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
 			mustContain: []string{
-				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at",
 				"FROM sessions WHERE id = ? AND state = 'active'",
 			},
 			wantArgs: []any{"missing-session-row"},
@@ -154,6 +154,7 @@ func TestFillSessionMemory_SetsMemoryType(t *testing.T) {
 		&m,
 		sql.NullString{String: "sess-1", Valid: true},
 		sql.NullString{String: "agent-a", Valid: true},
+		sql.NullString{String: "", Valid: true},
 		sql.NullString{String: "src", Valid: true},
 		sql.NullString{String: "user", Valid: true},
 		sql.NullString{String: "text", Valid: true},
@@ -174,6 +175,7 @@ func TestFillSessionMemory_PopulatesFields(t *testing.T) {
 		&m,
 		sql.NullString{String: "sess-1", Valid: true},
 		sql.NullString{String: "agent-a", Valid: true},
+		sql.NullString{String: "chat-app", Valid: true},
 		sql.NullString{String: "src", Valid: true},
 		sql.NullString{String: "user", Valid: true},
 		sql.NullString{String: "text", Valid: true},
@@ -187,6 +189,9 @@ func TestFillSessionMemory_PopulatesFields(t *testing.T) {
 	}
 	if result.AgentID != "agent-a" {
 		t.Errorf("AgentID = %q, want %q", result.AgentID, "agent-a")
+	}
+	if result.AppID != "chat-app" {
+		t.Errorf("AppID = %q, want %q", result.AppID, "chat-app")
 	}
 	if result.State != domain.StateActive {
 		t.Errorf("State = %q, want %q", result.State, domain.StateActive)

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -63,6 +63,49 @@ func TestSessionRepoListFiltersAndPaginates(t *testing.T) {
 	}
 }
 
+func TestSessionRepoListSortsByContent(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"SELECT COUNT(*) FROM sessions WHERE state = 'active'",
+			},
+			rows: &scriptedRows{
+				columns: []string{"COUNT(*)"},
+				values:  [][]driver.Value{{int64(1)}},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, session_id, agent_id, source, seq, role, content, content_type, tags, state, created_at",
+				"FROM sessions WHERE state = 'active'",
+				"ORDER BY content ASC, id ASC LIMIT ? OFFSET ?",
+			},
+			wantArgs: []any{int64(5), int64(0)},
+			rows: &scriptedRows{
+				columns: sessionColumns(),
+				values: [][]driver.Value{
+					sessionRow("s-1", "sess-1", "agent-1", "chat", 1, "assistant", "alpha", []byte(`[]`), "active", now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", false, "cluster-1")
+	memories, total, err := repo.List(context.Background(), domain.MemoryFilter{
+		SortBy:  "content",
+		SortDir: "asc",
+		Limit:   5,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 1 || len(memories) != 1 || memories[0].ID != "s-1" {
+		t.Fatalf("page = total:%d memories:%+v, want one s-1", total, memories)
+	}
+}
+
 func TestSessionRepoGetByIDMissingTableReturnsNotFound(t *testing.T) {
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{

--- a/server/internal/repository/tidb/testutil_test.go
+++ b/server/internal/repository/tidb/testutil_test.go
@@ -114,6 +114,7 @@ func createTables(db *sql.DB) error {
 		memory_type     VARCHAR(20)     NOT NULL DEFAULT 'pinned',
 		agent_id        VARCHAR(100)    NULL,
 		session_id      VARCHAR(100)    NULL,
+		app_id          VARCHAR(100)    NOT NULL DEFAULT '',
 		state           VARCHAR(20)     NOT NULL DEFAULT 'active',
 		version         INT             DEFAULT 1,
 		updated_by      VARCHAR(100),
@@ -125,6 +126,7 @@ func createTables(db *sql.DB) error {
 		INDEX idx_state               (state),
 		INDEX idx_agent               (agent_id),
 		INDEX idx_session             (session_id),
+		INDEX idx_app                 (app_id),
 		INDEX idx_updated             (updated_at)
 	)`)
 	if err != nil {

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -43,6 +43,7 @@ type IngestRequest struct {
 	Messages           []IngestMessage `json:"messages"`
 	SessionID          string          `json:"session_id"`
 	AgentID            string          `json:"agent_id"`
+	AppID              string          `json:"appId,omitempty"`
 	Mode               IngestMode      `json:"mode"`
 	DisableSessionSave bool            `json:"disableSessionSave,omitempty"`
 }
@@ -125,7 +126,7 @@ func (s *IngestService) Ingest(ctx context.Context, agentName string, req Ingest
 	// Cap conversation size to avoid blowing LLM token limits.
 	formatted = truncateRunes(formatted, maxExtractionConversationRunes)
 
-	insightIDs, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.SessionID, formatted)
+	insightIDs, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted)
 	if err != nil {
 		slog.Error("insight extraction failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
@@ -387,7 +388,7 @@ func (s *IngestService) ExtractPhase1WithRouting(ctx context.Context, messages [
 
 // ReconcilePhase2 runs reconciliation of extracted facts against existing memories.
 // Equivalent to the existing reconcile() pipeline, now exported for use by the handler.
-func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID, sessionID string, facts []ExtractedFact) (*IngestResult, error) {
+func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) (*IngestResult, error) {
 	if len(facts) == 0 {
 		return &IngestResult{Status: "complete"}, nil
 	}
@@ -396,7 +397,7 @@ func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID,
 		slog.Warn("ReconcilePhase2: truncating facts", "count", len(facts), "max", maxFacts)
 		facts = facts[:maxFacts]
 	}
-	insightIDs, warnings, err := s.reconcile(ctx, agentName, agentID, sessionID, facts)
+	insightIDs, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, facts)
 	if err != nil {
 		slog.Error("ReconcilePhase2: reconciliation failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
@@ -416,7 +417,7 @@ func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID,
 // ReconcileContent runs the full ingest pipeline (extract facts + reconcile)
 // for raw content strings (as opposed to conversation messages).
 // Each content string is wrapped as a single user message for fact extraction.
-func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID, sessionID string, contents []string) (*IngestResult, error) {
+func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID, appID, sessionID string, contents []string) (*IngestResult, error) {
 	if len(contents) == 0 {
 		return nil, &domain.ValidationError{Field: "content", Message: "required"}
 	}
@@ -467,7 +468,7 @@ func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID
 		}, nil
 	}
 
-	insightIDs, warnings, err := s.reconcile(ctx, agentName, agentID, sessionID, allFacts)
+	insightIDs, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, allFacts)
 	totalWarnings += warnings
 	if err != nil {
 		slog.Error("reconcile content: batched reconciliation failed", "err", err)
@@ -530,6 +531,7 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 		MemoryType: domain.TypeInsight,
 		Source:     agentName,
 		AgentID:    req.AgentID,
+		AppID:      req.AppID,
 		SessionID:  req.SessionID,
 		Embedding:  embedding,
 		State:      domain.StateActive,
@@ -553,7 +555,7 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 }
 
 // extractAndReconcile runs Phase 1a (extraction) + Phase 2 (reconciliation).
-func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, sessionID, conversation string) ([]string, int, error) {
+func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string) ([]string, int, error) {
 	const maxFacts = 50 // Cap extracted facts to bound reconciliation prompt size
 
 	// Phase 1a: Extract facts only — no message_tags needed here (smart-ingest / raw-ingest path).
@@ -573,7 +575,7 @@ func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agen
 	}
 
 	// Phase 2: Reconcile each fact against existing memories.
-	return s.reconcile(ctx, agentName, agentID, sessionID, facts)
+	return s.reconcile(ctx, agentName, agentID, appID, sessionID, facts)
 }
 
 // normalizeParsedFacts converts []ExtractedFact from a successful parse into a
@@ -990,7 +992,7 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 // all facts and all retrieved memories to the LLM in a single call for batch
 // decision-making. This gives the LLM a complete view of both the new facts and
 // the existing knowledge base, enabling better ADD/UPDATE/DELETE/NOOP decisions.
-func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessionID string, facts []ExtractedFact) ([]string, int, error) {
+func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]string, int, error) {
 	start := time.Now()
 	var (
 		applyActionsDuration   time.Duration
@@ -1004,6 +1006,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessi
 		slog.Info("reconcile timings",
 			"agent_id", agentID,
 			"session_id", sessionID,
+			"app_id", appID,
 			"facts", len(facts),
 			"existing", existingMemoriesCount,
 			"status", status,
@@ -1020,7 +1023,8 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessi
 	// until the score distribution is analyzed from prod metrics.
 	// Once a threshold is validated, add: if score >= threshold { drop or annotate }
 	for i := range facts {
-		if id, score, err := s.memories.NearDupSearch(ctx, projectReconcileFactText(facts[i])); err == nil && id != "" {
+		appFilter := domain.MemoryFilter{AppID: &appID}
+		if id, score, err := s.memories.NearDupSearch(ctx, projectReconcileFactText(facts[i]), appFilter); err == nil && id != "" {
 			metrics.NearDupCosineScore.Observe(score)
 		}
 	}
@@ -1032,7 +1036,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessi
 
 	// Step 1: For each fact, search for relevant existing memories and collect them.
 	gatherExistingStart := time.Now()
-	existingMemories, gatherErr := s.gatherExistingMemories(ctx, agentID, texts)
+	existingMemories, gatherErr := s.gatherExistingMemories(ctx, agentID, appID, texts)
 	gatherExistingDuration = time.Since(gatherExistingStart)
 	if gatherErr != nil {
 		status = "gather_error"
@@ -1043,7 +1047,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, sessi
 
 	if len(existingMemories) == 0 {
 		applyActionsStart := time.Now()
-		resultIDs, warningCount, err := s.addAllFacts(ctx, agentName, agentID, sessionID, facts)
+		resultIDs, warningCount, err := s.addAllFacts(ctx, agentName, agentID, appID, sessionID, facts)
 		applyActionsDuration = time.Since(applyActionsStart)
 		warnings = warningCount
 		if err != nil {
@@ -1229,6 +1233,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				ctx,
 				agentName,
 				agentID,
+				appID,
 				sessionID,
 				normalizedText,
 				event.Tags,
@@ -1266,7 +1271,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 			metadata := SetSourceProvenanceMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs, sourceTurns)
 			if existingMemories[intID].MemoryType == domain.TypePinned {
 				slog.Warn("skipping UPDATE for pinned memory — treating as ADD", "id", realID)
-				newID, addErr := s.addInsight(ctx, agentName, agentID, sessionID, normalizedText, effectiveTags, metadata)
+				newID, addErr := s.addInsight(ctx, agentName, agentID, appID, sessionID, normalizedText, effectiveTags, metadata)
 				if addErr != nil {
 					slog.Warn("failed to add insight (pinned fallback)", "err", addErr)
 					warnings++
@@ -1275,7 +1280,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				resultIDs = append(resultIDs, newID)
 				continue
 			}
-			newID, updateErr := s.updateInsight(ctx, agentName, agentID, sessionID, realID, normalizedText, effectiveTags, metadata)
+			newID, updateErr := s.updateInsight(ctx, agentName, agentID, appID, sessionID, realID, normalizedText, effectiveTags, metadata)
 			if updateErr != nil {
 				slog.Warn("failed to update insight", "err", updateErr, "id", event.ID)
 				warnings++
@@ -1337,7 +1342,7 @@ type factSearchResult struct {
 // logged and skipped (partial recall is acceptable for the LLM reconciler).
 // However, if every single search attempt fails (total outage), an error is
 // returned to prevent silent duplicate writes via addAllFacts.
-func (s *IngestService) gatherExistingMemories(ctx context.Context, agentID string, facts []string) ([]domain.Memory, error) {
+func (s *IngestService) gatherExistingMemories(ctx context.Context, agentID, appID string, facts []string) ([]domain.Memory, error) {
 	const perFactLimit = 5
 	const contentMaxLen = 150
 	const maxExistingMemories = 60
@@ -1347,6 +1352,7 @@ func (s *IngestService) gatherExistingMemories(ctx context.Context, agentID stri
 		State:      "active",
 		MemoryType: "insight,pinned",
 		AgentID:    agentID,
+		AppID:      &appID,
 	}
 	ftsAvailable := s.memories.FTSAvailable()
 
@@ -1515,11 +1521,11 @@ func (s *IngestService) searchExistingMemoriesForFact(
 
 // addAllFacts adds all facts as new insights when no existing memories are
 // found (i.e., all facts are guaranteed new). Called only when gatherExistingMemories returns empty.
-func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, sessionID string, facts []ExtractedFact) ([]string, int, error) {
+func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]string, int, error) {
 	var ids []string
 	var warnings int
 	for _, fact := range facts {
-		id, err := s.addInsight(ctx, agentName, agentID, sessionID, fact.Text, fact.Tags, metadataForExtractedFact(fact))
+		id, err := s.addInsight(ctx, agentName, agentID, appID, sessionID, fact.Text, fact.Tags, metadataForExtractedFact(fact))
 		if err != nil {
 			slog.Warn("failed to add fact", "err", err, "fact_len", len(fact.Text))
 			warnings++
@@ -1531,7 +1537,7 @@ func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, ses
 }
 
 // addInsight creates a new insight memory with the given content and tags.
-func (s *IngestService) addInsight(ctx context.Context, agentName, agentID, sessionID, content string, tags []string, metadata json.RawMessage) (string, error) {
+func (s *IngestService) addInsight(ctx context.Context, agentName, agentID, appID, sessionID, content string, tags []string, metadata json.RawMessage) (string, error) {
 	if len(tags) > maxTags {
 		tags = tags[:maxTags]
 	}
@@ -1552,6 +1558,7 @@ func (s *IngestService) addInsight(ctx context.Context, agentName, agentID, sess
 		MemoryType: domain.TypeInsight,
 		Source:     agentName,
 		AgentID:    agentID,
+		AppID:      appID,
 		SessionID:  sessionID,
 		Embedding:  embedding,
 		Tags:       tags,
@@ -1573,7 +1580,7 @@ func (s *IngestService) addInsight(ctx context.Context, agentName, agentID, sess
 }
 
 // updateInsight archives the old memory and creates a new one atomically (append-new + archive-old model).
-func (s *IngestService) updateInsight(ctx context.Context, agentName, agentID, sessionID, oldID, newContent string, tags []string, metadata json.RawMessage) (string, error) {
+func (s *IngestService) updateInsight(ctx context.Context, agentName, agentID, appID, sessionID, oldID, newContent string, tags []string, metadata json.RawMessage) (string, error) {
 	if len(tags) > maxTags {
 		tags = tags[:maxTags]
 	}
@@ -1597,6 +1604,7 @@ func (s *IngestService) updateInsight(ctx context.Context, agentName, agentID, s
 		MemoryType: domain.TypeInsight,
 		Source:     agentName,
 		AgentID:    agentID,
+		AppID:      appID,
 		SessionID:  sessionID,
 		Embedding:  embedding,
 		Tags:       tags,

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -507,7 +507,7 @@ func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
 	memRepo := &memoryRepoMock{}
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "sess-1", []ExtractedFact{
+	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "", "sess-1", []ExtractedFact{
 		{Text: "Jon lost his job, which motivated him to start a dance studio", Tags: []string{"work"}, SourceSeqs: []int{4, 2, 4}},
 	})
 	if err != nil {
@@ -537,7 +537,7 @@ func TestReconcilePhase2AddPersistsSourceTurnMetadata(t *testing.T) {
 	memRepo := &memoryRepoMock{}
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "sess-1", []ExtractedFact{
+	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "", "sess-1", []ExtractedFact{
 		{
 			Text:       "Jon lost his job, which motivated him to start a dance studio",
 			Tags:       []string{"work"},
@@ -1392,7 +1392,7 @@ func (m *memoryRepoMock) ListBootstrap(ctx context.Context, limit int) ([]domain
 	return nil, nil
 }
 
-func (m *memoryRepoMock) NearDupSearch(_ context.Context, _ string) (string, float64, error) {
+func (m *memoryRepoMock) NearDupSearch(_ context.Context, _ string, _ domain.MemoryFilter) (string, float64, error) {
 	return "", 0, nil
 }
 
@@ -2176,7 +2176,7 @@ func TestGatherExistingMemoriesFiltersLowScoreVectorResults(t *testing.T) {
 
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"test fact"})
+	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"test fact"})
 	if err != nil {
 		t.Fatalf("gatherExistingMemories() error = %v", err)
 	}
@@ -2207,7 +2207,7 @@ func TestGatherExistingMemoriesFTSOnlyMode(t *testing.T) {
 	// No embedder, no autoModel — FTS-only deployment.
 	svc := NewIngestService(memRepo, nil, nil, "", ModeSmart)
 
-	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"Go programming", "TiDB database"})
+	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"Go programming", "TiDB database"})
 	if err != nil {
 		t.Fatalf("gatherExistingMemories() error = %v", err)
 	}
@@ -2246,7 +2246,7 @@ func TestGatherExistingMemoriesHybridDedup(t *testing.T) {
 
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"dark mode preference"})
+	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"dark mode preference"})
 	if err != nil {
 		t.Fatalf("gatherExistingMemories() error = %v", err)
 	}
@@ -2288,7 +2288,7 @@ func TestGatherExistingMemoriesParallelMergeKeepsFactOrder(t *testing.T) {
 
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"fact-1", "fact-2"})
+	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"fact-1", "fact-2"})
 	if err != nil {
 		t.Fatalf("gatherExistingMemories() error = %v", err)
 	}
@@ -2340,7 +2340,7 @@ func TestGatherExistingMemoriesSearchesFactsInParallel(t *testing.T) {
 
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	_, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{
+	_, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{
 		"fact-1",
 		"fact-2",
 		"fact-3",
@@ -2371,7 +2371,7 @@ func TestGatherExistingMemoriesTotalOutageReturnsError(t *testing.T) {
 
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	_, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"test fact"})
+	_, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"test fact"})
 	if err == nil {
 		t.Fatal("expected error on total search outage, got nil")
 	}
@@ -2397,7 +2397,7 @@ func TestGatherExistingMemoriesPartialLegFailureContinues(t *testing.T) {
 
 	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
 
-	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"test fact"})
+	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"test fact"})
 	if err != nil {
 		t.Fatalf("expected partial success, got error: %v", err)
 	}
@@ -2423,7 +2423,7 @@ func TestGatherExistingMemoriesFTSOnlyTotalOutage(t *testing.T) {
 	// No embedder, no autoModel — FTS-only deployment.
 	svc := NewIngestService(memRepo, nil, nil, "", ModeSmart)
 
-	_, err := svc.gatherExistingMemories(context.Background(), "agent-1", []string{"test fact"})
+	_, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"test fact"})
 	if err == nil {
 		t.Fatal("expected error on FTS-only total outage, got nil")
 	}
@@ -2433,7 +2433,7 @@ func TestReconcileContentRequiresLLM(t *testing.T) {
 	t.Parallel()
 
 	svc := NewIngestService(&memoryRepoMock{}, nil, nil, "", ModeSmart)
-	_, err := svc.ReconcileContent(context.Background(), "agent", "agent", "", []string{"prefers dark mode"})
+	_, err := svc.ReconcileContent(context.Background(), "agent", "agent", "", "", []string{"prefers dark mode"})
 	if err == nil {
 		t.Fatal("expected error when llm is nil")
 	}
@@ -2450,7 +2450,7 @@ func TestReconcileContentValidatesInput(t *testing.T) {
 	t.Parallel()
 
 	svc := NewIngestService(&memoryRepoMock{}, nil, nil, "", ModeSmart)
-	_, err := svc.ReconcileContent(context.Background(), "agent", "agent", "", nil)
+	_, err := svc.ReconcileContent(context.Background(), "agent", "agent", "", "", nil)
 	if err == nil {
 		t.Fatal("expected validation error for empty contents")
 	}

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -8,7 +8,9 @@ import (
 	"log/slog"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/qiffang/mnemos/server/internal/domain"
@@ -19,11 +21,12 @@ import (
 )
 
 const (
-	maxContentLen     = 50000
-	maxTags           = 20
-	maxBulkSize       = 100
-	maxBulkDeleteSize = 1000
-	defaultMinScore   = 0.3
+	maxContentLen        = 50000
+	maxTags              = 20
+	maxBulkSize          = 100
+	maxBulkDeleteSize    = 1000
+	defaultMinScore      = 0.3
+	maxLooseSearchTokens = 5
 
 	// secondHopWeight is the RRF weight applied to second-hop vector search results.
 	// Lower than 1.0 to prevent indirect matches from outranking direct hits.
@@ -53,7 +56,7 @@ func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, emb
 	}
 }
 
-func (s *MemoryService) Create(ctx context.Context, agentID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, int, error) {
+func (s *MemoryService) Create(ctx context.Context, agentID, appID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, int, error) {
 	if err := validateMemoryInput(content, tags); err != nil {
 		return nil, 0, err
 	}
@@ -85,6 +88,7 @@ func (s *MemoryService) Create(ctx context.Context, agentID, content string, tag
 			Embedding:  embedding,
 			MemoryType: domain.TypeInsight,
 			AgentID:    agentID,
+			AppID:      appID,
 			State:      domain.StateActive,
 			Version:    1,
 			UpdatedBy:  agentID,
@@ -100,7 +104,7 @@ func (s *MemoryService) Create(ctx context.Context, agentID, content string, tag
 		return mem, 1, nil
 	}
 
-	result, err := s.ingest.ReconcileContent(ctx, agentID, agentID, "", []string{content})
+	result, err := s.ingest.ReconcileContent(ctx, agentID, agentID, appID, "", []string{content})
 	if err != nil {
 		return nil, 0, err
 	}
@@ -141,10 +145,11 @@ func (s *MemoryService) Create(ctx context.Context, agentID, content string, tag
 
 }
 
-func (s *MemoryService) CreatePinned(ctx context.Context, agentID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, int, error) {
+func (s *MemoryService) CreatePinned(ctx context.Context, agentID, appID, content string, tags []string, metadata json.RawMessage) (*domain.Memory, int, error) {
 	memories, err := s.BulkCreate(ctx, agentID, []BulkMemoryInput{
 		{
 			Content:  content,
+			AppID:    appID,
 			Tags:     tags,
 			Metadata: metadata,
 		},
@@ -194,6 +199,16 @@ func (s *MemoryService) Search(ctx context.Context, filter domain.MemoryFilter) 
 	// FTS probe still running (cold start) — fall back to LIKE-based keyword search.
 	slog.Warn("search: FTS not yet available, falling back to keyword search")
 	return s.keywordOnlySearch(ctx, searchFilter)
+}
+
+// ContentKeywordSearch performs direct content substring search for list filters.
+// Unlike Search(), it deliberately bypasses vector, FTS, and recall-style
+// ranking so UI list search behaves like a content filter.
+func (s *MemoryService) ContentKeywordSearch(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	if filter.Query == "" {
+		return s.List(ctx, filter)
+	}
+	return s.keywordOnlySearch(ctx, filter)
 }
 
 func (s *MemoryService) SearchCandidates(
@@ -266,6 +281,12 @@ func (s *MemoryService) ftsOnlySearch(ctx context.Context, filter domain.MemoryF
 	if err != nil {
 		return nil, 0, fmt.Errorf("FTS search: %w", err)
 	}
+	if len(ftsResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		ftsResults, err = s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
 	slog.Info("fts search completed", "query_len", len(filter.Query), "results", len(ftsResults))
 
 	page, total := s.paginate(ftsResults, offset, limit)
@@ -314,10 +335,124 @@ func (s *MemoryService) keywordOnlySearch(ctx context.Context, filter domain.Mem
 	if err != nil {
 		return nil, 0, fmt.Errorf("keyword search: %w", err)
 	}
+	if len(kwResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		kwResults, err = s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
 	slog.Info("keyword search completed (FTS unavailable)", "query_len", len(filter.Query), "results", len(kwResults))
 
 	page, total := s.paginate(kwResults, offset, limit)
 	return finalizeSearchResults(page, filter.Query), total, nil
+}
+
+func (s *MemoryService) looseTokenKeywordSearch(ctx context.Context, filter domain.MemoryFilter, fetchLimit int) ([]domain.Memory, error) {
+	tokens := looseSearchTokens(filter.Query)
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+	if fetchLimit <= 0 {
+		fetchLimit = 50
+	}
+
+	byID := make(map[string]domain.Memory)
+	for _, token := range tokens {
+		results, err := s.memories.KeywordSearch(ctx, token, filter, fetchLimit)
+		if err != nil {
+			return nil, fmt.Errorf("keyword token search: %w", err)
+		}
+		for _, memory := range results {
+			if _, ok := byID[memory.ID]; !ok {
+				byID[memory.ID] = memory
+			}
+		}
+	}
+
+	memories := make([]domain.Memory, 0, len(byID))
+	for _, memory := range byID {
+		memories = append(memories, memory)
+	}
+	sort.SliceStable(memories, func(i, j int) bool {
+		leftScore := looseSearchTokenMatchScore(memories[i].Content, tokens)
+		rightScore := looseSearchTokenMatchScore(memories[j].Content, tokens)
+		if leftScore != rightScore {
+			return leftScore > rightScore
+		}
+		if !memories[i].UpdatedAt.Equal(memories[j].UpdatedAt) {
+			return memories[i].UpdatedAt.After(memories[j].UpdatedAt)
+		}
+		return memories[i].ID < memories[j].ID
+	})
+	if len(memories) > fetchLimit {
+		memories = memories[:fetchLimit]
+	}
+	return memories, nil
+}
+
+var looseSearchStopWords = map[string]struct{}{
+	"a": {}, "an": {}, "and": {}, "are": {}, "as": {}, "at": {}, "be": {}, "by": {},
+	"did": {}, "do": {}, "does": {}, "for": {}, "from": {}, "has": {}, "have": {},
+	"how": {}, "if": {}, "in": {}, "is": {}, "not": {}, "of": {}, "on": {}, "or": {},
+	"the": {}, "to": {}, "was": {}, "were": {}, "what": {}, "when": {}, "where": {},
+	"whether": {}, "which": {}, "who": {}, "whom": {}, "whose": {}, "why": {}, "with": {},
+}
+
+func looseSearchTokens(query string) []string {
+	var tokens []string
+	seen := make(map[string]struct{})
+	var current strings.Builder
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		token := current.String()
+		current.Reset()
+		key := strings.ToLower(token)
+		if len(key) < 2 {
+			return
+		}
+		if _, ok := looseSearchStopWords[key]; ok {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		tokens = append(tokens, token)
+	}
+
+	for _, r := range query {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			current.WriteRune(r)
+			continue
+		}
+		flush()
+		if len(tokens) >= maxLooseSearchTokens {
+			return tokens
+		}
+	}
+	flush()
+	if len(tokens) > maxLooseSearchTokens {
+		return tokens[:maxLooseSearchTokens]
+	}
+	return tokens
+}
+
+func looseSearchTokenMatchScore(content string, tokens []string) int {
+	content = strings.ToLower(content)
+	score := 0
+	for _, token := range tokens {
+		if strings.Contains(content, strings.ToLower(token)) {
+			score++
+		}
+	}
+	return score
+}
+
+func shouldRunLooseKeywordFallback(query string) bool {
+	tokens := looseSearchTokens(query)
+	return len(tokens) == 1 || strings.ContainsAny(query, "?？")
 }
 
 func (s *MemoryService) ftsOnlyCandidates(ctx context.Context, filter domain.MemoryFilter, sourcePool RecallSourcePool, opts RecallCandidateOptions) ([]RecallCandidate, error) {
@@ -327,6 +462,12 @@ func (s *MemoryService) ftsOnlyCandidates(ctx context.Context, filter domain.Mem
 	ftsResults, err := s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
 	if err != nil {
 		return nil, fmt.Errorf("FTS search: %w", err)
+	}
+	if len(ftsResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		ftsResults, err = s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return dedupRecallCandidatesByContent(mergeRecallCandidates(sourcePool, ftsResults, nil, nil)), nil
 }
@@ -338,6 +479,12 @@ func (s *MemoryService) keywordOnlyCandidates(ctx context.Context, filter domain
 	kwResults, err := s.memories.KeywordSearch(ctx, filter.Query, filter, fetchLimit)
 	if err != nil {
 		return nil, fmt.Errorf("keyword search: %w", err)
+	}
+	if len(kwResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		kwResults, err = s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return dedupRecallCandidatesByContent(mergeRecallCandidates(sourcePool, kwResults, nil, nil)), nil
 }
@@ -393,6 +540,14 @@ func (s *MemoryService) hybridSearch(ctx context.Context, filter domain.MemoryFi
 		}
 	}
 
+	if len(vecResults) == 0 && len(kwResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		fallbackResults, fallbackErr := s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if fallbackErr != nil {
+			return nil, 0, fallbackErr
+		}
+		kwResults = fallbackResults
+	}
+
 	slog.Info("hybrid search completed", "query_len", len(filter.Query), "vec_results", len(vecResults), "kw_results", len(kwResults))
 
 	scores := rrfMerge(kwResults, vecResults)
@@ -430,6 +585,13 @@ func (s *MemoryService) hybridCandidates(ctx context.Context, filter domain.Memo
 		kwResults, err = s.memories.KeywordSearch(ctx, filter.Query, filter, fetchLimit)
 		if err != nil {
 			return nil, fmt.Errorf("keyword search: %w", err)
+		}
+	}
+
+	if len(vecResults) == 0 && len(kwResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		kwResults, err = s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -480,6 +642,14 @@ func (s *MemoryService) autoHybridSearch(ctx context.Context, filter domain.Memo
 		if kwErr != nil {
 			return nil, 0, fmt.Errorf("keyword search: %w", kwErr)
 		}
+	}
+
+	if len(vecResults) == 0 && len(kwResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		fallbackResults, fallbackErr := s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if fallbackErr != nil {
+			return nil, 0, fallbackErr
+		}
+		kwResults = fallbackResults
 	}
 
 	slog.Info("auto hybrid search completed", "query_len", len(filter.Query), "vec_results", len(vecResults), "kw_results", len(kwResults))
@@ -546,6 +716,13 @@ func (s *MemoryService) autoHybridCandidates(
 		}
 	}
 	keywordDuration := time.Since(keywordStart)
+
+	if len(vecResults) == 0 && len(kwResults) == 0 && shouldRunLooseKeywordFallback(filter.Query) {
+		kwResults, err = s.looseTokenKeywordSearch(ctx, filter, fetchLimit)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	var secondHopResults []domain.Memory
 	secondHopStart := time.Now()
@@ -916,6 +1093,7 @@ func (s *MemoryService) BulkCreate(ctx context.Context, agentName string, items 
 			Metadata:   item.Metadata,
 			Embedding:  embedding,
 			MemoryType: domain.TypePinned,
+			AppID:      item.AppID,
 			State:      domain.StateActive,
 			Version:    1,
 			UpdatedBy:  agentName,
@@ -954,15 +1132,26 @@ func ValidateBulkMemoryInputs(items []BulkMemoryInput) error {
 			}
 			return err
 		}
+		appID := item.AppID
+		if appID == "" {
+			appID = item.AppIDLegacy
+		}
+		appID = strings.TrimSpace(appID)
+		if len(appID) > 100 {
+			return &domain.ValidationError{Field: "memories[" + strconv.Itoa(i) + "].appId", Message: "too long (max 100)"}
+		}
+		items[i].AppID = appID
 	}
 	return nil
 }
 
 // BulkMemoryInput is the input shape for each item in a bulk create request.
 type BulkMemoryInput struct {
-	Content  string          `json:"content"`
-	Tags     []string        `json:"tags,omitempty"`
-	Metadata json.RawMessage `json:"metadata,omitempty"`
+	Content     string          `json:"content"`
+	AppID       string          `json:"appId,omitempty"`
+	AppIDLegacy string          `json:"app_id,omitempty"`
+	Tags        []string        `json:"tags,omitempty"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
 }
 
 func validateMemoryInput(content string, tags []string) error {

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -165,13 +165,17 @@ func (s *MemoryService) Get(ctx context.Context, id string) (*domain.Memory, err
 	return s.memories.GetByID(ctx, id)
 }
 
+func (s *MemoryService) List(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	mems, total, err := s.memories.List(ctx, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+	return finalizeSearchResults(mems, filter.Query), total, nil
+}
+
 func (s *MemoryService) Search(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
 	if filter.Query == "" {
-		mems, total, err := s.memories.List(ctx, filter)
-		if err != nil {
-			return nil, 0, err
-		}
-		return finalizeSearchResults(mems, filter.Query), total, nil
+		return s.List(ctx, filter)
 	}
 	searchFilter := filter
 	searchFilter.SessionID = ""

--- a/server/internal/service/memory_test.go
+++ b/server/internal/service/memory_test.go
@@ -389,6 +389,53 @@ func TestSearchFTSOnlyWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestSearchFallsBackToLooseTokensWhenFTSQuestionHasNoRows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	corpus := []domain.Memory{
+		{ID: "m-old", Content: "Bosn loves Flame", UpdatedAt: now.Add(-time.Minute), MemoryType: domain.TypeInsight, State: domain.StateActive},
+		{ID: "m-new", Content: "Flame loves Bosn", UpdatedAt: now, MemoryType: domain.TypeInsight, State: domain.StateActive},
+	}
+	var keywordQueries []string
+	memRepo := &memoryRepoMock{
+		ftsAvail: true,
+		ftsSearchHook: func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
+			return nil, nil
+		},
+		keywordSearchHook: func(_ context.Context, query string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			keywordQueries = append(keywordQueries, query)
+			query = strings.ToLower(query)
+			var matches []domain.Memory
+			for _, memory := range corpus {
+				if strings.Contains(strings.ToLower(memory.Content), query) {
+					matches = append(matches, memory)
+				}
+			}
+			return matches, nil
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "", ModeSmart)
+
+	results, total, err := svc.Search(context.Background(), domain.MemoryFilter{
+		Query: "Bosn loves Frame or not?",
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if total != 2 || len(results) != 2 {
+		t.Fatalf("expected 2 loose-token results, got total=%d results=%d", total, len(results))
+	}
+	if results[0].ID != "m-new" || results[1].ID != "m-old" {
+		t.Fatalf("unexpected loose-token result order: %#v", results)
+	}
+	wantQueries := []string{"Bosn", "loves", "Frame"}
+	if strings.Join(keywordQueries, ",") != strings.Join(wantQueries, ",") {
+		t.Fatalf("keyword fallback queries = %#v, want %#v", keywordQueries, wantQueries)
+	}
+}
+
 // TestSearchEmptyQueryReturnsList verifies that Search() with empty query
 // delegates to List() instead of any search path.
 func TestSearchEmptyQueryReturnsList(t *testing.T) {
@@ -469,13 +516,52 @@ func TestSearchIgnoresSessionAndSourceFilters(t *testing.T) {
 	}
 }
 
+func TestContentKeywordSearchBypassesFTSAndVector(t *testing.T) {
+	t.Parallel()
+
+	memRepo := &memoryRepoMock{
+		ftsAvail: true,
+		kwResults: []domain.Memory{
+			{ID: "kw-1", Content: "mem9小组负责验证", MemoryType: domain.TypeInsight, State: domain.StateActive},
+		},
+		ftsSearchHook: func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
+			t.Fatal("ContentKeywordSearch must not call FTS")
+			return nil, nil
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	results, total, err := svc.ContentKeywordSearch(context.Background(), domain.MemoryFilter{
+		Query:     "mem9小组",
+		Source:    "console",
+		SessionID: "session-1",
+		AgentID:   "agent-1",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("ContentKeywordSearch() error: %v", err)
+	}
+	if total != 1 || len(results) != 1 || results[0].ID != "kw-1" {
+		t.Fatalf("unexpected results: total=%d results=%+v", total, results)
+	}
+	if memRepo.lastKeywordFilter.Source != "console" {
+		t.Fatalf("expected Source filter preserved, got %q", memRepo.lastKeywordFilter.Source)
+	}
+	if memRepo.lastKeywordFilter.SessionID != "session-1" {
+		t.Fatalf("expected SessionID filter preserved, got %q", memRepo.lastKeywordFilter.SessionID)
+	}
+	if memRepo.lastAutoVectorFilter.Query != "" || memRepo.lastFTSFilter.Query != "" {
+		t.Fatalf("direct keyword search unexpectedly touched vector/FTS filters: auto=%+v fts=%+v", memRepo.lastAutoVectorFilter, memRepo.lastFTSFilter)
+	}
+}
+
 func TestCreateFallsBackToRawWhenLLMUnavailable(t *testing.T) {
 	t.Parallel()
 
 	repo := &memoryRepoMock{}
 	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
 
-	mem, _, err := svc.Create(context.Background(), "agent-1", "user prefers dark mode", []string{"prefs"}, json.RawMessage(`{"source":"manual"}`))
+	mem, _, err := svc.Create(context.Background(), "agent-1", "", "user prefers dark mode", []string{"prefs"}, json.RawMessage(`{"source":"manual"}`))
 	if err != nil {
 		t.Fatalf("Create() error = %v", err)
 	}
@@ -502,6 +588,7 @@ func TestCreatePinnedUsesBulkCreateSemantics(t *testing.T) {
 	mem, written, err := svc.CreatePinned(
 		context.Background(),
 		"agent-1",
+		"",
 		"user prefers pour-over coffee",
 		[]string{"preference", "coffee"},
 		json.RawMessage(`{"source":"manual"}`),
@@ -567,7 +654,7 @@ func TestCreateRunsReconcilePipeline(t *testing.T) {
 	repo := &memoryRepoMock{}
 	svc := NewMemoryService(repo, llmClient, nil, "auto-model", ModeSmart)
 
-	mem, _, err := svc.Create(context.Background(), "agent-1", "I use Go 1.22", nil, nil)
+	mem, _, err := svc.Create(context.Background(), "agent-1", "", "I use Go 1.22", nil, nil)
 	if err != nil {
 		t.Fatalf("Create() error: %v", err)
 	}

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -41,19 +41,19 @@ func NewSessionService(sessions repository.SessionRepo, embedder *embed.Embedder
 	}
 }
 
-func (s *SessionService) ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error) {
-	return s.sessions.ListBySessionIDs(ctx, sessionIDs, limitPerSession)
+func (s *SessionService) ListBySessionIDs(ctx context.Context, sessionIDs []string, appID *string, limitPerSession int) ([]*domain.Session, error) {
+	return s.sessions.ListBySessionIDs(ctx, sessionIDs, appID, limitPerSession)
 }
 
-func (s *SessionService) PatchTags(ctx context.Context, sessionID, contentHash string, tags []string) error {
-	return s.sessions.PatchTags(ctx, sessionID, contentHash, tags)
+func (s *SessionService) PatchTags(ctx context.Context, appID, sessionID, contentHash string, tags []string) error {
+	return s.sessions.PatchTags(ctx, appID, sessionID, contentHash, tags)
 }
 
 func (s *SessionService) BulkCreate(ctx context.Context, agentName string, req IngestRequest) error {
 	sessions := make([]*domain.Session, 0, len(req.Messages))
 	for i, msg := range req.Messages {
 		sess := newSessionFromIngestMessage(
-			req.SessionID, req.AgentID, agentName,
+			req.AppID, req.SessionID, req.AgentID, agentName,
 			i, msg,
 		)
 		sessions = append(sessions, sess)
@@ -64,8 +64,8 @@ func (s *SessionService) BulkCreate(ctx context.Context, agentName string, req I
 	return nil
 }
 
-func (s *SessionService) CreateRawTurn(ctx context.Context, sessionID, agentID, source string, seq int, role, content string) error {
-	sess := newSession(sessionID, agentID, source, seq, role, content, &seq)
+func (s *SessionService) CreateRawTurn(ctx context.Context, appID, sessionID, agentID, source string, seq int, role, content string) error {
+	sess := newSession(appID, sessionID, agentID, source, seq, role, content, &seq)
 	if err := s.sessions.BulkCreate(ctx, []*domain.Session{sess}); err != nil {
 		return fmt.Errorf("session raw create: %w", err)
 	}
@@ -121,6 +121,31 @@ func (s *SessionService) Search(ctx context.Context, f domain.MemoryFilter) ([]d
 	// All search paths return results sorted by score descending; dedupByContent
 	// therefore retains the highest-scored occurrence for each unique content string.
 	return dedupByContent(results), nil
+}
+
+// ContentKeywordSearch performs direct raw-session content substring search for
+// list filters, bypassing vector and FTS ranking.
+func (s *SessionService) ContentKeywordSearch(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	if f.Query == "" {
+		return s.List(ctx, f)
+	}
+
+	limit := f.Limit
+	if limit <= 0 || limit > 200 {
+		limit = DefaultSessionLimit
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	fetchLimit := limit * defaultSessionFetchMultiplier
+
+	results, err := s.sessions.KeywordSearch(ctx, f.Query, f, fetchLimit)
+	if err != nil {
+		return nil, 0, fmt.Errorf("session keyword search: %w", err)
+	}
+	page, total := paginateResults(results, offset, limit)
+	return populateRelativeAge(page), total, nil
 }
 
 func (s *SessionService) SearchCandidates(
@@ -201,7 +226,7 @@ func (s *SessionService) autoHybridCandidates(
 		return nil, err
 	}
 
-	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, kwResults, vecResults, opts)
+	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, kwResults, vecResults, f.AppID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -271,7 +296,7 @@ func (s *SessionService) hybridCandidates(
 		return nil, err
 	}
 
-	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, kwResults, vecResults, opts)
+	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, kwResults, vecResults, f.AppID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -293,7 +318,7 @@ func (s *SessionService) ftsCandidates(ctx context.Context, f domain.MemoryFilte
 	if err != nil {
 		return nil, fmt.Errorf("session fts search: %w", err)
 	}
-	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, results, nil, opts)
+	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, results, nil, f.AppID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +339,7 @@ func (s *SessionService) keywordCandidates(ctx context.Context, f domain.MemoryF
 	if err != nil {
 		return nil, fmt.Errorf("session keyword search: %w", err)
 	}
-	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, results, nil, opts)
+	adjacentResults, err := s.adjacentTurnResults(ctx, sourcePool, results, nil, f.AppID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -340,6 +365,7 @@ func (s *SessionService) adjacentTurnResults(
 	ctx context.Context,
 	sourcePool RecallSourcePool,
 	kwResults, vecResults []domain.Memory,
+	appID *string,
 	opts RecallCandidateOptions,
 ) ([]domain.Memory, error) {
 	if !opts.EnableAdjacentTurns {
@@ -351,6 +377,70 @@ func (s *SessionService) adjacentTurnResults(
 		return nil, nil
 	}
 
+	fetchLimit := adjacentTurnFetchLimit(seeds, opts.AdjacentTurnRadius)
+	start := time.Now()
+	groups := adjacentTurnSeedGroups(seeds, appID)
+	adjacent := make([]domain.Memory, 0, len(seeds)*opts.AdjacentTurnRadius*2)
+	sessionIDCount := 0
+	for _, group := range groups {
+		sessionIDs := adjacentTurnSessionIDs(group.seeds)
+		if len(sessionIDs) == 0 {
+			continue
+		}
+		sessionIDCount += len(sessionIDs)
+		groupAppID := group.appID
+		sessions, err := s.sessions.ListBySessionIDs(ctx, sessionIDs, &groupAppID, fetchLimit)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotSupported) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("session adjacent turn lookup: %w", err)
+		}
+		adjacent = append(adjacent, adjacentTurnMemories(group.seeds, sessions, opts.AdjacentTurnRadius)...)
+	}
+	if sessionIDCount == 0 {
+		return nil, nil
+	}
+	slog.InfoContext(ctx, "session adjacent turn expansion",
+		"source_pool", string(sourcePool),
+		"seed_count", len(seeds),
+		"session_count", sessionIDCount,
+		"fetch_limit", fetchLimit,
+		"adjacent_count", len(adjacent),
+		"total_ms", time.Since(start).Milliseconds(),
+	)
+	return adjacent, nil
+}
+
+type adjacentTurnSeedGroup struct {
+	appID string
+	seeds []RecallCandidate
+}
+
+func adjacentTurnSeedGroups(seeds []RecallCandidate, appID *string) []adjacentTurnSeedGroup {
+	if len(seeds) == 0 {
+		return nil
+	}
+	if appID != nil {
+		return []adjacentTurnSeedGroup{{appID: *appID, seeds: seeds}}
+	}
+
+	groups := make([]adjacentTurnSeedGroup, 0, len(seeds))
+	indexByAppID := make(map[string]int, len(seeds))
+	for _, seed := range seeds {
+		appID := seed.Memory.AppID
+		idx, ok := indexByAppID[appID]
+		if !ok {
+			idx = len(groups)
+			indexByAppID[appID] = idx
+			groups = append(groups, adjacentTurnSeedGroup{appID: appID})
+		}
+		groups[idx].seeds = append(groups[idx].seeds, seed)
+	}
+	return groups
+}
+
+func adjacentTurnSessionIDs(seeds []RecallCandidate) []string {
 	sessionIDs := make([]string, 0, len(seeds))
 	seenSessionIDs := make(map[string]struct{}, len(seeds))
 	for _, seed := range seeds {
@@ -363,29 +453,7 @@ func (s *SessionService) adjacentTurnResults(
 		seenSessionIDs[seed.Memory.SessionID] = struct{}{}
 		sessionIDs = append(sessionIDs, seed.Memory.SessionID)
 	}
-	if len(sessionIDs) == 0 {
-		return nil, nil
-	}
-
-	fetchLimit := adjacentTurnFetchLimit(seeds, opts.AdjacentTurnRadius)
-	start := time.Now()
-	sessions, err := s.sessions.ListBySessionIDs(ctx, sessionIDs, fetchLimit)
-	if err != nil {
-		if errors.Is(err, domain.ErrNotSupported) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("session adjacent turn lookup: %w", err)
-	}
-	adjacent := adjacentTurnMemories(seeds, sessions, opts.AdjacentTurnRadius)
-	slog.InfoContext(ctx, "session adjacent turn expansion",
-		"source_pool", string(sourcePool),
-		"seed_count", len(seeds),
-		"session_count", len(sessionIDs),
-		"fetch_limit", fetchLimit,
-		"adjacent_count", len(adjacent),
-		"total_ms", time.Since(start).Milliseconds(),
-	)
-	return adjacent, nil
+	return sessionIDs
 }
 
 func topAdjacentTurnSeeds(candidates []RecallCandidate, topN int) []RecallCandidate {
@@ -445,7 +513,7 @@ func adjacentTurnMemories(seeds []RecallCandidate, sessions []*domain.Session, r
 		if session == nil || session.SessionID == "" {
 			continue
 		}
-		bySession[session.SessionID] = append(bySession[session.SessionID], session)
+		bySession[sessionAppSessionKey(session.AppID, session.SessionID)] = append(bySession[sessionAppSessionKey(session.AppID, session.SessionID)], session)
 	}
 
 	seen := make(map[string]struct{}, len(seeds))
@@ -455,7 +523,7 @@ func adjacentTurnMemories(seeds []RecallCandidate, sessions []*domain.Session, r
 
 	results := make([]domain.Memory, 0, len(seeds)*radius*2)
 	for _, seed := range seeds {
-		turns := bySession[seed.Memory.SessionID]
+		turns := bySession[sessionAppSessionKey(seed.Memory.AppID, seed.Memory.SessionID)]
 		if len(turns) == 0 {
 			continue
 		}
@@ -482,6 +550,10 @@ func adjacentTurnMemories(seeds []RecallCandidate, sessions []*domain.Session, r
 		}
 	}
 	return results
+}
+
+func sessionAppSessionKey(appID, sessionID string) string {
+	return appID + "\x00" + sessionID
 }
 
 func adjacentTurnIndexes(seedIndex, total, radius int) []int {
@@ -569,8 +641,8 @@ func dedupByContent(mems []domain.Memory) []domain.Memory {
 // provenance for otherwise identical message bodies within the same session.
 //
 // TODO(content-hash-migration): migrate to SHA-256(role+content) — dropping sessionID from the hash keeps
-// the same write-time dedup guarantee (the unique index is (session_id, content_hash),
-// so cross-session collisions are still impossible) while making content_hash
+// the same write-time dedup guarantee (the unique index is (app_id, session_id, content_hash),
+// so cross-session/app collisions are still impossible) while making content_hash
 // comparable across sessions. That would let the search path dedup by content_hash
 // instead of by the raw content string.
 func sessionContentHash(sessionID, role, content string, seq *int) string {
@@ -594,16 +666,17 @@ func effectiveMessageSeq(msg IngestMessage, fallback int) int {
 	return fallback
 }
 
-func newSessionFromIngestMessage(sessionID, agentID, source string, fallbackSeq int, msg IngestMessage) *domain.Session {
+func newSessionFromIngestMessage(appID, sessionID, agentID, source string, fallbackSeq int, msg IngestMessage) *domain.Session {
 	seq := effectiveMessageSeq(msg, fallbackSeq)
-	return newSession(sessionID, agentID, source, seq, msg.Role, msg.Content, msg.Seq)
+	return newSession(appID, sessionID, agentID, source, seq, msg.Role, msg.Content, msg.Seq)
 }
 
-func newSession(sessionID, agentID, source string, seq int, role, content string, explicitSeq *int) *domain.Session {
+func newSession(appID, sessionID, agentID, source string, seq int, role, content string, explicitSeq *int) *domain.Session {
 	return &domain.Session{
 		ID:          uuid.New().String(),
 		SessionID:   sessionID,
 		AgentID:     agentID,
+		AppID:       appID,
 		Source:      source,
 		Seq:         seq,
 		Role:        role,

--- a/server/internal/service/session_test.go
+++ b/server/internal/service/session_test.go
@@ -17,12 +17,16 @@ type stubSessionRepo struct {
 
 	patchTagsCalled bool
 	patchTagsErr    error
+	patchedAppID    string
 	patchedSession  string
 	patchedHash     string
 	patchedTags     []string
 
 	keywordResults []domain.Memory
 	keywordErr     error
+	keywordQuery   string
+	keywordFilter  domain.MemoryFilter
+	keywordLimit   int
 	ftsResults     []domain.Memory
 	ftsErr         error
 	vecResults     []domain.Memory
@@ -31,8 +35,10 @@ type stubSessionRepo struct {
 	autoVecErr     error
 	ftsAvail       bool
 	sessionRows    []*domain.Session
+	listAppID      *string
 	listSessionIDs []string
 	listLimit      int
+	listCalls      []sessionListCall
 	getResult      *domain.Memory
 	getErr         error
 	listResults    []domain.Memory
@@ -40,6 +46,12 @@ type stubSessionRepo struct {
 	listFilter     domain.MemoryFilter
 	softDeleteID   string
 	bulkDeleteIDs  []string
+}
+
+type sessionListCall struct {
+	ids   []string
+	appID *string
+	limit int
 }
 
 func intPtr(v int) *int {
@@ -52,8 +64,9 @@ func (s *stubSessionRepo) BulkCreate(_ context.Context, sessions []*domain.Sessi
 	return s.bulkCreateErr
 }
 
-func (s *stubSessionRepo) PatchTags(_ context.Context, sessionID, contentHash string, tags []string) error {
+func (s *stubSessionRepo) PatchTags(_ context.Context, appID, sessionID, contentHash string, tags []string) error {
 	s.patchTagsCalled = true
+	s.patchedAppID = appID
 	s.patchedSession = sessionID
 	s.patchedHash = contentHash
 	s.patchedTags = tags
@@ -91,15 +104,33 @@ func (s *stubSessionRepo) FTSSearch(_ context.Context, _ string, _ domain.Memory
 	return s.ftsResults, s.ftsErr
 }
 
-func (s *stubSessionRepo) KeywordSearch(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+func (s *stubSessionRepo) KeywordSearch(_ context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	s.keywordQuery = query
+	s.keywordFilter = filter
+	s.keywordLimit = limit
 	return s.keywordResults, s.keywordErr
 }
 
 func (s *stubSessionRepo) FTSAvailable() bool { return s.ftsAvail }
 
-func (s *stubSessionRepo) ListBySessionIDs(_ context.Context, ids []string, limit int) ([]*domain.Session, error) {
+func (s *stubSessionRepo) ListBySessionIDs(_ context.Context, ids []string, appID *string, limit int) ([]*domain.Session, error) {
+	if appID != nil {
+		v := *appID
+		s.listAppID = &v
+	} else {
+		s.listAppID = nil
+	}
 	s.listSessionIDs = append([]string(nil), ids...)
 	s.listLimit = limit
+	call := sessionListCall{
+		ids:   append([]string(nil), ids...),
+		limit: limit,
+	}
+	if appID != nil {
+		v := *appID
+		call.appID = &v
+	}
+	s.listCalls = append(s.listCalls, call)
 	return append([]*domain.Session(nil), s.sessionRows...), nil
 }
 
@@ -114,6 +145,7 @@ func TestSessionService_BulkCreate_buildsCorrectSessions(t *testing.T) {
 	req := IngestRequest{
 		SessionID: "sess-1",
 		AgentID:   "agent-x",
+		AppID:     "chat-app",
 		Messages: []IngestMessage{
 			{Role: "user", Content: "Hello world"},
 			{Role: "assistant", Content: "Hi there"},
@@ -137,6 +169,9 @@ func TestSessionService_BulkCreate_buildsCorrectSessions(t *testing.T) {
 	}
 	if s0.AgentID != "agent-x" {
 		t.Errorf("session[0].AgentID = %q, want %q", s0.AgentID, "agent-x")
+	}
+	if s0.AppID != "chat-app" {
+		t.Errorf("session[0].AppID = %q, want %q", s0.AppID, "chat-app")
 	}
 	if s0.Role != "user" {
 		t.Errorf("session[0].Role = %q, want %q", s0.Role, "user")
@@ -224,7 +259,7 @@ func TestSessionService_PatchTags_delegates(t *testing.T) {
 	svc := newTestSessionService(repo)
 
 	tags := []string{"tech", "question"}
-	if err := svc.PatchTags(context.Background(), "sess-1", "hashval", tags); err != nil {
+	if err := svc.PatchTags(context.Background(), "chat-app", "sess-1", "hashval", tags); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -233,6 +268,9 @@ func TestSessionService_PatchTags_delegates(t *testing.T) {
 	}
 	if repo.patchedSession != "sess-1" {
 		t.Errorf("patchedSession = %q, want %q", repo.patchedSession, "sess-1")
+	}
+	if repo.patchedAppID != "chat-app" {
+		t.Errorf("patchedAppID = %q, want %q", repo.patchedAppID, "chat-app")
 	}
 	if repo.patchedHash != "hashval" {
 		t.Errorf("patchedHash = %q, want %q", repo.patchedHash, "hashval")
@@ -247,7 +285,7 @@ func TestSessionService_PatchTags_propagatesError(t *testing.T) {
 	repo := &stubSessionRepo{patchTagsErr: sentinel}
 	svc := newTestSessionService(repo)
 
-	err := svc.PatchTags(context.Background(), "s", "h", []string{"t"})
+	err := svc.PatchTags(context.Background(), "", "s", "h", []string{"t"})
 	if !errors.Is(err, sentinel) {
 		t.Errorf("expected sentinel error, got %v", err)
 	}
@@ -276,6 +314,41 @@ func TestSessionService_Search_keywordPath_returnsSessionType(t *testing.T) {
 	}
 	if results[0].MemoryType != domain.TypeSession {
 		t.Errorf("memory_type = %q, want %q", results[0].MemoryType, domain.TypeSession)
+	}
+}
+
+func TestSessionService_ContentKeywordSearchBypassesFTS(t *testing.T) {
+	memories := []domain.Memory{
+		{ID: "s1", Content: "old mem9小组 session", MemoryType: domain.TypeSession, State: domain.StateActive},
+		{ID: "s2", Content: "new mem9小组 session", MemoryType: domain.TypeSession, State: domain.StateActive},
+	}
+	repo := &stubSessionRepo{
+		keywordResults: memories,
+		ftsAvail:       true,
+	}
+	svc := newTestSessionService(repo)
+
+	results, total, err := svc.ContentKeywordSearch(context.Background(), domain.MemoryFilter{
+		Query:     "mem9小组",
+		Source:    "console",
+		SessionID: "session-1",
+		Limit:     1,
+		Offset:    1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 2 || len(results) != 1 || results[0].ID != "s2" {
+		t.Fatalf("unexpected page: total=%d results=%+v", total, results)
+	}
+	if repo.keywordQuery != "mem9小组" {
+		t.Fatalf("keyword query = %q, want mem9小组", repo.keywordQuery)
+	}
+	if repo.keywordFilter.Source != "console" || repo.keywordFilter.SessionID != "session-1" {
+		t.Fatalf("keyword filter = %+v", repo.keywordFilter)
+	}
+	if repo.keywordLimit != 3 {
+		t.Fatalf("keyword limit = %d, want 3", repo.keywordLimit)
 	}
 }
 
@@ -392,6 +465,66 @@ func TestSessionService_SearchCandidates_ExpandsAdjacentTurns(t *testing.T) {
 	}
 }
 
+func TestSessionService_SearchCandidates_AdjacentTurnsUseSeedAppID(t *testing.T) {
+	now := time.Now()
+	repo := &stubSessionRepo{
+		keywordResults: []domain.Memory{
+			{
+				ID:         "s-question",
+				SessionID:  "sess-1",
+				AppID:      "app-a",
+				Content:    "Which company do you like the most these days?",
+				MemoryType: domain.TypeSession,
+				Metadata:   json.RawMessage(`{"role":"user","seq":7,"content_type":"text"}`),
+				UpdatedAt:  now,
+				State:      domain.StateActive,
+			},
+		},
+		sessionRows: []*domain.Session{
+			{ID: "s-question", SessionID: "sess-1", AppID: "app-a", Seq: 7, Role: "user", Content: "Which company do you like the most these days?", ContentType: "text", State: domain.StateActive, CreatedAt: now.Add(-1 * time.Minute), UpdatedAt: now.Add(-1 * time.Minute)},
+			{ID: "s-answer", SessionID: "sess-1", AppID: "app-a", Seq: 8, Role: "assistant", Content: `Definitely "Under Armour" right now.`, ContentType: "text", State: domain.StateActive, CreatedAt: now, UpdatedAt: now},
+		},
+	}
+	svc := newTestSessionService(repo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{Query: "What company does John like?", Limit: 5}, RecallSourceSession, RecallCandidateOptions{
+		EnableAdjacentTurns: true,
+		AdjacentTurnRadius:  1,
+		AdjacentTurnTopN:    2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(candidates))
+	}
+	if repo.listAppID == nil || *repo.listAppID != "app-a" {
+		t.Fatalf("expected ListBySessionIDs to scope app-a, got %#v", repo.listAppID)
+	}
+}
+
+func TestAdjacentTurnMemoriesSeparatesSharedSessionIDByAppID(t *testing.T) {
+	now := time.Now()
+	seeds := []RecallCandidate{
+		{
+			Memory: domain.Memory{
+				ID:        "app-a-question",
+				SessionID: "shared-session",
+				AppID:     "app-a",
+			},
+		},
+	}
+	sessions := []*domain.Session{
+		{ID: "app-a-question", SessionID: "shared-session", AppID: "app-a", Seq: 1, Role: "user", Content: "question", ContentType: "text", State: domain.StateActive, CreatedAt: now, UpdatedAt: now},
+		{ID: "app-b-answer", SessionID: "shared-session", AppID: "app-b", Seq: 2, Role: "assistant", Content: "wrong app answer", ContentType: "text", State: domain.StateActive, CreatedAt: now.Add(time.Second), UpdatedAt: now.Add(time.Second)},
+	}
+
+	got := adjacentTurnMemories(seeds, sessions, 1)
+	if len(got) != 0 {
+		t.Fatalf("expected no adjacent memories from another app, got %+v", got)
+	}
+}
+
 func TestSessionContentHash_differentInputsProduceDifferentHashes(t *testing.T) {
 	cases := [][2]string{
 		{"sess-a role-user content-x", "sess-a role-user content-y"},
@@ -431,8 +564,8 @@ type capturingSessionRepo struct {
 func (c *capturingSessionRepo) BulkCreate(ctx context.Context, s []*domain.Session) error {
 	return c.stub.BulkCreate(ctx, s)
 }
-func (c *capturingSessionRepo) PatchTags(ctx context.Context, sid, hash string, tags []string) error {
-	return c.stub.PatchTags(ctx, sid, hash, tags)
+func (c *capturingSessionRepo) PatchTags(ctx context.Context, appID, sid, hash string, tags []string) error {
+	return c.stub.PatchTags(ctx, appID, sid, hash, tags)
 }
 func (c *capturingSessionRepo) GetByID(ctx context.Context, id string) (*domain.Memory, error) {
 	return c.stub.GetByID(ctx, id)
@@ -464,6 +597,6 @@ func (c *capturingSessionRepo) KeywordSearch(ctx context.Context, q string, f do
 }
 func (c *capturingSessionRepo) FTSAvailable() bool { return c.stub.FTSAvailable() }
 
-func (c *capturingSessionRepo) ListBySessionIDs(ctx context.Context, ids []string, limit int) ([]*domain.Session, error) {
-	return c.stub.ListBySessionIDs(ctx, ids, limit)
+func (c *capturingSessionRepo) ListBySessionIDs(ctx context.Context, ids []string, appID *string, limit int) ([]*domain.Session, error) {
+	return c.stub.ListBySessionIDs(ctx, ids, appID, limit)
 }

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -338,9 +338,36 @@ func (s *TenantService) GetInfo(ctx context.Context, tenantID string) (*domain.T
 	}, nil
 }
 
+func (s *TenantService) EnsureAppIDSchema(ctx context.Context, db *sql.DB) error {
+	backend := "tidb"
+	if s.pool != nil {
+		backend = s.pool.Backend()
+	}
+	switch backend {
+	case "tidb":
+		if err := tenant.EnsureMemoryAppIDSchema(ctx, db); err != nil {
+			return fmt.Errorf("ensure app_id schema: memories: %w", err)
+		}
+		if err := s.EnsureSessionsTable(ctx, db); err != nil {
+			return fmt.Errorf("ensure app_id schema: sessions: %w", err)
+		}
+		return nil
+	case "postgres", "db9":
+		if err := tenant.EnsurePostgresMemoryAppIDSchema(ctx, db, backend); err != nil {
+			return fmt.Errorf("ensure app_id schema: memories: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("ensure app_id schema: unsupported backend %q", backend)
+	}
+}
+
 func (s *TenantService) EnsureSessionsTable(ctx context.Context, db *sql.DB) error {
 	if _, err := db.ExecContext(ctx, tenant.BuildSessionsSchema(s.autoModel, s.autoDims, s.clientDims)); err != nil {
 		return fmt.Errorf("ensure sessions table: create: %w", err)
+	}
+	if err := tenant.EnsureSessionsAppIDSchema(ctx, db); err != nil {
+		return fmt.Errorf("ensure sessions table: app_id schema: %w", err)
 	}
 	if s.autoModel != "" {
 		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sessions_cosine")

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -28,24 +29,72 @@ const defaultTaskTimeout = 30 * time.Minute
 
 // SessionFile is the expected JSON format for session file uploads.
 type SessionFile struct {
-	AgentID   string          `json:"agent_id"`
-	SessionID string          `json:"session_id"`
-	Messages  []IngestMessage `json:"messages"`
+	AgentID     string          `json:"agent_id"`
+	AppID       string          `json:"appId"`
+	AppIDLegacy string          `json:"app_id"`
+	SessionID   string          `json:"session_id"`
+	Messages    []IngestMessage `json:"messages"`
+
+	appIDSet       bool
+	appIDLegacySet bool
 }
 
 // MemoryFile is the expected JSON format for memory file uploads.
 type MemoryFile struct {
-	AgentID  string            `json:"agent_id"`
-	Memories []MemoryFileEntry `json:"memories"`
+	AgentID     string            `json:"agent_id"`
+	AppID       string            `json:"appId"`
+	AppIDLegacy string            `json:"app_id"`
+	Memories    []MemoryFileEntry `json:"memories"`
+
+	appIDSet       bool
+	appIDLegacySet bool
 }
 
 // MemoryFileEntry is a single memory entry in a memory file.
 type MemoryFileEntry struct {
-	Content    string         `json:"content"`
-	Source     string         `json:"source,omitempty"`
-	Tags       []string       `json:"tags,omitempty"`
-	Metadata   map[string]any `json:"metadata,omitempty"`
-	MemoryType string         `json:"memory_type,omitempty"`
+	Content     string         `json:"content"`
+	AppID       string         `json:"appId,omitempty"`
+	AppIDLegacy string         `json:"app_id,omitempty"`
+	Source      string         `json:"source,omitempty"`
+	Tags        []string       `json:"tags,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	MemoryType  string         `json:"memory_type,omitempty"`
+
+	appIDSet       bool
+	appIDLegacySet bool
+}
+
+type sessionFileJSON SessionFile
+
+func (f *SessionFile) UnmarshalJSON(data []byte) error {
+	var parsed sessionFileJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	*f = SessionFile(parsed)
+	return decodeUploadAppIDFields(data, &f.AppID, &f.appIDSet, &f.AppIDLegacy, &f.appIDLegacySet)
+}
+
+type memoryFileJSON MemoryFile
+
+func (f *MemoryFile) UnmarshalJSON(data []byte) error {
+	var parsed memoryFileJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	*f = MemoryFile(parsed)
+	return decodeUploadAppIDFields(data, &f.AppID, &f.appIDSet, &f.AppIDLegacy, &f.appIDLegacySet)
+}
+
+type memoryFileEntryJSON MemoryFileEntry
+
+func (e *MemoryFileEntry) UnmarshalJSON(data []byte) error {
+	var parsed memoryFileEntryJSON
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+	*e = MemoryFileEntry(parsed)
+	return decodeUploadAppIDFields(data, &e.AppID, &e.appIDSet, &e.AppIDLegacy, &e.appIDLegacySet)
 }
 
 // UploadWorker processes queued upload tasks.
@@ -56,6 +105,8 @@ type UploadWorker struct {
 	embedder     *embed.Embedder
 	llmClient    *llm.Client
 	autoModel    string
+	autoDims     int
+	clientDims   int
 	ftsEnabled   bool
 	mode         IngestMode
 	logger       *slog.Logger
@@ -73,6 +124,8 @@ func NewUploadWorker(
 	embedder *embed.Embedder,
 	llmClient *llm.Client,
 	autoModel string,
+	autoDims int,
+	clientDims int,
 	ftsEnabled bool,
 	mode IngestMode,
 	logger *slog.Logger,
@@ -93,6 +146,8 @@ func NewUploadWorker(
 		embedder:     embedder,
 		llmClient:    llmClient,
 		autoModel:    autoModel,
+		autoDims:     autoDims,
+		clientDims:   clientDims,
 		ftsEnabled:   ftsEnabled,
 		mode:         mode,
 		logger:       logger,
@@ -186,6 +241,9 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 	if err != nil {
 		return w.failTask(ctx, task, fmt.Errorf("get tenant db: %w", err), logger)
 	}
+	if err := w.ensureAppIDSchema(taskCtx, db); err != nil {
+		return w.failTask(ctx, task, fmt.Errorf("ensure app_id schema: %w", err), logger)
+	}
 
 	memRepo := repository.NewMemoryRepo(w.pool.Backend(), db, w.autoModel, w.ftsEnabled, tenantInfo.ClusterID)
 	ingestSvc := NewIngestService(memRepo, w.llmClient, w.embedder, w.autoModel, w.mode)
@@ -217,6 +275,11 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 		}
 		if file.AgentID == "" {
 			file.AgentID = task.AgentID
+		}
+		rawFileAppID, _ := resolveUploadAppID(file.AppID, file.appIDSet, file.AppIDLegacy, file.appIDLegacySet)
+		fileAppID, err := normalizeUploadAppID(rawFileAppID, "appId")
+		if err != nil {
+			return w.failTask(ctx, task, fmt.Errorf("validate session app_id: %w", err), logger)
 		}
 		if file.SessionID == "" {
 			file.SessionID = task.SessionID
@@ -250,6 +313,7 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 			}
 			_, err := ingestSvc.Ingest(taskCtx, agentName, IngestRequest{
 				AgentID:   file.AgentID,
+				AppID:     fileAppID,
 				SessionID: file.SessionID,
 				Messages:  chunk,
 				Mode:      w.mode,
@@ -269,6 +333,11 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 		file, err := parseMemoryFile(data, task.AgentID)
 		if err != nil {
 			return w.failTask(ctx, task, fmt.Errorf("parse memory file: %w", err), logger)
+		}
+		rawFileAppID, _ := resolveUploadAppID(file.AppID, file.appIDSet, file.AppIDLegacy, file.appIDLegacySet)
+		fileAppID, err := normalizeUploadAppID(rawFileAppID, "appId")
+		if err != nil {
+			return w.failTask(ctx, task, fmt.Errorf("validate memory app_id: %w", err), logger)
 		}
 
 		// Handle empty file: mark done immediately
@@ -303,7 +372,14 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 			}
 			batch := file.Memories[i:end]
 			memories := make([]*domain.Memory, 0, len(batch))
-			for _, entry := range batch {
+			for j, entry := range batch {
+				appID := fileAppID
+				if entryAppID, ok := resolveUploadAppID(entry.AppID, entry.appIDSet, entry.AppIDLegacy, entry.appIDLegacySet); ok {
+					appID, err = normalizeUploadAppID(entryAppID, fmt.Sprintf("memories[%d].appId", i+j))
+					if err != nil {
+						return w.failTask(ctx, task, fmt.Errorf("validate memory app_id: %w", err), logger)
+					}
+				}
 				metadata, err := marshalMetadata(entry.Metadata)
 				if err != nil {
 					return w.failTask(ctx, task, fmt.Errorf("marshal memory metadata: %w", err), logger)
@@ -320,6 +396,7 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 					Metadata:   metadata,
 					MemoryType: memType,
 					AgentID:    file.AgentID,
+					AppID:      appID,
 					State:      domain.StateActive,
 					Version:    1,
 					UpdatedBy:  agentName,
@@ -367,6 +444,21 @@ func (w *UploadWorker) recordActivity(tenantID string) {
 		return
 	}
 	w.activity.RecordMemoryActivity(tenantID, time.Now().UTC())
+}
+
+func (w *UploadWorker) ensureAppIDSchema(ctx context.Context, db *sql.DB) error {
+	backend := "tidb"
+	if w.pool != nil {
+		backend = w.pool.Backend()
+	}
+	switch backend {
+	case "tidb":
+		return tenant.InitTiDBTenantSchema(ctx, db, w.autoModel, w.autoDims, w.clientDims, w.ftsEnabled)
+	case "postgres", "db9":
+		return tenant.EnsurePostgresMemoryAppIDSchema(ctx, db, backend)
+	default:
+		return fmt.Errorf("unsupported backend %q", backend)
+	}
 }
 
 func (w *UploadWorker) recordActivityOnly(tenantID string) {
@@ -463,13 +555,66 @@ func parseMemoryFile(data []byte, fallbackAgentID string) (MemoryFile, error) {
 	}, nil
 }
 
+func normalizeUploadAppID(value string, field string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) > 100 {
+		return "", &domain.ValidationError{Field: field, Message: "too long (max 100)"}
+	}
+	return value, nil
+}
+
+func decodeUploadAppIDFields(data []byte, appID *string, appIDSet *bool, legacyAppID *string, legacyAppIDSet *bool) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if rawAppID, ok := raw["appId"]; ok {
+		value, err := decodeUploadAppIDField(rawAppID)
+		if err != nil {
+			return err
+		}
+		*appID = value
+		*appIDSet = true
+	}
+	if rawAppID, ok := raw["app_id"]; ok {
+		value, err := decodeUploadAppIDField(rawAppID)
+		if err != nil {
+			return err
+		}
+		*legacyAppID = value
+		*legacyAppIDSet = true
+	}
+	return nil
+}
+
+func decodeUploadAppIDField(raw json.RawMessage) (string, error) {
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return "", nil
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return "", err
+	}
+	return value, nil
+}
+
+func resolveUploadAppID(appID string, appIDSet bool, legacyAppID string, legacyAppIDSet bool) (string, bool) {
+	if appIDSet {
+		return appID, true
+	}
+	if legacyAppIDSet {
+		return legacyAppID, true
+	}
+	return "", false
+}
+
 // parseSessionFile tries to parse data as a JSON SessionFile first.
 // If that fails, it tries JSONL format (one JSON object per line).
 // Supports both simple {role, content} lines and OpenClaw's nested
 // format: {"type":"message","message":{"role":"...","content":[...]}}.
 func parseSessionFile(data []byte) (SessionFile, error) {
 	var file SessionFile
-	if err := json.Unmarshal(data, &file); err == nil && (len(file.Messages) > 0 || file.AgentID != "" || file.SessionID != "") {
+	if err := json.Unmarshal(data, &file); err == nil && (len(file.Messages) > 0 || file.AgentID != "" || file.SessionID != "" || file.appIDSet || file.appIDLegacySet) {
 		return file, nil
 	}
 

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -3,7 +3,10 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
 func TestChunkMessages(t *testing.T) {
@@ -104,6 +107,107 @@ func TestMarshalMetadata(t *testing.T) {
 			t.Errorf("unexpected empty result: %s", s)
 		}
 	})
+}
+
+func TestNormalizeUploadAppID(t *testing.T) {
+	got, err := normalizeUploadAppID("  app-a  ", "appId")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "app-a" {
+		t.Fatalf("appID = %q, want app-a", got)
+	}
+
+	got, err = normalizeUploadAppID(" \t ", "appId")
+	if err != nil {
+		t.Fatalf("unexpected error for blank appID: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("blank appID = %q, want empty", got)
+	}
+
+	_, err = normalizeUploadAppID(strings.Repeat("x", 101), "memories[0].appId")
+	if err == nil {
+		t.Fatal("expected validation error for oversized appID")
+	}
+	var ve *domain.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("error = %T, want ValidationError", err)
+	}
+	if ve.Field != "memories[0].appId" {
+		t.Fatalf("field = %q, want memories[0].appId", ve.Field)
+	}
+}
+
+func TestParseMemoryFilePreservesEntryDefaultAppIDOverride(t *testing.T) {
+	file, err := parseMemoryFile([]byte(`{
+		"agent_id": "agent-a",
+		"appId": "file-app",
+		"memories": [
+			{"content": "inherits file app"},
+			{"content": "explicit empty app", "appId": ""},
+			{"content": "explicit null app", "appId": null},
+			{"content": "explicit legacy empty app", "app_id": ""},
+			{"content": "explicit entry app", "appId": "entry-app"}
+		]
+	}`), "fallback-agent")
+	if err != nil {
+		t.Fatalf("parse memory file: %v", err)
+	}
+	fileAppID, ok := resolveUploadAppID(file.AppID, file.appIDSet, file.AppIDLegacy, file.appIDLegacySet)
+	if !ok || fileAppID != "file-app" {
+		t.Fatalf("file appID = %q, ok = %v, want file-app/true", fileAppID, ok)
+	}
+
+	got := make([]string, 0, len(file.Memories))
+	for _, entry := range file.Memories {
+		appID := fileAppID
+		if entryAppID, ok := resolveUploadAppID(entry.AppID, entry.appIDSet, entry.AppIDLegacy, entry.appIDLegacySet); ok {
+			appID = entryAppID
+		}
+		got = append(got, appID)
+	}
+
+	want := []string{"file-app", "", "", "", "entry-app"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d memories, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("memory[%d] appID = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestParseUploadFileAppIDPrefersExplicitDefaultOverLegacy(t *testing.T) {
+	memoryFile, err := parseMemoryFile([]byte(`{
+		"agent_id": "agent-a",
+		"appId": null,
+		"app_id": "legacy-app",
+		"memories": [{"content": "uses default app"}]
+	}`), "fallback-agent")
+	if err != nil {
+		t.Fatalf("parse memory file: %v", err)
+	}
+	appID, ok := resolveUploadAppID(memoryFile.AppID, memoryFile.appIDSet, memoryFile.AppIDLegacy, memoryFile.appIDLegacySet)
+	if !ok || appID != "" {
+		t.Fatalf("memory file appID = %q, ok = %v, want empty/true", appID, ok)
+	}
+
+	sessionFile, err := parseSessionFile([]byte(`{
+		"agent_id": "agent-a",
+		"session_id": "session-a",
+		"appId": "",
+		"app_id": "legacy-app",
+		"messages": [{"role": "user", "content": "hello"}]
+	}`))
+	if err != nil {
+		t.Fatalf("parse session file: %v", err)
+	}
+	appID, ok = resolveUploadAppID(sessionFile.AppID, sessionFile.appIDSet, sessionFile.AppIDLegacy, sessionFile.appIDLegacySet)
+	if !ok || appID != "" {
+		t.Fatalf("session file appID = %q, ok = %v, want empty/true", appID, ok)
+	}
 }
 
 func TestParseSessionFile(t *testing.T) {

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -71,6 +71,9 @@ func (c *schemaInitConn) ExecContext(_ context.Context, query string, _ []driver
 
 func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	if strings.Contains(query, "information_schema.COLUMNS") {
+		if strings.Contains(query, "COUNT(*)") {
+			return &schemaInitRows{values: [][]driver.Value{{int64(0)}}}, nil
+		}
 		return &schemaRows{rows: c.recorder.schemaRows}, nil
 	}
 	if strings.Contains(query, "information_schema.TABLES") {
@@ -276,9 +279,11 @@ func TestTiDBCloudProvisioner_InitSchema_AutoEmbedding(t *testing.T) {
 	wantSubstrings := []string{
 		"CREATE TABLE IF NOT EXISTS memories",
 		"embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{\"dimensions\": 1024}')) STORED",
+		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content",
 		"CREATE TABLE IF NOT EXISTS sessions",
+		"ALTER TABLE sessions ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{\"dimensions\": 1024}')) STORED",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
 		"ALTER TABLE sessions ADD FULLTEXT INDEX idx_sessions_fts",
@@ -304,8 +309,10 @@ func TestTiDBCloudProvisioner_InitSchema_ClientEmbedding(t *testing.T) {
 	wantSubstrings := []string{
 		"CREATE TABLE IF NOT EXISTS memories",
 		"embedding VECTOR(1536) NULL",
+		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"CREATE TABLE IF NOT EXISTS sessions",
+		"ALTER TABLE sessions ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
 	}
 	for _, want := range wantSubstrings {
@@ -341,7 +348,9 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 		t.Fatalf("existing tables should skip CREATE TABLE:\n%s", executed)
 	}
 	wantSubstrings := []string{
+		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
+		"ALTER TABLE sessions ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
 	}
 	for _, want := range wantSubstrings {

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -18,6 +18,7 @@ const TenantMemorySchemaBase = `CREATE TABLE IF NOT EXISTS memories (
     memory_type     VARCHAR(20)     NOT NULL DEFAULT 'pinned',
     agent_id        VARCHAR(100)    NULL,
     session_id      VARCHAR(100)    NULL,
+    app_id          VARCHAR(100)    NOT NULL DEFAULT '',
     state           VARCHAR(20)     NOT NULL DEFAULT 'active',
     version         INT             DEFAULT 1,
     updated_by      VARCHAR(100),
@@ -29,6 +30,7 @@ const TenantMemorySchemaBase = `CREATE TABLE IF NOT EXISTS memories (
     INDEX idx_state               (state),
     INDEX idx_agent               (agent_id),
     INDEX idx_session             (session_id),
+    INDEX idx_app                 (app_id),
     INDEX idx_updated             (updated_at)
 )`
 
@@ -43,6 +45,7 @@ const TenantMemorySchemaPostgres = `CREATE TABLE IF NOT EXISTS memories (
     memory_type     VARCHAR(20)     NOT NULL DEFAULT 'pinned',
     agent_id        VARCHAR(100)    NULL,
     session_id      VARCHAR(100)    NULL,
+    app_id          VARCHAR(100)    NOT NULL DEFAULT '',
     state           VARCHAR(20)     NOT NULL DEFAULT 'active',
     version         INT             DEFAULT 1,
     updated_by      VARCHAR(100),
@@ -55,6 +58,7 @@ CREATE INDEX IF NOT EXISTS idx_source ON memories(source);
 CREATE INDEX IF NOT EXISTS idx_state ON memories(state);
 CREATE INDEX IF NOT EXISTS idx_agent ON memories(agent_id);
 CREATE INDEX IF NOT EXISTS idx_session ON memories(session_id);
+CREATE INDEX IF NOT EXISTS idx_app ON memories(app_id);
 CREATE INDEX IF NOT EXISTS idx_updated ON memories(updated_at);
 CREATE OR REPLACE FUNCTION update_updated_at() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = NOW(); RETURN NEW; END; $$ LANGUAGE plpgsql;
 DROP TRIGGER IF EXISTS trg_memories_updated ON memories;
@@ -72,6 +76,7 @@ const TenantMemorySchemaDB9Base = `CREATE TABLE IF NOT EXISTS memories (
     memory_type     VARCHAR(20)     NOT NULL DEFAULT 'pinned',
     agent_id        VARCHAR(100)    NULL,
     session_id      VARCHAR(100)    NULL,
+    app_id          VARCHAR(100)    NOT NULL DEFAULT '',
     state           VARCHAR(20)     NOT NULL DEFAULT 'active',
     version         INT             DEFAULT 1,
     updated_by      VARCHAR(100),
@@ -84,6 +89,7 @@ CREATE INDEX IF NOT EXISTS idx_memory_source ON memories(source);
 CREATE INDEX IF NOT EXISTS idx_memory_state ON memories(state);
 CREATE INDEX IF NOT EXISTS idx_memory_agent ON memories(agent_id);
 CREATE INDEX IF NOT EXISTS idx_memory_session ON memories(session_id);
+CREATE INDEX IF NOT EXISTS idx_memory_app ON memories(app_id);
 CREATE INDEX IF NOT EXISTS idx_memory_updated ON memories(updated_at);
 CREATE OR REPLACE FUNCTION update_updated_at() RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = NOW(); RETURN NEW; END; $$ LANGUAGE plpgsql;
 DROP TRIGGER IF EXISTS trg_memories_updated ON memories;
@@ -132,6 +138,7 @@ const TenantSessionsSchemaBase = `CREATE TABLE IF NOT EXISTS sessions (
     id           VARCHAR(36)     PRIMARY KEY,
     session_id   VARCHAR(100)    NULL,
     agent_id     VARCHAR(100)    NULL,
+    app_id       VARCHAR(100)    NOT NULL DEFAULT '',
     source       VARCHAR(100)    NULL,
     seq          INT             NOT NULL,
     role         VARCHAR(20)     NOT NULL,
@@ -145,9 +152,10 @@ const TenantSessionsSchemaBase = `CREATE TABLE IF NOT EXISTS sessions (
     updated_at   TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     INDEX        idx_sessions_session (session_id),
     INDEX        idx_sessions_agent   (agent_id),
+    INDEX        idx_sessions_app     (app_id),
     INDEX        idx_sessions_state   (state),
     INDEX        idx_sessions_created (created_at),
-    UNIQUE INDEX idx_sessions_dedup   (session_id, content_hash)
+    UNIQUE INDEX idx_sessions_dedup   (app_id, session_id, content_hash)
 )`
 
 // BuildSessionsSchema builds the TiDB sessions schema with optional auto-embedding.
@@ -182,6 +190,12 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 	if err := ensureTable(ctx, db, "memories", BuildMemorySchema(autoModel, autoDims, clientDims)); err != nil {
 		return fmt.Errorf("init schema: memories table: %w", err)
 	}
+	if err := ensureColumn(ctx, db, "memories", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
+		return fmt.Errorf("init schema: memories app_id column: %w", err)
+	}
+	if err := ensurePlainIndex(ctx, db, "memories", "idx_app", "app_id"); err != nil {
+		return fmt.Errorf("init schema: memories app_id index: %w", err)
+	}
 	if err := ensureVectorIndex(ctx, db, "memories", "idx_cosine"); err != nil {
 		return fmt.Errorf("init schema: memories vector index: %w", err)
 	}
@@ -194,6 +208,15 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 	if err := ensureTable(ctx, db, "sessions", BuildSessionsSchema(autoModel, autoDims, clientDims)); err != nil {
 		return fmt.Errorf("init schema: sessions table: %w", err)
 	}
+	if err := ensureColumn(ctx, db, "sessions", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
+		return fmt.Errorf("init schema: sessions app_id column: %w", err)
+	}
+	if err := ensurePlainIndex(ctx, db, "sessions", "idx_sessions_app", "app_id"); err != nil {
+		return fmt.Errorf("init schema: sessions app_id index: %w", err)
+	}
+	if err := ensureSessionsDedupIndex(ctx, db); err != nil {
+		return fmt.Errorf("init schema: sessions app_id dedup index: %w", err)
+	}
 	if err := ensureVectorIndex(ctx, db, "sessions", "idx_sessions_cosine"); err != nil {
 		return fmt.Errorf("init schema: sessions vector index: %w", err)
 	}
@@ -203,6 +226,118 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 		}
 	}
 	return nil
+}
+
+func ensureColumn(ctx context.Context, db *sql.DB, table, column, definition string) error {
+	exists, err := ColumnExists(ctx, db, table, column)
+	if err != nil {
+		return fmt.Errorf("check column: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"ALTER TABLE %s ADD COLUMN %s %s",
+		table, column, definition,
+	)); err != nil && !IsDuplicateColumnError(err) {
+		return fmt.Errorf("add column: %w", err)
+	}
+	return nil
+}
+
+func ensurePlainIndex(ctx context.Context, db *sql.DB, table, indexName, columns string) error {
+	exists, err := IndexExists(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check index: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE INDEX %s ON %s(%s)",
+		indexName, table, columns,
+	)); err != nil && !IsIndexExistsError(err) {
+		return fmt.Errorf("create index: %w", err)
+	}
+	return nil
+}
+
+func ensureSessionsDedupIndex(ctx context.Context, db *sql.DB) error {
+	columns, err := indexColumns(ctx, db, "sessions", "idx_sessions_dedup")
+	if err != nil {
+		return fmt.Errorf("check dedup index columns: %w", err)
+	}
+	if strings.Join(columns, ",") == "app_id,session_id,content_hash" {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE sessions DROP INDEX idx_sessions_dedup`); err != nil && !IsIndexNotFoundError(err) {
+		return fmt.Errorf("drop old dedup index: %w", err)
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE sessions ADD UNIQUE INDEX idx_sessions_dedup (app_id, session_id, content_hash)`); err != nil && !IsIndexExistsError(err) {
+		return fmt.Errorf("add app scoped dedup index: %w", err)
+	}
+	return nil
+}
+
+func indexColumns(ctx context.Context, db *sql.DB, table, indexName string) ([]string, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT COLUMN_NAME
+		   FROM information_schema.STATISTICS
+		  WHERE TABLE_SCHEMA = DATABASE()
+		    AND TABLE_NAME = ?
+		    AND INDEX_NAME = ?
+		  ORDER BY SEQ_IN_INDEX`,
+		table, indexName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return nil, err
+		}
+		columns = append(columns, column)
+	}
+	return columns, rows.Err()
+}
+
+// EnsureMemoryAppIDSchema completes the app-scoped memory schema for existing tenants.
+func EnsureMemoryAppIDSchema(ctx context.Context, db *sql.DB) error {
+	if err := ensureColumn(ctx, db, "memories", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	return ensurePlainIndex(ctx, db, "memories", "idx_app", "app_id")
+}
+
+// EnsurePostgresMemoryAppIDSchema completes the app-scoped memory schema for
+// PostgreSQL-compatible tenant databases.
+func EnsurePostgresMemoryAppIDSchema(ctx context.Context, db *sql.DB, backend string) error {
+	if _, err := db.ExecContext(ctx, `ALTER TABLE memories ADD COLUMN IF NOT EXISTS app_id VARCHAR(100) NOT NULL DEFAULT ''`); err != nil {
+		return fmt.Errorf("memories app_id column: %w", err)
+	}
+	indexName := "idx_app"
+	if backend == "db9" {
+		indexName = "idx_memory_app"
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON memories(app_id)`, indexName)); err != nil {
+		return fmt.Errorf("memories app_id index: %w", err)
+	}
+	return nil
+}
+
+// EnsureSessionsAppIDSchema completes the app-scoped raw session schema for existing tenants.
+func EnsureSessionsAppIDSchema(ctx context.Context, db *sql.DB) error {
+	if err := ensureColumn(ctx, db, "sessions", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
+		return err
+	}
+	if err := ensurePlainIndex(ctx, db, "sessions", "idx_sessions_app", "app_id"); err != nil {
+		return err
+	}
+	return ensureSessionsDedupIndex(ctx, db)
 }
 
 func ensureTable(ctx context.Context, db *sql.DB, table, createSQL string) error {

--- a/server/internal/tenant/util.go
+++ b/server/internal/tenant/util.go
@@ -27,6 +27,40 @@ func IsTableNotFoundError(err error) bool {
 	return strings.Contains(err.Error(), "doesn't exist")
 }
 
+// IsDuplicateColumnError reports whether err is a duplicate column error (MySQL 1060).
+func IsDuplicateColumnError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == 1060
+	}
+	return strings.Contains(err.Error(), "Duplicate column")
+}
+
+// IsIndexNotFoundError reports whether err is an index-not-found error.
+func IsIndexNotFoundError(err error) bool {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		return mysqlErr.Number == 1091
+	}
+	return strings.Contains(err.Error(), "check that column/key exists")
+}
+
+// ColumnExists reports whether the named column exists on the given table in the current database.
+func ColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.COLUMNS
+		 WHERE TABLE_SCHEMA = DATABASE()
+		   AND TABLE_NAME = ?
+		   AND COLUMN_NAME = ?`,
+		table, column,
+	).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
 // IndexExists reports whether the named index exists on the given table in the current database.
 func IndexExists(ctx context.Context, db *sql.DB, table, indexName string) (bool, error) {
 	var count int

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS memories (
   -- Agent & session tracking
   agent_id        VARCHAR(100)    NULL     COMMENT 'Agent that created this memory',
   session_id      VARCHAR(100)    NULL     COMMENT 'Session this memory originated from',
+  app_id          VARCHAR(100)    NOT NULL DEFAULT '' COMMENT 'Application isolation ID',
 
   -- Lifecycle
   state           VARCHAR(20)     NOT NULL DEFAULT 'active'
@@ -111,6 +112,7 @@ CREATE TABLE IF NOT EXISTS memories (
   INDEX idx_state               (state),
   INDEX idx_agent               (agent_id),
   INDEX idx_session             (session_id),
+  INDEX idx_app                 (app_id),
   INDEX idx_updated             (updated_at)
 );
 
@@ -144,12 +146,14 @@ CREATE TABLE IF NOT EXISTS memories (
 --   ADD COLUMN memory_type  VARCHAR(20) NOT NULL DEFAULT 'pinned',
 --   ADD COLUMN agent_id     VARCHAR(100) NULL,
 --   ADD COLUMN session_id   VARCHAR(100) NULL,
+--   ADD COLUMN app_id       VARCHAR(100) NOT NULL DEFAULT '',
 --   ADD COLUMN state        VARCHAR(20) NOT NULL DEFAULT 'active',
 --   ADD COLUMN superseded_by VARCHAR(36) NULL;
 -- CREATE INDEX idx_memory_type ON memories(memory_type);
 -- CREATE INDEX idx_state ON memories(state);
 -- CREATE INDEX idx_agent ON memories(agent_id);
 -- CREATE INDEX idx_session ON memories(session_id);
+-- CREATE INDEX idx_app ON memories(app_id);
 -- Step 2: Migrate tombstoned records.
 -- UPDATE memories SET state = 'deleted', deleted_at = updated_at WHERE tombstone = 1;
 -- Step 3: Add constraint (AFTER code migration).

--- a/server/schema_db9.sql
+++ b/server/schema_db9.sql
@@ -119,6 +119,7 @@ CREATE TABLE IF NOT EXISTS memories (
     memory_type     VARCHAR(20)     NOT NULL DEFAULT 'pinned',
     agent_id        VARCHAR(100)    NULL,
     session_id      VARCHAR(100)    NULL,
+    app_id          VARCHAR(100)    NOT NULL DEFAULT '',
     state           VARCHAR(20)     NOT NULL DEFAULT 'active',
     version         INT             DEFAULT 1,
     updated_by      VARCHAR(100),
@@ -131,6 +132,7 @@ CREATE INDEX IF NOT EXISTS idx_memory_source ON memories(source);
 CREATE INDEX IF NOT EXISTS idx_memory_state ON memories(state);
 CREATE INDEX IF NOT EXISTS idx_memory_agent ON memories(agent_id);
 CREATE INDEX IF NOT EXISTS idx_memory_session ON memories(session_id);
+CREATE INDEX IF NOT EXISTS idx_memory_app ON memories(app_id);
 CREATE INDEX IF NOT EXISTS idx_memory_updated ON memories(updated_at);
 
 -- HNSW vector index for efficient ANN search

--- a/server/schema_pg.sql
+++ b/server/schema_pg.sql
@@ -91,6 +91,7 @@ CREATE TABLE IF NOT EXISTS memories (
     memory_type     VARCHAR(20)     NOT NULL DEFAULT 'pinned',
     agent_id        VARCHAR(100)    NULL,
     session_id      VARCHAR(100)    NULL,
+    app_id          VARCHAR(100)    NOT NULL DEFAULT '',
     state           VARCHAR(20)     NOT NULL DEFAULT 'active',
     version         INT             DEFAULT 1,
     updated_by      VARCHAR(100),
@@ -103,6 +104,7 @@ CREATE INDEX IF NOT EXISTS idx_memory_source ON memories(source);
 CREATE INDEX IF NOT EXISTS idx_memory_state ON memories(state);
 CREATE INDEX IF NOT EXISTS idx_memory_agent ON memories(agent_id);
 CREATE INDEX IF NOT EXISTS idx_memory_session ON memories(session_id);
+CREATE INDEX IF NOT EXISTS idx_memory_app ON memories(app_id);
 CREATE INDEX IF NOT EXISTS idx_memory_updated ON memories(updated_at);
 
 CREATE TABLE IF NOT EXISTS upload_tasks (

--- a/site/AGENTS.md
+++ b/site/AGENTS.md
@@ -34,6 +34,7 @@ cd site && npx tsc --noEmit
 
 - TypeScript config extends `astro/tsconfigs/strict`.
 - Current content model is centralized in `src/content/site.ts`; copy changes usually belong there, not inline in components.
+- Any user-facing UI copy added or changed under `site/` must go through the existing i18n/content layer and update every supported locale in the same change. Do not hardcode visible UI text in components unless it is a protocol literal, stable identifier, or code sample.
 - Output is static (`output: 'static'`).
 - Netlify should keep `site/` as the package directory with the base directory unset. `netlify.toml` still lives here, but its build paths resolve from the repo root so it can build both `site/` and `dashboard/app/`, then copy dashboard assets into `site/dist/your-memory/`.
 - Locale and theme state use typed string unions and storage keys defined in `src/content/site.ts`.

--- a/site/src/components/ApiReference.astro
+++ b/site/src/components/ApiReference.astro
@@ -1,6 +1,7 @@
 ---
 import {
   DEFAULT_LOCALE,
+  localizeApiPageCopy,
   siteCopy,
   siteLocales,
   type SiteApiFieldCopy,
@@ -18,21 +19,50 @@ function linkRel(link: SiteLinkCopy): string | undefined {
 function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFieldCopy[] {
   return Array.isArray(fields) && fields.length > 0;
 }
+
+function endpointAnchor(groupId: string, endpoint: { method: string; path: string }, index: number): string {
+  const pathSlug = endpoint.path
+    .toLowerCase()
+    .replace(/^\/+/, "")
+    .replace(/[{}]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `api-${groupId}-${endpoint.method.toLowerCase()}-${pathSlug || index}`;
+}
+
+function endpointTestPayload(
+  group: { title: string },
+  endpoint: {
+    method: string;
+    path: string;
+    summary: string;
+    description?: string;
+    headers?: SiteApiFieldCopy[];
+    queryParams?: SiteApiFieldCopy[];
+    bodyFields?: SiteApiFieldCopy[];
+  },
+): string {
+  return JSON.stringify({
+    groupTitle: group.title,
+    method: endpoint.method,
+    path: endpoint.path,
+    summary: endpoint.summary,
+    description: endpoint.description ?? "",
+    headers: endpoint.headers ?? [],
+    queryParams: endpoint.queryParams ?? [],
+    bodyFields: endpoint.bodyFields ?? [],
+  });
+}
+
+const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 ---
 
 <section class="api-page" data-api-root data-api-locale={DEFAULT_LOCALE}>
   {siteLocales.map((locale) => {
-    const copy = siteCopy[locale].apiPage;
+    const copy = localizeApiPageCopy(locale, siteCopy[locale].apiPage);
     return (
       <div class="api-copy" data-api-copy={locale} hidden={locale !== DEFAULT_LOCALE}>
         <div class="container api-shell">
-          <section class="api-hero">
-            <p class="section-kicker">{copy.kicker}</p>
-            <h1 class="api-title">{copy.title}</h1>
-            <p class="api-intro">{copy.intro}</p>
-            <p class="api-summary">{copy.summary}</p>
-          </section>
-
           <div class="api-layout">
             <aside class="api-sidebar">
               <button class="api-toc-toggle" data-api-toc-toggle type="button">
@@ -41,16 +71,66 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
               </button>
               <nav class="api-toc surface-card">
                 <p class="api-toc-title">{copy.labels.sidebarTitle}</p>
+                <label class="api-toc-search">
+                  <span class="api-toc-search-label">{copy.labels.apiSearch}</span>
+                  <input
+                    type="search"
+                    inputmode="search"
+                    placeholder={copy.labels.apiSearchPlaceholder}
+                    autocomplete="off"
+                    data-api-toc-search
+                  />
+                </label>
+                <p class="api-toc-empty" data-api-toc-empty hidden>{copy.labels.apiSearchEmpty}</p>
                 <ol class="api-toc-list">
-                  <li>
+                  <li data-api-toc-static>
                     <a href="#api-auth" class="api-toc-link">{copy.labels.sidebarAuth}</a>
                   </li>
-                  <li>
+                  <li data-api-toc-static>
                     <a href="#api-quickstart" class="api-toc-link">{copy.labels.sidebarQuickstart}</a>
                   </li>
                   {copy.endpointGroups.map((group) => (
-                    <li>
-                      <a href={`#api-${group.id}`} class="api-toc-link">{group.title}</a>
+                    <li
+                      data-api-toc-group
+                      data-api-search={[
+                        group.title,
+                        group.description,
+                      ].join(" ")}
+                    >
+                      <div class="api-toc-group-row">
+                        <button
+                          class="api-toc-link api-toc-group-link"
+                          type="button"
+                          data-api-toc-group-toggle
+                          aria-expanded="true"
+                        >
+                          {group.title}
+                        </button>
+                      </div>
+                      <ol class="api-toc-sublist" data-api-toc-sublist>
+                        {group.endpoints.map((endpoint, index) => (
+                          <li
+                            data-api-toc-endpoint
+                            data-api-search={[
+                              group.title,
+                              endpoint.method,
+                              endpoint.path,
+                              endpoint.summary,
+                              endpoint.description ?? "",
+                            ].join(" ")}
+                          >
+                            <a href={`#${endpointAnchor(group.id, endpoint, index)}`} class="api-toc-link api-toc-sublink">
+                              <span class={`api-toc-method api-method-${endpoint.method.toLowerCase()}`}>
+                                {endpoint.method}
+                              </span>
+                              <span class="api-toc-endpoint-text">
+                                <span class="api-toc-endpoint-summary">{endpoint.summary}</span>
+                                <code class="api-toc-endpoint-path">{endpoint.path}</code>
+                              </span>
+                            </a>
+                          </li>
+                        ))}
+                      </ol>
                     </li>
                   ))}
                 </ol>
@@ -58,6 +138,13 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
             </aside>
 
             <div class="api-content">
+              <section class="api-hero">
+                <p class="section-kicker">{copy.kicker}</p>
+                <h1 class="api-title">{copy.title}</h1>
+                <p class="api-intro">{copy.intro}</p>
+                <p class="api-summary">{copy.summary}</p>
+              </section>
+
               <section
                 class="api-section"
                 id={locale === DEFAULT_LOCALE ? "api-auth" : undefined}
@@ -114,14 +201,29 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
                   </div>
 
                   <div class="api-endpoint-list">
-                    {group.endpoints.map((endpoint) => (
-                      <article class="surface-card api-endpoint-card">
+                    {group.endpoints.map((endpoint, index) => (
+                      <article
+                        class="surface-card api-endpoint-card"
+                        id={locale === DEFAULT_LOCALE ? endpointAnchor(group.id, endpoint, index) : undefined}
+                        data-api-anchor={endpointAnchor(group.id, endpoint, index)}
+                      >
                         <div class="api-endpoint-head">
-                          <div class="api-endpoint-route">
-                            <span class={`api-method api-method-${endpoint.method.toLowerCase()}`}>
-                              {endpoint.method}
-                            </span>
-                            <code class="api-path">{endpoint.path}</code>
+                          <div class="api-endpoint-top">
+                            <div class="api-endpoint-route">
+                              <span class={`api-method api-method-${endpoint.method.toLowerCase()}`}>
+                                {endpoint.method}
+                              </span>
+                              <code class="api-path">{endpoint.path}</code>
+                            </div>
+                            <button
+                              class="api-test-button"
+                              type="button"
+                              data-api-test-open
+                              data-api-test-endpoint={endpointTestPayload(group, endpoint)}
+                            >
+                              <span aria-hidden="true">▶</span>
+                              {copy.labels.testApi}
+                            </button>
                           </div>
                           <p class="api-endpoint-summary">{endpoint.summary}</p>
                           {endpoint.description && <p class="api-endpoint-description">{endpoint.description}</p>}
@@ -236,6 +338,92 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
       </div>
     );
   })}
+
+  <div class="api-test-modal" data-api-test-modal hidden>
+    <div class="api-test-dialog surface-card" role="dialog" aria-modal="true" aria-labelledby="api-test-title">
+      <div class="api-test-header">
+        <div>
+          <p class="api-test-kicker" data-api-test-method>GET</p>
+          <h2 id="api-test-title" data-api-test-title>
+            {defaultApiLabels.testTitle}
+          </h2>
+          <code class="api-test-path" data-api-test-path></code>
+        </div>
+        <button
+          class="api-test-close"
+          type="button"
+          data-api-test-close
+          data-i18n="apiPage.labels.close"
+          data-i18n-attr="aria-label:apiPage.labels.closeApiTestModal"
+          aria-label={defaultApiLabels.closeApiTestModal}
+        >
+          {defaultApiLabels.close}
+        </button>
+      </div>
+
+      <div class="api-test-action-row">
+        <label class="api-test-save-option">
+          <input type="checkbox" data-api-test-save-info checked />
+          <span data-i18n="apiPage.labels.saveFormInfo">
+            {defaultApiLabels.saveFormInfo}
+          </span>
+        </label>
+        <div class="api-test-action-buttons">
+          <button class="api-test-secondary" type="button" data-api-test-reset data-i18n="apiPage.labels.reset">
+            {defaultApiLabels.reset}
+          </button>
+          <button class="api-test-run" type="submit" form="api-test-form" data-api-test-run data-i18n="apiPage.labels.run">
+            {defaultApiLabels.run}
+          </button>
+        </div>
+      </div>
+
+      <div class="api-test-main">
+        <form id="api-test-form" class="api-test-form" data-api-test-form>
+          <label class="api-test-control api-test-control-wide">
+            <span class="api-test-field-title" data-i18n="apiPage.labels.baseUrl">{defaultApiLabels.baseUrl}</span>
+            <input type="url" data-api-test-base-url placeholder="https://api.mem9.ai" />
+          </label>
+
+          <div class="api-test-section" data-api-test-section="path">
+            <h3 data-i18n="apiPage.labels.pathParams">{defaultApiLabels.pathParams}</h3>
+            <div class="api-test-fields" data-api-test-path-fields></div>
+          </div>
+
+          <div class="api-test-section" data-api-test-section="headers">
+            <h3 data-i18n="apiPage.labels.headers">{defaultApiLabels.headers}</h3>
+            <div class="api-test-fields" data-api-test-header-fields></div>
+          </div>
+
+          <div class="api-test-section" data-api-test-section="query">
+            <h3 data-i18n="apiPage.labels.queryParams">{defaultApiLabels.queryParams}</h3>
+            <div class="api-test-fields" data-api-test-query-fields></div>
+          </div>
+
+          <div class="api-test-section" data-api-test-section="body">
+            <h3 data-i18n="apiPage.labels.body">{defaultApiLabels.body}</h3>
+            <div class="api-test-fields" data-api-test-body-fields></div>
+            <label class="api-test-control api-test-json-body" data-api-test-json-wrap>
+              <span class="api-test-field-title" data-i18n="apiPage.labels.jsonBody">{defaultApiLabels.jsonBody}</span>
+              <textarea data-api-test-json rows="12" spellcheck="false"></textarea>
+            </label>
+          </div>
+
+          <div class="api-test-url" data-api-test-url></div>
+        </form>
+
+        <section class="api-test-response" data-api-test-response>
+          <div class="api-test-response-head">
+            <div class="api-test-response-status">
+              <h3 data-i18n="apiPage.labels.response">{defaultApiLabels.response}</h3>
+              <p data-api-test-status>{defaultApiLabels.ready}</p>
+            </div>
+          </div>
+          <pre class="api-test-code"><code data-api-test-output>{defaultApiLabels.responseReady}</code></pre>
+        </section>
+      </div>
+    </div>
+  </div>
 </section>
 
 <style>
@@ -249,14 +437,13 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
 
   .api-shell {
     display: grid;
-    gap: 1.8rem;
   }
 
   .api-hero {
     width: min(100%, 72rem);
     display: grid;
     gap: 0.8rem;
-    padding: 0;
+    padding: 0 0 0.45rem;
   }
 
   .api-title {
@@ -281,8 +468,8 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
   /* Two-column layout */
   .api-layout {
     display: grid;
-    grid-template-columns: minmax(13rem, 16rem) minmax(0, 1fr);
-    gap: 1.35rem;
+    grid-template-columns: minmax(17rem, 22rem) minmax(0, 1fr);
+    gap: clamp(2.4rem, 4vw, 4rem);
     align-items: start;
   }
 
@@ -299,21 +486,8 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     max-height: inherit;
     overflow-y: auto;
     overscroll-behavior: contain;
-    scrollbar-gutter: stable;
+    scrollbar-gutter: auto;
     -webkit-overflow-scrolling: touch;
-  }
-
-  .api-toc::-webkit-scrollbar {
-    width: 0.55rem;
-  }
-
-  .api-toc::-webkit-scrollbar-thumb {
-    background: var(--button-active-border);
-    border-radius: 999px;
-  }
-
-  .api-toc::-webkit-scrollbar-track {
-    background: transparent;
   }
 
   .api-toc-title {
@@ -324,10 +498,49 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     margin-bottom: 0.9rem;
   }
 
+  .api-toc-search {
+    display: grid;
+    gap: 0.38rem;
+    margin-bottom: 0.85rem;
+  }
+
+  .api-toc-search-label {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+  }
+
+  .api-toc-search input {
+    width: 100%;
+    min-height: 2.2rem;
+    border: 1px solid var(--border);
+    border-radius: 0.72rem;
+    background: var(--button-bg);
+    color: var(--text);
+    padding: 0.46rem 0.58rem;
+    font: inherit;
+    font-size: 0.82rem;
+    outline: none;
+    box-shadow: var(--surface-inset);
+  }
+
+  .api-toc-search input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent), var(--surface-inset);
+  }
+
+  .api-toc-empty {
+    margin: 0 0 0.85rem;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
+  }
+
   .api-toc-list {
     list-style: none;
     display: grid;
-    gap: 0.3rem;
+    gap: 0.55rem;
   }
 
   .api-toc-link {
@@ -354,6 +567,93 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     opacity: 1;
   }
 
+  .api-toc-group-row {
+    display: block;
+  }
+
+  .api-toc-group-link {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    padding: 0.42rem 0.6rem;
+    border: 0;
+    border-left: 2px solid transparent;
+    border-radius: 0.8rem;
+    text-align: left;
+    background: transparent;
+    color: var(--text-dim);
+    cursor: pointer;
+    font: inherit;
+    appearance: none;
+    -webkit-appearance: none;
+  }
+
+  .api-toc-sublist {
+    list-style: none;
+    display: grid;
+    gap: 0.22rem;
+    margin: 0.24rem 0 0.1rem 0.72rem;
+    padding-left: 0.7rem;
+    border-left: 1px solid var(--border);
+  }
+
+  .api-toc-sublist[hidden] {
+    display: none;
+  }
+
+  .api-toc-sublink {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 0.42rem;
+    padding: 0.32rem 0.46rem;
+    border-left: 0;
+    border-radius: 0.62rem;
+    font-size: 0.78rem;
+    line-height: 1.32;
+  }
+
+  .api-toc-sublink.is-active {
+    border-left: 0;
+    background: var(--button-active-bg);
+  }
+
+  .api-toc-method {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.5rem;
+    padding: 0.1rem 0.28rem;
+    border-radius: 0.42rem;
+    border: 1px solid var(--button-active-border);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    line-height: 1.1;
+    color: var(--text);
+  }
+
+  .api-toc-endpoint-text {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    display: grid;
+    gap: 0.16rem;
+  }
+
+  .api-toc-endpoint-summary {
+    min-width: 0;
+  }
+
+  .api-toc-endpoint-path {
+    display: block;
+    min-width: 0;
+    color: var(--text-muted);
+    font-size: 0.68rem;
+    line-height: 1.25;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   /* Content area */
   .api-content {
     display: grid;
@@ -378,7 +678,7 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
 
   .api-auth-grid {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1rem;
   }
 
@@ -393,6 +693,13 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
   .api-auth-card {
     display: grid;
     gap: 0.55rem;
+    align-content: start;
+    min-height: 10.5rem;
+  }
+
+  .api-auth-card h3 {
+    font-size: 1rem;
+    line-height: 1.28;
   }
 
   .api-auth-card p,
@@ -436,6 +743,28 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     color: var(--accent);
   }
 
+  .api-field-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    padding: 0 0 0.55rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text);
+    font-size: 0.82rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .api-field-title::before {
+    content: '';
+    width: 0.22rem;
+    height: 0.95rem;
+    border-radius: 999px;
+    background: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+  }
+
   .api-code {
     padding: 0.95rem 1rem;
     border-radius: 0.95rem;
@@ -460,12 +789,27 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
 
   .api-endpoint-card {
     display: grid;
-    gap: 1.25rem;
+    gap: 1.15rem;
+    scroll-margin-top: 6rem;
   }
 
   .api-endpoint-head {
     display: grid;
-    gap: 0.6rem;
+    gap: 0.7rem;
+    padding: 0.95rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.9rem;
+    background:
+      linear-gradient(180deg, color-mix(in srgb, var(--button-active-bg) 72%, transparent), transparent),
+      var(--button-bg);
+    box-shadow: var(--surface-inset);
+  }
+
+  .api-endpoint-top {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
   }
 
   .api-endpoint-route {
@@ -473,6 +817,90 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     align-items: center;
     flex-wrap: wrap;
     gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .api-test-button,
+  .api-test-run,
+  .api-test-secondary,
+  .api-test-close {
+    border: 1px solid var(--button-active-border);
+    background: var(--button-bg);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s, transform 0.2s;
+  }
+
+  .api-test-button {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.34rem;
+    min-width: 6.7rem;
+    min-height: 2.28rem;
+    padding: 0.48rem 0.86rem;
+    border-radius: 0.55rem;
+    border-color: rgba(17, 17, 17, 0.9);
+    background: linear-gradient(180deg, #202020, #0f0f0f);
+    color: #ffffff;
+    font-weight: 750;
+    font-size: 0.8rem;
+    letter-spacing: 0;
+    box-shadow:
+      0 0 0 2px rgba(17, 17, 17, 0.07),
+      0 10px 22px rgba(17, 17, 17, 0.14),
+      var(--surface-inset);
+  }
+
+  .api-test-button span {
+    font-size: 0.66rem;
+    line-height: 1;
+  }
+
+  .api-test-button:hover,
+  .api-test-run:hover,
+  .api-test-secondary:hover,
+  .api-test-close:hover {
+    background: var(--button-hover-bg);
+    border-color: var(--border-strong);
+  }
+
+  .api-test-button:hover {
+    background: linear-gradient(180deg, #303030, #111111);
+    border-color: #111111;
+  }
+
+  .api-test-button:focus-visible {
+    outline: 3px solid rgba(17, 17, 17, 0.28);
+    outline-offset: 3px;
+  }
+
+  :global(html[data-theme='dark']) .api-test-button {
+    border-color: rgba(255, 255, 255, 0.82);
+    background: linear-gradient(180deg, #ffffff, #e8e8e4);
+    color: #111111;
+    box-shadow:
+      0 0 0 2px rgba(255, 255, 255, 0.12),
+      0 10px 22px rgba(255, 255, 255, 0.12),
+      var(--surface-inset);
+  }
+
+  :global(html[data-theme='dark']) .api-test-button:hover {
+    background: linear-gradient(180deg, #ffffff, #f4f4f1);
+    border-color: #ffffff;
+  }
+
+  :global(html[data-theme='dark']) .api-test-button:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.35);
+  }
+
+  .api-test-button:active,
+  .api-test-run:active,
+  .api-test-secondary:active,
+  .api-test-close:active {
+    transform: translateY(1px);
   }
 
   .api-method {
@@ -486,38 +914,95 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     font-size: 0.72rem;
     letter-spacing: 0.05em;
     border: 1px solid var(--button-active-border);
+    color: var(--text);
+    box-shadow: var(--surface-inset);
   }
 
   .api-method-get {
-    background: rgba(58, 123, 213, 0.12);
+    background: #dbeafe;
+    border-color: #93c5fd;
+    color: #1d4ed8;
   }
 
   .api-method-post {
-    background: rgba(44, 156, 104, 0.12);
+    background: #d1fae5;
+    border-color: #86efac;
+    color: #047857;
   }
 
   .api-method-put {
-    background: rgba(214, 142, 33, 0.12);
+    background: #fef3c7;
+    border-color: #fcd34d;
+    color: #92400e;
+  }
+
+  .api-method-patch {
+    background: #ede9fe;
+    border-color: #c4b5fd;
+    color: #6d28d9;
   }
 
   .api-method-delete {
-    background: rgba(198, 70, 70, 0.12);
+    background: #fee2e2;
+    border-color: #fca5a5;
+    color: #b91c1c;
+  }
+
+  :global(html[data-theme='dark']) .api-method-get {
+    background: rgba(96, 165, 250, 0.24);
+    border-color: rgba(147, 197, 253, 0.62);
+    color: #dbeafe;
+  }
+
+  :global(html[data-theme='dark']) .api-method-post {
+    background: rgba(52, 211, 153, 0.22);
+    border-color: rgba(110, 231, 183, 0.62);
+    color: #d1fae5;
+  }
+
+  :global(html[data-theme='dark']) .api-method-put {
+    background: rgba(251, 191, 36, 0.24);
+    border-color: rgba(252, 211, 77, 0.64);
+    color: #fef3c7;
+  }
+
+  :global(html[data-theme='dark']) .api-method-patch {
+    background: rgba(196, 181, 253, 0.24);
+    border-color: rgba(221, 214, 254, 0.64);
+    color: #ede9fe;
+  }
+
+  :global(html[data-theme='dark']) .api-method-delete {
+    background: rgba(248, 113, 113, 0.22);
+    border-color: rgba(252, 165, 165, 0.64);
+    color: #fee2e2;
   }
 
   .api-path {
-    font-size: 0.96rem;
-    color: var(--text);
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.28rem 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: 0.62rem;
+    background: var(--bg-terminal);
+    color: var(--accent);
+    font-size: 0.9rem;
+    line-height: 1.35;
     word-break: break-word;
+    box-shadow: var(--surface-inset);
   }
 
   .api-endpoint-summary {
-    font-size: 1.08rem;
-    font-weight: 600;
+    font-size: 1.14rem;
+    font-weight: 700;
     color: var(--text);
+    line-height: 1.35;
   }
 
   .api-endpoint-description {
-    color: var(--text-dim);
+    max-width: 82ch;
+    color: var(--text-muted);
     line-height: 1.68;
   }
 
@@ -529,17 +1014,22 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
   .api-field-block {
     display: grid;
     gap: 0.55rem;
-    padding: 0;
+    padding: 0.95rem 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.9rem;
+    background: color-mix(in srgb, var(--button-bg) 70%, transparent);
+    box-shadow: var(--surface-inset);
   }
 
   .api-field-list {
     display: grid;
-    gap: 0.8rem;
+    gap: 0.85rem;
+    margin-top: 0.1rem;
   }
 
   .api-field-row {
     display: grid;
-    gap: 0.2rem;
+    gap: 0.34rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--border);
   }
@@ -557,15 +1047,34 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     color: var(--text);
   }
 
+  .api-field-row dt code {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    padding: 0.18rem 0.46rem;
+    border: 1px solid var(--button-active-border);
+    border-radius: 0.52rem;
+    background: var(--button-active-bg);
+    color: var(--text);
+    font-size: 0.82rem;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+  }
+
+  .api-field-row dd {
+    color: var(--text-muted);
+    font-size: 0.94rem;
+  }
+
   .api-required {
     display: inline-flex;
     align-items: center;
     padding: 0.12rem 0.42rem;
     border-radius: 999px;
-    background: var(--button-active-bg);
-    border: 1px solid var(--button-active-border);
+    background: color-mix(in srgb, var(--accent) 13%, var(--button-active-bg));
+    border: 1px solid color-mix(in srgb, var(--accent) 42%, var(--button-active-border));
     font-size: 0.72rem;
-    color: var(--text-dim);
+    color: var(--text);
   }
 
   .api-cta {
@@ -593,6 +1102,461 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
     box-shadow: var(--surface-inset), var(--surface-shadow-soft);
   }
 
+  .api-test-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 90;
+    display: grid;
+    place-items: center;
+    padding: 1.2rem;
+    background: rgba(0, 0, 0, 0.56);
+    backdrop-filter: blur(12px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
+  .api-test-modal[hidden] {
+    display: none;
+  }
+
+  .api-test-modal.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .api-test-dialog {
+    width: min(96vw, 90rem);
+    max-height: min(92dvh, 56rem);
+    overflow: auto;
+    padding: 1rem;
+    background: linear-gradient(180deg, var(--surface-elevated-start), var(--surface-elevated-end));
+    box-shadow: var(--surface-shadow), var(--surface-inset);
+  }
+
+  .api-test-header {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 0.8rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .api-test-kicker {
+    margin-bottom: 0.32rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+  }
+
+  .api-test-header h2 {
+    font-size: clamp(1.1rem, 2vw, 1.55rem);
+    line-height: 1.18;
+  }
+
+  .api-test-path {
+    display: inline-block;
+    margin-top: 0.45rem;
+    max-width: 100%;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--border);
+    border-radius: 0.55rem;
+    background: var(--bg-terminal);
+    color: var(--accent);
+    overflow-wrap: anywhere;
+  }
+
+  .api-test-close,
+  .api-test-secondary,
+  .api-test-run {
+    min-height: 2.35rem;
+    border-radius: 999px;
+    padding: 0.45rem 0.9rem;
+    font-weight: 700;
+  }
+
+  .api-test-form {
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  .api-test-action-row {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.65rem;
+    padding: 0.78rem 0 0;
+  }
+
+  .api-test-save-option {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    color: var(--text-dim);
+    font-size: 0.84rem;
+    line-height: 1;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .api-test-save-option input {
+    width: 1rem;
+    height: 1rem;
+    margin: 0;
+    accent-color: var(--accent);
+    cursor: pointer;
+  }
+
+  .api-test-save-option:hover {
+    color: var(--text);
+  }
+
+  .api-test-action-buttons {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.65rem;
+  }
+
+  .api-test-main {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(24rem, 0.86fr);
+    gap: 1rem;
+    align-items: start;
+    padding-top: 0.65rem;
+  }
+
+  .api-test-control {
+    display: grid;
+    gap: 0.5rem;
+    min-width: 0;
+    align-content: start;
+  }
+
+  .api-test-field-title,
+  .api-test-label-line,
+  .api-test-section h3,
+  .api-test-response h3 {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.05em;
+    color: var(--text);
+    font-weight: 760;
+  }
+
+  .api-test-field-title,
+  .api-test-label-line {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.28rem;
+    min-height: 1.25rem;
+    line-height: 1.25;
+  }
+
+  .api-test-label-name {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .api-test-required-mark {
+    color: #ff6b6b;
+    font-size: 0.98rem;
+    font-weight: 900;
+    line-height: 1;
+    text-shadow: 0 0 12px rgba(255, 107, 107, 0.52);
+  }
+
+  .api-test-control input,
+  .api-test-control textarea {
+    width: 100%;
+    border: 1px solid var(--border);
+    border-radius: 0.72rem;
+    background: var(--button-bg);
+    color: var(--text);
+    padding: 0.58rem 0.68rem;
+    font: inherit;
+    font-size: 0.88rem;
+    outline: none;
+    box-shadow: var(--surface-inset);
+  }
+
+  .api-test-control textarea {
+    min-height: 11rem;
+    resize: vertical;
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    line-height: 1.55;
+  }
+
+  .api-test-control input:focus,
+  .api-test-control textarea:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent), var(--surface-inset);
+  }
+
+  .api-test-section {
+    display: grid;
+    gap: 0.55rem;
+    padding: 0.72rem;
+    border: 1px solid var(--border);
+    border-radius: 0.9rem;
+    background: color-mix(in srgb, var(--button-bg) 70%, transparent);
+    box-shadow: var(--surface-inset);
+  }
+
+  .api-test-section[hidden],
+  .api-test-response[hidden] {
+    display: none;
+  }
+
+  .api-test-fields {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.65rem;
+  }
+
+  .api-test-help {
+    border-left: 2px solid color-mix(in srgb, var(--accent) 34%, var(--border));
+    padding-left: 0.44rem;
+    color: var(--text-dim);
+    font-size: 0.72rem;
+    line-height: 1.45;
+    margin-top: -0.04rem;
+  }
+
+  .api-test-json-body {
+    margin-top: 0.2rem;
+  }
+
+  .api-test-url {
+    padding: 0.65rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    background: var(--bg-terminal);
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  :global(.api-test-control) {
+    display: grid;
+    gap: 0.36rem;
+    min-width: 0;
+    align-content: start;
+  }
+
+  :global(.api-test-label-line) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.28rem;
+    min-height: 1rem;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.05em;
+    line-height: 1.25;
+    color: var(--text);
+    font-weight: 760;
+  }
+
+  :global(.api-test-label-name) {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  :global(.api-test-required-mark) {
+    color: #ff6b6b;
+    font-size: 0.86rem;
+    font-weight: 900;
+    line-height: 1;
+    text-shadow: 0 0 12px rgba(255, 107, 107, 0.52);
+  }
+
+  :global(.api-test-control input),
+  :global(.api-test-control textarea) {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    border: 1px solid var(--border);
+    border-radius: 0.58rem;
+    background: var(--button-bg);
+    color: var(--text);
+    padding: 0.46rem 0.56rem;
+    font: inherit;
+    font-size: 0.78rem;
+    outline: none;
+    box-shadow: var(--surface-inset);
+  }
+
+  :global(.api-test-control textarea) {
+    min-height: 9rem;
+    resize: vertical;
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    line-height: 1.48;
+  }
+
+  :global(.api-test-control input:focus),
+  :global(.api-test-control textarea:focus) {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent), var(--surface-inset);
+  }
+
+  :global(.api-test-help) {
+    border-left: 2px solid color-mix(in srgb, var(--accent) 34%, var(--border));
+    padding-left: 0.44rem;
+    color: var(--text-dim);
+    font-size: 0.7rem;
+    line-height: 1.38;
+    margin-top: -0.02rem;
+  }
+
+  .api-test-run {
+    min-width: 7rem;
+    border-color: rgba(17, 17, 17, 0.9);
+    background: linear-gradient(180deg, #202020, #0f0f0f);
+    color: #ffffff;
+    box-shadow:
+      0 0 0 3px rgba(17, 17, 17, 0.08),
+      0 12px 26px rgba(17, 17, 17, 0.16),
+      var(--surface-inset);
+  }
+
+  .api-test-run:hover {
+    background: linear-gradient(180deg, #303030, #111111);
+    border-color: #111111;
+    color: #ffffff;
+  }
+
+  .api-test-run:focus-visible {
+    outline: 3px solid rgba(17, 17, 17, 0.28);
+    outline-offset: 3px;
+  }
+
+  :global(html[data-theme='dark']) .api-test-run {
+    border-color: rgba(255, 255, 255, 0.82);
+    background: linear-gradient(180deg, #ffffff, #e8e8e4);
+    color: #111111;
+    box-shadow:
+      0 0 0 3px rgba(255, 255, 255, 0.14),
+      0 12px 26px rgba(255, 255, 255, 0.14),
+      var(--surface-inset);
+  }
+
+  :global(html[data-theme='dark']) .api-test-run:hover {
+    background: linear-gradient(180deg, #ffffff, #f4f4f1);
+    border-color: #ffffff;
+    color: #111111;
+  }
+
+  :global(html[data-theme='dark']) .api-test-run:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.35);
+  }
+
+  .api-test-run[disabled] {
+    cursor: progress;
+    opacity: 0.68;
+  }
+
+  .api-test-response {
+    display: grid;
+    gap: 0.5rem;
+    min-height: 26rem;
+    align-content: start;
+    padding: 0;
+  }
+
+  .api-test-response-head {
+    display: flex;
+    align-items: center;
+    justify-content: start;
+    gap: 0.75rem;
+    min-height: 1.25rem;
+    padding-top: 0;
+  }
+
+  .api-test-response-head > div {
+    min-width: 0;
+  }
+
+  .api-test-response-status {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.55rem;
+    min-height: 0;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .api-test-response-head p {
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+  }
+
+  .api-test-code {
+    height: min(56vh, 33rem);
+    margin: 0;
+    padding: 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: 0.9rem;
+    background: var(--bg-terminal);
+    overflow: auto;
+    box-shadow: var(--surface-inset), var(--surface-shadow-soft);
+  }
+
+  .api-test-code code {
+    display: block;
+    white-space: pre;
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    line-height: 1.5;
+    color: var(--text);
+  }
+
+  :global(.api-json-key) {
+    color: #0f5f99;
+    font-weight: 700;
+  }
+
+  :global(.api-json-string) {
+    color: #047857;
+  }
+
+  :global(.api-json-number),
+  :global(.api-json-boolean) {
+    color: #9a4b00;
+    font-weight: 700;
+  }
+
+  :global(.api-json-null) {
+    color: #be185d;
+  }
+
+  :global(html[data-theme='dark']) :global(.api-json-key) {
+    color: #7dd3fc;
+  }
+
+  :global(html[data-theme='dark']) :global(.api-json-string) {
+    color: #86efac;
+  }
+
+  :global(html[data-theme='dark']) :global(.api-json-number),
+  :global(html[data-theme='dark']) :global(.api-json-boolean) {
+    color: #fbbf24;
+  }
+
+  :global(html[data-theme='dark']) :global(.api-json-null) {
+    color: #f472b6;
+  }
+
   /* Mobile TOC toggle */
   .api-toc-toggle {
     display: none;
@@ -601,6 +1565,14 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
   @media (max-width: 980px) {
     .api-layout {
       grid-template-columns: 1fr;
+    }
+
+    .api-test-main {
+      grid-template-columns: 1fr;
+    }
+
+    .api-test-code {
+      height: 20rem;
     }
 
     .api-sidebar {
@@ -684,6 +1656,33 @@ function hasFields(fields: SiteApiFieldCopy[] | undefined): fields is SiteApiFie
 
     .api-code code {
       font-size: 0.79rem;
+    }
+
+    .api-endpoint-top,
+    .api-test-header {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .api-test-action-row,
+    .api-test-response-head {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .api-test-action-buttons {
+      display: flex;
+      align-items: stretch;
+      justify-content: stretch;
+    }
+
+    .api-test-fields {
+      grid-template-columns: 1fr;
+    }
+
+    .api-test-run,
+    .api-test-secondary {
+      flex: 1;
     }
   }
 </style>

--- a/site/src/components/DocsPage.astro
+++ b/site/src/components/DocsPage.astro
@@ -1,5 +1,5 @@
 ---
-import { docsCopy, resolveDocsLocale, type DocsLink, type DocsLocale } from '../content/docs';
+import { docsCopy, resolveDocsLocale, type DocsLink, type DocsLocale, type DocsSection } from '../content/docs';
 import { DEFAULT_LOCALE } from '../content/site';
 
 const localeOrder: DocsLocale[] = ['zh', 'en', 'ja', 'ko', 'id', 'th'];
@@ -11,6 +11,39 @@ function linkTarget(link: DocsLink): string | undefined {
 
 function linkRel(link: DocsLink): string | undefined {
   return link.external ? 'noopener noreferrer' : undefined;
+}
+
+function docsSearchLabel(locale: DocsLocale): string {
+  return locale === 'zh' ? '搜索文档' : 'Search docs';
+}
+
+function docsSearchPlaceholder(locale: DocsLocale): string {
+  return locale === 'zh' ? '搜索导航或正文内容' : 'Search navigation or content';
+}
+
+function docsSearchEmpty(locale: DocsLocale): string {
+  return locale === 'zh' ? '没有匹配的文档。' : 'No matching docs.';
+}
+
+function plainText(value: string | undefined): string {
+  return (value ?? '').replace(/<[^>]*>/g, ' ');
+}
+
+function docsSectionSearchText(section: DocsSection): string {
+  return [
+    section.label,
+    section.title,
+    section.intro,
+    ...(section.paragraphs ?? []).map(plainText),
+    ...(section.bullets ?? []),
+    ...(section.links ?? []).map((link) => link.label),
+    ...(section.subsections ?? []).flatMap((subsection) => [
+      subsection.title,
+      ...(subsection.paragraphs ?? []).map(plainText),
+      ...(subsection.bullets ?? []),
+      ...(subsection.links ?? []).map((link) => link.label),
+    ]),
+  ].join(' ');
 }
 ---
 
@@ -34,10 +67,21 @@ function linkRel(link: DocsLink): string | undefined {
               </button>
               <div class="docs-toc surface-card">
                 <p class="docs-toc-title">{copy.hero.tocTitle}</p>
+                <label class="docs-toc-search">
+                  <span class="docs-toc-search-label">{docsSearchLabel(locale)}</span>
+                  <input
+                    type="search"
+                    inputmode="search"
+                    placeholder={docsSearchPlaceholder(locale)}
+                    autocomplete="off"
+                    data-docs-toc-search
+                  />
+                </label>
+                <p class="docs-toc-empty" data-docs-toc-empty hidden>{docsSearchEmpty(locale)}</p>
                 <nav aria-label={copy.hero.tocTitle}>
                   <div class="docs-toc-groups">
                     {copy.tocGroups.map((group) => (
-                      <details class="docs-toc-group" open>
+                      <details class="docs-toc-group" open data-docs-toc-group data-docs-search={group.title}>
                         <summary class="docs-toc-group-summary">
                           <span class="docs-toc-group-title">{group.title}</span>
                           <span class="docs-toc-group-icon" aria-hidden="true"></span>
@@ -48,7 +92,13 @@ function linkRel(link: DocsLink): string | undefined {
                             if (!section) return null;
 
                             return (
-                              <li>
+                              <li
+                                data-docs-toc-section
+                                data-docs-search={[
+                                  group.title,
+                                  docsSectionSearchText(section),
+                                ].join(' ')}
+                              >
                                 <a href={`#${section.id}`} class="docs-toc-link">
                                   <span class="docs-toc-index">{section.label}</span>
                                   <span>{section.title}</span>
@@ -217,6 +267,45 @@ function linkRel(link: DocsLink): string | undefined {
     letter-spacing: 0.05em;
     color: var(--accent);
     margin-bottom: 0.9rem;
+  }
+
+  .docs-toc-search {
+    display: grid;
+    gap: 0.38rem;
+    margin-bottom: 0.85rem;
+  }
+
+  .docs-toc-search-label {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+  }
+
+  .docs-toc-search input {
+    width: 100%;
+    min-height: 2.2rem;
+    border: 1px solid var(--border);
+    border-radius: 0.72rem;
+    background: var(--button-bg);
+    color: var(--text);
+    padding: 0.46rem 0.58rem;
+    font: inherit;
+    font-size: 0.82rem;
+    outline: none;
+    box-shadow: var(--surface-inset);
+  }
+
+  .docs-toc-search input:focus {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent), var(--surface-inset);
+  }
+
+  .docs-toc-empty {
+    margin: 0 0 0.85rem;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.45;
   }
 
   .docs-toc-list {

--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -71,16 +71,16 @@ const isActivePath = (path: string): boolean => currentPath === path;
           {nav.api}
         </a>
         <a
-          href="/your-memory/"
-          class="nav-section-link nav-external-link"
-          target="_blank"
-          rel="noopener"
+          href="/release-notes"
+          class:list={[
+            'nav-section-link',
+            'nav-release-notes-link',
+            isActivePath('/release-notes') && 'is-active',
+          ]}
+          data-i18n="nav.releaseNotes"
+          aria-current={isActivePath('/release-notes') ? 'page' : undefined}
         >
-          <span data-i18n="nav.yourMemory">{nav.yourMemory}</span>
-          <svg class="external-icon" viewBox="0 0 16 16" aria-hidden="true">
-            <path d="M6 3.5h6.5V10" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-            <path d="M12.5 3.5L4 12" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/>
-          </svg>
+          {nav.releaseNotes}
         </a>
         <a
           href="https://github.com/mem9-ai/mem9"
@@ -102,13 +102,59 @@ const isActivePath = (path: string): boolean => currentPath === path;
       </div>
 
       <div class="nav-actions">
-        <a
-          href="https://mem9.ai/console"
-          class="nav-login-link"
-          data-i18n="nav.login"
-        >
-          {nav.login}
-        </a>
+        <div class="menu-shell login-shell" data-menu-shell="login" data-open="false">
+          <button
+            type="button"
+            class="nav-login-link"
+            data-menu-trigger="login"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls="login-menu"
+            aria-label={nav.login}
+            title={nav.login}
+            data-i18n-attr="aria-label:nav.login;title:nav.login"
+          >
+            <span data-i18n="nav.login">{nav.login}</span>
+            <svg class="login-caret" viewBox="0 0 12 12" aria-hidden="true"><path d="M3 5l3 3 3-3" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+
+          <div
+            id="login-menu"
+            class="nav-menu login-menu surface-card"
+            data-menu="login"
+            role="menu"
+            hidden
+          >
+            <a
+              href="/your-memory/"
+              class="login-menu-item"
+              role="menuitem"
+              title={nav.yourMemoryDescription}
+              data-i18n-attr="title:nav.yourMemoryDescription"
+            >
+              <span class="login-option-content">
+                <span class="login-option-label" data-i18n="nav.yourMemory">{nav.yourMemory}</span>
+                <span class="login-option-tooltip" data-i18n="nav.yourMemoryDescription">
+                  {nav.yourMemoryDescription}
+                </span>
+              </span>
+            </a>
+            <a
+              href="https://mem9.ai/console"
+              class="login-menu-item"
+              role="menuitem"
+              title={nav.webConsoleDescription}
+              data-i18n-attr="title:nav.webConsoleDescription"
+            >
+              <span class="login-option-content">
+                <span class="login-option-label" data-i18n="nav.webConsole">{nav.webConsole}</span>
+                <span class="login-option-tooltip" data-i18n="nav.webConsoleDescription">
+                  {nav.webConsoleDescription}
+                </span>
+              </span>
+            </a>
+          </div>
+        </div>
 
         <div class="menu-shell" data-menu-shell="language" data-open="false">
           <button
@@ -406,28 +452,6 @@ const isActivePath = (path: string): boolean => currentPath === path;
     color: var(--text);
   }
 
-  /* External link icon */
-  .nav-external-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.3rem;
-  }
-
-  .external-icon {
-    width: 0.9rem;
-    height: 0.9rem;
-    opacity: 0.7;
-    flex-shrink: 0;
-    color: var(--text-soft);
-    transition: opacity 0.18s ease, color 0.18s ease;
-  }
-
-  .nav-external-link:hover .external-icon,
-  .nav-external-link:focus-visible .external-icon {
-    opacity: 1;
-    color: var(--text);
-  }
-
   /* GitHub icon link */
   .nav-github-link {
     display: inline-flex;
@@ -464,6 +488,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    gap: 0.35rem;
     min-width: 5.4rem;
     height: 2.55rem;
     padding: 0 1.15rem;
@@ -472,6 +497,7 @@ const isActivePath = (path: string): boolean => currentPath === path;
     background: var(--text);
     color: var(--bg-deep);
     box-shadow: 0 12px 28px rgba(0, 0, 0, 0.16);
+    cursor: pointer;
     font-size: 0.93rem;
     font-weight: 700;
     line-height: 1;
@@ -484,6 +510,17 @@ const isActivePath = (path: string): boolean => currentPath === path;
       color 0.2s ease;
   }
 
+  .login-caret {
+    width: 0.72rem;
+    height: 0.72rem;
+    transition: transform 0.2s ease;
+  }
+
+  .login-shell[data-open='true'] .login-caret {
+    transform: rotate(180deg);
+  }
+
+  .login-shell[data-open='true'] .nav-login-link,
   .nav-login-link:hover,
   .nav-login-link:focus-visible {
     transform: translateY(-1px);
@@ -492,6 +529,81 @@ const isActivePath = (path: string): boolean => currentPath === path;
     color: var(--bg-deep);
     opacity: 1;
     box-shadow: 0 16px 34px rgba(0, 0, 0, 0.18);
+  }
+
+  .login-menu {
+    min-width: 14.5rem;
+    overflow: visible;
+  }
+
+  .login-menu-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.7rem;
+    border: 1px solid transparent;
+    border-radius: 0.8rem;
+    padding: 0.65rem 0.75rem;
+    color: var(--text-dim);
+    white-space: nowrap;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+  }
+
+  .login-menu-item:hover,
+  .login-menu-item:focus-visible {
+    background: var(--button-active-bg);
+    border-color: var(--button-active-border);
+    color: var(--text);
+    opacity: 1;
+  }
+
+  .login-option-content {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .login-option-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .login-option-tooltip {
+    position: absolute;
+    right: calc(100% + 0.55rem);
+    top: 50%;
+    z-index: 35;
+    width: max-content;
+    max-width: min(18rem, calc(100vw - 2rem));
+    transform: translateY(-50%) translateX(0.25rem);
+    padding: 0.45rem 0.6rem;
+    border: 1px solid var(--border-strong);
+    border-radius: 0.65rem;
+    background: var(--menu-surface);
+    color: var(--text);
+    box-shadow: var(--menu-shadow);
+    font-size: 0.78rem;
+    font-weight: 500;
+    line-height: 1.35;
+    white-space: normal;
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+    transition:
+      opacity 0.15s ease,
+      transform 0.15s ease,
+      visibility 0.15s ease;
+  }
+
+  .login-menu-item:hover .login-option-tooltip,
+  .login-menu-item:focus-visible .login-option-tooltip {
+    opacity: 1;
+    transform: translateY(-50%);
+    visibility: visible;
   }
 
   .menu-shell {
@@ -612,8 +724,23 @@ const isActivePath = (path: string): boolean => currentPath === path;
     .nav-login-link {
       min-width: 0;
       height: 2.35rem;
-      padding: 0 0.9rem;
+      padding: 0 0.85rem 0 0.95rem;
       font-size: 0.84rem;
+    }
+
+    .login-menu {
+      min-width: min(15rem, calc(100vw - 2rem));
+    }
+
+    .login-option-tooltip {
+      right: 0;
+      top: calc(100% + 0.35rem);
+      transform: translateY(-0.15rem);
+    }
+
+    .login-menu-item:hover .login-option-tooltip,
+    .login-menu-item:focus-visible .login-option-tooltip {
+      transform: translateY(0);
     }
 
     .icon-button {

--- a/site/src/components/ReleaseNotes.astro
+++ b/site/src/components/ReleaseNotes.astro
@@ -1,0 +1,350 @@
+---
+import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
+---
+
+<section class="release-notes" data-release-notes-root data-release-notes-locale={DEFAULT_LOCALE}>
+  {siteLocales.map((locale) => {
+    const releaseNotes = siteCopy[locale].releaseNotesPage;
+    return (
+      <div
+        class="release-notes-copy"
+        data-release-notes-copy={locale}
+        hidden={locale !== DEFAULT_LOCALE}
+      >
+        <div class="container release-notes-shell">
+          <header class="release-notes-header">
+            <p class="section-kicker">{releaseNotes.kicker}</p>
+            <h1>{releaseNotes.title}</h1>
+            <p>{releaseNotes.intro}</p>
+            <div class="release-notes-star">
+              <span>{releaseNotes.starPrompt}</span>
+              <a href={releaseNotes.starHref} target="_blank" rel="noopener">
+                <img
+                  src={releaseNotes.starBadgeSrc}
+                  alt={releaseNotes.starBadgeAlt}
+                  loading="lazy"
+                />
+              </a>
+            </div>
+            <div class="release-notes-updated">
+              <span>{releaseNotes.updatedLabel}</span>
+              <strong>{releaseNotes.updatedValue}</strong>
+            </div>
+          </header>
+
+          <div class="release-note-groups">
+            {releaseNotes.groups.map((group, groupIndex) => (
+              <section
+                class="release-note-period"
+                aria-labelledby={`release-period-${locale}-${groupIndex}`}
+              >
+                <h2 id={`release-period-${locale}-${groupIndex}`}>{group.period}</h2>
+                <div class="release-note-list">
+                  {group.items.map((item) => (
+                    <article class="release-note-card surface-card">
+                      <div class="release-note-meta">{item.date}</div>
+                      <h3>{item.title}</h3>
+                      <p class="release-note-summary">{item.summary}</p>
+
+                      {item.sections && item.sections.length > 0 && (
+                        <div class="release-note-sections">
+                          {item.sections.map((section) => (
+                            <section class="release-note-section">
+                              <h4>{section.title}</h4>
+                              {section.body && <p>{section.body}</p>}
+                              {section.items &&
+                                section.items.length > 0 &&
+                                (section.ordered === false ? (
+                                  <ul>
+                                    {section.items.map((entry) => (
+                                      <li>{entry}</li>
+                                    ))}
+                                  </ul>
+                                ) : (
+                                  <ol>
+                                    {section.items.map((entry) => (
+                                      <li>{entry}</li>
+                                    ))}
+                                  </ol>
+                                ))}
+                            </section>
+                          ))}
+                        </div>
+                      )}
+
+                      <div class="release-note-sources" aria-label={releaseNotes.sourcesLabel}>
+                        <span>{releaseNotes.sourcesLabel}</span>
+                        <div>
+                          {item.sources.map((source) => (
+                            <a href={source.href} target="_blank" rel="noopener">
+                              {source.label}
+                            </a>
+                          ))}
+                        </div>
+                        <p>{releaseNotes.sourcesFeedback}</p>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  })}
+</section>
+
+<style>
+  .release-notes {
+    padding-top: 7rem;
+  }
+
+  .release-notes-copy[hidden] {
+    display: none;
+  }
+
+  .release-notes-shell {
+    display: grid;
+    gap: 4rem;
+  }
+
+  .release-notes-header {
+    max-width: 820px;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .release-notes-header h1 {
+    max-width: 920px;
+    font-size: clamp(2.35rem, 4.8vw, 4.25rem);
+    letter-spacing: -0.045em;
+  }
+
+  .release-notes-header p:not(.section-kicker) {
+    max-width: 760px;
+    color: var(--text-dim);
+    font-size: clamp(1.05rem, 2vw, 1.25rem);
+  }
+
+  .release-notes-star {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    max-width: 760px;
+    color: var(--text-dim);
+    font-size: 0.96rem;
+  }
+
+  .release-notes-star a {
+    display: inline-flex;
+    align-items: center;
+    line-height: 1;
+  }
+
+  .release-notes-star img {
+    display: block;
+    height: 1.25rem;
+    width: auto;
+  }
+
+  .release-notes-updated {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    width: fit-content;
+    margin-top: 0.45rem;
+    padding: 0.48rem 0.66rem;
+    border: 1px solid var(--border);
+    border-radius: 0.65rem;
+    background: var(--button-bg);
+    color: var(--text-dim);
+    font-size: 0.88rem;
+    box-shadow: var(--surface-inset);
+  }
+
+  .release-notes-updated strong {
+    color: var(--text);
+    font-weight: 700;
+  }
+
+  .release-note-groups {
+    display: grid;
+    gap: 4rem;
+  }
+
+  .release-note-period {
+    padding: 0;
+    display: grid;
+    grid-template-columns: minmax(10rem, 0.28fr) minmax(0, 1fr);
+    gap: 2rem;
+    align-items: start;
+  }
+
+  .release-note-period h2 {
+    position: sticky;
+    top: 6rem;
+    color: var(--text);
+    font-size: clamp(1.35rem, 2vw, 1.75rem);
+    letter-spacing: -0.03em;
+  }
+
+  .release-note-list {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .release-note-card {
+    display: grid;
+    gap: 1rem;
+    padding: clamp(1.1rem, 2vw, 1.45rem);
+    border-radius: 0.75rem;
+  }
+
+  .release-note-meta {
+    width: fit-content;
+    padding: 0.28rem 0.48rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    color: var(--accent);
+    background: var(--button-bg);
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    line-height: 1;
+  }
+
+  .release-note-card h3 {
+    max-width: 780px;
+    font-size: clamp(1.35rem, 2vw, 1.85rem);
+    letter-spacing: -0.035em;
+  }
+
+  .release-note-summary {
+    max-width: 820px;
+    color: var(--text-dim);
+    font-size: 1rem;
+  }
+
+  .release-note-sections {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .release-note-section {
+    display: grid;
+    gap: 0.55rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: 0.65rem;
+    background: var(--button-bg);
+    box-shadow: var(--surface-inset);
+  }
+
+  .release-note-section h4 {
+    font-size: 0.86rem;
+    letter-spacing: 0;
+  }
+
+  .release-note-section p {
+    color: var(--text-dim);
+  }
+
+  .release-note-section ol,
+  .release-note-section ul {
+    display: grid;
+    gap: 0.38rem;
+    padding-left: 1.2rem;
+    color: var(--text-dim);
+  }
+
+  .release-note-section li::marker {
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  .release-note-sources {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 0.45rem 0.8rem;
+    align-items: center;
+    color: var(--text-soft);
+    font-size: 0.84rem;
+  }
+
+  .release-note-sources > span {
+    font-family: var(--font-mono);
+    color: var(--text-soft);
+  }
+
+  .release-note-sources div {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+
+  .release-note-sources p {
+    grid-column: 2;
+    color: var(--text-soft);
+    font-size: 0.8rem;
+    line-height: 1.55;
+  }
+
+  .release-note-sources a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.75rem;
+    padding: 0.2rem 0.48rem;
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    background: var(--button-bg);
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 0.76rem;
+    line-height: 1;
+  }
+
+  .release-note-sources a:hover,
+  .release-note-sources a:focus-visible {
+    border-color: var(--button-active-border);
+    background: var(--button-active-bg);
+    color: var(--text);
+    opacity: 1;
+  }
+
+  @media (max-width: 820px) {
+    .release-notes {
+      padding-top: 5rem;
+    }
+
+    .release-note-period {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .release-note-period h2 {
+      position: static;
+    }
+  }
+
+  @media (max-width: 560px) {
+    .release-notes-shell,
+    .release-note-groups {
+      gap: 2.75rem;
+    }
+
+    .release-notes-header h1 {
+      font-size: 2.6rem;
+    }
+
+    .release-note-sources {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.55rem;
+    }
+
+    .release-note-sources p {
+      grid-column: 1;
+    }
+  }
+</style>

--- a/site/src/content/docs.ts
+++ b/site/src/content/docs.ts
@@ -441,6 +441,13 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
             ],
           },
           {
+            title: 'appId sub-spaces under one API key',
+            paragraphs: [
+              '`appId` lets one MEM9_API_KEY hold several isolated memory sub-spaces for different applications, agents, environments, or product scenarios. A memory or raw session written with `appId: "docs"` is associated with that appId, while a write with omitted, null, empty, or whitespace `appId` belongs to the default/global appId.',
+              'When querying, omitting `appId` means global search across every appId under the API key. Passing a non-empty `appId` searches only that exact sub-space. Passing `appId=null` or `appId=` searches only the default/global appId. appId isolation does not change API key ownership, permissions, quota, or billing; it only scopes memory/session writes and read filters.',
+            ],
+          },
+          {
             title: 'Hybrid recall',
             paragraphs: [
               'mem9 combines keyword and semantic recall so the system can search by exact terms and by current-task relevance. The goal is not perfect retrieval every time; the goal is to bring back better memory than a plain local file lookup can.',
@@ -869,6 +876,13 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
             title: '共享空间',
             paragraphs: [
               '多个 Agent 可以连接到同一个 mem9 空间，复用同一份长期知识。这对多设备使用、团队共享项目上下文，以及自动化 Agent 反复处理同类任务都很有价值。',
+            ],
+          },
+          {
+            title: '同一个 API key 下的 appId 子空间',
+            paragraphs: [
+              '`appId` 用来让一个 MEM9_API_KEY 承载多个彼此隔离的子记忆空间，例如不同应用、Agent、环境或产品场景。写入时带 `appId: "docs"` 的 memory 或 raw session 会关联到该 appId；省略、null、空字符串或纯空白 `appId` 的写入会归到默认/global appId。',
+              '查询时，不传 `appId` 表示跨该 API key 下的全部 appId 全局搜索；传非空 `appId` 表示只查这个精确子空间；传 `appId=null` 或 `appId=` 表示只查默认/global appId。appId 隔离不会改变 API key 的归属、权限、quota 或计费，只影响 memory/session 的写入归属和读取过滤。',
             ],
           },
           {

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -43,6 +43,9 @@ export interface SiteNavCopy {
   benchmark: string;
   openclaw: string;
   yourMemory: string;
+  yourMemoryDescription: string;
+  webConsole: string;
+  webConsoleDescription: string;
   login: string;
   billing: string;
   security: string;
@@ -50,6 +53,7 @@ export interface SiteNavCopy {
   github: string;
   docs: string;
   api: string;
+  releaseNotes: string;
   contact: string;
 }
 
@@ -257,6 +261,26 @@ export interface SiteApiPageCopy {
     sidebarTitle: string;
     sidebarAuth: string;
     sidebarQuickstart: string;
+    apiSearch: string;
+    apiSearchPlaceholder: string;
+    apiSearchEmpty: string;
+    testApi: string;
+    testTitle: string;
+    close: string;
+    closeApiTestModal: string;
+    reset: string;
+    run: string;
+    baseUrl: string;
+    pathParams: string;
+    jsonBody: string;
+    ready: string;
+    responseReady: string;
+    emptyResponse: string;
+    running: string;
+    runningRequest: string;
+    requestFailed: string;
+    pathParameter: string;
+    saveFormInfo: string;
   };
   authTitle: string;
   authCards: {
@@ -272,6 +296,59 @@ export interface SiteApiPageCopy {
   ctaBody: string;
   ctaLinks: SiteLinkCopy[];
 }
+
+export interface SiteReleaseNoteSource {
+  label: string;
+  href: string;
+}
+
+export interface SiteReleaseNoteSection {
+  title: string;
+  body?: string;
+  items?: string[];
+  ordered?: boolean;
+}
+
+export interface SiteReleaseNoteItem {
+  date: string;
+  title: string;
+  summary: string;
+  sections?: SiteReleaseNoteSection[];
+  sources: SiteReleaseNoteSource[];
+}
+
+export interface SiteReleaseNoteGroup {
+  period: string;
+  items: SiteReleaseNoteItem[];
+}
+
+export interface SiteReleaseNotesPageCopy {
+  meta: SiteMeta;
+  kicker: string;
+  title: string;
+  intro: string;
+  starPrompt: string;
+  starBadgeAlt: string;
+  starBadgeSrc: string;
+  starHref: string;
+  updatedLabel: string;
+  updatedValue: string;
+  sourcesLabel: string;
+  sourcesFeedback: string;
+  groups: SiteReleaseNoteGroup[];
+}
+
+type SiteReleaseNoteDraftItem = Omit<SiteReleaseNoteItem, 'sources'> & {
+  sources?: SiteReleaseNoteSource[];
+};
+
+type SiteReleaseNoteDraftGroup = Omit<SiteReleaseNoteGroup, 'items'> & {
+  items: SiteReleaseNoteDraftItem[];
+};
+
+type SiteReleaseNotesPageDraft = Omit<SiteReleaseNotesPageCopy, 'groups'> & {
+  groups: SiteReleaseNoteDraftGroup[];
+};
 
 export interface SiteBenchmarkCategoryScore {
   name: string;
@@ -338,6 +415,7 @@ export interface SiteDictionary {
   benchmark: SiteBenchmarkCopy;
   faq: SiteFaqCopy;
   apiPage: SiteApiPageCopy;
+  releaseNotesPage: SiteReleaseNotesPageCopy;
   securityPage: SiteSecurityPageCopy;
   billing: SiteBillingPageCopy;
   footer: SiteFooterCopy;
@@ -386,10 +464,17 @@ const createMemoryCode = `curl -sX POST "$API/memories" \\
   -H "Content-Type: application/json" \\
   -H "X-API-Key: $API_KEY" \\
   -H "X-Mnemo-Agent-Id: openclaw-main" \\
-  -d '{"content":"Project uses PostgreSQL 15","tags":["tech","database"],"metadata":{"source":"setup-note"}}'`;
-const listMemoryCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/memories?q=postgres&limit=5"';
+  -d '{"appId":"docs","content":"Project uses PostgreSQL 15","tags":["tech","database"],"metadata":{"source":"setup-note"}}'`;
+const smartIngestCode = `curl -sX POST "$API/memories" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $API_KEY" \\
+  -H "X-Mnemo-Agent-Id: openclaw-main" \\
+  -d '{"appId":"docs","session_id":"ses-001","mode":"smart","sync":true,"messages":[{"role":"user","content":"We use PostgreSQL 15"},{"role":"assistant","content":"Noted."}]}'`;
+const listMemoryCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/memories?q=postgres&appId=docs&limit=5"';
 const filterMemoryCode =
-  'curl -s -H "X-API-Key: $API_KEY" "$API/memories?tags=tech&source=openclaw-main&limit=10"';
+  'curl -s -H "X-API-Key: $API_KEY" "$API/memories?tags=tech&source=openclaw-main&appId=null&limit=10"';
+const keywordListMemoryCode =
+  'curl -s -H "X-API-Key: $API_KEY" "$API/memories?q=postgres&search_mode=keyword&appId=docs&limit=10&sort_by=updated_at&sort_dir=desc"';
 const getMemoryCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/memories/{id}"';
 const updateMemoryCode = `curl -sX PUT "$API/memories/{id}" \\
   -H "Content-Type: application/json" \\
@@ -405,17 +490,23 @@ const importMemoryFileCode = `curl -sX POST "$API/imports" \\
   -H "X-API-Key: $API_KEY" \\
   -F "file=@memory.json" \\
   -F "file_type=memory" \\
-  -F "agent_id=openclaw-main"`;
+  -F "agent_id=openclaw-main"
+
+# memory.json may include:
+# {"appId":"docs","memories":[{"content":"Project uses PostgreSQL 15","appId":"docs"}]}`;
 const importSessionFileCode = `curl -sX POST "$API/imports" \\
   -H "X-API-Key: $API_KEY" \\
   -F "file=@session.json" \\
   -F "file_type=session" \\
   -F "session_id=ses-001" \\
-  -F "agent_id=openclaw-main"`;
+  -F "agent_id=openclaw-main"
+
+# session.json may include:
+# {"appId":"docs","session_id":"ses-001","messages":[{"role":"user","content":"..."}]}`;
 const listImportsCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/imports"';
 const getImportCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/imports/{id}"';
 const sessionMessagesCode =
-  'curl -s -H "X-API-Key: $API_KEY" "$API/session-messages?session_id=ses-001&session_id=ses-002&limit_per_session=20"';
+  'curl -s -H "X-API-Key: $API_KEY" "$API/session-messages?session_id=ses-001&session_id=ses-002&appId=docs&limit_per_session=20"';
 const keyStatusCode = 'curl -s -H "X-API-Key: $API_KEY" https://api.mem9.ai/v1alpha2/status';
 const chainKeyStatusCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" https://api.mem9.ai/v1alpha2/status';
 const createSpaceChainCode = `curl -sX POST https://api.mem9.ai/v1alpha2/space-chains \\
@@ -885,12 +976,12 @@ const faqCopyByLocale: Record<SiteLocale, SiteFaqCopy> = {
 };
 
 const hostedReadHeaders: SiteApiFieldCopy[] = [
-  { name: 'X-API-Key', description: 'Hosted API key for your mem9 space.', required: true },
+  { name: 'X-API-Key', description: 'mem9 API key for your space.', required: true },
   { name: 'X-Mnemo-Agent-Id', description: 'Optional agent identity header for attribution.' },
 ];
 
 const hostedJSONWriteHeaders: SiteApiFieldCopy[] = [
-  { name: 'X-API-Key', description: 'Hosted API key for your mem9 space.', required: true },
+  { name: 'X-API-Key', description: 'mem9 API key for your space.', required: true },
   { name: 'Content-Type', description: 'Set to `application/json` for JSON request bodies.', required: true },
   { name: 'X-Mnemo-Agent-Id', description: 'Optional agent identity header for attribution.' },
 ];
@@ -901,7 +992,7 @@ const hostedUpdateHeaders: SiteApiFieldCopy[] = [
 ];
 
 const hostedMultipartHeaders: SiteApiFieldCopy[] = [
-  { name: 'X-API-Key', description: 'Hosted API key for your mem9 space.', required: true },
+  { name: 'X-API-Key', description: 'mem9 API key for your space.', required: true },
   {
     name: 'Content-Type',
     description: 'Your HTTP client sends this as `multipart/form-data`.',
@@ -920,26 +1011,45 @@ const chainJSONWriteHeaders: SiteApiFieldCopy[] = [
 ];
 
 const memoryCreateBodyFields: SiteApiFieldCopy[] = [
-  { name: 'content', description: 'Plain memory content for direct writes.' },
-  { name: 'messages', description: 'Conversation messages for ingest-based writes.' },
+  { name: 'content', description: 'Plain memory content for direct writes. Required when `messages` is absent.' },
+  { name: 'messages', description: 'Conversation messages for ingest-based writes. Required when `content` is absent.' },
+  {
+    name: 'appId',
+    description:
+      'Optional application isolation id, max 100 characters. Omitted, null, empty, or whitespace values write to the default/global appId; non-empty values are trimmed and stored exactly.',
+  },
+  { name: 'memory_type', description: 'Only accepted with `content` writes. Use `insight` or `pinned`; defaults to `insight`.' },
   { name: 'agent_id', description: 'Optional agent id to store with the write.' },
   { name: 'session_id', description: 'Optional session id for ingest or attribution.' },
   { name: 'tags', description: 'Optional string tags stored on the memory.' },
   { name: 'metadata', description: 'Optional JSON metadata payload.' },
   { name: 'mode', description: 'Ingest mode such as `smart` or `raw` when using `messages`.' },
   { name: 'sync', description: 'When true, wait for completion before returning.' },
+  { name: 'disableSessionSave', description: 'Message ingest only. When true, skip raw session persistence and only extract/reconcile facts.' },
 ];
 
 const memoryListQueryParams: SiteApiFieldCopy[] = [
-  { name: 'q', description: 'Semantic / keyword search query.' },
+  { name: 'q', description: 'Search query. Omit to list memories by filters.' },
+  {
+    name: 'search_mode',
+    description:
+      'Optional search behavior. Use `keyword` for direct content substring matching in list UIs; omit it for the default recall-style search.',
+  },
   { name: 'tags', description: 'Comma-separated tag filter.' },
   { name: 'source', description: 'Filter by stored source value.' },
   { name: 'state', description: 'Filter by lifecycle state such as `active` or `archived`.' },
   { name: 'memory_type', description: 'Filter by `insight`, `pinned`, or `session`.' },
   { name: 'agent_id', description: 'Filter by agent id.' },
   { name: 'session_id', description: 'Filter by session id.' },
+  {
+    name: 'appId',
+    description:
+      'Optional appId filter. Omit to search all appIds, pass a value for exact isolation, or use `appId=null` / `appId=` for default/global.',
+  },
   { name: 'limit', description: 'Page size. The handler caps large values.' },
   { name: 'offset', description: 'Offset for pagination.' },
+  { name: 'sort_by', description: 'Sort field used when listing memories, such as `updated_at`.' },
+  { name: 'sort_dir', description: 'Sort direction, `asc` or `desc`.' },
   {
     name: 'scanAll',
     description:
@@ -962,10 +1072,18 @@ const importBodyFields: SiteApiFieldCopy[] = [
   { name: 'file_type', description: 'Use `memory` or `session`.', required: true },
   { name: 'agent_id', description: 'Optional agent id for attribution.' },
   { name: 'session_id', description: 'Required when uploading `session` files.' },
+  { name: 'file.appId', description: 'Optional top-level appId inside JSON memory/session files.' },
+  { name: 'file.memories[].appId', description: 'Optional per-memory appId override inside JSON memory files.' },
+  { name: 'file.sessions[].appId', description: 'Optional per-session appId override inside JSON session files.' },
 ];
 
 const sessionMessagesQueryParams: SiteApiFieldCopy[] = [
   { name: 'session_id', description: 'Repeat this query param for each session to fetch.', required: true },
+  {
+    name: 'appId',
+    description:
+      'Optional appId filter. Omit to fetch matching sessions across all appIds, or use `appId=null` / `appId=` for default/global.',
+  },
   { name: 'limit_per_session', description: 'Optional per-session row limit.' },
 ];
 
@@ -997,10 +1115,21 @@ const memoryObjectResponseFields: SiteApiFieldCopy[] = [
   { name: 'id', description: 'Memory id.', required: true },
   { name: 'content', description: 'Stored memory content.', required: true },
   { name: 'memory_type', description: 'Memory type such as `insight`, `pinned`, or `session`.', required: true },
+  { name: 'appId', description: 'Application isolation id. Empty string means default/global.' },
+  { name: 'source', description: 'Stored source value when present.' },
+  { name: 'tags', description: 'String tag array when present.' },
+  { name: 'metadata', description: 'Raw JSON metadata when present.' },
+  { name: 'agent_id', description: 'Agent id associated with the memory when present.' },
+  { name: 'session_id', description: 'Session id associated with the memory when present.' },
+  { name: 'updated_by', description: 'Agent or actor that last updated the memory when present.' },
+  { name: 'superseded_by', description: 'Replacement memory id when this memory has been superseded.' },
   { name: 'state', description: 'Lifecycle state.', required: true },
   { name: 'version', description: 'Current integer version.', required: true },
   { name: 'created_at', description: 'Creation timestamp.', required: true },
   { name: 'updated_at', description: 'Last update timestamp.', required: true },
+  { name: 'score', description: 'Search relevance score when returned by search endpoints.' },
+  { name: 'confidence', description: 'Recall confidence score when returned by recall-style search.' },
+  { name: 'relative_age', description: 'Human-readable recency string populated for query-time search results.' },
 ];
 
 const statusOnlyResponseFields: SiteApiFieldCopy[] = [
@@ -1028,6 +1157,18 @@ const importTaskDetailResponseFields: SiteApiFieldCopy[] = [
 
 const sessionMessagesResponseFields: SiteApiFieldCopy[] = [
   { name: 'messages', description: 'Array of captured session message rows.', required: true },
+  { name: 'messages[].id', description: 'Session message row id.', required: true },
+  { name: 'messages[].session_id', description: 'Session id for the row.' },
+  { name: 'messages[].agent_id', description: 'Agent id for the row when present.' },
+  { name: 'messages[].appId', description: 'Application isolation id for each raw session row.' },
+  { name: 'messages[].seq', description: 'Sequence number within the session.', required: true },
+  { name: 'messages[].role', description: 'Message role such as `user` or `assistant`.', required: true },
+  { name: 'messages[].content', description: 'Message content.', required: true },
+  { name: 'messages[].content_type', description: 'Content type for the captured message.', required: true },
+  { name: 'messages[].tags', description: 'Captured tags for the row.', required: true },
+  { name: 'messages[].state', description: 'Lifecycle state for the row.', required: true },
+  { name: 'messages[].created_at', description: 'Creation timestamp.', required: true },
+  { name: 'messages[].updated_at', description: 'Last update timestamp.', required: true },
   { name: 'limit_per_session', description: 'Applied per-session limit.', required: true },
 ];
 
@@ -1269,51 +1410,75 @@ const versionEndpoint: SiteApiEndpointCopy = {
 const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   en: {
     meta: {
-      title: 'mem9 API | Hosted API Reference',
+      title: 'mem9 API | API Reference',
       description:
-        'Reference for provisioning API keys, reading and writing memories, importing files, and querying session messages on the hosted mem9 API.',
+        'Reference for provisioning API keys, reading and writing memories, importing files, appId isolation, and querying session messages with the mem9 API.',
     },
     kicker: 'API',
-    title: 'Hosted mem9 API reference',
+    title: 'mem9 API reference',
     intro:
-      'Use the hosted mem9 API to provision a space, write or search memory, import existing files, and inspect captured session messages.',
+      'Use the mem9 API to provision a space, write or search memory, isolate sub-spaces with appId, import existing files, and inspect captured session messages. The examples use mem9.ai; self-hosted deployments use the same routes under your own base URL.',
     summary:
       'Prefer `v1alpha2` for day-to-day usage. `v1alpha1` stays available for key provisioning and tenant-scoped compatibility.',
     labels: {
       headers: 'Headers',
       queryParams: 'Query Params',
       body: 'Body',
-      response: 'Response',
+      response: 'Response Body',
       examples: 'Examples',
       required: 'Required',
       next: 'Next',
       sidebarTitle: 'On this page',
       sidebarAuth: 'Authentication',
       sidebarQuickstart: 'Quick Start',
+      apiSearch: 'Search API',
+      apiSearchPlaceholder: 'Search path or name',
+      apiSearchEmpty: 'No matching APIs.',
+      testApi: 'Test API',
+      testTitle: 'Test API',
+      close: 'Close',
+      closeApiTestModal: 'Close API test modal',
+      reset: 'Reset',
+      run: 'Run',
+      baseUrl: 'Base URL',
+      pathParams: 'Path Params',
+      jsonBody: 'JSON body',
+      ready: 'Ready',
+      responseReady: 'Run a request to inspect the response.',
+      emptyResponse: 'empty response',
+      running: 'Running...',
+      runningRequest: 'Running request...',
+      requestFailed: 'Request failed',
+      pathParameter: 'Path parameter.',
+      saveFormInfo: 'Save form info',
     },
     authTitle: 'Base URL & authentication',
     authCards: [
       {
-        title: 'Hosted base URL',
-        body: 'Use `https://api.mem9.ai`. For normal client traffic, send requests to `https://api.mem9.ai/v1alpha2/mem9s/...`.',
+        title: 'Base URL',
+        body: 'For mem9.ai, use `https://api.mem9.ai`. For self-hosting, replace it with your deployment origin; runtime memory calls live under `/v1alpha2/mem9s/...`.',
       },
       {
-        title: 'Primary auth header',
-        body: 'Send your mem9 API key in `X-API-Key`. This is the default hosted auth model for `v1alpha2`.',
+        title: 'API key header',
+        body: 'Send the space API key in `X-API-Key` for `v1alpha2` runtime calls. mem9.ai keys can be provisioned with `POST /v1alpha1/mem9s`; self-hosted deployments use keys from their own control plane.',
       },
       {
-        title: 'Optional agent identity',
-        body: 'Send `X-Mnemo-Agent-Id` when you want writes and imports attributed to a specific agent. Legacy tenant-scoped routes still exist under `v1alpha1`.',
+        title: 'Agent identity',
+        body: '`X-Mnemo-Agent-Id` is optional. Use it to attribute writes and imports to a specific agent; request body `agent_id` takes precedence when both are present.',
+      },
+      {
+        title: 'appId isolation',
+        body: '`appId` partitions memories and raw sessions under the same API key. Omit `appId` to search all appIds, pass a value for exact scope, or pass `null`/empty for default global memory.',
       },
     ],
     quickstartTitle: 'Quick start',
     quickstartDescription:
-      'A minimal hosted flow is: provision a key, export it into your shell, then create and search memories.',
+      'A minimal mem9.ai flow is: provision a key, export it into your shell, then create and search memories. For self-hosting, keep the same paths and replace the base URL.',
     quickstartSteps: [
       'Provision a new API key with `POST /v1alpha1/mem9s`.',
       'Export that key as `API_KEY` and set `API=https://api.mem9.ai/v1alpha2/mem9s`.',
-      'Create a memory with `POST /memories`.',
-      'Search it back with `GET /memories?q=...`.',
+      'Create a memory with `POST /memories`. Add `appId` when one API key should hold separate app-specific memory pools.',
+      'Search it back with `GET /memories?q=...`. Omit `appId` to search all appIds, or pass one appId to isolate the result set.',
     ],
     quickstartExamples: [
       { label: 'Provision key', code: provisionKeyCode },
@@ -1325,56 +1490,60 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       {
         id: 'provisioning',
         title: 'Provisioning',
-        description: 'Create the initial key you will reuse for hosted mem9 access.',
+        description: 'Create the initial key you will reuse for mem9.ai API access.',
         endpoints: [
           {
             method: 'POST',
             path: '/v1alpha1/mem9s',
             summary: 'Provision a new mem9 API key.',
             description:
-              'No auth or request body is required. The hosted service returns `201` with an `id` field, and that `id` is the key you store and reuse.',
+              'No auth or request body is required. The mem9.ai service returns `201` with an `id` field, and that `id` is the key you store and reuse.',
             responseFields: provisionResponseFields,
             examples: [{ label: 'Provision key', code: provisionKeyCode }],
           },
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
-        description: 'Create, search, read, update, and delete stored memories in your mem9 space.',
+        description:
+          'Create, search, read, update, and delete stored memories in your mem9 space. The optional `appId` field lets one API key host multiple isolated application sub-spaces.',
         endpoints: [
           {
             method: 'POST',
             path: '/v1alpha2/mem9s/memories',
             summary: 'Create a memory or ingest messages.',
             description:
-              'Use `content` for direct writes or `messages` for ingest-driven writes. Do not send both in the same request.',
+              'Use `content` for direct writes or `messages` for ingest-driven writes. Do not send both in the same request. `appId` is optional; omitted, null, empty, and whitespace values are stored as the default/global appId.',
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: 'Create memory', code: createMemoryCode }],
+            examples: [
+              { label: 'Create memory', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories',
             summary: 'List or search memories.',
             description:
-              'When `q` is present, the handler runs recall search. Without `q`, the endpoint behaves like a filtered list API.',
+              'When `q` is present, the handler runs recall search by default. Use `search_mode=keyword` for direct content substring matching. `appId` has three-state query semantics: omit it to search all appIds, pass a non-empty value for exact isolation, or pass `appId=null` / `appId=` for the default/global appId.',
             headers: hostedReadHeaders,
             queryParams: memoryListQueryParams,
             responseFields: memoryListResponseFields,
             examples: [
               { label: 'Search memories', code: listMemoryCode },
               { label: 'Filter by tags / source', code: filterMemoryCode },
+              { label: 'Direct content keyword search', code: keywordListMemoryCode },
             ],
           },
           {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories/{id}',
             summary: 'Read one memory by id.',
-            description: 'Fetch a single stored memory object from the hosted service.',
+            description: 'Fetch a single stored memory object from the mem9 API.',
             headers: hostedReadHeaders,
             responseFields: memoryObjectResponseFields,
             examples: [{ label: 'Get memory', code: getMemoryCode }],
@@ -1401,10 +1570,11 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
-        description: 'Upload memory or session files and poll their background task status.',
+        description: 'Upload memory or session files and poll their background task status. Imported memories and raw sessions can carry `appId` at the file, memory, or session level.',
         endpoints: [
           {
             method: 'POST',
@@ -1443,14 +1613,14 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       {
         id: 'session-messages',
         title: 'Session Messages',
-        description: 'Inspect raw captured conversation rows that were stored during ingest.',
+        description: 'Inspect raw captured conversation rows that were stored during ingest. `appId` uses the same omitted / exact / default-global filtering behavior as memory search.',
         endpoints: [
           {
             method: 'GET',
             path: '/v1alpha2/mem9s/session-messages',
             summary: 'List session messages by session id.',
             description:
-              'Repeat `session_id` in the query string for each session you want to fetch. Use `limit_per_session` to cap rows per session.',
+              'Repeat `session_id` in the query string for each session you want to fetch. Use `limit_per_session` to cap rows per session. If different appIds reused the same session id, pass `appId` to prevent cross-app raw session mixing.',
             headers: hostedReadHeaders,
             queryParams: sessionMessagesQueryParams,
             responseFields: sessionMessagesResponseFields,
@@ -1462,7 +1632,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         id: 'health',
         title: 'Health & Compatibility',
         description:
-          'Use `/healthz` for liveness checks. Legacy tenant-scoped routes still exist under `/v1alpha1/mem9s/{tenantID}/...`, but hosted clients should prefer `v1alpha2` plus `X-API-Key`.',
+          'Use `/healthz` for liveness checks. Legacy tenant-scoped routes still exist under `/v1alpha1/mem9s/{tenantID}/...`, but most clients should prefer `v1alpha2` plus `X-API-Key`.',
         endpoints: [
           {
             method: 'GET',
@@ -1487,47 +1657,71 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
   zh: {
     meta: {
-      title: 'mem9 API | Hosted API 文档',
-      description: '查看如何创建 API key、读写记忆、上传文件，以及查询 hosted mem9 API 的 session messages。',
+      title: 'mem9 API | API 文档',
+      description: '查看如何创建 API key、读写记忆、使用 appId 隔离子空间、上传文件，以及查询 mem9 API 的 session messages。',
     },
     kicker: 'API',
-    title: 'Hosted mem9 API 文档',
-    intro: '使用 hosted mem9 API 创建 space、写入或搜索记忆、导入已有文件，并查看捕获到的 session messages。',
+    title: 'mem9 API 文档',
+    intro: '使用 mem9 API 创建 space、写入或搜索记忆、通过 appId 隔离同一 API key 下的子空间、导入已有文件，并查看捕获到的 session messages。示例使用 mem9.ai；自托管部署可以使用自己的 base URL 调用同一组路径。',
     summary: '日常调用优先使用 `v1alpha2`。`v1alpha1` 继续保留给 key provision 和 tenant-scoped 兼容路径。',
     labels: {
       headers: '请求头',
       queryParams: '查询参数',
       body: '请求体',
-      response: '响应',
+      response: '响应 Body',
       examples: '示例',
       required: '必填',
       next: '下一步',
       sidebarTitle: '本页目录',
       sidebarAuth: '认证',
       sidebarQuickstart: '快速开始',
+      apiSearch: '搜索 API',
+      apiSearchPlaceholder: '搜索 path 或名称',
+      apiSearchEmpty: '没有匹配的 API。',
+      testApi: '测试 API',
+      testTitle: '测试 API',
+      close: '关闭',
+      closeApiTestModal: '关闭 API 测试弹窗',
+      reset: '重置',
+      run: '运行',
+      baseUrl: 'Base URL',
+      pathParams: '路径参数',
+      jsonBody: 'JSON 请求体',
+      ready: '就绪',
+      responseReady: '运行请求后在这里查看响应。',
+      emptyResponse: '空响应',
+      running: '运行中...',
+      runningRequest: '正在发送请求...',
+      requestFailed: '请求失败',
+      pathParameter: '路径参数。',
+      saveFormInfo: '保存表单信息',
     },
     authTitle: 'Base URL 与认证方式',
     authCards: [
       {
-        title: 'Hosted base URL',
-        body: '使用 `https://api.mem9.ai`。正常客户端请求应发送到 `https://api.mem9.ai/v1alpha2/mem9s/...`。',
+        title: 'Base URL',
+        body: '使用 mem9.ai 时 base URL 是 `https://api.mem9.ai`；自托管时替换成自己的服务地址。runtime memory 接口路径仍是 `/v1alpha2/mem9s/...`。',
       },
       {
-        title: '主认证 header',
-        body: '把 mem9 API key 放进 `X-API-Key`。这是 `v1alpha2` 的默认 hosted 认证模型。',
+        title: 'API key header',
+        body: '`v1alpha2` 调用把 space API key 放在 `X-API-Key`。mem9.ai 可通过 `POST /v1alpha1/mem9s` 创建 key；自托管则使用自己控制面生成的 key。',
       },
       {
-        title: '可选的 agent 身份',
-        body: '当你希望写入或导入归属到某个 agent 时，再额外发送 `X-Mnemo-Agent-Id`。旧的 tenant-scoped 路由仍保留在 `v1alpha1` 下。',
+        title: 'Agent 身份',
+        body: '`X-Mnemo-Agent-Id` 可选，用来标记写入或导入来自哪个 agent；如果请求体同时传了 `agent_id`，以请求体为准。',
+      },
+      {
+        title: 'appId 隔离',
+        body: '`appId` 用来在同一个 API key 下隔离 memory 和 raw session 子空间。不传 `appId` 表示搜索全部子空间；传具体值表示精确隔离；传 `null` 或空值表示 default/global 记忆。',
       },
     ],
     quickstartTitle: 'Quick start',
-    quickstartDescription: '最小 hosted 流程是：先 provision 一个 key，把它导出到 shell，然后创建并搜索记忆。',
+    quickstartDescription: '最小 mem9.ai 流程是：先 provision 一个 key，把它导出到 shell，然后创建并搜索记忆。自托管时保留相同路径，只替换 base URL。',
     quickstartSteps: [
       '通过 `POST /v1alpha1/mem9s` 创建新的 API key。',
       '把该 key 导出成 `API_KEY`，并设置 `API=https://api.mem9.ai/v1alpha2/mem9s`。',
-      '用 `POST /memories` 写入一条记忆。',
-      '再用 `GET /memories?q=...` 搜回来。',
+      '用 `POST /memories` 写入一条记忆；当一个 API key 需要承载多个应用场景时，传入 `appId`。',
+      '再用 `GET /memories?q=...` 搜回来；不传 `appId` 表示跨全部 appId 搜索，传入某个 `appId` 表示只查该子空间。',
     ],
     quickstartExamples: [
       { label: '创建 key', code: provisionKeyCode },
@@ -1539,53 +1733,56 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       {
         id: 'provisioning',
         title: 'Provisioning',
-        description: '创建你后续会重复使用的 hosted mem9 访问 key。',
+        description: '创建你后续会重复使用的 mem9.ai API 访问 key。',
         endpoints: [
           {
             method: 'POST',
             path: '/v1alpha1/mem9s',
             summary: '创建新的 mem9 API key。',
-            description: '不需要认证，也不需要请求体。hosted 服务会返回 `201` 和一个 `id` 字段，这个 `id` 就是你要保存和复用的 key。',
+            description: '不需要认证，也不需要请求体。mem9.ai 服务会返回 `201` 和一个 `id` 字段，这个 `id` 就是你要保存和复用的 key。',
             responseFields: provisionResponseFields,
             examples: [{ label: '创建 key', code: provisionKeyCode }],
           },
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
-        description: '在你的 mem9 space 中创建、搜索、读取、更新和删除记忆。',
+        description: '在你的 mem9 space 中创建、搜索、读取、更新和删除记忆。可选的 `appId` 让同一个 API key 拥有多个相互隔离的应用子记忆空间。',
         endpoints: [
           {
             method: 'POST',
             path: '/v1alpha2/mem9s/memories',
             summary: '创建记忆或执行 message ingest。',
-            description: '直接写入时使用 `content`；走 ingest 时使用 `messages`。同一个请求里不要同时发送这两个字段。',
+            description: '直接写入时使用 `content`；走 ingest 时使用 `messages`。同一个请求里不要同时发送这两个字段。`appId` 可选；省略、null、空字符串和纯空白都会写入默认/global appId。',
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: '创建记忆', code: createMemoryCode }],
+            examples: [
+              { label: '创建记忆', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories',
             summary: '列出或搜索记忆。',
-            description: '带 `q` 时走 recall search；不带 `q` 时更像一个带过滤条件的列表接口。',
+            description: '带 `q` 时默认走 recall search；`search_mode=keyword` 用于直接按 content 子串搜索。`appId` 是三态语义：不传表示跨全部 appId 搜索，传非空值表示精确隔离，传 `appId=null` 或 `appId=` 表示只查默认/global appId。',
             headers: hostedReadHeaders,
             queryParams: memoryListQueryParams,
             responseFields: memoryListResponseFields,
             examples: [
               { label: '搜索记忆', code: listMemoryCode },
               { label: '按标签 / source 过滤', code: filterMemoryCode },
+              { label: '直接内容关键词搜索', code: keywordListMemoryCode },
             ],
           },
           {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories/{id}',
             summary: '按 id 读取单条记忆。',
-            description: '从 hosted 服务里拉取一条完整的记忆对象。',
+            description: '从 mem9 API 拉取一条完整的记忆对象。',
             headers: hostedReadHeaders,
             responseFields: memoryObjectResponseFields,
             examples: [{ label: '读取记忆', code: getMemoryCode }],
@@ -1611,10 +1808,11 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
-        description: '上传 memory / session 文件，并轮询后台任务状态。',
+        description: '上传 memory / session 文件，并轮询后台任务状态。导入的 memory 和 raw session 可以在文件级、memory 级或 session 级携带 `appId`。',
         endpoints: [
           {
             method: 'POST',
@@ -1652,13 +1850,13 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       {
         id: 'session-messages',
         title: 'Session Messages',
-        description: '查看在 ingest 过程中被保存下来的原始对话消息。',
+        description: '查看在 ingest 过程中被保存下来的原始对话消息。`appId` 使用和 memory 搜索一致的不传 / 精确值 / 默认 global 三态过滤。',
         endpoints: [
           {
             method: 'GET',
             path: '/v1alpha2/mem9s/session-messages',
             summary: '按 session id 读取 session messages。',
-            description: '为每个要查询的 session 重复传 `session_id` 参数；用 `limit_per_session` 控制每个 session 的返回上限。',
+            description: '为每个要查询的 session 重复传 `session_id` 参数；用 `limit_per_session` 控制每个 session 的返回上限。如果不同 appId 复用了同一个 session id，传入 `appId` 可以避免 raw session 串到其它应用。',
             headers: hostedReadHeaders,
             queryParams: sessionMessagesQueryParams,
             responseFields: sessionMessagesResponseFields,
@@ -1669,7 +1867,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       {
         id: 'health',
         title: 'Health 与兼容性',
-        description: '用 `/healthz` 做存活检查。旧的 tenant-scoped 路由仍存在于 `/v1alpha1/mem9s/{tenantID}/...` 下，但 hosted 客户端应优先使用 `v1alpha2` + `X-API-Key`。',
+        description: '用 `/healthz` 做存活检查。旧的 tenant-scoped 路由仍存在于 `/v1alpha1/mem9s/{tenantID}/...` 下，但大多数客户端应优先使用 `v1alpha2` + `X-API-Key`。',
         endpoints: [
           {
             method: 'GET',
@@ -1693,34 +1891,54 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
   'zh-Hant': {
     meta: {
-      title: 'mem9 API | Hosted API 文件',
-      description: '查看如何建立 API key、讀寫記憶、上傳檔案，以及查詢 hosted mem9 API 的 session messages。',
+      title: 'mem9 API | API 文件',
+      description: '查看如何建立 API key、讀寫記憶、上傳檔案，以及查詢 mem9 API 的 session messages。',
     },
     kicker: 'API',
-    title: 'Hosted mem9 API 文件',
-    intro: '使用 hosted mem9 API 建立 space、寫入或搜尋記憶、匯入既有檔案，並查看捕捉到的 session messages。',
+    title: 'mem9 API 文件',
+    intro: '使用 mem9 API 建立 space、寫入或搜尋記憶、匯入既有檔案，並查看捕捉到的 session messages。',
     summary: '日常呼叫優先使用 `v1alpha2`。`v1alpha1` 持續保留給 key provision 與 tenant-scoped 相容路徑。',
     labels: {
       headers: '請求頭',
       queryParams: '查詢參數',
       body: '請求體',
-      response: '回應',
+      response: '回應 Body',
       examples: '範例',
       required: '必填',
       next: '下一步',
       sidebarTitle: '本頁目錄',
       sidebarAuth: '驗證',
       sidebarQuickstart: '快速開始',
+      apiSearch: '搜尋 API',
+      apiSearchPlaceholder: '搜尋 path 或名稱',
+      apiSearchEmpty: '沒有符合的 API。',
+      testApi: '測試 API',
+      testTitle: '測試 API',
+      close: '關閉',
+      closeApiTestModal: '關閉 API 測試彈窗',
+      reset: '重設',
+      run: '執行',
+      baseUrl: 'Base URL',
+      pathParams: '路徑參數',
+      jsonBody: 'JSON 請求體',
+      ready: '就緒',
+      responseReady: '執行請求後在這裡查看回應。',
+      emptyResponse: '空回應',
+      running: '執行中...',
+      runningRequest: '正在送出請求...',
+      requestFailed: '請求失敗',
+      pathParameter: '路徑參數。',
+      saveFormInfo: '儲存表單資訊',
     },
     authTitle: 'Base URL 與驗證方式',
     authCards: [
       {
-        title: 'Hosted base URL',
+        title: 'Base URL',
         body: '使用 `https://api.mem9.ai`。一般客戶端請求應發送到 `https://api.mem9.ai/v1alpha2/mem9s/...`。',
       },
       {
         title: '主要驗證 header',
-        body: '把 mem9 API key 放進 `X-API-Key`。這是 `v1alpha2` 的預設 hosted 驗證模式。',
+        body: '把 mem9 API key 放進 `X-API-Key`。這是 `v1alpha2` 的預設驗證模式。',
       },
       {
         title: '可選 agent 身分',
@@ -1728,7 +1946,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       },
     ],
     quickstartTitle: 'Quick start',
-    quickstartDescription: '最小 hosted 流程是：先 provision 一個 key，把它 export 到 shell，然後建立並搜尋記憶。',
+    quickstartDescription: '最小 mem9.ai 流程是：先 provision 一個 key，把它 export 到 shell，然後建立並搜尋記憶。',
     quickstartSteps: [
       '透過 `POST /v1alpha1/mem9s` 建立新的 API key。',
       '把該 key export 成 `API_KEY`，並設定 `API=https://api.mem9.ai/v1alpha2/mem9s`。',
@@ -1758,7 +1976,6 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1772,7 +1989,10 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: '建立記憶', code: createMemoryCode }],
+            examples: [
+              { label: '建立記憶', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
@@ -1817,6 +2037,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -1899,34 +2120,54 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
   ja: {
     meta: {
-      title: 'mem9 API | Hosted API リファレンス',
+      title: 'mem9 API | API リファレンス',
       description: 'API key の発行、memory の読み書き、ファイル import、session messages の取得方法を確認できます。',
     },
     kicker: 'API',
-    title: 'Hosted mem9 API リファレンス',
-    intro: 'hosted mem9 API を使って space を発行し、memory を書き込み / 検索し、既存ファイルを import し、保存済み session messages を確認できます。',
+    title: 'mem9 API リファレンス',
+    intro: 'mem9 API を使って space を発行し、memory を書き込み / 検索し、既存ファイルを import し、保存済み session messages を確認できます。',
     summary: '日常利用では `v1alpha2` を優先してください。`v1alpha1` は key の provision と tenant-scoped な互換ルート向けに残っています。',
     labels: {
       headers: 'Headers',
       queryParams: 'Query Params',
       body: 'Body',
-      response: 'Response',
+      response: 'Response Body',
       examples: 'Examples',
       required: '必須',
       next: 'Next',
       sidebarTitle: 'このページの内容',
       sidebarAuth: '認証',
       sidebarQuickstart: 'クイックスタート',
+      apiSearch: 'API を検索',
+      apiSearchPlaceholder: 'path または名前を検索',
+      apiSearchEmpty: '一致する API はありません。',
+      testApi: 'API をテスト',
+      testTitle: 'API をテスト',
+      close: '閉じる',
+      closeApiTestModal: 'API テストモーダルを閉じる',
+      reset: 'リセット',
+      run: '実行',
+      baseUrl: 'Base URL',
+      pathParams: 'パスパラメータ',
+      jsonBody: 'JSON body',
+      ready: '準備完了',
+      responseReady: 'リクエストを実行するとレスポンスを確認できます。',
+      emptyResponse: '空のレスポンス',
+      running: '実行中...',
+      runningRequest: 'リクエストを実行中...',
+      requestFailed: 'リクエストに失敗しました',
+      pathParameter: 'パスパラメータ。',
+      saveFormInfo: 'フォーム情報を保存',
     },
     authTitle: 'Base URL と認証',
     authCards: [
       {
-        title: 'Hosted base URL',
+        title: 'Base URL',
         body: '`https://api.mem9.ai` を使います。通常のクライアント通信は `https://api.mem9.ai/v1alpha2/mem9s/...` に送ってください。',
       },
       {
         title: '主要な認証 header',
-        body: 'mem9 API key は `X-API-Key` に送ります。これが `v1alpha2` の標準的な hosted 認証です。',
+        body: 'mem9 API key は `X-API-Key` に送ります。これが `v1alpha2` の標準的な認証です。',
       },
       {
         title: '任意の agent identity',
@@ -1934,7 +2175,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       },
     ],
     quickstartTitle: 'Quick start',
-    quickstartDescription: '最小の hosted フローは、key を provision して shell に export し、その後 memory を作成して検索することです。',
+    quickstartDescription: '最小の mem9.ai フローは、key を provision して shell に export し、その後 memory を作成して検索することです。',
     quickstartSteps: [
       '`POST /v1alpha1/mem9s` で新しい API key を作成する。',
       'その key を `API_KEY` として export し、`API=https://api.mem9.ai/v1alpha2/mem9s` を設定する。',
@@ -1957,14 +2198,13 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             method: 'POST',
             path: '/v1alpha1/mem9s',
             summary: '新しい mem9 API key を発行する。',
-            description: '認証も request body も不要です。hosted service は `201` と `id` を返し、その `id` が保存して再利用する key になります。',
+            description: '認証も request body も不要です。service は `201` と `id` を返し、その `id` が保存して再利用する key になります。',
             responseFields: provisionResponseFields,
             examples: [{ label: 'Key を発行', code: provisionKeyCode }],
           },
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -1978,7 +2218,10 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: 'Memory を作成', code: createMemoryCode }],
+            examples: [
+              { label: 'Memory を作成', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
@@ -1997,7 +2240,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories/{id}',
             summary: 'id で 1 件の memory を取得する。',
-            description: 'hosted service から単一の memory object を取得します。',
+            description: 'mem9 API から単一の memory object を取得します。',
             headers: hostedReadHeaders,
             responseFields: memoryObjectResponseFields,
             examples: [{ label: 'Memory を取得', code: getMemoryCode }],
@@ -2023,6 +2266,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2105,34 +2349,54 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
   ko: {
     meta: {
-      title: 'mem9 API | Hosted API 레퍼런스',
+      title: 'mem9 API | API 레퍼런스',
       description: 'API key 발급, memory 읽기/쓰기, 파일 import, session messages 조회 방법을 확인할 수 있습니다.',
     },
     kicker: 'API',
-    title: 'Hosted mem9 API 레퍼런스',
-    intro: 'hosted mem9 API 로 space 를 만들고, memory 를 쓰고 검색하고, 기존 파일을 import 하고, 저장된 session messages 를 확인할 수 있습니다.',
+    title: 'mem9 API 레퍼런스',
+    intro: 'mem9 API 로 space 를 만들고, memory 를 쓰고 검색하고, 기존 파일을 import 하고, 저장된 session messages 를 확인할 수 있습니다.',
     summary: '일상적인 사용은 `v1alpha2` 를 우선하세요. `v1alpha1` 은 key provision 과 tenant-scoped 호환 경로를 위해 남아 있습니다.',
     labels: {
       headers: 'Headers',
       queryParams: 'Query Params',
       body: 'Body',
-      response: 'Response',
+      response: 'Response Body',
       examples: 'Examples',
       required: '필수',
       next: '다음',
       sidebarTitle: '이 페이지 목차',
       sidebarAuth: '인증',
       sidebarQuickstart: '빠른 시작',
+      apiSearch: 'API 검색',
+      apiSearchPlaceholder: 'path 또는 이름 검색',
+      apiSearchEmpty: '일치하는 API가 없습니다.',
+      testApi: 'API 테스트',
+      testTitle: 'API 테스트',
+      close: '닫기',
+      closeApiTestModal: 'API 테스트 모달 닫기',
+      reset: '초기화',
+      run: '실행',
+      baseUrl: 'Base URL',
+      pathParams: '경로 파라미터',
+      jsonBody: 'JSON body',
+      ready: '준비됨',
+      responseReady: '요청을 실행하면 응답을 확인할 수 있습니다.',
+      emptyResponse: '빈 응답',
+      running: '실행 중...',
+      runningRequest: '요청 실행 중...',
+      requestFailed: '요청 실패',
+      pathParameter: '경로 파라미터.',
+      saveFormInfo: '폼 정보 저장',
     },
     authTitle: 'Base URL 과 인증',
     authCards: [
       {
-        title: 'Hosted base URL',
+        title: 'Base URL',
         body: '`https://api.mem9.ai` 를 사용합니다. 일반적인 클라이언트 트래픽은 `https://api.mem9.ai/v1alpha2/mem9s/...` 로 보내세요.',
       },
       {
         title: '기본 인증 header',
-        body: 'mem9 API key 는 `X-API-Key` 로 보냅니다. 이것이 `v1alpha2` 의 기본 hosted 인증 방식입니다.',
+        body: 'mem9 API key 는 `X-API-Key` 로 보냅니다. 이것이 `v1alpha2` 의 기본 인증 방식입니다.',
       },
       {
         title: '선택적 agent identity',
@@ -2140,7 +2404,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       },
     ],
     quickstartTitle: 'Quick start',
-    quickstartDescription: '가장 작은 hosted 흐름은 key 를 provision 하고 shell 에 export 한 뒤, memory 를 생성하고 검색하는 것입니다.',
+    quickstartDescription: '가장 작은 mem9.ai 흐름은 key 를 provision 하고 shell 에 export 한 뒤, memory 를 생성하고 검색하는 것입니다.',
     quickstartSteps: [
       '`POST /v1alpha1/mem9s` 로 새 API key 를 만든다.',
       '그 key 를 `API_KEY` 로 export 하고 `API=https://api.mem9.ai/v1alpha2/mem9s` 를 설정한다.',
@@ -2163,14 +2427,13 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             method: 'POST',
             path: '/v1alpha1/mem9s',
             summary: '새 mem9 API key 를 발급합니다.',
-            description: '인증도 request body 도 필요 없습니다. hosted service 는 `201` 과 `id` 를 반환하며, 이 `id` 가 저장하고 재사용할 key 입니다.',
+            description: '인증도 request body 도 필요 없습니다. service 는 `201` 과 `id` 를 반환하며, 이 `id` 가 저장하고 재사용할 key 입니다.',
             responseFields: provisionResponseFields,
             examples: [{ label: 'Key 발급', code: provisionKeyCode }],
           },
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -2184,7 +2447,10 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: 'Memory 생성', code: createMemoryCode }],
+            examples: [
+              { label: 'Memory 생성', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
@@ -2203,7 +2469,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories/{id}',
             summary: 'id 로 단일 memory 를 조회합니다.',
-            description: 'hosted service 에서 하나의 memory object 를 가져옵니다.',
+            description: 'mem9 API 에서 하나의 memory object 를 가져옵니다.',
             headers: hostedReadHeaders,
             responseFields: memoryObjectResponseFields,
             examples: [{ label: 'Memory 조회', code: getMemoryCode }],
@@ -2229,6 +2495,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2311,34 +2578,54 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
   id: {
     meta: {
-      title: 'mem9 API | Referensi Hosted API',
-      description: 'Pelajari cara membuat API key, membaca dan menulis memory, mengimpor file, dan membaca session messages di hosted mem9 API.',
+      title: 'mem9 API | Referensi API',
+      description: 'Pelajari cara membuat API key, membaca dan menulis memory, mengimpor file, dan membaca session messages di mem9 API.',
     },
     kicker: 'API',
-    title: 'Referensi hosted mem9 API',
-    intro: 'Gunakan hosted mem9 API untuk membuat space, menulis atau mencari memory, mengimpor file yang sudah ada, dan melihat session messages yang tersimpan.',
+    title: 'Referensi mem9 API',
+    intro: 'Gunakan mem9 API untuk membuat space, menulis atau mencari memory, mengimpor file yang sudah ada, dan melihat session messages yang tersimpan.',
     summary: 'Gunakan `v1alpha2` untuk pemakaian harian. `v1alpha1` tetap tersedia untuk provision key dan kompatibilitas tenant-scoped.',
     labels: {
       headers: 'Headers',
       queryParams: 'Query Params',
       body: 'Body',
-      response: 'Response',
+      response: 'Response Body',
       examples: 'Examples',
       required: 'Wajib',
       next: 'Next',
       sidebarTitle: 'Di halaman ini',
       sidebarAuth: 'Autentikasi',
       sidebarQuickstart: 'Quick Start',
+      apiSearch: 'Cari API',
+      apiSearchPlaceholder: 'Cari path atau nama',
+      apiSearchEmpty: 'Tidak ada API yang cocok.',
+      testApi: 'Uji API',
+      testTitle: 'Uji API',
+      close: 'Tutup',
+      closeApiTestModal: 'Tutup modal uji API',
+      reset: 'Reset',
+      run: 'Jalankan',
+      baseUrl: 'Base URL',
+      pathParams: 'Parameter path',
+      jsonBody: 'Body JSON',
+      ready: 'Siap',
+      responseReady: 'Jalankan request untuk melihat respons.',
+      emptyResponse: 'respons kosong',
+      running: 'Menjalankan...',
+      runningRequest: 'Menjalankan request...',
+      requestFailed: 'Request gagal',
+      pathParameter: 'Parameter path.',
+      saveFormInfo: 'Simpan info formulir',
     },
     authTitle: 'Base URL & autentikasi',
     authCards: [
       {
-        title: 'Hosted base URL',
+        title: 'Base URL',
         body: 'Gunakan `https://api.mem9.ai`. Untuk trafik client normal, kirim request ke `https://api.mem9.ai/v1alpha2/mem9s/...`.',
       },
       {
         title: 'Header autentikasi utama',
-        body: 'Kirim mem9 API key Anda di `X-API-Key`. Ini adalah model auth hosted default untuk `v1alpha2`.',
+        body: 'Kirim mem9 API key Anda di `X-API-Key`. Ini adalah model auth default untuk `v1alpha2`.',
       },
       {
         title: 'Identitas agent opsional',
@@ -2346,7 +2633,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       },
     ],
     quickstartTitle: 'Quick start',
-    quickstartDescription: 'Alur hosted paling kecil adalah: provision key, export ke shell, lalu buat dan cari memory.',
+    quickstartDescription: 'Alur mem9.ai paling kecil adalah: provision key, export ke shell, lalu buat dan cari memory.',
     quickstartSteps: [
       'Provision API key baru dengan `POST /v1alpha1/mem9s`.',
       'Export key itu sebagai `API_KEY`, lalu set `API=https://api.mem9.ai/v1alpha2/mem9s`.',
@@ -2376,7 +2663,6 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -2390,7 +2676,10 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: 'Buat memory', code: createMemoryCode }],
+            examples: [
+              { label: 'Buat memory', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
@@ -2409,7 +2698,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories/{id}',
             summary: 'Baca satu memory berdasarkan id.',
-            description: 'Ambil satu memory object dari hosted service.',
+            description: 'Ambil satu memory object dari mem9 API.',
             headers: hostedReadHeaders,
             responseFields: memoryObjectResponseFields,
             examples: [{ label: 'Ambil memory', code: getMemoryCode }],
@@ -2435,6 +2724,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2517,34 +2807,54 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
   th: {
     meta: {
-      title: 'mem9 API | เอกสาร Hosted API',
-      description: 'ดูวิธีสร้าง API key อ่านและเขียน memory อัปโหลดไฟล์ และอ่าน session messages บน hosted mem9 API',
+      title: 'mem9 API | เอกสาร API',
+      description: 'ดูวิธีสร้าง API key อ่านและเขียน memory อัปโหลดไฟล์ และอ่าน session messages บน mem9 API',
     },
     kicker: 'API',
-    title: 'เอกสาร hosted mem9 API',
-    intro: 'ใช้ hosted mem9 API เพื่อสร้าง space เขียนหรือค้นหา memory นำเข้าไฟล์เดิม และดู session messages ที่ถูกเก็บไว้',
+    title: 'เอกสาร mem9 API',
+    intro: 'ใช้ mem9 API เพื่อสร้าง space เขียนหรือค้นหา memory นำเข้าไฟล์เดิม และดู session messages ที่ถูกเก็บไว้',
     summary: 'สำหรับการใช้งานประจำวันให้ใช้ `v1alpha2` เป็นหลัก ส่วน `v1alpha1` ยังมีไว้สำหรับ provision key และเส้นทาง tenant-scoped แบบเดิม',
     labels: {
       headers: 'Headers',
       queryParams: 'Query Params',
       body: 'Body',
-      response: 'Response',
+      response: 'Response Body',
       examples: 'Examples',
       required: 'จำเป็น',
       next: 'ถัดไป',
       sidebarTitle: 'ในหน้านี้',
       sidebarAuth: 'การยืนยันตัวตน',
       sidebarQuickstart: 'เริ่มต้นอย่างรวดเร็ว',
+      apiSearch: 'ค้นหา API',
+      apiSearchPlaceholder: 'ค้นหา path หรือชื่อ',
+      apiSearchEmpty: 'ไม่พบ API ที่ตรงกัน',
+      testApi: 'ทดสอบ API',
+      testTitle: 'ทดสอบ API',
+      close: 'ปิด',
+      closeApiTestModal: 'ปิดหน้าต่างทดสอบ API',
+      reset: 'รีเซ็ต',
+      run: 'เรียกใช้',
+      baseUrl: 'Base URL',
+      pathParams: 'พารามิเตอร์ path',
+      jsonBody: 'JSON body',
+      ready: 'พร้อม',
+      responseReady: 'เรียกใช้ request เพื่อดู response',
+      emptyResponse: 'response ว่าง',
+      running: 'กำลังเรียกใช้...',
+      runningRequest: 'กำลังส่ง request...',
+      requestFailed: 'Request ล้มเหลว',
+      pathParameter: 'พารามิเตอร์ path',
+      saveFormInfo: 'บันทึกข้อมูลฟอร์ม',
     },
     authTitle: 'Base URL และการยืนยันตัวตน',
     authCards: [
       {
-        title: 'Hosted base URL',
+        title: 'Base URL',
         body: 'ใช้ `https://api.mem9.ai` สำหรับ client ปกติให้ส่ง request ไปที่ `https://api.mem9.ai/v1alpha2/mem9s/...`',
       },
       {
         title: 'Header สำหรับ auth หลัก',
-        body: 'ส่ง mem9 API key ของคุณใน `X-API-Key` นี่คือรูปแบบ auth หลักของ hosted `v1alpha2`',
+        body: 'ส่ง mem9 API key ของคุณใน `X-API-Key` นี่คือรูปแบบ auth หลักของ `v1alpha2`',
       },
       {
         title: 'Agent identity แบบเลือกได้',
@@ -2552,7 +2862,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
       },
     ],
     quickstartTitle: 'Quick start',
-    quickstartDescription: 'ลำดับ hosted ที่เล็กที่สุดคือ provision key, export เข้า shell แล้วสร้างและค้นหา memory',
+    quickstartDescription: 'ลำดับ mem9.ai ที่เล็กที่สุดคือ provision key, export เข้า shell แล้วสร้างและค้นหา memory',
     quickstartSteps: [
       'สร้าง API key ใหม่ด้วย `POST /v1alpha1/mem9s`',
       'export key นั้นเป็น `API_KEY` และตั้ง `API=https://api.mem9.ai/v1alpha2/mem9s`',
@@ -2582,7 +2892,6 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       keyStatusEndpointGroup,
-      spaceChainEndpointGroup,
       {
         id: 'memories',
         title: 'Memories',
@@ -2596,7 +2905,10 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             headers: hostedJSONWriteHeaders,
             bodyFields: memoryCreateBodyFields,
             responseFields: statusOnlyResponseFields,
-            examples: [{ label: 'สร้าง memory', code: createMemoryCode }],
+            examples: [
+              { label: 'สร้าง memory', code: createMemoryCode },
+              { label: 'Smart ingest', code: smartIngestCode },
+            ],
           },
           {
             method: 'GET',
@@ -2615,7 +2927,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
             method: 'GET',
             path: '/v1alpha2/mem9s/memories/{id}',
             summary: 'อ่าน memory เดียวตาม id',
-            description: 'ดึง memory object เดียวจาก hosted service',
+            description: 'ดึง memory object เดียวจาก mem9 API',
             headers: hostedReadHeaders,
             responseFields: memoryObjectResponseFields,
             examples: [{ label: 'อ่าน memory', code: getMemoryCode }],
@@ -2641,6 +2953,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
           batchDeleteMemoryEndpoint,
         ],
       },
+      spaceChainEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2723,6 +3036,2213 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
   },
 };
 
+const releaseNoteSourceGroups: SiteReleaseNoteSource[][][] = [
+  [
+    [
+      { label: 'mem9 issue #347', href: 'https://github.com/mem9-ai/mem9/issues/347' },
+    ],
+    [
+      { label: 'mem9 feat/app-id', href: 'https://github.com/mem9-ai/mem9/tree/feat/app-id' },
+      { label: 'console-fe feat/app-id', href: 'https://github.com/mem9-ai/mem9-console-fe/tree/feat/app-id' },
+      { label: 'console-server feat/app-id', href: 'https://github.com/mem9-ai/mem9-console-server/tree/feat/app-id' },
+    ],
+    [
+      { label: 'mem9 4494822', href: 'https://github.com/mem9-ai/mem9/commit/4494822' },
+      { label: 'mem9 d9cc02a', href: 'https://github.com/mem9-ai/mem9/commit/d9cc02a' },
+      { label: 'mem9 cbd9b16', href: 'https://github.com/mem9-ai/mem9/commit/cbd9b16' },
+    ],
+    [
+      { label: 'console-server #72', href: 'https://github.com/mem9-ai/mem9-console-server/pull/72' },
+      { label: 'console-server #64', href: 'https://github.com/mem9-ai/mem9-console-server/pull/64' },
+      { label: 'console-fe #52', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/52' },
+    ],
+    [
+      { label: 'console-fe #53', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/53' },
+      { label: 'console-fe #34', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/34' },
+      { label: 'console-fe #28', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/28' },
+    ],
+    [
+      { label: 'mem9 #337', href: 'https://github.com/mem9-ai/mem9/pull/337' },
+      { label: 'console-server #61', href: 'https://github.com/mem9-ai/mem9-console-server/pull/61' },
+      { label: 'console-fe #56', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/56' },
+    ],
+    [
+      { label: 'mem9 #338', href: 'https://github.com/mem9-ai/mem9/pull/338' },
+      { label: 'console-fe #57', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/57' },
+    ],
+  ],
+  [
+    [
+      { label: 'mem9 #335', href: 'https://github.com/mem9-ai/mem9/pull/335' },
+      { label: 'mem9 #326', href: 'https://github.com/mem9-ai/mem9/pull/326' },
+      { label: 'console-fe #51', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/51' },
+    ],
+    [
+      { label: 'mem9 #327', href: 'https://github.com/mem9-ai/mem9/pull/327' },
+      { label: 'mem9 #332', href: 'https://github.com/mem9-ai/mem9/pull/332' },
+      { label: 'console-server #56', href: 'https://github.com/mem9-ai/mem9-console-server/pull/56' },
+      { label: 'console-fe #47', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/47' },
+    ],
+    [
+      { label: 'console-fe #49', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/49' },
+    ],
+    [
+      { label: 'mem9 #309', href: 'https://github.com/mem9-ai/mem9/pull/309' },
+      { label: 'console-server #30', href: 'https://github.com/mem9-ai/mem9-console-server/pull/30' },
+      { label: 'console-server #31', href: 'https://github.com/mem9-ai/mem9-console-server/pull/31' },
+      { label: 'console-server #33', href: 'https://github.com/mem9-ai/mem9-console-server/pull/33' },
+      { label: 'console-fe #28', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/28' },
+    ],
+    [
+      { label: 'console-server #32', href: 'https://github.com/mem9-ai/mem9-console-server/pull/32' },
+      { label: 'console-server #35', href: 'https://github.com/mem9-ai/mem9-console-server/pull/35' },
+      { label: 'console-server #37', href: 'https://github.com/mem9-ai/mem9-console-server/pull/37' },
+      { label: 'console-fe #29', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/29' },
+    ],
+    [
+      { label: 'mem9 #308', href: 'https://github.com/mem9-ai/mem9/pull/308' },
+      { label: 'console-server #37', href: 'https://github.com/mem9-ai/mem9-console-server/pull/37' },
+      { label: 'console-fe #29', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/29' },
+    ],
+    [
+      { label: 'console-server #28', href: 'https://github.com/mem9-ai/mem9-console-server/pull/28' },
+      { label: 'console-server #27', href: 'https://github.com/mem9-ai/mem9-console-server/pull/27' },
+    ],
+  ],
+];
+
+function attachReleaseNoteSources(copy: SiteReleaseNotesPageDraft): SiteReleaseNotesPageCopy {
+  return {
+    ...copy,
+    groups: copy.groups.map((group, groupIndex) => ({
+      ...group,
+      items: group.items.map((item, itemIndex) => ({
+        ...item,
+        sources: releaseNoteSourceGroups[groupIndex]?.[itemIndex] ?? [],
+      })),
+    })),
+  };
+}
+
+const releaseNotesPageCopyEn = attachReleaseNoteSources({
+    meta: {
+      title: 'Release Notes | mem9',
+      description:
+        'Customer-facing mem9 release notes covering new console, API, Space Chain, billing, and memory management features.',
+    },
+    kicker: 'Release Notes',
+    title: 'What is new in mem9',
+    intro: 'Here, the mem9 authors update recently shipped important features.',
+    starPrompt: 'Open source is not easy. Please support us by starring mem9 on GitHub.',
+    starBadgeAlt: 'GitHub stars for mem9-ai/mem9',
+    starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+    starHref: 'https://github.com/mem9-ai/mem9',
+    updatedLabel: 'Last updated',
+    updatedValue: 'June 4, 2026',
+    sourcesLabel: 'PR sources',
+    sourcesFeedback: 'You are welcome to open the PRs or issues and share your feedback.',
+    groups: [
+    {
+      period: 'June 2026',
+      items: [
+        {
+          date: 'June 4, 2026',
+          title: 'Major performance update for mem9.ai',
+          summary:
+            'The official mem9.ai service is receiving an important performance update. Because of early deployment choices, parts of the service and database were running across regions, which added unnecessary latency. We are migrating data in two phases to bring API latency down substantially.',
+          sections: [
+            {
+              title: 'Rollout',
+              items: [
+                'Phase 1 was released at noon Beijing time on June 4 and reduced typical API latency from about 4-6 seconds on average to about 1.3 seconds.',
+                'Phase 2 is expected to finish later this week and migrates metadata, with the goal of bringing average latency down to within a few hundred milliseconds.',
+              ],
+            },
+            {
+              title: 'Feedback',
+              body: 'No client-side change is required. This update improves the hosted mem9.ai service path, and feedback on official service performance is welcome.',
+            },
+          ],
+        },
+        {
+          date: 'June 4, 2026',
+          title: 'appId isolation under one API key',
+          summary:
+            'A single mem9 API key can now hold multiple isolated application memory spaces with `appId`. Memories and raw sessions written with an appId stay associated with that app, so different products, agents, environments, or workflows can share the same key without mixing their day-to-day memory.',
+          sections: [
+            {
+              title: 'How appId scopes memory',
+              items: [
+                'When writing memory or ingesting messages, send `appId`, for example `appId: "docs"` or `appId: "support-bot"`.',
+                'When searching, omit `appId` to search across all appIds under the key, pass a non-empty appId to search one sub-space, or pass `appId=null` / `appId=` to search only default global memory.',
+                'In Console, use the appId filter, appId column, and memory creation appId field to inspect or write memories for a specific application.',
+              ],
+            },
+          ],
+        },
+        {
+          date: 'June 4, 2026',
+          title: 'API reference refresh with live API testing',
+          summary:
+            'The mem9 API reference has been refreshed with a clearer layout, updated endpoint content, and a built-in API test console. Developers can now read the docs and try requests from the same page instead of switching between documentation and separate tooling.',
+          sections: [
+            {
+              title: 'What changed',
+              items: [
+                'The API page now has a clearer sidebar and endpoint layout.',
+                'The documentation content was updated for authentication, appId isolation, memory APIs, imports, session messages, and Space Chain APIs.',
+              ],
+            },
+            {
+              title: 'Where to try it',
+              body: 'Open the API page and use the API test panel to set the base URL, API key, headers, path/query/body fields, run a request, and inspect the response directly in the documentation page.',
+            },
+          ],
+        },
+        {
+          date: 'June 3, 2026',
+          title: 'Import an existing mem9 API key into Console',
+          summary:
+            'Users who already received a mem9 API key from an agent setup or API flow can now attach that key to a Console Space. The Console keeps raw key material protected, shows masked key details, and moves claimed keys into the organization quota model.',
+          sections: [
+            {
+              title: 'Claim flow',
+              items: [
+                'Open the Console claim flow from the setup link, or go directly to `/console/claim`.',
+                'Paste the existing key, choose an organization and project, then bind it to an empty Space or create a new Space during the flow.',
+                'After binding, manage the Space from Console without exposing the raw key in normal views.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'console-server #72', href: 'https://github.com/mem9-ai/mem9-console-server/pull/72' },
+            { label: 'console-server #64', href: 'https://github.com/mem9-ai/mem9-console-server/pull/64' },
+            { label: 'console-fe #52', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/52' },
+          ],
+        },
+        {
+          date: 'June 3, 2026',
+          title: 'Embedded billing, payment methods, and invoices',
+          summary:
+            'The Console billing area now includes a fuller Stripe-backed billing experience: current plan, billing address, payment methods, plan change controls, coupons, cancel/resume actions, and invoice history.',
+          sections: [
+            {
+              title: 'Where to manage it',
+              items: [
+                'Open Console, select the organization, then go to Billing.',
+                'Use Upgrade or Change plan to enter billing details, choose a plan, and confirm payment with Stripe Elements.',
+                'Review saved payment methods and invoices from the same Billing page.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'console-fe #53', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/53' },
+            { label: 'console-fe #34', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/34' },
+            { label: 'console-fe #28', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/28' },
+          ],
+        },
+        {
+          date: 'June 1, 2026',
+          title: 'Space Chain knowledge routing',
+          summary:
+            'Space Chains can now route extracted knowledge to the right Space Chain node based on routing policy fields. This makes a chain act more like a knowledgebase: broad ingest can land in the right team, project, or topic Space while recall still works across the chain.',
+          sections: [
+            {
+              title: 'Routing setup',
+              items: [
+                'Open a Space Chain detail page and configure the knowledge extraction policy.',
+                'Use the node selector and routing diagram to decide where extracted facts should be written.',
+                'When creating memory, enable smart ingest to extract and route facts instead of writing only one raw memory item.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'mem9 #337', href: 'https://github.com/mem9-ai/mem9/pull/337' },
+            { label: 'console-server #61', href: 'https://github.com/mem9-ai/mem9-console-server/pull/61' },
+            { label: 'console-fe #56', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/56' },
+          ],
+        },
+        {
+          date: 'June 1, 2026',
+          title: 'Server-side memory sorting and search controls',
+          summary:
+            'Memory tables now sort and filter against the full server result set, not just the current page. Users can sort by content, type, tags, and updated time while combining the sort with search controls.',
+          sections: [
+            {
+              title: 'Table controls',
+              items: [
+                'Open a Space or Space Chain memory workbench.',
+                'Click a table header to sort ascending or descending.',
+                'Use the search fields for content, type, and tags; the server applies the filter and sort before pagination.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'mem9 #338', href: 'https://github.com/mem9-ai/mem9/pull/338' },
+            { label: 'console-fe #57', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/57' },
+          ],
+        },
+      ],
+    },
+    {
+      period: 'May 2026',
+      items: [
+        {
+          date: 'May 30, 2026',
+          title: 'Faster Space Chain recall with timing visibility',
+          summary:
+            'Space Chain recall now parallelizes node scans and auth resolution, then keeps global reranking behavior. The Console also shows recall timing so teams can see how long test recalls take.',
+          sections: [
+            {
+              title: 'What changed',
+              body: 'Recall work is parallelized behind the scenes, while global reranking behavior stays the same.',
+            },
+            {
+              title: 'How to validate',
+              items: [
+                'Open a Space Chain detail page and use the Recall test panel.',
+                'Enable Force scanAll when you want to test cross-chain recall behavior.',
+                'Check the elapsed time shown with the result to compare query performance.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'mem9 #335', href: 'https://github.com/mem9-ai/mem9/pull/335' },
+            { label: 'mem9 #326', href: 'https://github.com/mem9-ai/mem9/pull/326' },
+            { label: 'console-fe #51', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/51' },
+          ],
+        },
+        {
+          date: 'May 25, 2026',
+          title: 'Session memory management and batch cleanup',
+          summary:
+            'The memory workbench can now list session memory rows, filter by All, Insight, Pinned, or Session, select rows, change page size, and delete selected memories in bulk. The API also supports session-row deletion and a request-level switch to avoid saving raw session rows when only extracted facts are needed.',
+          sections: [
+            {
+              title: 'Console cleanup',
+              items: [
+                'Open a Space memory workbench and choose the memory type filter.',
+                'Select one or more rows, then delete selected memories from the toolbar.',
+              ],
+            },
+            {
+              title: 'API option',
+              body: 'For API ingest flows, set `disableSessionSave` when you want fact extraction without preserving raw session messages.',
+            },
+          ],
+          sources: [
+            { label: 'mem9 #327', href: 'https://github.com/mem9-ai/mem9/pull/327' },
+            { label: 'mem9 #332', href: 'https://github.com/mem9-ai/mem9/pull/332' },
+            { label: 'console-server #56', href: 'https://github.com/mem9-ai/mem9-console-server/pull/56' },
+            { label: 'console-fe #47', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/47' },
+          ],
+        },
+        {
+          date: 'May 26, 2026',
+          title: 'Console localization for seven languages',
+          summary:
+            'The Console now supports English, Simplified Chinese, Traditional Chinese, Japanese, Korean, Indonesian, and Thai across the shell, auth pages, Spaces, Memories, Settings, Project, and Space Chain flows.',
+          sections: [
+            {
+              title: 'Language switcher',
+              items: [
+                'Open the language menu in the Console header or auth page.',
+                'Choose a language; the selection is saved locally and updates the document language.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'console-fe #49', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/49' },
+          ],
+        },
+        {
+          date: 'May 19, 2026',
+          title: 'Billing and usage dashboards',
+          summary:
+            'Organizations can review billing plan state, entitlements, request usage summaries, daily rollups, and detailed usage events. The runtime now has quota gates and durable metering so commercial usage can be tracked without changing self-hosted behavior.',
+          sections: [
+            {
+              title: 'Where to view it',
+              items: [
+                'Open Console and select an organization.',
+                'Go to Billing to review plan and entitlement state.',
+                'Go to Usage to inspect memory recall and memory write request totals over a selected date range.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'mem9 #309', href: 'https://github.com/mem9-ai/mem9/pull/309' },
+            { label: 'console-server #30', href: 'https://github.com/mem9-ai/mem9-console-server/pull/30' },
+            { label: 'console-server #31', href: 'https://github.com/mem9-ai/mem9-console-server/pull/31' },
+            { label: 'console-server #33', href: 'https://github.com/mem9-ai/mem9-console-server/pull/33' },
+            { label: 'console-fe #28', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/28' },
+          ],
+        },
+        {
+          date: 'May 19, 2026',
+          title: 'Space memory explorer and runtime tools',
+          summary:
+            'Spaces now have a memory workbench with summary metrics, imports, memory list/detail reads, create/edit/delete controls, and a shared recall test panel. Raw API keys stay server-side while Console proxies the authorized memory operations.',
+          sections: [
+            {
+              title: 'Workspace tools',
+              items: [
+                'Open a Space detail page in Console.',
+                'Use the Memories tab to browse, create, edit, or delete memories.',
+                'Use the Recall test panel to test what the Space would retrieve for a query.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'console-server #32', href: 'https://github.com/mem9-ai/mem9-console-server/pull/32' },
+            { label: 'console-server #35', href: 'https://github.com/mem9-ai/mem9-console-server/pull/35' },
+            { label: 'console-server #37', href: 'https://github.com/mem9-ai/mem9-console-server/pull/37' },
+            { label: 'console-fe #29', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/29' },
+          ],
+        },
+        {
+          date: 'May 15, 2026',
+          title: 'Space Chain runtime support',
+          summary:
+            'Space Chains are now available at runtime, with ordered recall and write behavior, chain key authentication, and provenance in chain responses. This lets a single chain key retrieve from multiple Spaces in a controlled order.',
+          sections: [
+            {
+              title: 'Runtime setup',
+              items: [
+                'Create or open a Space Chain in Console.',
+                'Add Space nodes in the order you want recall to search them.',
+                'Create a chain key binding, then use that key with `scanAll=true` when you want recall across the chain.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'mem9 #308', href: 'https://github.com/mem9-ai/mem9/pull/308' },
+            { label: 'console-server #37', href: 'https://github.com/mem9-ai/mem9-console-server/pull/37' },
+            { label: 'console-fe #29', href: 'https://github.com/mem9-ai/mem9-console-fe/pull/29' },
+          ],
+        },
+        {
+          date: 'May 14, 2026',
+          title: 'Safer Space API key management and organization roles',
+          summary:
+            'Space API keys are stored in an encrypted catalog with stable masked display values, explicit reveal workflows, and active binding checks. Organization roles now distinguish owner, admin, and member permissions for resource and key management.',
+          sections: [
+            {
+              title: 'Permissions',
+              items: [
+                'Owners and admins can create, bind, and reveal Space keys from the Space key management flow.',
+                'Members can continue reading allowed resources without receiving mutation permissions.',
+                'Use masked key values in normal views; reveal a key only when you need to copy it into a client.',
+              ],
+            },
+          ],
+          sources: [
+            { label: 'console-server #28', href: 'https://github.com/mem9-ai/mem9-console-server/pull/28' },
+            { label: 'console-server #27', href: 'https://github.com/mem9-ai/mem9-console-server/pull/27' },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyZh = attachReleaseNoteSources({
+  meta: {
+    title: '发布说明 | mem9',
+    description: 'mem9 面向客户的发布说明，覆盖 Console、API、Space Chain、计费和记忆管理的新功能。',
+  },
+  kicker: '发布说明',
+  title: 'mem9 最近更新了什么',
+  intro: '在这里 mem9 作者们会更新最近上线了哪些重要的功能。',
+  starPrompt: '开源项目不容易，请大家给我们Star来支持我们。',
+  starBadgeAlt: 'mem9-ai/mem9 的 GitHub Stars',
+  starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+  starHref: 'https://github.com/mem9-ai/mem9',
+  updatedLabel: '最后更新',
+  updatedValue: '2026 年 6 月 4 日',
+  sourcesLabel: 'PR 来源',
+  sourcesFeedback: '欢迎进入PR、issue提交您的反馈。',
+  groups: [
+    {
+      period: '2026 年 6 月',
+      items: [
+        {
+          date: '2026 年 6 月 4 日',
+          title: 'mem9.ai 官方服务迎来重要性能更新',
+          summary:
+            'mem9.ai 官方服务正在进行一次重要的性能优化。由于早期部署时服务和数据库存在跨区访问，API 请求产生了额外延迟。我们正在分两个阶段迁移数据，以显著降低官方托管服务的 API 延迟。',
+          sections: [
+            {
+              title: '发布节奏',
+              items: [
+                '第一阶段已在北京时间 6 月 4 日中午发布，将普遍 API 延迟从平均约 4-6 秒降低到约 1.3 秒。',
+                '第二阶段预计在本周完成元数据迁移，目标是把平均延迟进一步降低到几百毫秒以内。',
+              ],
+            },
+            {
+              title: '反馈',
+              body: '这次更新不需要客户端改动，会直接优化 mem9.ai 官方服务链路。欢迎大家继续反馈 mem9 官方服务的性能体验。',
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 4 日',
+          title: '同一个 API key 下的 appId 隔离',
+          summary:
+            '同一个 mem9 API key 现在可以通过 `appId` 承载多个相互隔离的应用记忆空间。写入时带 appId 的 memory 和 raw session 会归属到对应应用，适合把不同产品、Agent、环境或工作流放在同一把 key 下，同时避免日常记忆互相混在一起。',
+          sections: [
+            {
+              title: 'appId 如何隔离记忆',
+              items: [
+                '写入 memory 或 ingest messages 时传入 `appId`，例如 `appId: "docs"` 或 `appId: "support-bot"`。',
+                '搜索时，不传 `appId` 表示跨该 key 下的全部 appId 搜索；传非空 appId 表示只查一个子空间；传 `appId=null` 或 `appId=` 表示只查默认/global 记忆。',
+                '在 Console 中，可以用 appId 过滤器、appId 列和创建 memory 时的 appId 字段，查看或写入某个应用的记忆。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 4 日',
+          title: 'API 文档更新，并支持站内直接测试 API',
+          summary:
+            'mem9 API 文档完成了一次重要更新：页面布局更清晰，endpoint 内容补充得更完整，并新增了内置 API 测试控制台。开发者现在可以在同一个页面阅读文档并直接发起请求，不必在文档和外部调试工具之间来回切换。',
+          sections: [
+            {
+              title: '更新内容',
+              items: [
+                'API 页面更新了侧边栏和 endpoint 信息结构，阅读路径更清晰。',
+                '文档内容补充了鉴权、appId 隔离、memory API、imports、session messages 和 Space Chain API。',
+              ],
+            },
+            {
+              title: '在哪里体验',
+              body: '从站点导航打开 API 页面，在 API test 面板里设置 base URL、API key、headers、path/query/body 字段，运行请求，并直接在文档页查看响应。',
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 3 日',
+          title: '把已有 mem9 API key 导入 Console',
+          summary:
+            '已经通过 Agent 安装或 API 流程拿到 mem9 API key 的用户，现在可以把 key 绑定到 Console 的 Space。Console 会保护原始 key，只展示脱敏信息，并把已认领的 key 纳入组织配额模型。',
+          sections: [
+            {
+              title: '认领流程',
+              items: [
+                '从安装流程里的认领链接进入 Console，或直接打开 `/console/claim`。',
+                '粘贴已有 key，选择组织和项目，然后绑定到一个空 Space，或在流程中创建新 Space。',
+                '绑定后即可在 Console 管理这个 Space，普通页面不会暴露原始 key。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 3 日',
+          title: '内嵌计费、支付方式和发票',
+          summary:
+            'Console 的 Billing 区域现在提供更完整的 Stripe 计费体验，包括当前套餐、账单地址、支付方式、套餐变更、优惠码、取消/恢复订阅和发票历史。',
+          sections: [
+            {
+              title: '在哪里管理',
+              items: [
+                '打开 Console，选择组织，然后进入 Billing。',
+                '点击 Upgrade 或 Change plan，填写账单信息、选择套餐，并通过 Stripe Elements 完成支付确认。',
+                '在同一个 Billing 页面查看已保存的支付方式和发票。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 1 日',
+          title: 'Space Chain 知识路由',
+          summary:
+            'Space Chain 现在可以根据路由策略把提取出的知识写入正确的链节点。这样一条链可以像知识库一样工作：宽泛输入会落到对应团队、项目或主题 Space，同时仍可跨链召回。',
+          sections: [
+            {
+              title: '路由配置',
+              items: [
+                '打开 Space Chain 详情页，配置 knowledge extraction policy。',
+                '通过节点选择器和路由图决定提取出的事实应该写到哪里。',
+                '创建 memory 时启用 smart ingest，让系统提取并路由事实，而不是只写入一条原始 memory。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 1 日',
+          title: '服务端记忆排序和搜索控件',
+          summary:
+            'Memory 表格现在会基于服务端完整结果集排序和过滤，而不是只重排当前页。用户可以按内容、类型、标签和更新时间排序，并结合搜索条件使用。',
+          sections: [
+            {
+              title: '表格控件',
+              items: [
+                '打开 Space 或 Space Chain 的 memory workbench。',
+                '点击表头切换升序或降序排序。',
+                '使用内容、类型和标签搜索框；服务端会先过滤和排序，再分页返回。',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      period: '2026 年 5 月',
+      items: [
+        {
+          date: '2026 年 5 月 30 日',
+          title: '更快的 Space Chain 召回和耗时展示',
+          summary:
+            'Space Chain 召回现在会并行扫描节点并并行解析鉴权节点，同时保留全局 rerank 行为。Console 也会展示召回耗时，方便团队观察测试查询的速度。',
+          sections: [
+            {
+              title: '变更内容',
+              body: '召回链路在后台并行化处理，同时保留全局 rerank 行为。',
+            },
+            {
+              title: '如何验证',
+              items: [
+                '打开 Space Chain 详情页，使用 Recall test 面板。',
+                '需要测试跨链召回时启用 Force scanAll。',
+                '查看结果旁边的耗时，用来比较查询性能。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 25 日',
+          title: 'Session memory 管理和批量清理',
+          summary:
+            'Memory workbench 现在可以列出 session memory，按 All、Insight、Pinned、Session 过滤，选择行、调整页大小，并批量删除选中的 memories。API 也支持删除 session 行，并支持只提取事实、不保存原始 session 的请求级开关。',
+          sections: [
+            {
+              title: 'Console 清理',
+              items: [
+                '打开 Space memory workbench，选择 memory 类型过滤器。',
+                '选择一行或多行，然后从工具栏删除选中的 memories。',
+              ],
+            },
+            {
+              title: 'API 选项',
+              body: 'API ingest 时，如果只需要事实提取、不想保存原始会话消息，可设置 `disableSessionSave`。',
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 26 日',
+          title: 'Console 支持七种语言',
+          summary:
+            'Console 现在支持英语、简体中文、繁体中文、日语、韩语、印尼语和泰语，覆盖 shell、登录页、Spaces、Memories、Settings、Project 和 Space Chain 流程。',
+          sections: [
+            {
+              title: '语言切换',
+              items: [
+                '在 Console header 或登录页打开语言菜单。',
+                '选择语言；选择会保存在本地，并更新页面语言属性。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 19 日',
+          title: '计费和用量看板',
+          summary:
+            '组织现在可以查看计费套餐状态、权益、请求用量汇总、每日 rollup 和详细用量事件。runtime 已支持配额闸门和持久 metering，用于商业用量跟踪，同时不改变自托管行为。',
+          sections: [
+            {
+              title: '在哪里查看',
+              items: [
+                '打开 Console 并选择组织。',
+                '进入 Billing 查看套餐和权益状态。',
+                '进入 Usage，按日期范围查看 memory recall 和 memory write 请求总量。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 19 日',
+          title: 'Space memory 浏览器和运行时工具',
+          summary:
+            'Space 现在有 memory workbench，支持汇总指标、imports、memory 列表/详情、创建/编辑/删除，以及共享 Recall test 面板。原始 API key 保持在服务端，Console 会代理已授权的 memory 操作。',
+          sections: [
+            {
+              title: '工作台能力',
+              items: [
+                '在 Console 打开 Space 详情页。',
+                '使用 Memories tab 浏览、创建、编辑或删除 memories。',
+                '使用 Recall test 面板测试这个 Space 对查询会召回什么。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 15 日',
+          title: 'Space Chain 运行时支持',
+          summary:
+            'Space Chain 现在可在运行时使用，支持有序召回和写入、chain key 鉴权，以及链响应中的来源信息。一个 chain key 可以按受控顺序从多个 Space 召回。',
+          sections: [
+            {
+              title: '运行时配置',
+              items: [
+                '在 Console 创建或打开 Space Chain。',
+                '按照希望召回搜索的顺序添加 Space 节点。',
+                '创建 chain key binding；需要跨链召回时，用这个 key 并设置 `scanAll=true`。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 14 日',
+          title: '更安全的 Space API key 管理和组织角色',
+          summary:
+            'Space API key 会存储在加密目录中，普通页面展示稳定的脱敏值，并提供显式 reveal 流程和 active binding 检查。组织角色现在区分 owner、admin 和 member 权限。',
+          sections: [
+            {
+              title: '权限变化',
+              items: [
+                'Owner 和 admin 可以在 Space key 管理流程中创建、绑定和 reveal key。',
+                'Member 可以继续读取允许访问的资源，但没有变更权限。',
+                '普通页面使用脱敏 key；只有需要复制到客户端时才 reveal。',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyZhHant = attachReleaseNoteSources({
+  meta: {
+    title: '發布說明 | mem9',
+    description: 'mem9 面向客戶的發布說明，涵蓋 Console、API、Space Chain、計費和記憶管理的新功能。',
+  },
+  kicker: '發布說明',
+  title: 'mem9 最近更新了什麼',
+  intro: '在這裡 mem9 作者們會更新最近上線了哪些重要功能。',
+  starPrompt: '開源專案不容易，請大家給我們Star來支持我們。',
+  starBadgeAlt: 'mem9-ai/mem9 的 GitHub Stars',
+  starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+  starHref: 'https://github.com/mem9-ai/mem9',
+  updatedLabel: '最後更新',
+  updatedValue: '2026 年 6 月 4 日',
+  sourcesLabel: 'PR 來源',
+  sourcesFeedback: '歡迎進入PR、issue提交您的回饋。',
+  groups: [
+    {
+      period: '2026 年 6 月',
+      items: [
+        {
+          date: '2026 年 6 月 4 日',
+          title: 'mem9.ai 官方服務迎來重要效能更新',
+          summary:
+            'mem9.ai 官方服務正在進行重要效能優化。由於早期部署時服務和資料庫存在跨區存取，API 請求產生了額外延遲。我們正在分兩個階段遷移資料，以大幅降低官方託管服務的 API 延遲。',
+          sections: [
+            {
+              title: '發布節奏',
+              items: [
+                '第一階段已在北京時間 6 月 4 日中午發布，將普遍 API 延遲從平均約 4-6 秒降低到約 1.3 秒。',
+                '第二階段預計在本週完成中繼資料遷移，目標是把平均延遲進一步降低到幾百毫秒以內。',
+              ],
+            },
+            {
+              title: '回饋',
+              body: '這次更新不需要客戶端改動，會直接優化 mem9.ai 官方服務鏈路。歡迎大家繼續回饋 mem9 官方服務的效能體驗。',
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 4 日',
+          title: '同一把 API key 下的 appId 隔離',
+          summary:
+            '同一把 mem9 API key 現在可以透過 `appId` 承載多個彼此隔離的應用記憶空間。寫入時帶 appId 的 memory 和 raw session 會歸屬到對應應用，適合把不同產品、Agent、環境或工作流程放在同一把 key 下，同時避免日常記憶互相混在一起。',
+          sections: [
+            {
+              title: 'appId 如何隔離記憶',
+              items: [
+                '寫入 memory 或 ingest messages 時傳入 `appId`，例如 `appId: "docs"` 或 `appId: "support-bot"`。',
+                '搜尋時，不傳 `appId` 表示跨該 key 下的全部 appId 搜尋；傳非空 appId 表示只查一個子空間；傳 `appId=null` 或 `appId=` 表示只查預設/global 記憶。',
+                '在 Console 中，可以用 appId 篩選器、appId 欄位和建立 memory 時的 appId 欄位，查看或寫入某個應用的記憶。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 4 日',
+          title: 'API 文件更新，並支援站內直接測試 API',
+          summary:
+            'mem9 API 文件完成重要更新：頁面版面更清楚，endpoint 內容補充得更完整，並新增內建 API 測試控制台。開發者現在可以在同一個頁面閱讀文件並直接發起請求，不必在文件和外部除錯工具之間來回切換。',
+          sections: [
+            {
+              title: '更新內容',
+              items: [
+                'API 頁面更新了側邊欄和 endpoint 資訊結構，閱讀路徑更清晰。',
+                '文件內容補充了鑑權、appId 隔離、memory API、imports、session messages 和 Space Chain API。',
+              ],
+            },
+            {
+              title: '在哪裡體驗',
+              body: '從站點導覽開啟 API 頁面，在 API test 面板裡設定 base URL、API key、headers、path/query/body 欄位，執行請求，並直接在文件頁查看回應。',
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 3 日',
+          title: '把既有 mem9 API key 匯入 Console',
+          summary:
+            '已經透過 Agent 安裝或 API 流程拿到 mem9 API key 的使用者，現在可以把 key 綁定到 Console 的 Space。Console 會保護原始 key，只顯示脫敏資訊，並把已認領的 key 納入組織配額模型。',
+          sections: [
+            {
+              title: '認領流程',
+              items: [
+                '從安裝流程裡的認領連結進入 Console，或直接開啟 `/console/claim`。',
+                '貼上既有 key，選擇組織和專案，然後綁定到一個空 Space，或在流程中建立新 Space。',
+                '綁定後即可在 Console 管理這個 Space，普通頁面不會暴露原始 key。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 3 日',
+          title: '內嵌計費、付款方式和發票',
+          summary:
+            'Console 的 Billing 區域現在提供更完整的 Stripe 計費體驗，包括目前方案、帳單地址、付款方式、方案變更、優惠碼、取消/恢復訂閱和發票歷史。',
+          sections: [
+            {
+              title: '在哪裡管理',
+              items: [
+                '開啟 Console，選擇組織，然後進入 Billing。',
+                '點擊 Upgrade 或 Change plan，填寫帳單資訊、選擇方案，並透過 Stripe Elements 完成付款確認。',
+                '在同一個 Billing 頁面查看已儲存的付款方式和發票。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 1 日',
+          title: 'Space Chain 知識路由',
+          summary:
+            'Space Chain 現在可以根據路由策略把提取出的知識寫入正確的鏈節點。這樣一條鏈可以像知識庫一樣工作：寬泛輸入會落到對應團隊、專案或主題 Space，同時仍可跨鏈召回。',
+          sections: [
+            {
+              title: '路由設定',
+              items: [
+                '開啟 Space Chain 詳情頁，設定 knowledge extraction policy。',
+                '透過節點選擇器和路由圖決定提取出的事實應該寫到哪裡。',
+                '建立 memory 時啟用 smart ingest，讓系統提取並路由事實，而不是只寫入一條原始 memory。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 6 月 1 日',
+          title: '服務端記憶排序和搜尋控制',
+          summary:
+            'Memory 表格現在會基於服務端完整結果集排序和篩選，而不是只重排目前頁面。使用者可以按內容、類型、標籤和更新時間排序，並結合搜尋條件使用。',
+          sections: [
+            {
+              title: '表格控制',
+              items: [
+                '開啟 Space 或 Space Chain 的 memory workbench。',
+                '點擊表頭切換升序或降序排序。',
+                '使用內容、類型和標籤搜尋框；服務端會先篩選和排序，再分頁返回。',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      period: '2026 年 5 月',
+      items: [
+        {
+          date: '2026 年 5 月 30 日',
+          title: '更快的 Space Chain 召回和耗時展示',
+          summary:
+            'Space Chain 召回現在會並行掃描節點並並行解析鑑權節點，同時保留全域 rerank 行為。Console 也會展示召回耗時，方便團隊觀察測試查詢速度。',
+          sections: [
+            {
+              title: '變更內容',
+              body: '召回鏈路在後台並行化處理，同時保留全域 rerank 行為。',
+            },
+            {
+              title: '如何驗證',
+              items: [
+                '開啟 Space Chain 詳情頁，使用 Recall test 面板。',
+                '需要測試跨鏈召回時啟用 Force scanAll。',
+                '查看結果旁邊的耗時，用來比較查詢效能。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 25 日',
+          title: 'Session memory 管理和批量清理',
+          summary:
+            'Memory workbench 現在可以列出 session memory，按 All、Insight、Pinned、Session 篩選，選擇行、調整頁大小，並批量刪除選中的 memories。API 也支援刪除 session 行，並支援只提取事實、不保存原始 session 的請求級開關。',
+          sections: [
+            {
+              title: 'Console 清理',
+              items: [
+                '開啟 Space memory workbench，選擇 memory 類型篩選器。',
+                '選擇一行或多行，然後從工具列刪除選中的 memories。',
+              ],
+            },
+            {
+              title: 'API 選項',
+              body: 'API ingest 時，如果只需要事實提取、不想保存原始會話訊息，可設定 `disableSessionSave`。',
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 26 日',
+          title: 'Console 支援七種語言',
+          summary:
+            'Console 現在支援英語、簡體中文、繁體中文、日語、韓語、印尼語和泰語，覆蓋 shell、登入頁、Spaces、Memories、Settings、Project 和 Space Chain 流程。',
+          sections: [
+            {
+              title: '語言切換',
+              items: [
+                '在 Console header 或登入頁開啟語言選單。',
+                '選擇語言；選擇會保存在本地，並更新頁面語言屬性。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 19 日',
+          title: '計費和用量看板',
+          summary:
+            '組織現在可以查看計費方案狀態、權益、請求用量彙總、每日 rollup 和詳細用量事件。runtime 已支援配額閘門和持久 metering，用於商業用量追蹤，同時不改變自託管行為。',
+          sections: [
+            {
+              title: '在哪裡查看',
+              items: [
+                '開啟 Console 並選擇組織。',
+                '進入 Billing 查看方案和權益狀態。',
+                '進入 Usage，按日期範圍查看 memory recall 和 memory write 請求總量。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 19 日',
+          title: 'Space memory 瀏覽器和執行時工具',
+          summary:
+            'Space 現在有 memory workbench，支援彙總指標、imports、memory 列表/詳情、建立/編輯/刪除，以及共用 Recall test 面板。原始 API key 保持在服務端，Console 會代理已授權的 memory 操作。',
+          sections: [
+            {
+              title: '工作台能力',
+              items: [
+                '在 Console 開啟 Space 詳情頁。',
+                '使用 Memories tab 瀏覽、建立、編輯或刪除 memories。',
+                '使用 Recall test 面板測試這個 Space 對查詢會召回什麼。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 15 日',
+          title: 'Space Chain 執行時支援',
+          summary:
+            'Space Chain 現在可在執行時使用，支援有序召回和寫入、chain key 鑑權，以及鏈回應中的來源資訊。一個 chain key 可以按受控順序從多個 Space 召回。',
+          sections: [
+            {
+              title: '執行時設定',
+              items: [
+                '在 Console 建立或開啟 Space Chain。',
+                '按照希望召回搜尋的順序新增 Space 節點。',
+                '建立 chain key binding；需要跨鏈召回時，用這個 key 並設定 `scanAll=true`。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026 年 5 月 14 日',
+          title: '更安全的 Space API key 管理和組織角色',
+          summary:
+            'Space API key 會儲存在加密目錄中，普通頁面展示穩定的脫敏值，並提供明確 reveal 流程和 active binding 檢查。組織角色現在區分 owner、admin 和 member 權限。',
+          sections: [
+            {
+              title: '權限變化',
+              items: [
+                'Owner 和 admin 可以在 Space key 管理流程中建立、綁定和 reveal key。',
+                'Member 可以繼續讀取允許存取的資源，但沒有變更權限。',
+                '普通頁面使用脫敏 key；只有需要複製到客戶端時才 reveal。',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyJa = attachReleaseNoteSources({
+  meta: {
+    title: 'リリースノート | mem9',
+    description: 'Console、API、Space Chain、課金、メモリ管理に関する mem9 の顧客向けリリースノートです。',
+  },
+  kicker: 'リリースノート',
+  title: 'mem9 の最新アップデート',
+  intro: 'ここでは mem9 の作者が、最近リリースされた重要な機能を更新していきます。',
+  starPrompt: 'オープンソースの継続は簡単ではありません。GitHub で mem9 に Star を付けて応援してください。',
+  starBadgeAlt: 'mem9-ai/mem9 の GitHub Stars',
+  starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+  starHref: 'https://github.com/mem9-ai/mem9',
+  updatedLabel: '最終更新',
+  updatedValue: '2026年6月4日',
+  sourcesLabel: 'PR ソース',
+  sourcesFeedback: 'PR や issue を開いて、ぜひフィードバックをお寄せください。',
+  groups: [
+    {
+      period: '2026年6月',
+      items: [
+        {
+          date: '2026年6月4日',
+          title: 'mem9.ai 公式サービスの重要なパフォーマンス更新',
+          summary:
+            'mem9.ai 公式サービスで重要なパフォーマンス改善を進めています。初期デプロイ時の構成により、一部のサービスとデータベースがリージョンをまたいで動作していたため、API リクエストに余分な遅延が発生していました。データ移行を 2 段階で進め、公式ホストサービスの API レイテンシを大きく下げます。',
+          sections: [
+            {
+              title: 'ロールアウト',
+              items: [
+                '第 1 段階は北京時間 6 月 4 日正午にリリースされ、一般的な API レイテンシは平均約 4-6 秒から約 1.3 秒に下がりました。',
+                '第 2 段階ではメタデータを移行し、今週中の完了を予定しています。平均レイテンシを数百ミリ秒以内に下げることを目標にしています。',
+              ],
+            },
+            {
+              title: 'フィードバック',
+              body: 'クライアント側の変更は不要です。この更新は mem9.ai 公式サービスの経路を直接改善します。公式サービスのパフォーマンスに関するフィードバックを歓迎します。',
+            },
+          ],
+        },
+        {
+          date: '2026年6月4日',
+          title: '1 つの API key で appId ごとの分離',
+          summary:
+            '1 つの mem9 API key で、`appId` によって複数の分離されたアプリケーションメモリ空間を扱えるようになりました。appId 付きで書き込まれた memory と raw session は対応するアプリに紐づくため、異なるプロダクト、Agent、環境、ワークフローを同じ key で扱いながら日常的なメモリの混在を避けられます。',
+          sections: [
+            {
+              title: 'appId によるメモリ分離',
+              items: [
+                'memory の書き込みや ingest messages では `appId` を送ります。例: `appId: "docs"` または `appId: "support-bot"`。',
+                '検索時は、`appId` を省略すると key 配下の全 appId を横断検索します。空でない appId を渡すと 1 つのサブ空間のみ、`appId=null` または `appId=` を渡すとデフォルト/global メモリのみを検索します。',
+                'Console では appId フィルター、appId 列、memory 作成時の appId フィールドを使って、特定アプリのメモリを確認または書き込みできます。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年6月4日',
+          title: 'API ドキュメント刷新とページ内 API テスト',
+          summary:
+            'mem9 API リファレンスを刷新しました。レイアウトを整理し、endpoint の内容を更新し、組み込みの API テストコンソールを追加しています。開発者はドキュメントと別ツールを行き来せず、同じページで読みながらリクエストを試せます。',
+          sections: [
+            {
+              title: '変更点',
+              items: [
+                'API ページのサイドバーと endpoint レイアウトが読みやすくなりました。',
+                '認証、appId 分離、memory API、imports、session messages、Space Chain API の内容を更新しました。',
+              ],
+            },
+            {
+              title: '試す場所',
+              body: 'サイトナビゲーションから API ページを開き、API test パネルで base URL、API key、headers、path/query/body フィールドを設定してリクエストを実行し、レスポンスをその場で確認できます。',
+            },
+          ],
+        },
+        {
+          date: '2026年6月3日',
+          title: '既存の mem9 API key を Console にインポート',
+          summary:
+            'Agent セットアップや API フローで既に mem9 API key を受け取っているユーザーは、その key を Console の Space に紐づけられるようになりました。Console は生の key を保護し、マスク済み情報のみを表示し、認領済み key を組織のクォータモデルに移行します。',
+          sections: [
+            {
+              title: '認領フロー',
+              items: [
+                'セットアップ手順の認領リンクから Console を開くか、直接 `/console/claim` にアクセスします。',
+                '既存 key を貼り付け、組織とプロジェクトを選び、空の Space に紐づけるかフロー内で新しい Space を作成します。',
+                '紐づけ後は Console から Space を管理できます。通常画面では生の key は表示されません。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年6月3日',
+          title: '組み込み課金、支払い方法、請求書',
+          summary:
+            'Console の Billing エリアに、Stripe ベースのより完全な課金体験が入りました。現在のプラン、請求先住所、支払い方法、プラン変更、クーポン、キャンセル/再開、請求書履歴を扱えます。',
+          sections: [
+            {
+              title: '管理場所',
+              items: [
+                'Console を開き、組織を選択して Billing に移動します。',
+                'Upgrade または Change plan から請求情報を入力し、プランを選び、Stripe Elements で支払いを確定します。',
+                '同じ Billing ページで保存済みの支払い方法と請求書を確認できます。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年6月1日',
+          title: 'Space Chain の知識ルーティング',
+          summary:
+            'Space Chain は、ルーティングポリシーのフィールドに基づいて抽出された知識を正しいチェーンノードへ書き込めるようになりました。広い入力を適切なチーム、プロジェクト、トピックの Space に配置しつつ、チェーン全体で recall できます。',
+          sections: [
+            {
+              title: 'ルーティング設定',
+              items: [
+                'Space Chain 詳細ページを開き、knowledge extraction policy を設定します。',
+                'ノードセレクターとルーティング図で、抽出された事実を書き込む場所を決めます。',
+                'memory 作成時に smart ingest を有効にすると、単一の raw memory だけでなく事実を抽出してルーティングできます。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年6月1日',
+          title: 'サーバー側メモリ並び替えと検索コントロール',
+          summary:
+            'Memory テーブルは現在ページだけでなく、サーバー側の完全な結果セットに対して並び替えとフィルターを適用します。内容、種類、タグ、更新日時で並び替えながら検索条件と組み合わせられます。',
+          sections: [
+            {
+              title: 'テーブル操作',
+              items: [
+                'Space または Space Chain の memory workbench を開きます。',
+                'テーブルヘッダーをクリックして昇順または降順に切り替えます。',
+                '内容、種類、タグの検索欄を使います。サーバーはページネーション前にフィルターと並び替えを適用します。',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      period: '2026年5月',
+      items: [
+        {
+          date: '2026年5月30日',
+          title: 'タイミング表示付きの高速 Space Chain recall',
+          summary:
+            'Space Chain recall はノードスキャンと認証解決を並列化し、グローバル rerank の動作を保ったまま高速化しました。Console では recall の所要時間も表示され、テストクエリの速度を確認できます。',
+          sections: [
+            {
+              title: '変更点',
+              body: 'recall 処理はバックグラウンドで並列化され、グローバル rerank の動作は維持されます。',
+            },
+            {
+              title: '確認方法',
+              items: [
+                'Space Chain 詳細ページを開き、Recall test パネルを使います。',
+                'チェーン横断の recall をテストしたい場合は Force scanAll を有効にします。',
+                '結果に表示される経過時間を見てクエリ性能を比較できます。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年5月25日',
+          title: 'Session memory 管理と一括クリーンアップ',
+          summary:
+            'memory workbench で session memory 行を一覧表示し、All、Insight、Pinned、Session でフィルターし、行選択、ページサイズ変更、選択した memories の一括削除ができるようになりました。API でも session 行の削除と、抽出事実だけが必要な場合に raw session を保存しないリクエスト単位のスイッチをサポートします。',
+          sections: [
+            {
+              title: 'Console での整理',
+              items: [
+                'Space memory workbench を開き、memory type フィルターを選択します。',
+                '1 行または複数行を選び、ツールバーから選択した memories を削除します。',
+              ],
+            },
+            {
+              title: 'API オプション',
+              body: 'API ingest フローでは、raw session message を保存せず事実抽出だけを行いたい場合に `disableSessionSave` を設定します。',
+            },
+          ],
+        },
+        {
+          date: '2026年5月26日',
+          title: 'Console が 7 言語に対応',
+          summary:
+            'Console は英語、簡体字中国語、繁体字中国語、日本語、韓国語、インドネシア語、タイ語に対応しました。shell、認証ページ、Spaces、Memories、Settings、Project、Space Chain フローをカバーします。',
+          sections: [
+            {
+              title: '言語切り替え',
+              items: [
+                'Console ヘッダーまたは認証ページで言語メニューを開きます。',
+                '言語を選択します。選択はローカルに保存され、ドキュメント言語も更新されます。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年5月19日',
+          title: '課金と利用状況ダッシュボード',
+          summary:
+            '組織は課金プラン状態、権限、リクエスト利用状況のサマリー、日次 rollup、詳細な利用イベントを確認できます。runtime にはクォータゲートと永続 metering が入り、セルフホスト挙動を変えずに商用利用を追跡できます。',
+          sections: [
+            {
+              title: '確認場所',
+              items: [
+                'Console を開き、組織を選択します。',
+                'Billing でプランと権限状態を確認します。',
+                'Usage で日付範囲を選び、memory recall と memory write のリクエスト合計を確認します。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年5月19日',
+          title: 'Space memory explorer と runtime ツール',
+          summary:
+            'Spaces に memory workbench が追加され、サマリーメトリクス、imports、memory 一覧/詳細、作成/編集/削除、共有 Recall test パネルを利用できます。生の API key はサーバー側に保持され、Console が認可済み memory 操作をプロキシします。',
+          sections: [
+            {
+              title: 'ワークベンチ機能',
+              items: [
+                'Console で Space 詳細ページを開きます。',
+                'Memories tab で memories を閲覧、作成、編集、削除します。',
+                'Recall test パネルで、その Space がクエリに対して何を取得するかをテストします。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年5月15日',
+          title: 'Space Chain runtime 対応',
+          summary:
+            'Space Chains は runtime で利用可能になり、順序付き recall と書き込み、chain key 認証、チェーンレスポンス内の provenance をサポートします。1 つの chain key で複数 Space から制御された順序で recall できます。',
+          sections: [
+            {
+              title: 'runtime 設定',
+              items: [
+                'Console で Space Chain を作成または開きます。',
+                'recall に検索させたい順序で Space ノードを追加します。',
+                'chain key binding を作成し、チェーン横断 recall が必要な場合はその key と `scanAll=true` を使います。',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026年5月14日',
+          title: 'より安全な Space API key 管理と組織ロール',
+          summary:
+            'Space API keys は暗号化されたカタログに保存され、安定したマスク表示、明示的な reveal フロー、active binding チェックを備えます。組織ロールは owner、admin、member の権限を区別します。',
+          sections: [
+            {
+              title: '権限',
+              items: [
+                'Owner と admin は Space key 管理フローで key の作成、紐づけ、reveal ができます。',
+                'Member は許可されたリソースの読み取りを続けられますが、変更権限はありません。',
+                '通常画面ではマスク済み key を使い、クライアントにコピーする必要がある場合だけ reveal します。',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyKo = attachReleaseNoteSources({
+  meta: {
+    title: '릴리스 노트 | mem9',
+    description: 'Console, API, Space Chain, 결제, 메모리 관리의 새로운 기능을 다루는 mem9 고객용 릴리스 노트입니다.',
+  },
+  kicker: '릴리스 노트',
+  title: 'mem9의 최신 업데이트',
+  intro: '여기에서 mem9 작성자들이 최근 출시된 중요한 기능을 업데이트합니다.',
+  starPrompt: '오픈소스 프로젝트를 지속하는 일은 쉽지 않습니다. GitHub에서 mem9에 Star를 눌러 응원해 주세요.',
+  starBadgeAlt: 'mem9-ai/mem9 GitHub Stars',
+  starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+  starHref: 'https://github.com/mem9-ai/mem9',
+  updatedLabel: '마지막 업데이트',
+  updatedValue: '2026년 6월 4일',
+  sourcesLabel: 'PR 출처',
+  sourcesFeedback: 'PR 또는 issue에 들어가 피드백을 남겨 주세요.',
+  groups: [
+    {
+      period: '2026년 6월',
+      items: [
+        {
+          date: '2026년 6월 4일',
+          title: 'mem9.ai 공식 서비스의 주요 성능 업데이트',
+          summary:
+            'mem9.ai 공식 서비스에 중요한 성능 개선을 적용하고 있습니다. 초기 배포 구성 때문에 일부 서비스와 데이터베이스가 서로 다른 리전에 있어 API 요청에 불필요한 지연이 있었습니다. 데이터를 두 단계로 이전해 공식 호스팅 서비스의 API 지연 시간을 크게 낮춥니다.',
+          sections: [
+            {
+              title: '출시 일정',
+              items: [
+                '1단계는 베이징 시간 6월 4일 정오에 배포되었고, 일반적인 API 지연 시간이 평균 약 4-6초에서 약 1.3초로 줄었습니다.',
+                '2단계는 이번 주 안에 메타데이터 이전을 완료할 예정이며, 평균 지연 시간을 수백 밀리초 이내로 낮추는 것이 목표입니다.',
+              ],
+            },
+            {
+              title: '피드백',
+              body: '클라이언트 측 변경은 필요하지 않습니다. 이 업데이트는 mem9.ai 공식 서비스 경로를 직접 개선하며, 공식 서비스 성능에 대한 피드백을 환영합니다.',
+            },
+          ],
+        },
+        {
+          date: '2026년 6월 4일',
+          title: '하나의 API key 안에서 appId 격리',
+          summary:
+            '하나의 mem9 API key가 `appId`로 여러 개의 격리된 애플리케이션 메모리 공간을 담을 수 있습니다. appId와 함께 기록된 memory와 raw session은 해당 앱에 연결되므로, 서로 다른 제품, Agent, 환경, 워크플로를 같은 key로 사용하면서 일상 메모리가 섞이지 않게 할 수 있습니다.',
+          sections: [
+            {
+              title: 'appId가 메모리를 나누는 방식',
+              items: [
+                'memory를 쓰거나 ingest messages를 보낼 때 `appId`를 함께 보냅니다. 예: `appId: "docs"` 또는 `appId: "support-bot"`.',
+                '검색할 때 `appId`를 생략하면 해당 key 아래의 모든 appId를 검색합니다. 비어 있지 않은 appId를 전달하면 한 하위 공간만 검색하고, `appId=null` 또는 `appId=`는 기본/global 메모리만 검색합니다.',
+                'Console에서는 appId 필터, appId 열, memory 생성 시 appId 필드를 사용해 특정 애플리케이션의 메모리를 확인하거나 쓸 수 있습니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 6월 4일',
+          title: 'API 문서 개편 및 문서 안에서 API 테스트',
+          summary:
+            'mem9 API 레퍼런스가 더 명확한 레이아웃, 업데이트된 endpoint 설명, 내장 API 테스트 콘솔로 개편되었습니다. 개발자는 문서와 별도 도구를 오가지 않고 같은 페이지에서 문서를 읽고 요청을 시험할 수 있습니다.',
+          sections: [
+            {
+              title: '변경 내용',
+              items: [
+                'API 페이지의 사이드바와 endpoint 레이아웃이 더 명확해졌습니다.',
+                '인증, appId 격리, memory API, imports, session messages, Space Chain API 문서가 업데이트되었습니다.',
+              ],
+            },
+            {
+              title: '테스트 위치',
+              body: '사이트 내비게이션에서 API 페이지를 열고 API test 패널에서 base URL, API key, headers, path/query/body 필드를 설정한 뒤 요청을 실행하고 응답을 바로 확인할 수 있습니다.',
+            },
+          ],
+        },
+        {
+          date: '2026년 6월 3일',
+          title: '기존 mem9 API key를 Console로 가져오기',
+          summary:
+            'Agent 설치나 API 흐름에서 이미 mem9 API key를 받은 사용자는 이제 그 key를 Console의 Space에 연결할 수 있습니다. Console은 원본 key를 보호하고 마스킹된 정보만 보여 주며, claim된 key를 조직 quota 모델로 이동합니다.',
+          sections: [
+            {
+              title: 'Claim 흐름',
+              items: [
+                '설치 흐름의 claim 링크로 Console에 들어가거나 `/console/claim`을 직접 엽니다.',
+                '기존 key를 붙여넣고 조직과 프로젝트를 선택한 뒤 빈 Space에 연결하거나 흐름 안에서 새 Space를 만듭니다.',
+                '연결 후에는 원본 key를 일반 화면에 노출하지 않고 Console에서 Space를 관리할 수 있습니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 6월 3일',
+          title: '내장 결제, 결제 수단, 인보이스',
+          summary:
+            'Console의 Billing 영역에 Stripe 기반 결제 경험이 더 완성도 있게 들어갔습니다. 현재 플랜, 청구 주소, 결제 수단, 플랜 변경, 쿠폰, 구독 취소/재개, 인보이스 기록을 다룰 수 있습니다.',
+          sections: [
+            {
+              title: '관리 위치',
+              items: [
+                'Console을 열고 조직을 선택한 다음 Billing으로 이동합니다.',
+                'Upgrade 또는 Change plan에서 청구 정보를 입력하고 플랜을 선택한 뒤 Stripe Elements로 결제를 확인합니다.',
+                '같은 Billing 페이지에서 저장된 결제 수단과 인보이스를 확인합니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 6월 1일',
+          title: 'Space Chain 지식 라우팅',
+          summary:
+            'Space Chain은 이제 라우팅 정책 필드에 따라 추출된 지식을 올바른 Space Chain 노드에 쓸 수 있습니다. 넓은 범위의 입력을 적절한 팀, 프로젝트, 주제 Space에 저장하면서도 체인 전체 recall은 유지됩니다.',
+          sections: [
+            {
+              title: '라우팅 설정',
+              items: [
+                'Space Chain 상세 페이지를 열고 knowledge extraction policy를 설정합니다.',
+                '노드 선택기와 라우팅 다이어그램을 사용해 추출된 사실을 어디에 쓸지 결정합니다.',
+                'memory를 만들 때 smart ingest를 켜면 하나의 raw memory만 쓰는 대신 사실을 추출하고 라우팅합니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 6월 1일',
+          title: '서버 측 메모리 정렬과 검색 컨트롤',
+          summary:
+            'Memory 테이블은 이제 현재 페이지만이 아니라 서버의 전체 결과 집합에 대해 정렬과 필터를 적용합니다. 사용자는 내용, 유형, 태그, 업데이트 시간으로 정렬하고 검색 조건과 함께 사용할 수 있습니다.',
+          sections: [
+            {
+              title: '테이블 컨트롤',
+              items: [
+                'Space 또는 Space Chain memory workbench를 엽니다.',
+                '테이블 헤더를 클릭해 오름차순 또는 내림차순으로 정렬합니다.',
+                '내용, 유형, 태그 검색 필드를 사용하면 서버가 페이지네이션 전에 필터와 정렬을 적용합니다.',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      period: '2026년 5월',
+      items: [
+        {
+          date: '2026년 5월 30일',
+          title: '시간 표시가 포함된 더 빠른 Space Chain recall',
+          summary:
+            'Space Chain recall은 노드 스캔과 인증 해석을 병렬화하면서 글로벌 rerank 동작을 유지합니다. Console은 recall 소요 시간도 보여 주므로 팀이 테스트 쿼리 속도를 확인할 수 있습니다.',
+          sections: [
+            {
+              title: '변경 내용',
+              body: 'recall 작업은 백그라운드에서 병렬화되며 글로벌 rerank 동작은 그대로 유지됩니다.',
+            },
+            {
+              title: '검증 방법',
+              items: [
+                'Space Chain 상세 페이지를 열고 Recall test 패널을 사용합니다.',
+                '체인 전체 recall 동작을 테스트하려면 Force scanAll을 켭니다.',
+                '결과에 표시되는 경과 시간을 확인해 쿼리 성능을 비교합니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 5월 25일',
+          title: 'Session memory 관리와 일괄 정리',
+          summary:
+            'memory workbench에서 session memory 행을 나열하고 All, Insight, Pinned, Session으로 필터링하며, 행 선택, 페이지 크기 변경, 선택한 memories 일괄 삭제를 할 수 있습니다. API도 session 행 삭제와, 추출된 사실만 필요할 때 raw session 행을 저장하지 않는 요청 단위 스위치를 지원합니다.',
+          sections: [
+            {
+              title: 'Console 정리',
+              items: [
+                'Space memory workbench를 열고 memory type 필터를 선택합니다.',
+                '하나 이상의 행을 선택한 다음 툴바에서 선택한 memories를 삭제합니다.',
+              ],
+            },
+            {
+              title: 'API 옵션',
+              body: 'API ingest 흐름에서는 원본 session messages를 보존하지 않고 사실 추출만 원할 때 `disableSessionSave`를 설정합니다.',
+            },
+          ],
+        },
+        {
+          date: '2026년 5월 26일',
+          title: 'Console의 7개 언어 지원',
+          summary:
+            'Console은 영어, 중국어 간체, 중국어 번체, 일본어, 한국어, 인도네시아어, 태국어를 지원합니다. shell, 인증 페이지, Spaces, Memories, Settings, Project, Space Chain 흐름을 포함합니다.',
+          sections: [
+            {
+              title: '언어 전환',
+              items: [
+                'Console 헤더 또는 인증 페이지에서 언어 메뉴를 엽니다.',
+                '언어를 선택합니다. 선택은 로컬에 저장되고 문서 언어도 업데이트됩니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 5월 19일',
+          title: '결제와 사용량 대시보드',
+          summary:
+            '조직은 결제 플랜 상태, 권한, 요청 사용량 요약, 일별 rollup, 상세 사용 이벤트를 확인할 수 있습니다. runtime에는 quota gate와 지속 metering이 추가되어 self-hosted 동작을 바꾸지 않고 상업적 사용량을 추적할 수 있습니다.',
+          sections: [
+            {
+              title: '확인 위치',
+              items: [
+                'Console을 열고 조직을 선택합니다.',
+                'Billing에서 플랜과 entitlement 상태를 확인합니다.',
+                'Usage에서 선택한 날짜 범위의 memory recall 및 memory write 요청 합계를 확인합니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 5월 19일',
+          title: 'Space memory explorer와 runtime 도구',
+          summary:
+            'Spaces에는 summary metrics, imports, memory 목록/상세 조회, 생성/수정/삭제, 공유 Recall test 패널을 갖춘 memory workbench가 생겼습니다. 원본 API key는 서버 측에 유지되고 Console이 승인된 memory 작업을 프록시합니다.',
+          sections: [
+            {
+              title: '워크벤치 기능',
+              items: [
+                'Console에서 Space 상세 페이지를 엽니다.',
+                'Memories tab에서 memories를 탐색, 생성, 수정, 삭제합니다.',
+                'Recall test 패널로 해당 Space가 쿼리에 대해 무엇을 검색하는지 테스트합니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 5월 15일',
+          title: 'Space Chain runtime 지원',
+          summary:
+            'Space Chains는 이제 runtime에서 사용할 수 있으며, 순서 있는 recall과 write, chain key 인증, chain 응답의 provenance를 지원합니다. 하나의 chain key로 여러 Space에서 제어된 순서로 recall할 수 있습니다.',
+          sections: [
+            {
+              title: 'runtime 설정',
+              items: [
+                'Console에서 Space Chain을 만들거나 엽니다.',
+                'recall이 검색할 순서대로 Space 노드를 추가합니다.',
+                'chain key binding을 만들고 체인 전체 recall이 필요하면 해당 key와 `scanAll=true`를 사용합니다.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '2026년 5월 14일',
+          title: '더 안전한 Space API key 관리와 조직 역할',
+          summary:
+            'Space API keys는 암호화된 카탈로그에 저장되며 안정적인 마스킹 표시, 명시적인 reveal 흐름, active binding 검사를 제공합니다. 조직 역할은 owner, admin, member 권한을 구분합니다.',
+          sections: [
+            {
+              title: '권한',
+              items: [
+                'Owner와 admin은 Space key 관리 흐름에서 key를 만들고 연결하고 reveal할 수 있습니다.',
+                'Member는 허용된 리소스를 계속 읽을 수 있지만 변경 권한은 없습니다.',
+                '일반 화면에서는 마스킹된 key를 사용하고, 클라이언트에 복사해야 할 때만 reveal합니다.',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyId = attachReleaseNoteSources({
+  meta: {
+    title: 'Catatan Rilis | mem9',
+    description: 'Catatan rilis mem9 untuk pelanggan, mencakup Console, API, Space Chain, billing, dan manajemen memori.',
+  },
+  kicker: 'Catatan Rilis',
+  title: 'Apa yang baru di mem9',
+  intro: 'Di sini para pembuat mem9 akan memperbarui fitur penting yang baru saja dirilis.',
+  starPrompt: 'Proyek open-source tidak mudah dijalankan. Dukung kami dengan memberi Star untuk mem9 di GitHub.',
+  starBadgeAlt: 'GitHub stars untuk mem9-ai/mem9',
+  starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+  starHref: 'https://github.com/mem9-ai/mem9',
+  updatedLabel: 'Terakhir diperbarui',
+  updatedValue: '4 Juni 2026',
+  sourcesLabel: 'Sumber PR',
+  sourcesFeedback: 'Silakan buka PR atau issue dan kirimkan masukan Anda.',
+  groups: [
+    {
+      period: 'Juni 2026',
+      items: [
+        {
+          date: '4 Juni 2026',
+          title: 'Pembaruan performa besar untuk mem9.ai',
+          summary:
+            'Layanan resmi mem9.ai sedang menerima pembaruan performa penting. Karena pilihan deployment awal, sebagian layanan dan database berjalan lintas region sehingga menambah latency yang tidak perlu. Kami memigrasikan data dalam dua fase untuk menurunkan latency API layanan hosted secara signifikan.',
+          sections: [
+            {
+              title: 'Rilis bertahap',
+              items: [
+                'Fase 1 dirilis pada siang hari waktu Beijing tanggal 4 Juni dan menurunkan latency API umum dari rata-rata sekitar 4-6 detik menjadi sekitar 1,3 detik.',
+                'Fase 2 ditargetkan selesai minggu ini untuk memigrasikan metadata, dengan target menurunkan latency rata-rata ke kisaran beberapa ratus milidetik.',
+              ],
+            },
+            {
+              title: 'Masukan',
+              body: 'Tidak ada perubahan sisi klien yang diperlukan. Pembaruan ini langsung memperbaiki jalur layanan hosted mem9.ai, dan masukan tentang performa layanan resmi sangat kami harapkan.',
+            },
+          ],
+        },
+        {
+          date: '4 Juni 2026',
+          title: 'Isolasi appId dalam satu API key',
+          summary:
+            'Satu mem9 API key sekarang dapat memuat beberapa ruang memori aplikasi yang terisolasi dengan `appId`. Memory dan raw session yang ditulis dengan appId akan tetap terhubung ke aplikasi tersebut, sehingga produk, Agent, environment, atau workflow berbeda dapat berbagi key yang sama tanpa mencampur memori harian.',
+          sections: [
+            {
+              title: 'Cara appId memisahkan memori',
+              items: [
+                'Saat menulis memory atau ingest messages, kirim `appId`, misalnya `appId: "docs"` atau `appId: "support-bot"`.',
+                'Saat mencari, kosongkan `appId` untuk mencari semua appId di bawah key tersebut, kirim appId non-kosong untuk mencari satu sub-ruang, atau kirim `appId=null` / `appId=` untuk mencari hanya memori default/global.',
+                'Di Console, gunakan filter appId, kolom appId, dan field appId saat membuat memory untuk melihat atau menulis memori milik aplikasi tertentu.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '4 Juni 2026',
+          title: 'Penyegaran API reference dengan uji API langsung',
+          summary:
+            'API reference mem9 diperbarui dengan layout yang lebih jelas, konten endpoint yang diperbarui, dan konsol uji API bawaan. Developer kini dapat membaca dokumentasi dan mencoba request di halaman yang sama tanpa berpindah ke tooling terpisah.',
+          sections: [
+            {
+              title: 'Yang berubah',
+              items: [
+                'Halaman API kini memiliki sidebar dan layout endpoint yang lebih jelas.',
+                'Konten dokumentasi diperbarui untuk authentication, appId isolation, memory APIs, imports, session messages, dan Space Chain APIs.',
+              ],
+            },
+            {
+              title: 'Tempat mencoba',
+              body: 'Buka halaman API dari navigasi situs, lalu gunakan panel API test untuk mengatur base URL, API key, headers, field path/query/body, menjalankan request, dan melihat response langsung di halaman dokumentasi.',
+            },
+          ],
+        },
+        {
+          date: '3 Juni 2026',
+          title: 'Impor mem9 API key yang sudah ada ke Console',
+          summary:
+            'Pengguna yang sudah menerima mem9 API key dari setup Agent atau flow API kini dapat mengaitkan key tersebut ke Space di Console. Console melindungi key mentah, hanya menampilkan detail yang disamarkan, dan memindahkan key yang sudah diklaim ke model quota organisasi.',
+          sections: [
+            {
+              title: 'Flow klaim',
+              items: [
+                'Buka flow klaim Console dari link setup, atau langsung buka `/console/claim`.',
+                'Tempel key yang sudah ada, pilih organisasi dan proyek, lalu kaitkan ke Space kosong atau buat Space baru di dalam flow.',
+                'Setelah dikaitkan, kelola Space dari Console tanpa menampilkan key mentah di tampilan biasa.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '3 Juni 2026',
+          title: 'Billing, metode pembayaran, dan invoice tertanam',
+          summary:
+            'Area Billing di Console kini memiliki pengalaman billing berbasis Stripe yang lebih lengkap: plan saat ini, alamat billing, metode pembayaran, kontrol perubahan plan, kupon, aksi cancel/resume, dan riwayat invoice.',
+          sections: [
+            {
+              title: 'Tempat mengelola',
+              items: [
+                'Buka Console, pilih organisasi, lalu masuk ke Billing.',
+                'Gunakan Upgrade atau Change plan untuk memasukkan detail billing, memilih plan, dan mengonfirmasi pembayaran dengan Stripe Elements.',
+                'Tinjau metode pembayaran tersimpan dan invoice dari halaman Billing yang sama.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '1 Juni 2026',
+          title: 'Routing knowledge di Space Chain',
+          summary:
+            'Space Chain kini dapat merutekan knowledge yang diekstrak ke node Space Chain yang tepat berdasarkan field routing policy. Chain bisa bertindak lebih seperti knowledgebase: ingest yang luas masuk ke Space tim, proyek, atau topik yang benar, sementara recall tetap bisa berjalan lintas chain.',
+          sections: [
+            {
+              title: 'Pengaturan routing',
+              items: [
+                'Buka halaman detail Space Chain dan konfigurasi knowledge extraction policy.',
+                'Gunakan node selector dan diagram routing untuk menentukan lokasi penulisan fakta yang diekstrak.',
+                'Saat membuat memory, aktifkan smart ingest agar sistem mengekstrak dan merutekan fakta, bukan hanya menulis satu item raw memory.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '1 Juni 2026',
+          title: 'Sorting memori sisi server dan kontrol pencarian',
+          summary:
+            'Tabel Memory sekarang melakukan sort dan filter terhadap seluruh hasil di server, bukan hanya halaman saat ini. Pengguna dapat sort berdasarkan content, type, tags, dan updated time sambil menggabungkannya dengan kontrol pencarian.',
+          sections: [
+            {
+              title: 'Kontrol tabel',
+              items: [
+                'Buka memory workbench untuk Space atau Space Chain.',
+                'Klik header tabel untuk mengurutkan naik atau turun.',
+                'Gunakan field pencarian untuk content, type, dan tags; server menerapkan filter dan sort sebelum pagination.',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      period: 'Mei 2026',
+      items: [
+        {
+          date: '30 Mei 2026',
+          title: 'Recall Space Chain lebih cepat dengan visibilitas waktu',
+          summary:
+            'Recall Space Chain kini memparalelkan pemindaian node dan penyelesaian auth, sambil mempertahankan perilaku reranking global. Console juga menampilkan timing recall agar tim dapat melihat durasi test recall.',
+          sections: [
+            {
+              title: 'Yang berubah',
+              body: 'Pekerjaan recall diparalelkan di belakang layar, sementara perilaku reranking global tetap sama.',
+            },
+            {
+              title: 'Cara memvalidasi',
+              items: [
+                'Buka halaman detail Space Chain dan gunakan panel Recall test.',
+                'Aktifkan Force scanAll jika ingin menguji perilaku recall lintas chain.',
+                'Periksa waktu yang ditampilkan bersama hasil untuk membandingkan performa query.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '25 Mei 2026',
+          title: 'Manajemen session memory dan pembersihan batch',
+          summary:
+            'Memory workbench kini dapat menampilkan row session memory, memfilter All, Insight, Pinned, atau Session, memilih row, mengubah page size, dan menghapus memories terpilih secara batch. API juga mendukung penghapusan session row dan switch per request untuk tidak menyimpan raw session saat hanya fakta hasil ekstraksi yang dibutuhkan.',
+          sections: [
+            {
+              title: 'Pembersihan di Console',
+              items: [
+                'Buka Space memory workbench dan pilih filter memory type.',
+                'Pilih satu atau beberapa row, lalu hapus memories terpilih dari toolbar.',
+              ],
+            },
+            {
+              title: 'Opsi API',
+              body: 'Untuk flow API ingest, set `disableSessionSave` saat Anda ingin ekstraksi fakta tanpa menyimpan raw session messages.',
+            },
+          ],
+        },
+        {
+          date: '26 Mei 2026',
+          title: 'Console mendukung tujuh bahasa',
+          summary:
+            'Console kini mendukung bahasa Inggris, Chinese Simplified, Chinese Traditional, Jepang, Korea, Indonesia, dan Thai di shell, halaman auth, Spaces, Memories, Settings, Project, dan flow Space Chain.',
+          sections: [
+            {
+              title: 'Pengalih bahasa',
+              items: [
+                'Buka menu bahasa di header Console atau halaman auth.',
+                'Pilih bahasa; pilihan disimpan secara lokal dan memperbarui bahasa dokumen.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '19 Mei 2026',
+          title: 'Dashboard billing dan usage',
+          summary:
+            'Organisasi dapat meninjau status plan billing, entitlements, ringkasan usage request, daily rollups, dan event usage terperinci. Runtime kini memiliki quota gate dan metering durable sehingga usage komersial dapat dilacak tanpa mengubah perilaku self-hosted.',
+          sections: [
+            {
+              title: 'Tempat melihat',
+              items: [
+                'Buka Console dan pilih organisasi.',
+                'Masuk ke Billing untuk meninjau status plan dan entitlement.',
+                'Masuk ke Usage untuk memeriksa total request memory recall dan memory write pada rentang tanggal yang dipilih.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '19 Mei 2026',
+          title: 'Space memory explorer dan runtime tools',
+          summary:
+            'Spaces kini memiliki memory workbench dengan summary metrics, imports, daftar/detail memory, kontrol create/edit/delete, dan panel Recall test bersama. Raw API key tetap berada di server sementara Console mem-proxy operasi memory yang sudah diotorisasi.',
+          sections: [
+            {
+              title: 'Alat workbench',
+              items: [
+                'Buka halaman detail Space di Console.',
+                'Gunakan tab Memories untuk menelusuri, membuat, mengedit, atau menghapus memories.',
+                'Gunakan panel Recall test untuk menguji apa yang akan diambil Space untuk sebuah query.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '15 Mei 2026',
+          title: 'Dukungan runtime Space Chain',
+          summary:
+            'Space Chains kini tersedia di runtime, dengan perilaku recall dan write berurutan, autentikasi chain key, dan provenance di response chain. Satu chain key dapat mengambil dari beberapa Space dalam urutan yang terkendali.',
+          sections: [
+            {
+              title: 'Pengaturan runtime',
+              items: [
+                'Buat atau buka Space Chain di Console.',
+                'Tambahkan node Space dalam urutan yang Anda inginkan untuk pencarian recall.',
+                'Buat chain key binding, lalu gunakan key tersebut dengan `scanAll=true` saat Anda ingin recall lintas chain.',
+              ],
+            },
+          ],
+        },
+        {
+          date: '14 Mei 2026',
+          title: 'Manajemen Space API key dan role organisasi yang lebih aman',
+          summary:
+            'Space API keys disimpan dalam katalog terenkripsi dengan nilai tampilan yang stabil dan tersamarkan, workflow reveal eksplisit, dan active binding checks. Role organisasi kini membedakan permission owner, admin, dan member untuk manajemen resource dan key.',
+          sections: [
+            {
+              title: 'Izin',
+              items: [
+                'Owner dan admin dapat membuat, bind, dan reveal Space keys dari flow manajemen Space key.',
+                'Member dapat tetap membaca resource yang diizinkan tanpa menerima permission mutasi.',
+                'Gunakan nilai key yang disamarkan di tampilan biasa; reveal key hanya saat perlu menyalinnya ke client.',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyTh = attachReleaseNoteSources({
+  meta: {
+    title: 'บันทึกการเผยแพร่ | mem9',
+    description: 'บันทึกการเผยแพร่ของ mem9 สำหรับลูกค้า ครอบคลุม Console, API, Space Chain, billing และการจัดการ memory',
+  },
+  kicker: 'บันทึกการเผยแพร่',
+  title: 'มีอะไรใหม่ใน mem9',
+  intro: 'ที่นี่ผู้สร้าง mem9 จะอัปเดตฟีเจอร์สำคัญที่เพิ่งเผยแพร่',
+  starPrompt: 'การทำโปรเจกต์ open-source ไม่ง่าย โปรดช่วยสนับสนุนเราด้วยการกด Star ให้ mem9 บน GitHub',
+  starBadgeAlt: 'GitHub stars สำหรับ mem9-ai/mem9',
+  starBadgeSrc: 'https://img.shields.io/github/stars/mem9-ai/mem9?style=social',
+  starHref: 'https://github.com/mem9-ai/mem9',
+  updatedLabel: 'อัปเดตล่าสุด',
+  updatedValue: '4 มิถุนายน 2026',
+  sourcesLabel: 'แหล่งที่มา PR',
+  sourcesFeedback: 'ยินดีให้คุณเข้าไปที่ PR หรือ issue แล้วส่งความคิดเห็นมาให้เรา',
+  groups: [
+    {
+      period: 'มิถุนายน 2026',
+      items: [
+        {
+          date: '4 มิถุนายน 2026',
+          title: 'การอัปเดตประสิทธิภาพครั้งสำคัญสำหรับ mem9.ai',
+          summary:
+            'บริการทางการของ mem9.ai กำลังได้รับการปรับปรุงประสิทธิภาพครั้งสำคัญ เนื่องจากการ deploy ช่วงแรกทำให้บางส่วนของ service และ database อยู่คนละ region จึงเกิด latency ที่ไม่จำเป็น เรากำลังย้ายข้อมูลเป็น 2 เฟสเพื่อลด API latency ของ hosted service อย่างชัดเจน',
+          sections: [
+            {
+              title: 'แผนการเผยแพร่',
+              items: [
+                'เฟส 1 เผยแพร่ตอนเที่ยงตามเวลา Beijing วันที่ 4 มิถุนายน และลด API latency ทั่วไปจากเฉลี่ยประมาณ 4-6 วินาที เหลือประมาณ 1.3 วินาที',
+                'เฟส 2 คาดว่าจะเสร็จภายในสัปดาห์นี้ โดยจะย้าย metadata และมีเป้าหมายให้ latency เฉลี่ยลดลงมาอยู่ในระดับไม่กี่ร้อยมิลลิวินาที',
+              ],
+            },
+            {
+              title: 'ข้อเสนอแนะ',
+              body: 'ไม่ต้องแก้ไขฝั่ง client การอัปเดตนี้ปรับปรุงเส้นทางของ hosted mem9.ai service โดยตรง เรายินดีรับความคิดเห็นเกี่ยวกับประสิทธิภาพของบริการทางการ',
+            },
+          ],
+        },
+        {
+          date: '4 มิถุนายน 2026',
+          title: 'แยก appId ภายใต้ API key เดียว',
+          summary:
+            'ตอนนี้ mem9 API key เดียวสามารถมีพื้นที่ memory ของหลายแอปที่แยกกันด้วย `appId` ได้ Memory และ raw session ที่เขียนพร้อม appId จะผูกกับแอปนั้น จึงเหมาะกับการใช้ key เดียวกับหลาย product, Agent, environment หรือ workflow โดยไม่ให้ memory ประจำวันปะปนกัน',
+          sections: [
+            {
+              title: 'appId แยก memory อย่างไร',
+              items: [
+                'เมื่อเขียน memory หรือ ingest messages ให้ส่ง `appId` เช่น `appId: "docs"` หรือ `appId: "support-bot"`',
+                'ตอน search ถ้าไม่ส่ง `appId` จะค้นหาข้ามทุก appId ภายใต้ key นั้น ถ้าส่ง appId ที่ไม่ว่างจะค้นหาเฉพาะ sub-space นั้น และถ้าส่ง `appId=null` หรือ `appId=` จะค้นหาเฉพาะ default/global memory',
+                'ใน Console ใช้ appId filter, appId column และ field appId ตอนสร้าง memory เพื่อดูหรือเขียน memory สำหรับแอปเฉพาะ',
+              ],
+            },
+          ],
+        },
+        {
+          date: '4 มิถุนายน 2026',
+          title: 'เอกสารอ้างอิง API ใหม่พร้อมทดสอบ API ในหน้าเอกสาร',
+          summary:
+            'mem9 API reference ได้รับการปรับปรุง layout ให้ชัดเจนขึ้น อัปเดตเนื้อหา endpoint และเพิ่ม API test console ในตัว Developer จึงอ่านเอกสารและลอง request ได้ในหน้าเดียว ไม่ต้องสลับไปใช้เครื่องมือแยกต่างหาก',
+          sections: [
+            {
+              title: 'สิ่งที่เปลี่ยน',
+              items: [
+                'หน้า API มี sidebar และ layout endpoint ที่ชัดเจนขึ้น',
+                'อัปเดตเนื้อหาสำหรับ authentication, appId isolation, memory APIs, imports, session messages และ Space Chain APIs',
+              ],
+            },
+            {
+              title: 'ลองได้ที่ไหน',
+              body: 'เปิดหน้า API จาก navigation ของ site แล้วใช้ API test panel ตั้งค่า base URL, API key, headers, field path/query/body, run request และดู response ได้ในหน้าเอกสารโดยตรง',
+            },
+          ],
+        },
+        {
+          date: '3 มิถุนายน 2026',
+          title: 'นำ mem9 API key ที่มีอยู่เข้า Console',
+          summary:
+            'ผู้ใช้ที่ได้รับ mem9 API key จากการติดตั้ง Agent หรือ flow API แล้ว ตอนนี้สามารถผูก key นั้นกับ Space ใน Console ได้ Console จะปกป้อง raw key แสดงเฉพาะข้อมูลที่ mask แล้ว และย้าย claimed key เข้า model quota ขององค์กร',
+          sections: [
+            {
+              title: 'ขั้นตอนการรับสิทธิ์',
+              items: [
+                'เปิด Console claim flow จากลิงก์ใน setup หรือเปิด `/console/claim` โดยตรง',
+                'วาง key ที่มีอยู่ เลือก organization และ project แล้วผูกกับ Space ว่าง หรือสร้าง Space ใหม่ใน flow',
+                'หลัง bind แล้วสามารถจัดการ Space จาก Console ได้โดยไม่เปิดเผย raw key ในหน้าทั่วไป',
+              ],
+            },
+          ],
+        },
+        {
+          date: '3 มิถุนายน 2026',
+          title: 'Billing, payment methods และ invoices ในตัว',
+          summary:
+            'พื้นที่ Billing ใน Console มีประสบการณ์ billing ที่ครบขึ้นบน Stripe: plan ปัจจุบัน billing address, payment methods, การเปลี่ยน plan, coupons, cancel/resume และประวัติ invoice',
+          sections: [
+            {
+              title: 'จัดการที่ไหน',
+              items: [
+                'เปิด Console เลือก organization แล้วไปที่ Billing',
+                'ใช้ Upgrade หรือ Change plan เพื่อกรอก billing details เลือก plan และยืนยัน payment ด้วย Stripe Elements',
+                'ตรวจ payment methods ที่บันทึกไว้และ invoices ได้จากหน้า Billing เดียวกัน',
+              ],
+            },
+          ],
+        },
+        {
+          date: '1 มิถุนายน 2026',
+          title: 'Knowledge routing ใน Space Chain',
+          summary:
+            'Space Chain สามารถ route knowledge ที่ extract แล้วไปยัง node ที่ถูกต้องตาม routing policy fields ได้ ทำให้ chain ทำงานเหมือน knowledgebase มากขึ้น: ingest กว้าง ๆ จะลง Space ของทีม โปรเจกต์ หรือหัวข้อที่เหมาะสม ขณะที่ recall ยังค้นข้าม chain ได้',
+          sections: [
+            {
+              title: 'ตั้งค่า routing',
+              items: [
+                'เปิดหน้า detail ของ Space Chain แล้วตั้งค่า knowledge extraction policy',
+                'ใช้ node selector และ routing diagram เพื่อกำหนดว่าข้อเท็จจริงที่ extract แล้วควรถูกเขียนไปที่ไหน',
+                'ตอนสร้าง memory ให้เปิด smart ingest เพื่อ extract และ route facts แทนการเขียน raw memory item เพียงรายการเดียว',
+              ],
+            },
+          ],
+        },
+        {
+          date: '1 มิถุนายน 2026',
+          title: 'การจัดเรียง memory และ search controls ฝั่ง server',
+          summary:
+            'ตาราง Memory ตอนนี้ sort และ filter กับ result set ทั้งหมดบน server ไม่ใช่แค่หน้าปัจจุบัน ผู้ใช้สามารถ sort ตาม content, type, tags และ updated time พร้อมใช้ร่วมกับ search controls ได้',
+          sections: [
+            {
+              title: 'ตัวควบคุมตาราง',
+              items: [
+                'เปิด memory workbench ของ Space หรือ Space Chain',
+                'คลิก header ของตารางเพื่อ sort ascending หรือ descending',
+                'ใช้ search fields สำหรับ content, type และ tags โดย server จะ filter และ sort ก่อน pagination',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      period: 'พฤษภาคม 2026',
+      items: [
+        {
+          date: '30 พฤษภาคม 2026',
+          title: 'Space Chain recall เร็วขึ้นพร้อมการแสดงเวลา',
+          summary:
+            'Space Chain recall ตอนนี้ parallelize การ scan node และ auth resolution พร้อมคง global reranking behavior ไว้ Console ยังแสดง recall timing เพื่อให้ทีมเห็นว่า test recall ใช้เวลานานแค่ไหน',
+          sections: [
+            {
+              title: 'สิ่งที่เปลี่ยน',
+              body: 'งาน recall ถูก parallelize อยู่เบื้องหลัง โดยยังคง global reranking behavior เดิม',
+            },
+            {
+              title: 'วิธีตรวจสอบ',
+              items: [
+                'เปิดหน้า detail ของ Space Chain แล้วใช้ Recall test panel',
+                'เปิด Force scanAll เมื่ออยากทดสอบพฤติกรรม cross-chain recall',
+                'ดู elapsed time ที่แสดงพร้อม result เพื่อเปรียบเทียบ query performance',
+              ],
+            },
+          ],
+        },
+        {
+          date: '25 พฤษภาคม 2026',
+          title: 'จัดการ session memory และ batch cleanup',
+          summary:
+            'memory workbench สามารถ list session memory rows, filter ตาม All, Insight, Pinned หรือ Session, เลือก rows, เปลี่ยน page size และลบ memories ที่เลือกแบบ batch ได้ API ยังรองรับการลบ session-row และ request-level switch เพื่อไม่บันทึก raw session rows เมื่อจำเป็นต้องใช้แค่ facts ที่ extract แล้ว',
+          sections: [
+            {
+              title: 'การล้างข้อมูลใน Console',
+              items: [
+                'เปิด Space memory workbench แล้วเลือก memory type filter',
+                'เลือกหนึ่งหรือหลาย rows แล้วลบ memories ที่เลือกจาก toolbar',
+              ],
+            },
+            {
+              title: 'ตัวเลือก API',
+              body: 'สำหรับ API ingest flows ให้ตั้ง `disableSessionSave` เมื่ออยาก extract facts โดยไม่เก็บ raw session messages',
+            },
+          ],
+        },
+        {
+          date: '26 พฤษภาคม 2026',
+          title: 'Console รองรับเจ็ดภาษา',
+          summary:
+            'Console รองรับ English, Simplified Chinese, Traditional Chinese, Japanese, Korean, Indonesian และ Thai ครอบคลุม shell, auth pages, Spaces, Memories, Settings, Project และ Space Chain flows',
+          sections: [
+            {
+              title: 'ตัวเลือกภาษา',
+              items: [
+                'เปิด language menu ใน Console header หรือ auth page',
+                'เลือกภาษา ระบบจะบันทึกไว้ในเครื่องและอัปเดต document language',
+              ],
+            },
+          ],
+        },
+        {
+          date: '19 พฤษภาคม 2026',
+          title: 'Billing และ usage dashboards',
+          summary:
+            'องค์กรสามารถดู billing plan state, entitlements, request usage summaries, daily rollups และ detailed usage events ได้ Runtime มี quota gates และ durable metering เพื่อ track commercial usage โดยไม่เปลี่ยน self-hosted behavior',
+          sections: [
+            {
+              title: 'ดูได้ที่ไหน',
+              items: [
+                'เปิด Console แล้วเลือก organization',
+                'ไปที่ Billing เพื่อดู plan และ entitlement state',
+                'ไปที่ Usage เพื่อตรวจยอด memory recall และ memory write request ในช่วงวันที่ที่เลือก',
+              ],
+            },
+          ],
+        },
+        {
+          date: '19 พฤษภาคม 2026',
+          title: 'Space memory explorer และ runtime tools',
+          summary:
+            'Spaces มี memory workbench พร้อม summary metrics, imports, memory list/detail, create/edit/delete controls และ shared Recall test panel Raw API keys ยังอยู่ฝั่ง server ขณะที่ Console proxy memory operations ที่ authorize แล้ว',
+          sections: [
+            {
+              title: 'เครื่องมือ workbench',
+              items: [
+                'เปิดหน้า detail ของ Space ใน Console',
+                'ใช้ Memories tab เพื่อ browse, create, edit หรือ delete memories',
+                'ใช้ Recall test panel เพื่อทดสอบว่า Space จะ retrieve อะไรสำหรับ query หนึ่ง',
+              ],
+            },
+          ],
+        },
+        {
+          date: '15 พฤษภาคม 2026',
+          title: 'รองรับ Space Chain runtime',
+          summary:
+            'Space Chains ใช้งานใน runtime ได้แล้ว พร้อม ordered recall/write behavior, chain key authentication และ provenance ใน chain responses ทำให้ chain key เดียว retrieve จากหลาย Space ตามลำดับที่ควบคุมได้',
+          sections: [
+            {
+              title: 'การตั้งค่า runtime',
+              items: [
+                'สร้างหรือเปิด Space Chain ใน Console',
+                'เพิ่ม Space nodes ตามลำดับที่อยากให้ recall ค้นหา',
+                'สร้าง chain key binding แล้วใช้ key นั้นพร้อม `scanAll=true` เมื่อต้องการ recall ข้าม chain',
+              ],
+            },
+          ],
+        },
+        {
+          date: '14 พฤษภาคม 2026',
+          title: 'จัดการ Space API key และ organization roles ให้ปลอดภัยขึ้น',
+          summary:
+            'Space API keys ถูกเก็บใน encrypted catalog พร้อม masked display values ที่เสถียร, explicit reveal workflows และ active binding checks Organization roles แยก owner, admin และ member permissions สำหรับ resource และ key management',
+          sections: [
+            {
+              title: 'สิทธิ์',
+              items: [
+                'Owner และ admin สามารถ create, bind และ reveal Space keys จาก Space key management flow',
+                'Member ยังอ่าน resources ที่ได้รับอนุญาตได้ แต่ไม่มี mutation permissions',
+                'ใช้ masked key values ในมุมมองทั่วไป และ reveal key เฉพาะตอนต้อง copy ไปยัง client',
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+});
+
+const releaseNotesPageCopyByLocale: Record<SiteLocale, SiteReleaseNotesPageCopy> = {
+  en: releaseNotesPageCopyEn,
+  zh: releaseNotesPageCopyZh,
+  'zh-Hant': releaseNotesPageCopyZhHant,
+  ja: releaseNotesPageCopyJa,
+  ko: releaseNotesPageCopyKo,
+  id: releaseNotesPageCopyId,
+  th: releaseNotesPageCopyTh,
+};
+
+const apiSharedTextTranslations: Partial<Record<SiteLocale, Record<string, string>>> = {
+  zh: {
+    'mem9 API key for your space.': '你的 mem9 space API key。',
+    'Optional agent identity header for attribution.': '可选的 agent 身份 header，用于归因。',
+    'Set to `application/json` for JSON request bodies.': '发送 JSON 请求体时设为 `application/json`。',
+    'Optional version guard for optimistic updates.': '可选的版本保护，用于乐观更新。',
+    'Your HTTP client sends this as `multipart/form-data`.': '由你的 HTTP 客户端以 `multipart/form-data` 发送。',
+    'Active Space Chain API key for this chain.': '这条 Space Chain 当前可用的 API key。',
+    'Plain memory content for direct writes. Required when `messages` is absent.': '直接写入的纯文本记忆内容。未提供 `messages` 时必填。',
+    'Conversation messages for ingest-based writes. Required when `content` is absent.': '用于 ingest 写入的对话消息。未提供 `content` 时必填。',
+    'Optional application isolation id, max 100 characters. Omitted, null, empty, or whitespace values write to the default/global appId; non-empty values are trimmed and stored exactly.': '可选的应用隔离 id，最多 100 个字符。省略、null、空字符串或纯空白会写入默认/global appId；非空值会 trim 后原样保存。',
+    'Only accepted with `content` writes. Use `insight` or `pinned`; defaults to `insight`.': '仅在 `content` 写入时可用。使用 `insight` 或 `pinned`；默认是 `insight`。',
+    'Optional agent id to store with the write.': '可选的 agent id，会随本次写入保存。',
+    'Optional session id for ingest or attribution.': '可选的 session id，用于 ingest 或归因。',
+    'Optional string tags stored on the memory.': '可选的字符串标签，会保存到记忆上。',
+    'Optional JSON metadata payload.': '可选的 JSON metadata 载荷。',
+    'Ingest mode such as `smart` or `raw` when using `messages`.': '使用 `messages` 时的 ingest 模式，例如 `smart` 或 `raw`。',
+    'When true, wait for completion before returning.': '为 true 时等待处理完成后再返回。',
+    'Message ingest only. When true, skip raw session persistence and only extract/reconcile facts.': '仅用于 message ingest。为 true 时跳过原始 session 持久化，只提取/合并 facts。',
+    'Search query. Omit to list memories by filters.': '搜索查询。省略时按过滤条件列出 memories。',
+    'Optional search behavior. Use `keyword` for direct content substring matching in list UIs; omit it for the default recall-style search.': '可选搜索行为。列表 UI 中使用 `keyword` 做 content 子串匹配；省略时使用默认 recall 风格搜索。',
+    'Comma-separated tag filter.': '逗号分隔的 tag 过滤器。',
+    'Filter by stored source value.': '按已保存的 source 值过滤。',
+    'Filter by lifecycle state such as `active` or `archived`.': '按生命周期状态过滤，例如 `active` 或 `archived`。',
+    'Filter by `insight`, `pinned`, or `session`.': '按 `insight`、`pinned` 或 `session` 过滤。',
+    'Filter by agent id.': '按 agent id 过滤。',
+    'Filter by session id.': '按 session id 过滤。',
+    'Optional appId filter. Omit to search all appIds, pass a value for exact isolation, or use `appId=null` / `appId=` for default/global.': '可选 appId 过滤器。省略表示搜索全部 appId，传值表示精确隔离，使用 `appId=null` / `appId=` 表示默认/global。',
+    'Page size. The handler caps large values.': '分页大小。服务端会限制过大的值。',
+    'Offset for pagination.': '分页 offset。',
+    'Sort field used when listing memories, such as `updated_at`.': '列出 memories 时使用的排序字段，例如 `updated_at`。',
+    'Sort direction, `asc` or `desc`.': '排序方向，`asc` 或 `desc`。',
+    'Space Chain keys only. When true, recall searches every node and globally reranks the merged facts.': '仅 Space Chain key 可用。为 true 时 recall 会搜索所有节点，并对合并后的 facts 做全局 rerank。',
+    'Updated memory content.': '更新后的记忆内容。',
+    'Updated tag array.': '更新后的 tag 数组。',
+    'Updated JSON metadata payload.': '更新后的 JSON metadata 载荷。',
+    'Array of memory ids to delete.': '要删除的 memory id 数组。',
+    'Uploaded file payload.': '上传的文件载荷。',
+    'Use `memory` or `session`.': '使用 `memory` 或 `session`。',
+    'Optional agent id for attribution.': '可选的 agent id，用于归因。',
+    'Required when uploading `session` files.': '上传 `session` 文件时必填。',
+    'Optional top-level appId inside JSON memory/session files.': 'JSON memory/session 文件中的可选顶层 appId。',
+    'Optional per-memory appId override inside JSON memory files.': 'JSON memory 文件中每条 memory 可选的 appId 覆盖值。',
+    'Optional per-session appId override inside JSON session files.': 'JSON session 文件中每个 session 可选的 appId 覆盖值。',
+    'Repeat this query param for each session to fetch.': '每个要获取的 session 都重复传入这个查询参数。',
+    'Optional per-session row limit.': '可选的每个 session 行数限制。',
+    'The newly provisioned mem9 API key / space identifier.': '新创建的 mem9 API key / space 标识符。',
+    'Health status string. Hosted service returns `ok`.': '健康状态字符串。托管服务返回 `ok`。',
+    'Go runtime version used by the server.': '服务端使用的 Go runtime 版本。',
+    'Server start timestamp.': '服务启动时间戳。',
+    '`active` when the key can be used, otherwise `inactive`.': 'key 可用时为 `active`，否则为 `inactive`。',
+    'Array of memory objects for the current page.': '当前页的 memory object 数组。',
+    'Total matched rows before pagination.': '分页前匹配的总行数。',
+    'Applied page size.': '实际应用的分页大小。',
+    'Applied page offset.': '实际应用的分页 offset。',
+    'Memory id.': 'Memory id。',
+    'Stored memory content.': '已保存的 memory 内容。',
+    'Memory type such as `insight`, `pinned`, or `session`.': 'Memory 类型，例如 `insight`、`pinned` 或 `session`。',
+    'Application isolation id. Empty string means default/global.': '应用隔离 id。空字符串表示默认/global。',
+    'Stored source value when present.': '存在时表示已保存的 source 值。',
+    'String tag array when present.': '存在时表示字符串 tag 数组。',
+    'Raw JSON metadata when present.': '存在时表示原始 JSON metadata。',
+    'Agent id associated with the memory when present.': '存在时表示与该 memory 关联的 agent id。',
+    'Session id associated with the memory when present.': '存在时表示与该 memory 关联的 session id。',
+    'Agent or actor that last updated the memory when present.': '存在时表示最后更新该 memory 的 agent 或 actor。',
+    'Replacement memory id when this memory has been superseded.': '当该 memory 被替代时，指向替代 memory id。',
+    'Lifecycle state.': '生命周期状态。',
+    'Current integer version.': '当前整数版本。',
+    'Creation timestamp.': '创建时间戳。',
+    'Last update timestamp.': '最后更新时间戳。',
+    'Search relevance score when returned by search endpoints.': '搜索 endpoint 返回时的相关性分数。',
+    'Recall confidence score when returned by recall-style search.': 'recall 风格搜索返回时的置信度分数。',
+    'Human-readable recency string populated for query-time search results.': '查询时搜索结果中的人类可读时间新近程度。',
+    'Handler result such as `ok` or `accepted`.': 'Handler 结果，例如 `ok` 或 `accepted`。',
+    'Task id for polling.': '用于轮询的 task id。',
+    'Initial task status such as `pending`.': '初始 task 状态，例如 `pending`。',
+    'Aggregate task status for the tenant.': 'tenant 下的聚合 task 状态。',
+    'Array of import task summaries.': 'import task 摘要数组。',
+    'Task id.': 'Task id。',
+    'Uploaded file name.': '上传文件名。',
+    'Task status.': 'Task 状态。',
+    'Total chunk count.': '总 chunk 数。',
+    'Completed chunk count.': '已完成 chunk 数。',
+    'Error message when the task fails.': 'task 失败时的错误消息。',
+    'Array of captured session message rows.': '捕获到的 session message 行数组。',
+    'Session message row id.': 'Session message 行 id。',
+    'Session id for the row.': '该行的 session id。',
+    'Agent id for the row when present.': '存在时表示该行的 agent id。',
+    'Application isolation id for each raw session row.': '每条 raw session 行的应用隔离 id。',
+    'Sequence number within the session.': 'session 内的序号。',
+    'Message role such as `user` or `assistant`.': '消息角色，例如 `user` 或 `assistant`。',
+    'Message content.': '消息内容。',
+    'Content type for the captured message.': '捕获消息的 content type。',
+    'Captured tags for the row.': '该行捕获到的 tags。',
+    'Lifecycle state for the row.': '该行的生命周期状态。',
+    'Applied per-session limit.': '实际应用的每 session 限制。',
+    'Validate whether a Space key or Space Chain key is currently usable before making runtime calls.': '在发起 runtime 调用前，验证 Space key 或 Space Chain key 当前是否可用。',
+    'Check API key status.': '检查 API key 状态。',
+    'Send either a normal mem9 Space key or a Space Chain key in `X-API-Key`. The response is `active` or `inactive`; unknown keys return `404`.': '在 `X-API-Key` 中发送普通 mem9 Space key 或 Space Chain key。响应为 `active` 或 `inactive`；未知 key 返回 `404`。',
+    'Space API key or Space Chain API key.': 'Space API key 或 Space Chain API key。',
+    'Check Space key': '检查 Space key',
+    'Check Space Chain key': '检查 Space Chain key',
+    'Delete multiple memories.': '批量删除 memories。',
+    'Deletes the provided memory ids in one request. When authenticated with a Space Chain key, the handler resolves each id to the node that owns it.': '在一个请求中删除给定的 memory ids。使用 Space Chain key 认证时，handler 会将每个 id 解析到拥有它的节点。',
+    'Batch delete memories': '批量删除 memories',
+    'Space Chains': 'Space Chains',
+    'Create and manage ordered chains of Spaces. Runtime memory endpoints accept a Space Chain key and search the chain in node order, or all nodes when `scanAll=true`.': '创建和管理有序 Space 链。Runtime memory endpoint 可接受 Space Chain key，并按节点顺序搜索 chain；`scanAll=true` 时搜索所有节点。',
+    'Create a Space Chain.': '创建 Space Chain。',
+    'Creates a Space Chain and returns its first plaintext chain key once. Store `chain_api_key` securely; later list responses only expose masked or bound key records.': '创建 Space Chain，并且只返回一次首个明文 chain key。请安全保存 `chain_api_key`；后续列表响应只会暴露脱敏或绑定记录。',
+    'Create Space Chain': '创建 Space Chain',
+    'Export Space Chain env vars': '导出 Space Chain 环境变量',
+    'Read the Space Chain for a key.': '读取某个 key 对应的 Space Chain。',
+    'Looks up the active Space Chain associated with the `X-API-Key` chain key.': '查找与 `X-API-Key` chain key 关联的 active Space Chain。',
+    'Get by key': '按 key 获取',
+    'Read one Space Chain.': '读取单个 Space Chain。',
+    'Returns chain metadata, nodes, and bindings for a chain key authorized to manage this Space Chain.': '返回该管理 key 有权管理的 Space Chain metadata、nodes 和 bindings。',
+    'Get Space Chain': '获取 Space Chain',
+    'Update Space Chain details.': '更新 Space Chain 详情。',
+    'Updates the display name and description for a Space Chain.': '更新 Space Chain 的显示名称和描述。',
+    'Update Space Chain': '更新 Space Chain',
+    'Delete a Space Chain.': '删除 Space Chain。',
+    'Soft-deletes the Space Chain. A successful delete returns `204 No Content`.': '软删除 Space Chain。删除成功时返回 `204 No Content`。',
+    'Delete Space Chain': '删除 Space Chain',
+    'List Space Chain nodes.': '列出 Space Chain 节点。',
+    'Returns the ordered node list. Node positions are zero-based and define sequential recall order.': '返回有序节点列表。节点 position 从 0 开始，并定义顺序 recall 的访问顺序。',
+    'List nodes': '列出节点',
+    'Replace Space Chain nodes.': '替换 Space Chain 节点。',
+    'Replaces the entire ordered node list. Each node must reference a normal Space key / tenant id, not another Space Chain key.': '替换整个有序节点列表。每个节点必须引用普通 Space key / tenant id，不能引用另一个 Space Chain key。',
+    'Replace nodes': '替换节点',
+    'List Space Chain key bindings.': '列出 Space Chain key bindings。',
+    'Returns all key bindings visible to the management key for this Space Chain.': '返回该 Space Chain 管理 key 可见的全部 key bindings。',
+    'List bindings': '列出 bindings',
+    'Create a Space Chain key binding.': '创建 Space Chain key binding。',
+    'Creates another chain key. Omit `chain_api_key` to let mem9 generate a key.': '创建另一个 chain key。省略 `chain_api_key` 时由 mem9 生成 key。',
+    'Create binding': '创建 binding',
+    'Disable a Space Chain key binding.': '禁用 Space Chain key binding。',
+    'Disables an active binding. The API rejects disabling the last active key for a chain.': '禁用一个 active binding。API 会拒绝禁用某条 chain 的最后一个 active key。',
+    'Disable binding': '禁用 binding',
+    'Recall across a Space Chain.': '跨 Space Chain recall。',
+    'Use the normal memory search endpoint with a Space Chain key. By default recall visits nodes in order and stops early on high confidence; pass `scanAll=true` to search every node and globally rerank.': '使用普通 memory search endpoint，但传入 Space Chain key。默认 recall 会按顺序访问节点，并在高置信结果处提前停止；传 `scanAll=true` 时搜索所有节点并全局 rerank。',
+    'Recall with scanAll': '使用 scanAll recall',
+    'Check server version metadata.': '检查 server 版本 metadata。',
+    'Returns runtime metadata that is useful for support and deployment verification.': '返回对支持和部署验证有用的 runtime metadata。',
+    'Version check': '版本检查',
+  },
+};
+
+export function localizeApiSharedText(locale: SiteLocale, text: string): string {
+  if (locale === 'en') {
+    return text;
+  }
+
+  return apiSharedTextTranslations[locale]?.[text] ?? text;
+}
+
+function localizeApiFields(locale: SiteLocale, fields: SiteApiFieldCopy[] | undefined): SiteApiFieldCopy[] | undefined {
+  return fields?.map((field) => ({
+    ...field,
+    description: localizeApiSharedText(locale, field.description),
+  }));
+}
+
+function localizeApiEndpoint(locale: SiteLocale, endpoint: SiteApiEndpointCopy): SiteApiEndpointCopy {
+  return {
+    ...endpoint,
+    summary: localizeApiSharedText(locale, endpoint.summary),
+    description: endpoint.description ? localizeApiSharedText(locale, endpoint.description) : undefined,
+    notes: endpoint.notes?.map((note) => localizeApiSharedText(locale, note)),
+    headers: localizeApiFields(locale, endpoint.headers),
+    queryParams: localizeApiFields(locale, endpoint.queryParams),
+    bodyFields: localizeApiFields(locale, endpoint.bodyFields),
+    responseFields: localizeApiFields(locale, endpoint.responseFields),
+    examples: endpoint.examples?.map((example) => ({
+      ...example,
+      label: localizeApiSharedText(locale, example.label),
+    })),
+  };
+}
+
+export function localizeApiPageCopy(locale: SiteLocale, copy: SiteApiPageCopy): SiteApiPageCopy {
+  return {
+    ...copy,
+    endpointGroups: copy.endpointGroups.map((group) => ({
+      ...group,
+      title: localizeApiSharedText(locale, group.title),
+      description: localizeApiSharedText(locale, group.description),
+      endpoints: group.endpoints.map((endpoint) => localizeApiEndpoint(locale, endpoint)),
+    })),
+  };
+}
+
 export const siteCopy: Record<SiteLocale, SiteDictionary> = {
   en: {
     meta: {
@@ -2737,6 +5257,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'Benchmark',
       openclaw: 'OpenClaw',
       yourMemory: 'Your Memory',
+      yourMemoryDescription: 'Visual memory management',
+      webConsole: 'Web Console',
+      webConsoleDescription: 'Manage your spaces, space chains, usage, and orders.',
       login: 'Log in',
       billing: 'Pricing',
       security: 'Security',
@@ -2744,6 +5267,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: 'Docs',
       api: 'API',
+      releaseNotes: 'Release Notes',
       contact: 'Contact Us',
     },
     hero: {
@@ -2914,6 +5438,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale.en,
     apiPage: apiPageByLocale.en,
+    releaseNotesPage: releaseNotesPageCopyByLocale.en,
     securityPage: {
       meta: {
         title: 'Security & Privacy | mem9',
@@ -3086,6 +5611,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: '基准测试',
       openclaw: 'OpenClaw',
       yourMemory: '你的记忆',
+      yourMemoryDescription: '可视化记忆管理',
+      webConsole: 'Web Console',
+      webConsoleDescription: '管理您的空间、空间链、用量和订单。',
       login: '登录',
       billing: '定价',
       security: '安全',
@@ -3093,6 +5621,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: '文档',
       api: 'API',
+      releaseNotes: '发布说明',
       contact: '联系我们',
     },
     hero: {
@@ -3255,6 +5784,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale.zh,
     apiPage: apiPageByLocale.zh,
+    releaseNotesPage: releaseNotesPageCopyByLocale.zh,
     securityPage: {
       meta: {
         title: '安全与隐私 | mem9',
@@ -3421,6 +5951,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: '基準測試',
       openclaw: 'OpenClaw',
       yourMemory: '你的記憶',
+      yourMemoryDescription: '可視化記憶管理',
+      webConsole: 'Web Console',
+      webConsoleDescription: '管理您的空間、空間鏈、用量和訂單。',
       login: '登入',
       billing: '定價',
       security: '安全',
@@ -3428,6 +5961,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: '文檔',
       api: 'API',
+      releaseNotes: '發布說明',
       contact: '聯絡我們',
     },
     hero: {
@@ -3595,6 +6129,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale['zh-Hant'],
     apiPage: apiPageByLocale['zh-Hant'],
+    releaseNotesPage: releaseNotesPageCopyByLocale['zh-Hant'],
     securityPage: {
       meta: {
         title: '安全與隱私 | mem9',
@@ -3761,6 +6296,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'ベンチマーク',
       openclaw: 'OpenClaw',
       yourMemory: 'あなたの記憶',
+      yourMemoryDescription: 'ビジュアルなメモリ管理',
+      webConsole: 'Web Console',
+      webConsoleDescription: 'スペース、スペースチェーン、使用量、注文を管理します。',
       login: 'ログイン',
       billing: '料金',
       security: 'セキュリティ',
@@ -3768,6 +6306,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: 'ドキュメント',
       api: 'API',
+      releaseNotes: 'リリースノート',
       contact: 'お問い合わせ',
     },
     hero: {
@@ -3938,6 +6477,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale.ja,
     apiPage: apiPageByLocale.ja,
+    releaseNotesPage: releaseNotesPageCopyByLocale.ja,
     securityPage: {
       meta: {
         title: 'Security & Privacy | mem9',
@@ -4106,6 +6646,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: '벤치마크',
       openclaw: 'OpenClaw',
       yourMemory: '당신의 기억',
+      yourMemoryDescription: '시각적 메모리 관리',
+      webConsole: 'Web Console',
+      webConsoleDescription: '스페이스, 스페이스 체인, 사용량, 주문을 관리합니다.',
       login: '로그인',
       billing: '요금',
       security: '보안',
@@ -4113,6 +6656,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: '문서',
       api: 'API',
+      releaseNotes: '릴리스 노트',
       contact: '문의하기',
     },
     hero: {
@@ -4280,6 +6824,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale.ko,
     apiPage: apiPageByLocale.ko,
+    releaseNotesPage: releaseNotesPageCopyByLocale.ko,
     securityPage: {
       meta: {
         title: 'Security & Privacy | mem9',
@@ -4448,6 +6993,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'Benchmark',
       openclaw: 'OpenClaw',
       yourMemory: 'Memori Anda',
+      yourMemoryDescription: 'Manajemen memori visual',
+      webConsole: 'Web Console',
+      webConsoleDescription: 'Kelola space, rantai space, penggunaan, dan pesanan Anda.',
       login: 'Masuk',
       billing: 'Harga',
       security: 'Keamanan',
@@ -4455,6 +7003,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: 'Dokumentasi',
       api: 'API',
+      releaseNotes: 'Catatan Rilis',
       contact: 'Hubungi Kami',
     },
     hero: {
@@ -4625,6 +7174,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale.id,
     apiPage: apiPageByLocale.id,
+    releaseNotesPage: releaseNotesPageCopyByLocale.id,
     securityPage: {
       meta: {
         title: 'Security & Privacy | mem9',
@@ -4793,6 +7343,9 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       benchmark: 'เบนช์มาร์ก',
       openclaw: 'OpenClaw',
       yourMemory: 'ความทรงจำของคุณ',
+      yourMemoryDescription: 'การจัดการหน่วยความจำแบบภาพ',
+      webConsole: 'Web Console',
+      webConsoleDescription: 'จัดการพื้นที่ เชนพื้นที่ การใช้งาน และคำสั่งซื้อของคุณ',
       login: 'ล็อกอิน',
       billing: 'ราคา',
       security: 'ความปลอดภัย',
@@ -4800,6 +7353,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       github: 'GitHub',
       docs: 'เอกสาร',
       api: 'API',
+      releaseNotes: 'บันทึกการเผยแพร่',
       contact: 'ติดต่อเรา',
     },
     hero: {
@@ -4970,6 +7524,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     faq: faqCopyByLocale.th,
     apiPage: apiPageByLocale.th,
+    releaseNotesPage: releaseNotesPageCopyByLocale.th,
     securityPage: {
       meta: {
         title: 'Security & Privacy | mem9',

--- a/site/src/pages/release-notes.astro
+++ b/site/src/pages/release-notes.astro
@@ -1,0 +1,28 @@
+---
+import Footer from '../components/Footer.astro';
+import Navbar from '../components/Navbar.astro';
+import ReleaseNotes from '../components/ReleaseNotes.astro';
+import { DEFAULT_LOCALE, siteCopy } from '../content/site';
+import Layout from '../layouts/Layout.astro';
+
+const copy = siteCopy[DEFAULT_LOCALE];
+---
+
+<Layout
+  meta={copy.releaseNotesPage.meta}
+  locale={DEFAULT_LOCALE}
+  metaTitleKey="releaseNotesPage.meta.title"
+  metaDescriptionKey="releaseNotesPage.meta.description"
+>
+  <Navbar
+    nav={copy.nav}
+    aria={copy.aria}
+    localeNames={copy.localeNames}
+    themeOptions={copy.themeOptions}
+    currentPath="/release-notes"
+  />
+  <main>
+    <ReleaseNotes />
+  </main>
+  <Footer footer={copy.footer} />
+</Layout>

--- a/site/src/scripts/site-ui.ts
+++ b/site/src/scripts/site-ui.ts
@@ -14,7 +14,7 @@ import {
   type SiteThemePreference,
 } from '../content/site';
 
-type MenuName = 'language' | 'theme';
+type MenuName = 'login' | 'language' | 'theme';
 type OnboardingVersion = 'stable' | 'beta';
 type OnboardingCommandParts = {
   prefix: string;
@@ -494,6 +494,10 @@ function isApiPage(): boolean {
   return document.querySelector('[data-api-root]') !== null;
 }
 
+function isReleaseNotesPage(): boolean {
+  return document.querySelector('[data-release-notes-root]') !== null;
+}
+
 function updateDocsPage(locale: SiteLocale): void {
   const docsLocale = resolveDocsLocale(locale);
   const root = document.querySelector<HTMLElement>('[data-docs-root]');
@@ -559,6 +563,23 @@ function updateApiPage(locale: SiteLocale): void {
   });
 }
 
+function updateReleaseNotesPage(locale: SiteLocale): void {
+  const root = document.querySelector<HTMLElement>('[data-release-notes-root]');
+  const copy = siteCopy[locale].releaseNotesPage;
+
+  if (!root) {
+    return;
+  }
+
+  root.dataset.releaseNotesLocale = locale;
+  setDocumentLang(locale);
+  updateMetaElements(copy.meta.title, copy.meta.description);
+
+  document.querySelectorAll<HTMLElement>('[data-release-notes-copy]').forEach((sectionCopy) => {
+    sectionCopy.hidden = sectionCopy.dataset.releaseNotesCopy !== locale;
+  });
+}
+
 function updateFaqSection(locale: SiteLocale): void {
   const root = document.querySelector<HTMLElement>('[data-faq-root]');
 
@@ -582,6 +603,9 @@ function applyLocale(locale: SiteLocale): void {
   } else if (isApiPage()) {
     updateTranslations(dictionary);
     updateApiPage(locale);
+  } else if (isReleaseNotesPage()) {
+    updateTranslations(dictionary);
+    updateReleaseNotesPage(locale);
   } else {
     updateMeta(locale, dictionary);
     updateTranslations(dictionary);
@@ -768,6 +792,81 @@ function initOnboardingVersionControls(): void {
   });
 
   applyOnboardingVersion('stable');
+}
+
+function normalizeDocsTocQuery(value: string): string[] {
+  return value
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function initDocsTocSearch(): void {
+  const root = document.querySelector<HTMLElement>('[data-docs-root]');
+  if (!root) {
+    return;
+  }
+
+  function applyFilter(sectionCopy: HTMLElement): void {
+    const input = sectionCopy.querySelector<HTMLInputElement>('[data-docs-toc-search]');
+    const empty = sectionCopy.querySelector<HTMLElement>('[data-docs-toc-empty]');
+    if (!input || !empty) {
+      return;
+    }
+
+    const tokens = normalizeDocsTocQuery(input.value);
+    const hasQuery = tokens.length > 0;
+    let visibleGroups = 0;
+
+    sectionCopy.querySelectorAll<HTMLDetailsElement>('[data-docs-toc-group]').forEach((group) => {
+      const groupHaystack = (group.dataset.docsSearch ?? '').toLowerCase();
+      const groupMatches = hasQuery && tokens.every((token) => groupHaystack.includes(token));
+      let visibleSections = 0;
+
+      group.querySelectorAll<HTMLElement>('[data-docs-toc-section]').forEach((section) => {
+        const sectionHaystack = (section.dataset.docsSearch ?? '').toLowerCase();
+        const sectionMatches = !hasQuery || groupMatches || tokens.every((token) => sectionHaystack.includes(token));
+        section.hidden = !sectionMatches;
+        if (sectionMatches) {
+          visibleSections++;
+        }
+      });
+
+      const showGroup = !hasQuery || groupMatches || visibleSections > 0;
+      group.hidden = !showGroup;
+      if (showGroup && hasQuery) {
+        group.open = true;
+      }
+      if (showGroup) {
+        visibleGroups++;
+      }
+    });
+
+    empty.hidden = !hasQuery || visibleGroups > 0;
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-docs-copy]').forEach((sectionCopy) => {
+    const input = sectionCopy.querySelector<HTMLInputElement>('[data-docs-toc-search]');
+    if (!input) {
+      return;
+    }
+
+    input.addEventListener('input', () => applyFilter(sectionCopy));
+    applyFilter(sectionCopy);
+  });
+
+  const mutation = new MutationObserver(() => {
+    const activeCopy = root.querySelector<HTMLElement>('[data-docs-copy]:not([hidden])');
+    if (activeCopy) {
+      applyFilter(activeCopy);
+    }
+  });
+
+  mutation.observe(root, {
+    attributes: true,
+    attributeFilter: ['data-docs-locale'],
+  });
 }
 
 function initDocsScrollSpy(): void {
@@ -1063,6 +1162,828 @@ function initApiMobileToc(): void {
   });
 }
 
+function normalizeApiTocQuery(value: string): string[] {
+  return value
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function initApiTocSearch(): void {
+  const root = document.querySelector<HTMLElement>('[data-api-root]');
+  if (!root) {
+    return;
+  }
+
+  function setGroupExpanded(group: HTMLElement, expanded: boolean): void {
+    const toggle = group.querySelector<HTMLButtonElement>('[data-api-toc-group-toggle]');
+    const sublist = group.querySelector<HTMLElement>('[data-api-toc-sublist]');
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+    }
+    if (sublist) {
+      sublist.hidden = !expanded;
+    }
+  }
+
+  function applyFilter(sectionCopy: HTMLElement): void {
+    const input = sectionCopy.querySelector<HTMLInputElement>('[data-api-toc-search]');
+    const empty = sectionCopy.querySelector<HTMLElement>('[data-api-toc-empty]');
+    if (!input || !empty) {
+      return;
+    }
+
+    const tokens = normalizeApiTocQuery(input.value);
+    const hasQuery = tokens.length > 0;
+    let visibleGroups = 0;
+
+    sectionCopy.querySelectorAll<HTMLElement>('[data-api-toc-static]').forEach((item) => {
+      item.hidden = hasQuery;
+    });
+
+    sectionCopy.querySelectorAll<HTMLElement>('[data-api-toc-group]').forEach((group) => {
+      const groupHaystack = (group.dataset.apiSearch ?? '').toLowerCase();
+      const groupMatches = hasQuery && tokens.every((token) => groupHaystack.includes(token));
+      let visibleEndpoints = 0;
+      const toggle = group.querySelector<HTMLButtonElement>('[data-api-toc-group-toggle]');
+
+      group.querySelectorAll<HTMLElement>('[data-api-toc-endpoint]').forEach((endpoint) => {
+        const endpointHaystack = (endpoint.dataset.apiSearch ?? '').toLowerCase();
+        const endpointMatches = !hasQuery || groupMatches || tokens.every((token) => endpointHaystack.includes(token));
+        endpoint.hidden = !endpointMatches;
+        if (endpointMatches) {
+          visibleEndpoints++;
+        }
+      });
+
+      const showGroup = !hasQuery || groupMatches || visibleEndpoints > 0;
+      group.hidden = !showGroup;
+      setGroupExpanded(group, showGroup && (!hasQuery || visibleEndpoints > 0));
+      if (showGroup) {
+        visibleGroups++;
+      }
+    });
+
+    empty.hidden = !hasQuery || visibleGroups > 0;
+  }
+
+  document.querySelectorAll<HTMLElement>('[data-api-copy]').forEach((sectionCopy) => {
+    const input = sectionCopy.querySelector<HTMLInputElement>('[data-api-toc-search]');
+    if (!input) {
+      return;
+    }
+    input.addEventListener('input', () => applyFilter(sectionCopy));
+    applyFilter(sectionCopy);
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('[data-api-toc-group-toggle]').forEach((toggle) => {
+    toggle.addEventListener('click', () => {
+      const group = toggle.closest<HTMLElement>('[data-api-toc-group]');
+      const sectionCopy = toggle.closest<HTMLElement>('[data-api-copy]');
+      const input = sectionCopy?.querySelector<HTMLInputElement>('[data-api-toc-search]');
+      if (!group || (input && input.value.trim() !== '')) {
+        return;
+      }
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      setGroupExpanded(group, !expanded);
+    });
+  });
+
+  const mutation = new MutationObserver(() => {
+    const activeCopy = root.querySelector<HTMLElement>('[data-api-copy]:not([hidden])');
+    if (activeCopy) {
+      applyFilter(activeCopy);
+    }
+  });
+
+  mutation.observe(root, {
+    attributes: true,
+    attributeFilter: ['data-api-locale'],
+  });
+}
+
+type ApiTestField = {
+  name: string;
+  description: string;
+  required: boolean;
+};
+
+type ApiTestEndpoint = {
+  groupTitle: string;
+  method: string;
+  path: string;
+  summary: string;
+  description: string;
+  headers: ApiTestField[];
+  queryParams: ApiTestField[];
+  bodyFields: ApiTestField[];
+};
+
+type ApiTestModalElements = {
+  modal: HTMLElement;
+  form: HTMLFormElement;
+  title: HTMLElement;
+  method: HTMLElement;
+  path: HTMLElement;
+  baseUrl: HTMLInputElement;
+  saveInfo: HTMLInputElement;
+  pathFields: HTMLElement;
+  headerFields: HTMLElement;
+  queryFields: HTMLElement;
+  bodyFields: HTMLElement;
+  jsonWrap: HTMLElement;
+  json: HTMLTextAreaElement;
+  url: HTMLElement;
+  response: HTMLElement;
+  status: HTMLElement;
+  output: HTMLElement;
+  run: HTMLButtonElement;
+};
+
+type ApiTestSavedForm = {
+  baseUrl: string;
+  path: Record<string, string>;
+  headers: Record<string, string>;
+  query: Record<string, string>;
+  body: Record<string, string>;
+  json: string;
+};
+
+const API_TEST_STORAGE_PREFIX = 'mem9.apiTestForm.';
+let activeApiTestEndpoint: ApiTestEndpoint | null = null;
+
+function apiTestLabels(): SiteDictionary['apiPage']['labels'] {
+  return siteCopy[currentLocale()].apiPage.labels;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseApiTestField(value: unknown): ApiTestField | null {
+  if (!isRecord(value) || typeof value.name !== 'string') {
+    return null;
+  }
+
+  return {
+    name: value.name,
+    description: typeof value.description === 'string' ? value.description : '',
+    required: value.required === true,
+  };
+}
+
+function parseApiTestFields(value: unknown): ApiTestField[] {
+  return Array.isArray(value)
+    ? value.map(parseApiTestField).filter((field): field is ApiTestField => field !== null)
+    : [];
+}
+
+function parseApiTestEndpoint(value: string | undefined): ApiTestEndpoint | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.method !== 'string' ||
+      typeof parsed.path !== 'string' ||
+      typeof parsed.summary !== 'string'
+    ) {
+      return null;
+    }
+
+    return {
+      groupTitle: typeof parsed.groupTitle === 'string' ? parsed.groupTitle : '',
+      method: parsed.method.toUpperCase(),
+      path: parsed.path,
+      summary: parsed.summary,
+      description: typeof parsed.description === 'string' ? parsed.description : '',
+      headers: parseApiTestFields(parsed.headers),
+      queryParams: parseApiTestFields(parsed.queryParams),
+      bodyFields: parseApiTestFields(parsed.bodyFields),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getApiTestModalElements(): ApiTestModalElements | null {
+  const modal = document.querySelector<HTMLElement>('[data-api-test-modal]');
+  const form = document.querySelector<HTMLFormElement>('[data-api-test-form]');
+  const title = document.querySelector<HTMLElement>('[data-api-test-title]');
+  const method = document.querySelector<HTMLElement>('[data-api-test-method]');
+  const path = document.querySelector<HTMLElement>('[data-api-test-path]');
+  const baseUrl = document.querySelector<HTMLInputElement>('[data-api-test-base-url]');
+  const saveInfo = document.querySelector<HTMLInputElement>('[data-api-test-save-info]');
+  const pathFields = document.querySelector<HTMLElement>('[data-api-test-path-fields]');
+  const headerFields = document.querySelector<HTMLElement>('[data-api-test-header-fields]');
+  const queryFields = document.querySelector<HTMLElement>('[data-api-test-query-fields]');
+  const bodyFields = document.querySelector<HTMLElement>('[data-api-test-body-fields]');
+  const jsonWrap = document.querySelector<HTMLElement>('[data-api-test-json-wrap]');
+  const json = document.querySelector<HTMLTextAreaElement>('[data-api-test-json]');
+  const url = document.querySelector<HTMLElement>('[data-api-test-url]');
+  const response = document.querySelector<HTMLElement>('[data-api-test-response]');
+  const status = document.querySelector<HTMLElement>('[data-api-test-status]');
+  const output = document.querySelector<HTMLElement>('[data-api-test-output]');
+  const run = document.querySelector<HTMLButtonElement>('[data-api-test-run]');
+
+  if (
+    !modal ||
+    !form ||
+    !title ||
+    !method ||
+    !path ||
+    !baseUrl ||
+    !saveInfo ||
+    !pathFields ||
+    !headerFields ||
+    !queryFields ||
+    !bodyFields ||
+    !jsonWrap ||
+    !json ||
+    !url ||
+    !response ||
+    !status ||
+    !output ||
+    !run
+  ) {
+    return null;
+  }
+
+  return {
+    modal,
+    form,
+    title,
+    method,
+    path,
+    baseUrl,
+    saveInfo,
+    pathFields,
+    headerFields,
+    queryFields,
+    bodyFields,
+    jsonWrap,
+    json,
+    url,
+    response,
+    status,
+    output,
+    run,
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function highlightJson(value: string): string {
+  return value.replace(
+    /("(?:\\.|[^"\\])*")(\s*:)?|\b(true|false)\b|\bnull\b|-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?/g,
+    (match, stringToken: string | undefined, colon: string | undefined, booleanToken: string | undefined) => {
+      if (stringToken) {
+        const className = colon ? 'api-json-key' : 'api-json-string';
+        return `<span class="${className}">${escapeHtml(stringToken)}</span>${colon ?? ''}`;
+      }
+
+      if (booleanToken) {
+        return `<span class="api-json-boolean">${match}</span>`;
+      }
+
+      if (match === 'null') {
+        return '<span class="api-json-null">null</span>';
+      }
+
+      return `<span class="api-json-number">${match}</span>`;
+    },
+  );
+}
+
+function formatApiTestOutput(text: string): string {
+  if (text.trim() === '') {
+    return `<span class="api-json-null">(${escapeHtml(apiTestLabels().emptyResponse)})</span>`;
+  }
+
+  try {
+    return highlightJson(JSON.stringify(JSON.parse(text) as unknown, null, 2));
+  } catch {
+    return escapeHtml(text);
+  }
+}
+
+function apiTestInputValue(fieldName: string): unknown {
+  const lowerName = fieldName.toLowerCase();
+
+  if (lowerName.includes('limit')) {
+    return 10;
+  }
+
+  if (lowerName.includes('offset')) {
+    return 0;
+  }
+
+  if (lowerName.includes('scanall')) {
+    return false;
+  }
+
+  if (lowerName.includes('tags') || lowerName.includes('ids') || lowerName.includes('nodes')) {
+    return [];
+  }
+
+  if (lowerName.includes('metadata')) {
+    return {};
+  }
+
+  if (lowerName.includes('messages')) {
+    return [{ role: 'user', content: 'Hello mem9' }];
+  }
+
+  if (lowerName.includes('content')) {
+    return 'Example memory content';
+  }
+
+  if (lowerName.includes('memory_type')) {
+    return 'pinned';
+  }
+
+  if (lowerName.includes('app')) {
+    return null;
+  }
+
+  return '';
+}
+
+function buildApiTestJsonTemplate(fields: ApiTestField[]): string {
+  const body = fields.reduce<Record<string, unknown>>((current, field) => {
+    current[field.name] = apiTestInputValue(field.name);
+    return current;
+  }, {});
+
+  return JSON.stringify(body, null, 2);
+}
+
+function isApiTestMultipart(endpoint: ApiTestEndpoint): boolean {
+  return endpoint.headers.some((field) => field.name.toLowerCase() === 'content-type' && field.description.toLowerCase().includes('multipart'));
+}
+
+function extractApiTestPathParams(path: string): ApiTestField[] {
+  const labels = apiTestLabels();
+  return Array.from(path.matchAll(/\{([^}]+)\}/g)).map((match) => ({
+    name: match[1] ?? '',
+    description: labels.pathParameter,
+    required: true,
+  }));
+}
+
+function setApiTestSectionVisibility(container: HTMLElement, visible: boolean): void {
+  const section = container.closest<HTMLElement>('[data-api-test-section]');
+  if (section) {
+    section.hidden = !visible;
+  }
+}
+
+function createApiTestInput(container: HTMLElement, scope: string, field: ApiTestField, type = 'text'): HTMLInputElement {
+  const label = document.createElement('label');
+  label.className = 'api-test-control';
+
+  const labelText = document.createElement('span');
+  labelText.className = 'api-test-label-line';
+
+  const labelName = document.createElement('span');
+  labelName.className = 'api-test-label-name';
+  labelName.textContent = field.name;
+  labelText.append(labelName);
+
+  if (field.required) {
+    const labels = apiTestLabels();
+    const requiredMark = document.createElement('span');
+    requiredMark.className = 'api-test-required-mark';
+    requiredMark.textContent = '*';
+    requiredMark.setAttribute('aria-label', labels.required);
+    labelText.append(requiredMark);
+  }
+
+  const input = document.createElement('input');
+  input.type = type;
+  input.autocomplete = 'off';
+  input.dataset.apiTestScope = scope;
+  input.dataset.apiTestName = field.name;
+  if (field.required && type !== 'file') {
+    input.required = true;
+  }
+
+  if (field.name.toLowerCase() === 'content-type') {
+    input.value = field.description.toLowerCase().includes('multipart') ? 'multipart/form-data' : 'application/json';
+  }
+
+  label.append(labelText, input);
+
+  if (field.description) {
+    const help = document.createElement('p');
+    help.className = 'api-test-help';
+    help.textContent = field.description;
+    label.append(help);
+  }
+
+  container.append(label);
+  return input;
+}
+
+function renderApiTestFields(container: HTMLElement, scope: string, fields: ApiTestField[], multipart = false): void {
+  container.replaceChildren();
+  fields.forEach((field) => {
+    const type = multipart && field.name.toLowerCase() === 'file' ? 'file' : 'text';
+    createApiTestInput(container, scope, field, type);
+  });
+  setApiTestSectionVisibility(container, fields.length > 0);
+}
+
+function readApiTestTextInputs(scope: string): Array<{ name: string; value: string }> {
+  return Array.from(document.querySelectorAll<HTMLInputElement>(`[data-api-test-scope="${scope}"]`))
+    .filter((input) => input.type !== 'file')
+    .map((input) => ({
+      name: input.dataset.apiTestName ?? '',
+      value: input.value.trim(),
+    }))
+    .filter((entry) => entry.name !== '');
+}
+
+function apiTestStorageKey(endpoint: ApiTestEndpoint): string {
+  return `${API_TEST_STORAGE_PREFIX}${encodeURIComponent(`${endpoint.method}:${endpoint.path}`)}`;
+}
+
+function isApiTestApiKeyName(name: string): boolean {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, '').includes('apikey');
+}
+
+function collectApiTestSavedInputs(scope: string): Record<string, string> {
+  return Array.from(document.querySelectorAll<HTMLInputElement>(`[data-api-test-scope="${scope}"]`))
+    .filter((input) => input.type !== 'file')
+    .reduce<Record<string, string>>((saved, input) => {
+      const name = input.dataset.apiTestName ?? '';
+      if (name === '' || isApiTestApiKeyName(name)) {
+        return saved;
+      }
+
+      saved[name] = input.value;
+      return saved;
+    }, {});
+}
+
+function applyApiTestSavedInputs(scope: string, saved: Record<string, string>): void {
+  document.querySelectorAll<HTMLInputElement>(`[data-api-test-scope="${scope}"]`).forEach((input) => {
+    const name = input.dataset.apiTestName ?? '';
+    if (name === '' || isApiTestApiKeyName(name) || !(name in saved)) {
+      return;
+    }
+
+    input.value = saved[name] ?? '';
+  });
+}
+
+function sanitizeApiTestJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeApiTestJsonValue);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.entries(value).reduce<Record<string, unknown>>((sanitized, [key, nestedValue]) => {
+    if (!isApiTestApiKeyName(key)) {
+      sanitized[key] = sanitizeApiTestJsonValue(nestedValue);
+    }
+    return sanitized;
+  }, {});
+}
+
+function sanitizeApiTestJsonText(text: string): string {
+  if (text.trim() === '') {
+    return '';
+  }
+
+  try {
+    return JSON.stringify(sanitizeApiTestJsonValue(JSON.parse(text) as unknown), null, 2);
+  } catch {
+    return '';
+  }
+}
+
+function parseApiTestStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.entries(value).reduce<Record<string, string>>((record, [key, nestedValue]) => {
+    if (typeof nestedValue === 'string' && !isApiTestApiKeyName(key)) {
+      record[key] = nestedValue;
+    }
+    return record;
+  }, {});
+}
+
+function readApiTestSavedForm(endpoint: ApiTestEndpoint): ApiTestSavedForm | null {
+  try {
+    const raw = localStorage.getItem(apiTestStorageKey(endpoint));
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      return null;
+    }
+
+    return {
+      baseUrl: typeof parsed.baseUrl === 'string' ? parsed.baseUrl : '',
+      path: parseApiTestStringRecord(parsed.path),
+      headers: parseApiTestStringRecord(parsed.headers),
+      query: parseApiTestStringRecord(parsed.query),
+      body: parseApiTestStringRecord(parsed.body),
+      json: typeof parsed.json === 'string' ? sanitizeApiTestJsonText(parsed.json) : '',
+    };
+  } catch {
+    return null;
+  }
+}
+
+function collectApiTestSavedForm(elements: ApiTestModalElements): ApiTestSavedForm {
+  return {
+    baseUrl: elements.baseUrl.value,
+    path: collectApiTestSavedInputs('path'),
+    headers: collectApiTestSavedInputs('headers'),
+    query: collectApiTestSavedInputs('query'),
+    body: collectApiTestSavedInputs('body'),
+    json: elements.jsonWrap.hidden ? '' : sanitizeApiTestJsonText(elements.json.value),
+  };
+}
+
+function saveApiTestForm(elements: ApiTestModalElements): void {
+  if (!activeApiTestEndpoint || !elements.saveInfo.checked) {
+    return;
+  }
+
+  try {
+    localStorage.setItem(
+      apiTestStorageKey(activeApiTestEndpoint),
+      JSON.stringify(collectApiTestSavedForm(elements)),
+    );
+  } catch {
+    // Ignore storage quota or privacy-mode failures.
+  }
+}
+
+function clearApiTestSavedForm(endpoint: ApiTestEndpoint): void {
+  try {
+    localStorage.removeItem(apiTestStorageKey(endpoint));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+function restoreApiTestSavedForm(elements: ApiTestModalElements, endpoint: ApiTestEndpoint): void {
+  if (!elements.saveInfo.checked) {
+    return;
+  }
+
+  const saved = readApiTestSavedForm(endpoint);
+  if (!saved) {
+    return;
+  }
+
+  if (saved.baseUrl.trim() !== '') {
+    elements.baseUrl.value = saved.baseUrl;
+  }
+
+  applyApiTestSavedInputs('path', saved.path);
+  applyApiTestSavedInputs('headers', saved.headers);
+  applyApiTestSavedInputs('query', saved.query);
+  applyApiTestSavedInputs('body', saved.body);
+  if (!elements.jsonWrap.hidden && saved.json.trim() !== '') {
+    elements.json.value = saved.json;
+  }
+}
+
+function buildApiTestUrl(elements: ApiTestModalElements, endpoint: ApiTestEndpoint): URL {
+  const base = elements.baseUrl.value.trim().replace(/\/+$/u, '');
+  const baseUrl = base === '' ? defaultApiTestBaseUrl() : base;
+  const resolvedPath = endpoint.path.replace(/\{([^}]+)\}/g, (match, name: string) => {
+    const input = Array.from(document.querySelectorAll<HTMLInputElement>('[data-api-test-scope="path"]'))
+      .find((candidate) => candidate.dataset.apiTestName === name);
+    const value = input?.value.trim() ?? '';
+    return value === '' ? match : encodeURIComponent(value);
+  });
+  const url = new URL(resolvedPath, `${baseUrl}/`);
+
+  readApiTestTextInputs('query').forEach(({ name, value }) => {
+    if (value !== '') {
+      url.searchParams.append(name, value);
+    }
+  });
+
+  return url;
+}
+
+function defaultApiTestBaseUrl(): string {
+  return ['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)
+    ? 'http://localhost:8081'
+    : 'https://api.mem9.ai';
+}
+
+function updateApiTestUrlPreview(elements: ApiTestModalElements): void {
+  if (!activeApiTestEndpoint) {
+    return;
+  }
+
+  try {
+    elements.url.textContent = buildApiTestUrl(elements, activeApiTestEndpoint).toString();
+  } catch (error) {
+    elements.url.textContent = error instanceof Error ? error.message : String(error);
+  }
+}
+
+function openApiTestModal(elements: ApiTestModalElements, endpoint: ApiTestEndpoint): void {
+  const multipart = isApiTestMultipart(endpoint);
+  const labels = apiTestLabels();
+  activeApiTestEndpoint = endpoint;
+  if (elements.baseUrl.value.trim() === '') {
+    elements.baseUrl.value = defaultApiTestBaseUrl();
+  }
+  elements.title.textContent = endpoint.summary;
+  elements.method.textContent = `${endpoint.method} · ${endpoint.groupTitle}`;
+  elements.path.textContent = endpoint.path;
+  elements.response.hidden = false;
+  elements.status.textContent = labels.ready;
+  elements.output.textContent = labels.responseReady;
+  renderApiTestFields(elements.pathFields, 'path', extractApiTestPathParams(endpoint.path));
+  renderApiTestFields(elements.headerFields, 'headers', endpoint.headers);
+  renderApiTestFields(elements.queryFields, 'query', endpoint.queryParams);
+  renderApiTestFields(elements.bodyFields, 'body', multipart ? endpoint.bodyFields : [], multipart);
+  elements.jsonWrap.hidden = multipart || endpoint.bodyFields.length === 0;
+  elements.json.value = multipart || endpoint.bodyFields.length === 0 ? '' : buildApiTestJsonTemplate(endpoint.bodyFields);
+  setApiTestSectionVisibility(elements.bodyFields, endpoint.bodyFields.length > 0);
+  restoreApiTestSavedForm(elements, endpoint);
+  updateApiTestUrlPreview(elements);
+
+  elements.modal.hidden = false;
+  window.requestAnimationFrame(() => {
+    elements.modal.classList.add('is-visible');
+    elements.baseUrl.focus();
+  });
+}
+
+function closeApiTestModal(elements: ApiTestModalElements): void {
+  elements.modal.classList.remove('is-visible');
+  window.setTimeout(() => {
+    elements.modal.hidden = true;
+  }, 180);
+}
+
+async function runApiTest(elements: ApiTestModalElements): Promise<void> {
+  if (!activeApiTestEndpoint) {
+    return;
+  }
+
+  const labels = apiTestLabels();
+  const endpoint = activeApiTestEndpoint;
+  const multipart = isApiTestMultipart(endpoint);
+  const headers = new Headers();
+  readApiTestTextInputs('headers').forEach(({ name, value }) => {
+    if (value === '') {
+      return;
+    }
+    if (multipart && name.toLowerCase() === 'content-type') {
+      return;
+    }
+    headers.set(name, value);
+  });
+
+  let body: BodyInit | undefined;
+  if (multipart) {
+    const formData = new FormData();
+    document.querySelectorAll<HTMLInputElement>('[data-api-test-scope="body"]').forEach((input) => {
+      const name = input.dataset.apiTestName ?? '';
+      if (name === '') {
+        return;
+      }
+      if (input.type === 'file') {
+        const file = input.files?.[0];
+        if (file) {
+          formData.append(name, file);
+        }
+        return;
+      }
+      if (input.value.trim() !== '') {
+        formData.append(name, input.value.trim());
+      }
+    });
+    body = formData;
+  } else if (!elements.jsonWrap.hidden && elements.json.value.trim() !== '') {
+    JSON.parse(elements.json.value) as unknown;
+    body = elements.json.value;
+    if (!headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+  }
+
+  const url = buildApiTestUrl(elements, endpoint);
+  const startedAt = performance.now();
+  elements.run.disabled = true;
+  elements.run.textContent = labels.running;
+  elements.response.hidden = false;
+  elements.status.textContent = labels.runningRequest;
+  elements.output.textContent = '';
+
+  try {
+    const response = await fetch(url.toString(), {
+      method: endpoint.method,
+      headers,
+      body: ['GET', 'HEAD'].includes(endpoint.method) ? undefined : body,
+    });
+    const elapsed = Math.round(performance.now() - startedAt);
+    const text = await response.text();
+    elements.status.textContent = `${response.status} ${response.statusText} · ${elapsed}ms`;
+    elements.output.innerHTML = formatApiTestOutput(text);
+  } catch (error) {
+    const elapsed = Math.round(performance.now() - startedAt);
+    elements.status.textContent = `${labels.requestFailed} · ${elapsed}ms`;
+    elements.output.textContent = error instanceof Error ? error.message : String(error);
+  } finally {
+    elements.run.disabled = false;
+    elements.run.textContent = apiTestLabels().run;
+  }
+}
+
+function initApiTestConsole(): void {
+  const elements = getApiTestModalElements();
+  if (!elements) {
+    return;
+  }
+
+  document.querySelectorAll<HTMLButtonElement>('[data-api-test-open]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const endpoint = parseApiTestEndpoint(button.dataset.apiTestEndpoint);
+      if (endpoint) {
+        openApiTestModal(elements, endpoint);
+      }
+    });
+  });
+
+  document.querySelectorAll<HTMLButtonElement>('[data-api-test-close]').forEach((button) => {
+    button.addEventListener('click', () => closeApiTestModal(elements));
+  });
+
+  const resetButton = document.querySelector<HTMLButtonElement>('[data-api-test-reset]');
+  resetButton?.addEventListener('click', () => {
+    if (activeApiTestEndpoint) {
+      clearApiTestSavedForm(activeApiTestEndpoint);
+      openApiTestModal(elements, activeApiTestEndpoint);
+    }
+  });
+
+  elements.modal.addEventListener('click', (event) => {
+    if (event.target === elements.modal) {
+      closeApiTestModal(elements);
+    }
+  });
+
+  elements.saveInfo.addEventListener('change', () => {
+    if (elements.saveInfo.checked) {
+      saveApiTestForm(elements);
+    }
+  });
+
+  elements.form.addEventListener('input', () => {
+    updateApiTestUrlPreview(elements);
+    saveApiTestForm(elements);
+  });
+  elements.form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    runApiTest(elements).catch((error: unknown) => {
+      const labels = apiTestLabels();
+      elements.response.hidden = false;
+      elements.status.textContent = labels.requestFailed;
+      elements.output.textContent = error instanceof Error ? error.message : String(error);
+      elements.run.disabled = false;
+      elements.run.textContent = labels.run;
+    });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !elements.modal.hidden) {
+      closeApiTestModal(elements);
+    }
+  });
+}
+
 export function initSiteUI(): void {
   const locale = isSiteLocale(document.documentElement.dataset.locale)
     ? document.documentElement.dataset.locale
@@ -1085,6 +2006,7 @@ export function initSiteUI(): void {
   setOpenMenu(null);
 
   if (isDocsPage()) {
+    initDocsTocSearch();
     initDocsScrollSpy();
     initDocsProgressBar();
     initDocsBackToTop();
@@ -1093,6 +2015,8 @@ export function initSiteUI(): void {
 
   if (isApiPage()) {
     initApiScrollSpy();
+    initApiTocSearch();
     initApiMobileToc();
+    initApiTestConsole();
   }
 }


### PR DESCRIPTION
## Summary

Fix subtle memory list behavior issues that show up from the console memory table:

- route ordinary Space searches with `scanAll=true` through pageable local list results instead of recall top-k behavior
- include both insight/pinned memories and session memories when scan-all list search has no explicit memory type
- honor sort parameters for TiDB session memory list results

## Root Cause

The console can request sorted pageable memory rows, but the mem9 server query path for ordinary keyword searches still preferred recall behavior unless a type-specific path was selected. Session list rows also always ordered by `updated_at DESC`, so table sort changes could be lost for session-backed results.

## Changes

- Add a scan-all local list path for keyword searches.
- Add a `MemoryService.List` wrapper for finalized list results.
- Add TiDB session list ordering for `content`, `tags`, and `updated_at` with asc/desc support.
- Add handler and repository tests for mixed local memory scan-all and session sorting.

## Validation

- `make test`

## Related

Companion PRs:

- mem9-console-server: https://github.com/mem9-ai/mem9-console-server/pull/65
- mem9-console-fe: https://github.com/mem9-ai/mem9-console-fe/pull/58