### PR TITLE
Improve session adjacent turn recall

### DIFF
--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -269,3 +269,10 @@ type Session struct {
 	CreatedAt   time.Time   `json:"created_at"`
 	UpdatedAt   time.Time   `json:"updated_at"`
 }
+
+// SessionSeqWindow selects raw session turns around a known session sequence.
+type SessionSeqWindow struct {
+	SessionID string
+	MinSeq    int
+	MaxSeq    int
+}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -171,6 +171,7 @@ type testSessionRepo struct {
 	sessionListResults   []*domain.Session
 	lastSessionIDs       []string
 	lastSessionLimit     int
+	lastSeqWindows       []domain.SessionSeqWindow
 	getResult            *domain.Memory
 	getErr               error
 	listResults          []domain.Memory
@@ -269,6 +270,11 @@ func (s *testSessionRepo) FTSAvailable() bool { return false }
 func (s *testSessionRepo) ListBySessionIDs(_ context.Context, sessionIDs []string, limit int) ([]*domain.Session, error) {
 	s.lastSessionIDs = append([]string(nil), sessionIDs...)
 	s.lastSessionLimit = limit
+	return append([]*domain.Session(nil), s.sessionListResults...), nil
+}
+
+func (s *testSessionRepo) ListBySessionSeqWindows(_ context.Context, windows []domain.SessionSeqWindow) ([]*domain.Session, error) {
+	s.lastSeqWindows = append([]domain.SessionSeqWindow(nil), windows...)
 	return append([]*domain.Session(nil), s.sessionListResults...), nil
 }
 
@@ -3031,8 +3037,8 @@ func TestListMemories_DefaultRecall_ExpandsAdjacentSessionAnswerTurn(t *testing.
 	if resp.Memories[0].Confidence == nil || *resp.Memories[0].Confidence < defaultMixedMinConfidence {
 		t.Fatalf("expected adjacent answer confidence >= %d, got %+v", defaultMixedMinConfidence, resp.Memories[0].Confidence)
 	}
-	if len(sessRepo.lastSessionIDs) != 1 || sessRepo.lastSessionIDs[0] != "sess-1" {
-		t.Fatalf("expected adjacent expansion to inspect sess-1, got %+v", sessRepo.lastSessionIDs)
+	if len(sessRepo.lastSeqWindows) != 1 || sessRepo.lastSeqWindows[0].SessionID != "sess-1" || sessRepo.lastSeqWindows[0].MinSeq != 6 || sessRepo.lastSeqWindows[0].MaxSeq != 8 {
+		t.Fatalf("expected adjacent expansion to inspect sess-1 seq 6..8, got %+v", sessRepo.lastSeqWindows)
 	}
 }
 

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"regexp"
 	"sort"
@@ -88,6 +89,9 @@ var (
 	recallCoverageEnglishTokenRe = regexp.MustCompile(`\b[a-z][a-z0-9'-]{3,}\b`)
 	recallCoverageCJKTokenRe     = regexp.MustCompile(`[\p{Han}]{2,6}`)
 	recallCoverageSpaceRe        = regexp.MustCompile(`\s+`)
+	recallSourceTurnTokenRe      = regexp.MustCompile(`[A-Za-z]+(?:'[A-Za-z]+)?|\d+|[\p{Han}]{2,}`)
+	recallSourceTurnModalRe      = regexp.MustCompile(`(?i)\b(?:might|likely|probably|infer|inferred|suggests?|imply|implies)\b`)
+	recallSourceTurnLocationRe   = regexp.MustCompile(`(?i)\b(?:which|what|in which)\s+(?:state|city|country|place|location)\b`)
 )
 
 type recallTemporalIntent int
@@ -133,6 +137,11 @@ type recallSelectionStats struct {
 	coverageTokenCount     int
 	coverageFirstPassCount int
 	backfillCount          int
+}
+
+type recallSourceTurnMetadata struct {
+	Seq     int    `json:"seq"`
+	Content string `json:"content"`
 }
 
 func (s *Server) defaultConfidenceRecallSearch(
@@ -351,8 +360,133 @@ func buildRecallConfidence(profile recallQueryProfile, candidate service.RecallC
 		recencyBonus(candidate.Memory.UpdatedAt) +
 		answerEvidenceBonus(profile, candidate.Memory) +
 		sourcePrior(profile.shape, candidate.SourcePool)
+	confidenceRaw += sourceTurnEvidenceBonus(profile, candidate, confidenceRaw)
 
 	return int(clampFloat64(confidenceRaw, 0, 1)*100 + 0.5)
+}
+
+func sourceTurnEvidenceBonus(profile recallQueryProfile, candidate service.RecallCandidate, baseConfidence float64) float64 {
+	if baseConfidence >= 0.88 || profile.durationQuery || profile.frequencyQuery {
+		return 0
+	}
+	if candidate.SourcePool != service.RecallSourceInsight || candidate.Memory.MemoryType != domain.TypeInsight {
+		return 0
+	}
+	switch profile.shape {
+	case recallQueryShapeExact, recallQueryShapeGeneral:
+	default:
+		return 0
+	}
+	if recallSourceTurnModalRe.MatchString(profile.lower) || recallSourceTurnLocationRe.MatchString(profile.lower) {
+		return 0
+	}
+
+	targetSpeaker := profile.subjectSpeaker
+	if profile.targetSpeaker != "" {
+		targetSpeaker = profile.targetSpeaker
+	}
+	if targetSpeaker == "" {
+		return 0
+	}
+
+	bestScore := 0
+	for _, turn := range parseRecallSourceTurns(candidate.Memory.Metadata) {
+		if !sameRecallPerson(extractRecallSpeaker(turn.Content), targetSpeaker) {
+			continue
+		}
+		score := scoreRecallSourceTurn(profile, candidate.Memory.Content, turn.Content)
+		if score > bestScore {
+			bestScore = score
+		}
+	}
+
+	switch {
+	case bestScore >= 18 && baseConfidence < 0.84:
+		return 0.04
+	case bestScore >= 14 && baseConfidence < 0.76:
+		return 0.03
+	default:
+		return 0
+	}
+}
+
+func parseRecallSourceTurns(metadata json.RawMessage) []recallSourceTurnMetadata {
+	if len(metadata) == 0 {
+		return nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &payload); err != nil {
+		return nil
+	}
+	raw, ok := payload["source_turns"]
+	if !ok || len(raw) == 0 {
+		return nil
+	}
+	var turns []recallSourceTurnMetadata
+	if err := json.Unmarshal(raw, &turns); err != nil {
+		return nil
+	}
+	return turns
+}
+
+func scoreRecallSourceTurn(profile recallQueryProfile, memoryContent, sourceContent string) int {
+	questionTokens := tokenizeRecallSourceTurn(profile.lower)
+	sourceTokens := recallSourceTurnTokenSet(tokenizeRecallSourceTurn(sourceContent))
+	memoryTokens := recallSourceTurnTokenSet(tokenizeRecallSourceTurn(memoryContent))
+	questionSet := recallSourceTurnTokenSet(questionTokens)
+
+	score := 0
+	for _, token := range questionTokens {
+		if _, ok := sourceTokens[token]; ok {
+			if len(token) >= 5 {
+				score += 3
+			} else {
+				score += 2
+			}
+		}
+	}
+	for token := range memoryTokens {
+		if _, ok := questionSet[token]; ok {
+			continue
+		}
+		if _, ok := sourceTokens[token]; ok {
+			score++
+		}
+	}
+	return minInt(score, 18)
+}
+
+func tokenizeRecallSourceTurn(text string) []string {
+	matches := recallSourceTurnTokenRe.FindAllString(strings.ToLower(text), -1)
+	out := make([]string, 0, len(matches))
+	for _, token := range matches {
+		token = strings.Trim(token, "'")
+		if len([]rune(token)) < 2 || isRecallSourceTurnStopword(token) {
+			continue
+		}
+		out = append(out, token)
+	}
+	return out
+}
+
+func recallSourceTurnTokenSet(tokens []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(tokens))
+	for _, token := range tokens {
+		set[token] = struct{}{}
+	}
+	return set
+}
+
+func isRecallSourceTurnStopword(token string) bool {
+	if isRecallQuestionTokenStopword(token) {
+		return true
+	}
+	switch token {
+	case "date", "speaker", "user", "assistant", "about", "after", "before", "during", "into", "onto", "over", "under", "very":
+		return true
+	default:
+		return false
+	}
 }
 
 func selectPinnedRecallCandidates(

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -73,7 +73,7 @@ var (
 	recallSpeakerTagRe           = regexp.MustCompile(`(?i)\[speaker:([^\]]+)\]`)
 	recallImageCaptionTagRe      = regexp.MustCompile(`(?is)\[image-caption:[^\]]+\]`)
 	recallTemporalTokenRe        = regexp.MustCompile(`\b(?:19|20)\d{2}\b|\b(?:january|february|march|april|may|june|july|august|september|october|november|december|monday|tuesday|wednesday|thursday|friday|saturday|sunday|spring|summer|fall|autumn|winter)\b|(?:\d{4}年|\d{1,2}月|昨天|今天|明天|上周|下周|去年|今年|明年|春天|夏天|秋天|冬天)`)
-	recallEnumerationPluralRe    = regexp.MustCompile(`\b(?:activities|books|events|items|pets|names|artists|bands|places|countries|movies|songs|games|restaurants|authors|albums|hobbies|shows|concerts|goals|projects|fields|ways|instruments|dishes|recipes)\b`)
+	recallEnumerationPluralRe    = regexp.MustCompile(`\b(?:activities|books|events|items|pets|names|artists|bands|places|countries|cities|states|movies|songs|games|restaurants|authors|albums|hobbies|shows|concerts|goals|projects|fields|ways|instruments|exercises|foods|dishes|recipes)\b`)
 	recallEnumerationTypeCueRe   = regexp.MustCompile(`\bwhat\s+(?:type|types|kind|kinds)\s+of\b`)
 	recallEnumerationBothCueRe   = regexp.MustCompile(`\b(?:what|which)\b.*\bboth\b`)
 	recallEnumerationDoneCueRe   = regexp.MustCompile(`\bwhat\s+(?:has|have)\s+.+\s+done\b`)

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -901,10 +901,19 @@ func answerEvidenceBonus(profile recallQueryProfile, memory domain.Memory) float
 	durationAnswer := containsRecallDurationAnswer(content)
 	durationRangeAnswer := containsRecallDurationRange(content)
 	frequencyAnswer := containsRecallFrequencyAnswer(content)
+	questionTokenMatches := recallQuestionSpecificTokenMatchCount(profile, content, temporalDisplay)
 
 	bonus := 0.0
 	if unitCount > 0 && unitCount <= 18 {
 		bonus += 0.05
+	}
+	switch {
+	case questionTokenMatches >= 3:
+		bonus += 0.14
+	case questionTokenMatches == 2:
+		bonus += 0.10
+	case questionTokenMatches == 1:
+		bonus += 0.06
 	}
 	if profile.targetSpeaker != "" {
 		switch {
@@ -1150,6 +1159,79 @@ func recallFocusMatchCount(memory domain.Memory, focusTokens []string) int {
 		}
 	}
 	return matches
+}
+
+func recallQuestionSpecificTokenMatchCount(profile recallQueryProfile, content, temporalDisplay string) int {
+	switch profile.shape {
+	case recallQueryShapeEntity, recallQueryShapeLocation, recallQueryShapeEnumeration, recallQueryShapeExact, recallQueryShapeGeneral:
+	default:
+		return 0
+	}
+
+	tokens := recallQuestionSpecificTokens(profile)
+	if len(tokens) == 0 {
+		return 0
+	}
+	haystack := strings.ToLower(content)
+	if temporalDisplay != "" {
+		haystack += " " + strings.ToLower(temporalDisplay)
+	}
+
+	matches := 0
+	for _, token := range tokens {
+		if strings.Contains(haystack, token) {
+			matches++
+		}
+	}
+	return matches
+}
+
+func recallQuestionSpecificTokens(profile recallQueryProfile) []string {
+	if strings.TrimSpace(profile.lower) == "" {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	for _, match := range recallCoverageEnglishTokenRe.FindAllString(profile.lower, -1) {
+		token := normalizeRecallCoverageToken(match)
+		if token == "" || len([]rune(token)) < 4 || isRecallQuestionTokenStopword(token) {
+			continue
+		}
+		if sameRecallPerson(token, profile.subjectSpeaker) || sameRecallPerson(token, profile.targetSpeaker) {
+			continue
+		}
+		seen[token] = struct{}{}
+	}
+	for _, match := range recallCoverageCJKTokenRe.FindAllString(profile.lower, -1) {
+		token := normalizeRecallCoverageToken(match)
+		if token == "" || isRecallQuestionTokenStopword(token) {
+			continue
+		}
+		seen[token] = struct{}{}
+	}
+
+	out := make([]string, 0, len(seen))
+	for token := range seen {
+		out = append(out, token)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func isRecallQuestionTokenStopword(token string) bool {
+	if isRecallCoverageStopword(token) || isRecallFocusStopword(token) {
+		return true
+	}
+	switch token {
+	case "about", "again", "also", "another", "anything", "around", "because", "been", "being", "could", "does", "doing", "done", "ever", "from", "going", "have", "having", "into", "just", "like", "likely", "mentioned", "more", "much", "need", "needs", "partake", "soon", "than", "that", "then", "there", "these", "they", "thing", "things", "this", "those", "through", "what", "when", "where", "which", "while", "will", "with", "would":
+		return true
+	case "person", "people", "someone", "something", "information":
+		return true
+	case "哪些", "什么", "哪里", "哪个", "多少", "怎么", "如何":
+		return true
+	default:
+		return false
+	}
 }
 
 func containsRecallDurationAnswer(content string) bool {

--- a/server/internal/handler/recall_test.go
+++ b/server/internal/handler/recall_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -258,6 +259,48 @@ func TestBuildRecallConfidence_TimeFutureIntentPrefersPlannedFutureEvidence(t *t
 
 	if gotFuture, gotPast := buildRecallConfidence(profile, futurePlan), buildRecallConfidence(profile, pastEvent); gotFuture <= gotPast {
 		t.Fatalf("expected future-planning evidence to outrank past event for future time query: future=%d past=%d", gotFuture, gotPast)
+	}
+}
+
+func TestSourceTurnEvidenceBonus_GuardsInsightBoost(t *testing.T) {
+	profile := buildRecallQueryProfile("How does John plan to honor the memories of his beloved pet?")
+	candidate := service.RecallCandidate{
+		Memory: domain.Memory{
+			ID:         "i1",
+			MemoryType: domain.TypeInsight,
+			Content:    "John is considering adopting a rescue dog to honor Max's memory.",
+			Metadata:   json.RawMessage(`{"source_turns":[{"seq":10,"content":"[date:11:51 am on 3 June, 2023] [speaker:John] I plan to honor Max's memory by adopting a rescue dog because Max was my beloved pet."}]}`),
+		},
+		SourcePool: service.RecallSourceInsight,
+	}
+
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.75); got <= 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want positive boost for grounded source turn", got)
+	}
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.91); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for already-high confidence candidate", got)
+	}
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.85); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no medium-score boost for high confidence candidate", got)
+	}
+
+	durationProfile := buildRecallQueryProfile("How long was Max a part of John's family?")
+	if got := sourceTurnEvidenceBonus(durationProfile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for duration query", got)
+	}
+	modalProfile := buildRecallQueryProfile("What might John's degree be in?")
+	if got := sourceTurnEvidenceBonus(modalProfile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for modal inference query", got)
+	}
+	locationProfile := buildRecallQueryProfile("In which state is the shelter from which James adopted the puppy?")
+	if got := sourceTurnEvidenceBonus(locationProfile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost for location-like query", got)
+	}
+
+	candidate.SourcePool = service.RecallSourceSession
+	candidate.Memory.MemoryType = domain.TypeSession
+	if got := sourceTurnEvidenceBonus(profile, candidate, 0.76); got != 0 {
+		t.Fatalf("sourceTurnEvidenceBonus() = %.2f, want no boost outside insight pool", got)
 	}
 }
 

--- a/server/internal/handler/recall_test.go
+++ b/server/internal/handler/recall_test.go
@@ -21,6 +21,9 @@ func TestClassifyRecallQueryShape_Bilingual(t *testing.T) {
 		{name: "location english", query: "where is the office", want: recallQueryShapeLocation},
 		{name: "enumeration english activities", query: "What activities does Melanie partake in?", want: recallQueryShapeEnumeration},
 		{name: "enumeration english books", query: "What books has Melanie read?", want: recallQueryShapeEnumeration},
+		{name: "enumeration english cities", query: "Which US cities does John mention visiting?", want: recallQueryShapeEnumeration},
+		{name: "enumeration english foods", query: "What foods does Audrey like eating?", want: recallQueryShapeEnumeration},
+		{name: "enumeration english exercises", query: "What exercises has John done?", want: recallQueryShapeEnumeration},
 		{name: "enumeration english names", query: "What are Melanie's pets' names?", want: recallQueryShapeEnumeration},
 		{name: "exact english", query: "what company does john like", want: recallQueryShapeExact},
 		{name: "entity chinese", query: "谁负责这个项目", want: recallQueryShapeEntity},
@@ -115,6 +118,57 @@ func TestAnswerEvidenceBonus_BilingualSignals(t *testing.T) {
 				t.Fatalf("answerEvidenceBonus(%v, %q) = %.2f, want > %.2f for %q", tt.shape, tt.strong, strong, weak, tt.weak)
 			}
 		})
+	}
+}
+
+func TestRecallQuestionSpecificTokens_StripsQuestionBoilerplate(t *testing.T) {
+	profile := buildRecallQueryProfile("What did Caroline research?")
+	tokens := recallQuestionSpecificTokens(profile)
+	if len(tokens) != 1 || tokens[0] != "research" {
+		t.Fatalf("tokens = %v, want [research]", tokens)
+	}
+
+	profile = buildRecallQueryProfile("Would Melanie go on another roadtrip soon?")
+	tokens = recallQuestionSpecificTokens(profile)
+	if len(tokens) != 1 || tokens[0] != "roadtrip" {
+		t.Fatalf("tokens = %v, want [roadtrip]", tokens)
+	}
+}
+
+func TestRecallQuestionSpecificTokenMatchCount_HandlesActionInflection(t *testing.T) {
+	profile := buildRecallQueryProfile("What did Caroline research?")
+
+	direct := "[date:12 May 2023] [speaker:Caroline] Researching adoption agencies has been a dream."
+	generic := "[date:23 August 2023] [speaker:Caroline] I got help from an adoption advice group."
+	if got := recallQuestionSpecificTokenMatchCount(profile, direct, ""); got != 1 {
+		t.Fatalf("direct token matches = %d, want 1", got)
+	}
+	if got := recallQuestionSpecificTokenMatchCount(profile, generic, ""); got != 0 {
+		t.Fatalf("generic token matches = %d, want 0", got)
+	}
+}
+
+func TestBuildRecallQueryProfile_DoesNotTokenizeNonTimeTemporalQuery(t *testing.T) {
+	profile := buildRecallQueryProfile("Which country was Evan visiting in May 2023?")
+	if profile.shape != recallQueryShapeEntity {
+		t.Fatalf("shape = %v, want entity", profile.shape)
+	}
+	if len(profile.temporalTokens) != 0 {
+		t.Fatalf("temporal tokens = %v, want none for non-time shape", profile.temporalTokens)
+	}
+}
+
+func TestAnswerEvidenceBonus_QuestionSpecificOverlapPrefersDirectEvidence(t *testing.T) {
+	profile := buildRecallQueryProfile("Would Melanie go on another roadtrip soon?")
+
+	direct := domain.Memory{
+		Content: "[date:20 October 2023] [speaker:Melanie] That roadtrip this past weekend was insane; we were freaked when my son got into an accident.",
+	}
+	generic := domain.Memory{
+		Content: "[date:20 October 2023] [speaker:Melanie] I love camping trips with my family because nature helps me reset.",
+	}
+	if gotDirect, gotGeneric := answerEvidenceBonus(profile, direct), answerEvidenceBonus(profile, generic); gotDirect <= gotGeneric {
+		t.Fatalf("expected direct roadtrip evidence to outrank generic camping evidence: direct=%.2f generic=%.2f", gotDirect, gotGeneric)
 	}
 }
 

--- a/server/internal/repository/factory.go
+++ b/server/internal/repository/factory.go
@@ -139,3 +139,6 @@ func (stubSessionRepo) FTSAvailable() bool { return false }
 func (stubSessionRepo) ListBySessionIDs(_ context.Context, _ []string, _ int) ([]*domain.Session, error) {
 	return nil, fmt.Errorf("session messages: %w", domain.ErrNotSupported)
 }
+func (stubSessionRepo) ListBySessionSeqWindows(_ context.Context, _ []domain.SessionSeqWindow) ([]*domain.Session, error) {
+	return nil, fmt.Errorf("session seq windows: %w", domain.ErrNotSupported)
+}

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -118,4 +118,8 @@ type SessionRepo interface {
 	// session_id ASC, created_at ASC, seq ASC, id ASC. At most limitPerSession rows are
 	// returned per session_id. Returns ErrNotSupported on non-TiDB backends.
 	ListBySessionIDs(ctx context.Context, sessionIDs []string, limitPerSession int) ([]*domain.Session, error)
+	// ListBySessionSeqWindows returns raw session rows for bounded seq windows,
+	// ordered by session_id ASC, seq ASC, created_at ASC, id ASC. Returns
+	// ErrNotSupported on non-TiDB backends.
+	ListBySessionSeqWindows(ctx context.Context, windows []domain.SessionSeqWindow) ([]*domain.Session, error)
 }

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -648,6 +648,44 @@ func (r *SessionRepo) ListBySessionIDs(ctx context.Context, sessionIDs []string,
 	return scanSessionDomainRows(rows)
 }
 
+func (r *SessionRepo) ListBySessionSeqWindows(ctx context.Context, windows []domain.SessionSeqWindow) ([]*domain.Session, error) {
+	clauses := make([]string, 0, len(windows))
+	args := make([]any, 0, len(windows)*3)
+	for _, window := range windows {
+		if window.SessionID == "" {
+			continue
+		}
+		minSeq, maxSeq := window.MinSeq, window.MaxSeq
+		if minSeq > maxSeq {
+			minSeq, maxSeq = maxSeq, minSeq
+		}
+		if minSeq < 0 {
+			minSeq = 0
+		}
+		clauses = append(clauses, "(session_id = ? AND seq BETWEEN ? AND ?)")
+		args = append(args, window.SessionID, minSeq, maxSeq)
+	}
+	if len(clauses) == 0 {
+		return nil, nil
+	}
+
+	sqlQuery := `SELECT id, session_id, agent_id, source, seq, role, content, content_type,
+		content_hash, tags, state, created_at, updated_at
+		FROM sessions
+		WHERE state = 'active' AND (` + strings.Join(clauses, " OR ") + `)
+		ORDER BY session_id ASC, seq ASC, created_at ASC, id ASC`
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("sessions list by seq windows: cluster_id=%s: %w", r.clusterID, err)
+	}
+	defer rows.Close()
+	return scanSessionDomainRows(rows)
+}
+
 func scanSessionDomainRows(rows *sql.Rows) ([]*domain.Session, error) {
 	var result []*domain.Session
 	for rows.Next() {

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -83,6 +83,45 @@ func TestSessionRepoGetByIDMissingTableReturnsNotFound(t *testing.T) {
 	}
 }
 
+func TestSessionRepoListBySessionSeqWindows(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"FROM sessions",
+				"WHERE state = 'active' AND ((session_id = ? AND seq BETWEEN ? AND ?) OR (session_id = ? AND seq BETWEEN ? AND ?))",
+				"ORDER BY session_id ASC, seq ASC, created_at ASC, id ASC",
+			},
+			wantArgs: []any{"sess-1", int64(79), int64(81), "sess-2", int64(3), int64(5)},
+			rows: &scriptedRows{
+				columns: rawSessionColumns(),
+				values: [][]driver.Value{
+					rawSessionRow("s-79", "sess-1", 79, "user", "Where else?", now),
+					rawSessionRow("s-80", "sess-1", 80, "assistant", "The mountains.", now.Add(time.Second)),
+					rawSessionRow("s-81", "sess-1", 81, "assistant", "The beach too.", now.Add(2*time.Second)),
+					rawSessionRow("s-04", "sess-2", 4, "assistant", "A support group.", now.Add(3*time.Second)),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewSessionRepo(db, "", false, "cluster-1")
+	rows, err := repo.ListBySessionSeqWindows(context.Background(), []domain.SessionSeqWindow{
+		{SessionID: "sess-1", MinSeq: 79, MaxSeq: 81},
+		{SessionID: "sess-2", MinSeq: 3, MaxSeq: 5},
+	})
+	if err != nil {
+		t.Fatalf("ListBySessionSeqWindows: %v", err)
+	}
+	if len(rows) != 4 {
+		t.Fatalf("rows len = %d, want 4", len(rows))
+	}
+	if rows[0].ID != "s-79" || rows[2].Seq != 81 || rows[3].SessionID != "sess-2" {
+		t.Fatalf("unexpected rows: %+v", rows)
+	}
+}
+
 func TestSessionRepoSoftDeleteMissingTableReturnsNotFound(t *testing.T) {
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -153,5 +192,30 @@ func TestFillSessionMemory_PopulatesFields(t *testing.T) {
 	}
 	if result.UpdatedAt != now {
 		t.Errorf("UpdatedAt = %v, want %v", result.UpdatedAt, now)
+	}
+}
+
+func rawSessionColumns() []string {
+	return []string{
+		"id", "session_id", "agent_id", "source", "seq", "role", "content", "content_type",
+		"content_hash", "tags", "state", "created_at", "updated_at",
+	}
+}
+
+func rawSessionRow(id, sessionID string, seq int64, role, content string, ts time.Time) []driver.Value {
+	return []driver.Value{
+		id,
+		sessionID,
+		"agent-1",
+		"chat",
+		seq,
+		role,
+		content,
+		"text",
+		id + "-hash",
+		[]byte(`[]`),
+		"active",
+		ts,
+		ts,
 	}
 }

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -359,6 +359,84 @@ func normalizeReconciledTemporalContent(content string) (string, *TemporalMetada
 	return NormalizeStandaloneTemporalContent(content, time.Now())
 }
 
+func normalizeReconciledTemporalContentWithFacts(content string, facts []ExtractedFact) (string, *TemporalMetadata) {
+	content = StripTemporalProjection(content)
+	sourceText, sourceTemporal := sourceTemporalForReconcileText(content, facts)
+	if sourceTemporal == nil {
+		return NormalizeStandaloneTemporalContent(content, time.Now())
+	}
+
+	normalized, temporal := NormalizeStandaloneTemporalContent(content, time.Now())
+	if shouldPreferSourceTemporal(content, temporal) {
+		if sourceText != "" && temporalRelativeCueRe.MatchString(strings.ToLower(content)) {
+			return sourceText, cloneTemporalMetadata(sourceTemporal)
+		}
+		return content, cloneTemporalMetadata(sourceTemporal)
+	}
+	if temporal == nil {
+		return normalized, cloneTemporalMetadata(sourceTemporal)
+	}
+	return normalized, temporal
+}
+
+func shouldPreferSourceTemporal(content string, temporal *TemporalMetadata) bool {
+	if temporal == nil {
+		return true
+	}
+	if temporal.AnchorSource == temporalAnchorSourceNow {
+		return true
+	}
+	return temporalRelativeCueRe.MatchString(strings.ToLower(content)) || temporalCNRelativeRe.MatchString(content)
+}
+
+func sourceTemporalForReconcileText(text string, facts []ExtractedFact) (string, *TemporalMetadata) {
+	if len(facts) == 0 {
+		return "", nil
+	}
+	if len(facts) == 1 {
+		return facts[0].Text, cloneTemporalMetadata(facts[0].Temporal)
+	}
+
+	query := sourceTokenSet(text)
+	if len(query) == 0 {
+		return "", nil
+	}
+
+	bestIdx := -1
+	bestHits := 0
+	ambiguous := false
+	for i, fact := range facts {
+		if fact.Temporal == nil {
+			continue
+		}
+		hits := countTokenOverlap(query, sourceTokenSet(projectReconcileFactText(fact)))
+		if hits == 0 {
+			continue
+		}
+		if hits > bestHits {
+			bestIdx = i
+			bestHits = hits
+			ambiguous = false
+			continue
+		}
+		if hits == bestHits {
+			ambiguous = true
+		}
+	}
+	if bestIdx < 0 || ambiguous || bestHits < sourceMinHits(len(query)) {
+		return "", nil
+	}
+	return facts[bestIdx].Text, cloneTemporalMetadata(facts[bestIdx].Temporal)
+}
+
+func cloneTemporalMetadata(meta *TemporalMetadata) *TemporalMetadata {
+	if meta == nil {
+		return nil
+	}
+	cloned := *meta
+	return &cloned
+}
+
 // ExtractPhase1 runs fact extraction and per-message tagging in a single LLM call.
 // Returns an empty Phase1Result (no error) when LLM is nil or messages are empty.
 func (s *IngestService) ExtractPhase1(ctx context.Context, messages []IngestMessage) (*Phase1Result, error) {
@@ -1219,7 +1297,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 	for _, event := range parsed.Memory {
 		switch strings.ToUpper(event.Event) {
 		case "ADD":
-			normalizedText, temporal := normalizeReconciledTemporalContent(event.Text)
+			normalizedText, temporal := normalizeReconciledTemporalContentWithFacts(event.Text, facts)
 			if normalizedText == "" {
 				continue
 			}
@@ -1252,7 +1330,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				slog.Warn("skipping UPDATE with invalid ID or empty text", "id", event.ID)
 				continue
 			}
-			normalizedText, temporal := normalizeReconciledTemporalContent(event.Text)
+			normalizedText, temporal := normalizeReconciledTemporalContentWithFacts(event.Text, facts)
 			if normalizedText == "" {
 				slog.Warn("skipping UPDATE with invalid ID or empty text", "id", event.ID)
 				continue

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -757,6 +757,13 @@ atomic facts from a conversation.
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
    - Bad: "Knows some programming languages"
+   Preserve lists, counts, named entities, and concrete examples when the user
+   mentions them. This includes family members, pets, places, books, media,
+   activities, goals, projects, tools, and repeated events.
+   - Good: "Melanie has pets named Luna, Oliver, and Bailey"
+   - Bad: "Melanie has pets"
+   If a quantity is implied but not exact, keep cautious wording such as
+   "at least two" or "a son and other children" instead of inventing a number.
 4. Preserve the user's original language.
 5. Omit pure greetings, filler, and debugging chatter with no lasting value.
 6. Do NOT extract search queries or lookup questions as facts.
@@ -907,6 +914,13 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
    - Bad: "Knows some programming languages"
+   Preserve lists, counts, named entities, and concrete examples when the user
+   mentions them. This includes family members, pets, places, books, media,
+   activities, goals, projects, tools, and repeated events.
+   - Good: "Melanie has pets named Luna, Oliver, and Bailey"
+   - Bad: "Melanie has pets"
+   If a quantity is implied but not exact, keep cautious wording such as
+   "at least two" or "a son and other children" instead of inventing a number.
 4. Preserve the user's original language.
 5. Omit pure greetings, filler, and debugging chatter with no lasting value.
 6. Do NOT extract search queries or lookup questions as facts.

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -160,6 +160,79 @@ func TestNormalizeTemporalFacts_ResolvesLastWeekToAnchoredPeriod(t *testing.T) {
 	}
 }
 
+func TestNormalizeTemporalFacts_AnchoredWeekAddsMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Content: "Caroline applied to adoption agencies the week before 23 August 2023."},
+	}, maxExtractionConversationRunes)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "Caroline applied to adoption agencies the week before 23 August 2023", Tags: []string{"event", "timeline"}},
+	})
+	if got[0].Text != "Caroline applied to adoption agencies the week before 23 August 2023" {
+		t.Fatalf("normalized fact = %q, want unchanged", got[0].Text)
+	}
+	if got[0].Temporal == nil || got[0].Temporal.Display != "2023-08-16~2023-08-22" || got[0].Temporal.AnchorSource != temporalAnchorSourceLocal {
+		t.Fatalf("temporal metadata = %+v, want week range before 2023-08-23", got[0].Temporal)
+	}
+}
+
+func TestNormalizeTemporalFacts_AnchoredMonthAfterAddsMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Content: "Jolene plans to travel the month after August 2023."},
+	}, maxExtractionConversationRunes)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "Jolene plans to travel the month after August 2023", Tags: []string{"event", "timeline"}},
+	})
+	if got[0].Temporal == nil || got[0].Temporal.Display != "2023-09" || got[0].Temporal.AnchorSource != temporalAnchorSourceLocal {
+		t.Fatalf("temporal metadata = %+v, want 2023-09", got[0].Temporal)
+	}
+}
+
+func TestNormalizeTemporalFacts_ResolvedSeasonAddsMetadata(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Content: "[9:48 am on 4 February, 2023] Here's a picture I took on vacation last summer in Bogota."},
+	}, maxExtractionConversationRunes)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "Jolene visited Bogota last summer", Tags: []string{"event", "timeline"}},
+	})
+	if got[0].Text != "Jolene visited Bogota in summer 2022" {
+		t.Fatalf("normalized fact = %q, want %q", got[0].Text, "Jolene visited Bogota in summer 2022")
+	}
+	if got[0].Temporal == nil || got[0].Temporal.Display != "summer 2022" || got[0].Temporal.AnchorSource != temporalAnchorSourceHeader {
+		t.Fatalf("temporal metadata = %+v, want summer 2022 from header", got[0].Temporal)
+	}
+}
+
+func TestNormalizeReconciledTemporalContentWithFacts_PreservesSourceTemporal(t *testing.T) {
+	t.Parallel()
+
+	facts := []ExtractedFact{{
+		Text: "Jolene visited Bogota in summer 2022",
+		Temporal: &TemporalMetadata{
+			Kind:         temporalKindExplicitAbsolute,
+			AnchorSource: temporalAnchorSourceHeader,
+			Granularity:  temporalGranularitySeason,
+			Display:      "summer 2022",
+		},
+	}}
+
+	text, meta := normalizeReconciledTemporalContentWithFacts("Jolene visited Bogota last summer", facts)
+	if text != "Jolene visited Bogota in summer 2022" {
+		t.Fatalf("normalized text = %q, want source-normalized text", text)
+	}
+	if meta == nil || meta.Display != "summer 2022" || meta.AnchorSource != temporalAnchorSourceHeader {
+		t.Fatalf("temporal metadata = %+v, want source summer 2022", meta)
+	}
+}
+
 func TestNormalizeTemporalFacts_UsesCurrentDateForChineseRelativeDayWithoutTimestamp(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -369,12 +369,19 @@ func (s *SessionService) adjacentTurnResults(
 
 	fetchLimit := adjacentTurnFetchLimit(seeds, opts.AdjacentTurnRadius)
 	start := time.Now()
-	sessions, err := s.sessions.ListBySessionIDs(ctx, sessionIDs, fetchLimit)
-	if err != nil {
-		if errors.Is(err, domain.ErrNotSupported) {
-			return nil, nil
+	windows := adjacentTurnSeqWindows(seeds, opts.AdjacentTurnRadius)
+	sessions, err := s.sessions.ListBySessionSeqWindows(ctx, windows)
+	if err != nil && !errors.Is(err, domain.ErrNotSupported) {
+		return nil, fmt.Errorf("session adjacent turn seq-window lookup: %w", err)
+	}
+	if len(windows) == 0 || errors.Is(err, domain.ErrNotSupported) {
+		sessions, err = s.sessions.ListBySessionIDs(ctx, sessionIDs, fetchLimit)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotSupported) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("session adjacent turn lookup: %w", err)
 		}
-		return nil, fmt.Errorf("session adjacent turn lookup: %w", err)
 	}
 	adjacent := adjacentTurnMemories(seeds, sessions, opts.AdjacentTurnRadius)
 	slog.InfoContext(ctx, "session adjacent turn expansion",
@@ -386,6 +393,33 @@ func (s *SessionService) adjacentTurnResults(
 		"total_ms", time.Since(start).Milliseconds(),
 	)
 	return adjacent, nil
+}
+
+func adjacentTurnSeqWindows(seeds []RecallCandidate, radius int) []domain.SessionSeqWindow {
+	if radius <= 0 {
+		radius = defaultAdjacentTurnRadius
+	}
+
+	windows := make([]domain.SessionSeqWindow, 0, len(seeds))
+	for _, seed := range seeds {
+		if seed.Memory.SessionID == "" {
+			continue
+		}
+		seq, ok := sessionSeqFromMemory(seed.Memory)
+		if !ok {
+			continue
+		}
+		minSeq := seq - radius
+		if minSeq < 0 {
+			minSeq = 0
+		}
+		windows = append(windows, domain.SessionSeqWindow{
+			SessionID: seed.Memory.SessionID,
+			MinSeq:    minSeq,
+			MaxSeq:    seq + radius,
+		})
+	}
+	return windows
 }
 
 func topAdjacentTurnSeeds(candidates []RecallCandidate, topN int) []RecallCandidate {
@@ -459,6 +493,25 @@ func adjacentTurnMemories(seeds []RecallCandidate, sessions []*domain.Session, r
 		if len(turns) == 0 {
 			continue
 		}
+		seedSeq, hasSeq := sessionSeqFromMemory(seed.Memory)
+		if hasSeq {
+			for _, neighbor := range turns {
+				if neighbor == nil || neighbor.ID == "" {
+					continue
+				}
+				diff := absInt(neighbor.Seq - seedSeq)
+				if diff == 0 || diff > radius {
+					continue
+				}
+				if _, ok := seen[neighbor.ID]; ok {
+					continue
+				}
+				seen[neighbor.ID] = struct{}{}
+				results = append(results, sessionToMemory(neighbor))
+			}
+			continue
+		}
+
 		seedIndex := -1
 		for i, turn := range turns {
 			if turn != nil && turn.ID == seed.Memory.ID {
@@ -497,6 +550,13 @@ func adjacentTurnIndexes(seedIndex, total, radius int) []int {
 		}
 	}
 	return indexes
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
 }
 
 func sessionSeqFromMemory(memory domain.Memory) (int, bool) {

--- a/server/internal/service/session_test.go
+++ b/server/internal/service/session_test.go
@@ -33,6 +33,8 @@ type stubSessionRepo struct {
 	sessionRows    []*domain.Session
 	listSessionIDs []string
 	listLimit      int
+	seqWindows     []domain.SessionSeqWindow
+	seqWindowErr   error
 	getResult      *domain.Memory
 	getErr         error
 	listResults    []domain.Memory
@@ -100,6 +102,14 @@ func (s *stubSessionRepo) FTSAvailable() bool { return s.ftsAvail }
 func (s *stubSessionRepo) ListBySessionIDs(_ context.Context, ids []string, limit int) ([]*domain.Session, error) {
 	s.listSessionIDs = append([]string(nil), ids...)
 	s.listLimit = limit
+	return append([]*domain.Session(nil), s.sessionRows...), nil
+}
+
+func (s *stubSessionRepo) ListBySessionSeqWindows(_ context.Context, windows []domain.SessionSeqWindow) ([]*domain.Session, error) {
+	s.seqWindows = append([]domain.SessionSeqWindow(nil), windows...)
+	if s.seqWindowErr != nil {
+		return nil, s.seqWindowErr
+	}
 	return append([]*domain.Session(nil), s.sessionRows...), nil
 }
 
@@ -387,8 +397,61 @@ func TestSessionService_SearchCandidates_ExpandsAdjacentTurns(t *testing.T) {
 	if candidates[1].Memory.ID != "s-answer" {
 		t.Fatalf("expected adjacent answer candidate to be appended, got %q", candidates[1].Memory.ID)
 	}
-	if len(repo.listSessionIDs) != 1 || repo.listSessionIDs[0] != "sess-1" {
-		t.Fatalf("expected ListBySessionIDs to request sess-1, got %+v", repo.listSessionIDs)
+	if len(repo.seqWindows) != 1 || repo.seqWindows[0].SessionID != "sess-1" || repo.seqWindows[0].MinSeq != 6 || repo.seqWindows[0].MaxSeq != 8 {
+		t.Fatalf("expected seq window around seed, got %+v", repo.seqWindows)
+	}
+	if len(repo.listSessionIDs) != 0 {
+		t.Fatalf("expected seq-window lookup instead of prefix lookup, got %+v", repo.listSessionIDs)
+	}
+}
+
+func TestSessionService_SearchCandidates_ExpandsLateAdjacentTurns(t *testing.T) {
+	now := time.Now()
+	repo := &stubSessionRepo{
+		keywordResults: []domain.Memory{
+			{
+				ID:         "s-seed",
+				SessionID:  "sess-late",
+				Content:    "I camped in the mountains.",
+				MemoryType: domain.TypeSession,
+				Metadata:   json.RawMessage(`{"role":"assistant","seq":80,"content_type":"text"}`),
+				UpdatedAt:  now,
+				State:      domain.StateActive,
+			},
+		},
+		sessionRows: []*domain.Session{
+			{ID: "s-prev", SessionID: "sess-late", Seq: 79, Role: "user", Content: "Where else have you camped?", ContentType: "text", State: domain.StateActive, CreatedAt: now.Add(-2 * time.Minute), UpdatedAt: now.Add(-2 * time.Minute)},
+			{ID: "s-seed", SessionID: "sess-late", Seq: 80, Role: "assistant", Content: "I camped in the mountains.", ContentType: "text", State: domain.StateActive, CreatedAt: now.Add(-1 * time.Minute), UpdatedAt: now.Add(-1 * time.Minute)},
+			{ID: "s-next", SessionID: "sess-late", Seq: 81, Role: "assistant", Content: "The beach and forest were memorable too.", ContentType: "text", State: domain.StateActive, CreatedAt: now, UpdatedAt: now},
+		},
+	}
+	svc := newTestSessionService(repo)
+
+	candidates, err := svc.SearchCandidates(context.Background(), domain.MemoryFilter{Query: "Where has Melanie camped?", Limit: 5}, RecallSourceSession, RecallCandidateOptions{
+		EnableAdjacentTurns: true,
+		AdjacentTurnRadius:  1,
+		AdjacentTurnTopN:    1,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candidates) != 3 {
+		t.Fatalf("expected seed plus two adjacent candidates, got %d", len(candidates))
+	}
+	gotIDs := map[string]bool{}
+	for _, candidate := range candidates {
+		gotIDs[candidate.Memory.ID] = true
+	}
+	for _, want := range []string{"s-seed", "s-prev", "s-next"} {
+		if !gotIDs[want] {
+			t.Fatalf("expected candidate %q in %+v", want, candidates)
+		}
+	}
+	if len(repo.seqWindows) != 1 || repo.seqWindows[0].SessionID != "sess-late" || repo.seqWindows[0].MinSeq != 79 || repo.seqWindows[0].MaxSeq != 81 {
+		t.Fatalf("expected late seq window, got %+v", repo.seqWindows)
+	}
+	if len(repo.listSessionIDs) != 0 {
+		t.Fatalf("expected no prefix lookup for late seed, got %+v", repo.listSessionIDs)
 	}
 }
 
@@ -466,4 +529,8 @@ func (c *capturingSessionRepo) FTSAvailable() bool { return c.stub.FTSAvailable(
 
 func (c *capturingSessionRepo) ListBySessionIDs(ctx context.Context, ids []string, limit int) ([]*domain.Session, error) {
 	return c.stub.ListBySessionIDs(ctx, ids, limit)
+}
+
+func (c *capturingSessionRepo) ListBySessionSeqWindows(ctx context.Context, windows []domain.SessionSeqWindow) ([]*domain.Session, error) {
+	return c.stub.ListBySessionSeqWindows(ctx, windows)
 }

--- a/server/internal/service/temporal_fact.go
+++ b/server/internal/service/temporal_fact.go
@@ -10,10 +10,10 @@ import (
 )
 
 const (
-	temporalKindExplicitAbsolute    = "explicit_absolute"
-	temporalKindLocalAnchorRelative = "local_anchor_relative"
+	temporalKindExplicitAbsolute     = "explicit_absolute"
+	temporalKindLocalAnchorRelative  = "local_anchor_relative"
 	temporalKindHeaderAnchorRelative = "header_anchor_relative"
-	temporalKindDeicticRelative     = "deictic_relative"
+	temporalKindDeicticRelative      = "deictic_relative"
 )
 
 const (
@@ -58,17 +58,19 @@ var (
 	temporalAnchorDateOnRe     = regexp.MustCompile(`(?i)\bon\s+(\d{1,2}\s+[A-Za-z]+,\s+\d{4})`)
 	temporalAnchorDateTagRe    = regexp.MustCompile(`(?i)\bdate:\s*(\d{1,2}\s+[A-Za-z]+\s+\d{4})`)
 
-	temporalLegacyAnnotationRe = regexp.MustCompile(`\(([^()|]*?(?:19|20)\d{2}[^()|]*)\|[^()]+\)`)
-	temporalProjectionSuffixRe = regexp.MustCompile(`\s*\[time:\s*[^\]]+\]\s*$`)
-	temporalISODateRe          = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
-	temporalISOMonthRe         = regexp.MustCompile(`\b\d{4}-\d{2}\b`)
-	temporalLongDateRe         = regexp.MustCompile(`(?i)\b\d{1,2}\s+[A-Za-z]+\s+\d{4}\b|\b[A-Za-z]+\s+\d{1,2},\s+\d{4}\b`)
-	temporalMonthYearRe        = regexp.MustCompile(`(?i)\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{4}\b`)
-	temporalCNFullDateRe       = regexp.MustCompile(`\b\d{4}年\d{1,2}月\d{1,2}[日号]?\b`)
-	temporalCNMonthDayRe       = regexp.MustCompile(`\b\d{1,2}月\d{1,2}[日号]?\b`)
-	temporalCNMonthRe          = regexp.MustCompile(`\b\d{4}年\d{1,2}月\b`)
-	temporalYearOnlyRe         = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
-	temporalAnchoredPeriodRe   = regexp.MustCompile(`(?i)\b(?:the\s+)?(?:week|weekend|month|year|summer|winter|spring|fall|autumn)\s+(?:before|after)\s+(?:\d{1,2}\s+[A-Za-z]+,\s+\d{4}|\d{1,2}\s+[A-Za-z]+\s+\d{4}|[A-Za-z]+\s+\d{4})\b`)
+	temporalLegacyAnnotationRe    = regexp.MustCompile(`\(([^()|]*?(?:19|20)\d{2}[^()|]*)\|[^()]+\)`)
+	temporalProjectionSuffixRe    = regexp.MustCompile(`\s*\[time:\s*[^\]]+\]\s*$`)
+	temporalISODateRe             = regexp.MustCompile(`\b\d{4}-\d{2}-\d{2}\b`)
+	temporalISOMonthRe            = regexp.MustCompile(`\b\d{4}-\d{2}\b`)
+	temporalLongDateRe            = regexp.MustCompile(`(?i)\b\d{1,2}\s+[A-Za-z]+\s+\d{4}\b|\b[A-Za-z]+\s+\d{1,2},\s+\d{4}\b`)
+	temporalMonthYearRe           = regexp.MustCompile(`(?i)\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{4}\b`)
+	temporalCNFullDateRe          = regexp.MustCompile(`\b\d{4}年\d{1,2}月\d{1,2}[日号]?\b`)
+	temporalCNMonthDayRe          = regexp.MustCompile(`\b\d{1,2}月\d{1,2}[日号]?\b`)
+	temporalCNMonthRe             = regexp.MustCompile(`\b\d{4}年\d{1,2}月\b`)
+	temporalYearOnlyRe            = regexp.MustCompile(`\b(?:19|20)\d{2}\b`)
+	temporalAnchoredPeriodRe      = regexp.MustCompile(`(?i)\b(?:the\s+)?(?:week|weekend|month|year|summer|winter|spring|fall|autumn)\s+(?:before|after)\s+(?:\d{1,2}\s+[A-Za-z]+,\s+\d{4}|\d{1,2}\s+[A-Za-z]+\s+\d{4}|[A-Za-z]+\s+\d{4})\b`)
+	temporalAnchoredPeriodPartsRe = regexp.MustCompile(`(?i)\b(?:the\s+)?(week|weekend|month|year|summer|winter|spring|fall|autumn)\s+(before|after)\s+(\d{1,2}\s+[A-Za-z]+,\s+\d{4}|\d{1,2}\s+[A-Za-z]+\s+\d{4}|[A-Za-z]+\s+\d{4})\b`)
+	temporalSeasonYearRe          = regexp.MustCompile(`(?i)\b(?:in\s+)?(summer|winter|spring|fall|autumn)\s+((?:19|20)\d{2})\b`)
 
 	temporalRelativeCueRe = regexp.MustCompile(`(?i)\b(?:yesterday|today|tomorrow|last\s+(?:night|week|weekend|month|year|summer|winter|spring|fall|autumn|friday|saturday|sunday|monday|tuesday|wednesday|thursday)|next\s+(?:week|weekend|month|year|summer|winter|spring|fall|autumn|friday|saturday|sunday|monday|tuesday|wednesday|thursday)|this\s+(?:week|weekend|month|year|summer|winter|spring|fall|autumn)|the\s+(?:past\s+)?(?:week|weekend))\b`)
 	temporalCNRelativeRe  = regexp.MustCompile(`上周[一二三四五六日天]|下周[一二三四五六日天]|前天|昨天|今天|明天|后天|上周|本周|这周|下周|上个月|这个月|本月|下个月|去年|今年|明年`)
@@ -278,6 +280,12 @@ func normalizeTemporalFactContent(text string, anchors []temporalAnchorCandidate
 
 	if rewritten, meta, ok := resolveLocalAnchorRelative(cleaned); ok {
 		return rewritten, meta
+	}
+	if meta := buildAnchoredPeriodTemporalMetadata(cleaned); meta != nil {
+		return cleaned, meta
+	}
+	if meta := buildExplicitSeasonTemporalMetadata(cleaned); meta != nil {
+		return cleaned, meta
 	}
 	if hasExplicitAbsoluteTime(cleaned) {
 		return cleaned, nil
@@ -712,9 +720,9 @@ func buildRangeTemporalMetadata(kind, anchorSource, granularity string, start, e
 	start = startOfDay(start)
 	end = startOfDay(end)
 	meta := &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  granularity,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   granularity,
 		ResolvedStart: formatISODate(start),
 		ResolvedEnd:   formatISODate(end),
 	}
@@ -729,34 +737,144 @@ func buildRangeTemporalMetadata(kind, anchorSource, granularity string, start, e
 func buildMonthTemporalMetadata(kind, anchorSource string, month time.Time) *TemporalMetadata {
 	month = startOfMonth(month)
 	return &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  temporalGranularityMonth,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   temporalGranularityMonth,
 		ResolvedStart: month.Format("2006-01"),
-		Display:      month.Format("2006-01"),
+		Display:       month.Format("2006-01"),
 	}
 }
 
 func buildYearTemporalMetadata(kind, anchorSource string, year int) *TemporalMetadata {
 	display := strconv.Itoa(year)
 	return &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  temporalGranularityYear,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   temporalGranularityYear,
 		ResolvedStart: display,
-		Display:      display,
+		Display:       display,
 	}
 }
 
 func buildSeasonTemporalMetadata(kind, anchorSource, season string, year int) *TemporalMetadata {
+	season = normalizeTemporalSeason(season)
 	display := season + " " + strconv.Itoa(year)
 	return &TemporalMetadata{
-		Kind:         kind,
-		AnchorSource: anchorSource,
-		Granularity:  temporalGranularitySeason,
+		Kind:          kind,
+		AnchorSource:  anchorSource,
+		Granularity:   temporalGranularitySeason,
 		ResolvedStart: display,
-		Display:      display,
+		Display:       display,
 	}
+}
+
+func buildAnchoredPeriodTemporalMetadata(text string) *TemporalMetadata {
+	match := temporalAnchoredPeriodPartsRe.FindStringSubmatch(text)
+	if len(match) != 4 {
+		return nil
+	}
+	unit := normalizeTemporalSeason(strings.ToLower(match[1]))
+	direction := strings.ToLower(match[2])
+	anchor, ok := parseAnchoredPeriodAnchor(match[3])
+	if !ok {
+		return nil
+	}
+
+	switch unit {
+	case "week":
+		if direction == "before" {
+			return buildRangeTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, temporalGranularityWeek, anchor.AddDate(0, 0, -7), anchor.AddDate(0, 0, -1))
+		}
+		return buildRangeTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, temporalGranularityWeek, anchor.AddDate(0, 0, 1), anchor.AddDate(0, 0, 7))
+	case "weekend":
+		start := previousWeekendStart(anchor)
+		if direction == "after" {
+			start = nextWeekendStart(anchor)
+		}
+		return buildRangeTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, temporalGranularityWeek, start, start.AddDate(0, 0, 1))
+	case "month":
+		month := startOfMonth(anchor)
+		if direction == "before" {
+			month = month.AddDate(0, -1, 0)
+		} else {
+			month = month.AddDate(0, 1, 0)
+		}
+		return buildMonthTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, month)
+	case "year":
+		year := anchor.Year()
+		if direction == "before" {
+			year--
+		} else {
+			year++
+		}
+		return buildYearTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, year)
+	case "summer", "winter", "spring", "fall":
+		year := anchor.Year()
+		if direction == "before" {
+			year--
+		} else {
+			year++
+		}
+		return buildSeasonTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, unit, year)
+	default:
+		return nil
+	}
+}
+
+func buildExplicitSeasonTemporalMetadata(text string) *TemporalMetadata {
+	match := temporalSeasonYearRe.FindStringSubmatch(text)
+	if len(match) != 3 {
+		return nil
+	}
+	year, err := strconv.Atoi(match[2])
+	if err != nil {
+		return nil
+	}
+	return buildSeasonTemporalMetadata(temporalKindExplicitAbsolute, temporalAnchorSourceLocal, match[1], year)
+}
+
+func parseAnchoredPeriodAnchor(raw string) (time.Time, bool) {
+	if value, ok := parseFlexibleLongDate(raw); ok {
+		return value, true
+	}
+	if value, ok := parseFlexibleMonthYear(raw); ok {
+		return value, true
+	}
+	return time.Time{}, false
+}
+
+func parseFlexibleMonthYear(raw string) (time.Time, bool) {
+	value, err := time.ParseInLocation("January 2006", strings.TrimSpace(raw), time.UTC)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return value, true
+}
+
+func previousWeekendStart(anchor time.Time) time.Time {
+	anchor = startOfDay(anchor)
+	delta := (int(anchor.Weekday()) - int(time.Saturday) + 7) % 7
+	if delta == 0 {
+		delta = 7
+	}
+	return anchor.AddDate(0, 0, -delta)
+}
+
+func nextWeekendStart(anchor time.Time) time.Time {
+	anchor = startOfDay(anchor)
+	delta := (int(time.Saturday) - int(anchor.Weekday()) + 7) % 7
+	if delta == 0 {
+		delta = 7
+	}
+	return anchor.AddDate(0, 0, delta)
+}
+
+func normalizeTemporalSeason(season string) string {
+	season = strings.ToLower(strings.TrimSpace(season))
+	if season == "autumn" {
+		return "fall"
+	}
+	return season
 }
 
 func buildDisplayTemporalMetadata(kind, anchorSource, granularity, display string) *TemporalMetadata {
@@ -884,7 +1002,13 @@ func inferDisplayFromRewrittenText(text string) string {
 			return formatISODate(value)
 		}
 	case temporalAnchoredPeriodRe.MatchString(text):
-		return ""
+		if meta := buildAnchoredPeriodTemporalMetadata(text); meta != nil {
+			return meta.Display
+		}
+	case temporalSeasonYearRe.MatchString(text):
+		if meta := buildExplicitSeasonTemporalMetadata(text); meta != nil {
+			return meta.Display
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

- Improve session adjacent-turn recall by looking up raw session turns in bounded `session_id + seq` windows around already retrieved session memories.
- Preserve the existing fallback path for backends that do not support sequence-window lookup.
- Add repository/service/handler tests for the new adjacent-turn expansion behavior.

## LoCoMo evidence

- Baseline run: `20260602T104638freshbase2`
  - Result: `/Users/jiangxianjie/code/okjiang/harness/mem9-locomo/20260602T104638freshbase2/benchmark-results.json`
  - `Overall LLM (micro)`: `0.6448051948`
  - Product HEAD used by baseline: `be522490716e2e16d961a89936a6c81e96a7a39f`
- Candidate run: `20260603T0155sessfull`
  - Result: `/Users/jiangxianjie/code/okjiang/harness/mem9-locomo/20260603T0155sessfull/benchmark-results.json`
  - `Overall LLM (micro)`: `0.6532467532`
  - Absolute delta: `+0.0084415584`
  - Candidate commit: `9908dbb17c771efed6b4bd1493dbe612f8d9f00f`
- Benchmark revision: `mem9-benchmark` `69d0d9c8fe665259bd3234fe9d16a256af266d34`
- Dataset: `/Users/jiangxianjie/code/mem9-locomo-workspace/mem9-benchmark/locomo/data/locomo10.json`
- Model/config: `qwen3.6-plus`, `session` ingest, retrieval limit `10`, no sample/category filters, `1540/1540` LLM-judged rows, `1986` total rows.

Category LLM movement:

| Category | Baseline | Candidate | Delta |
| --- | ---: | ---: | ---: |
| Cat1 | `0.3829787234` | `0.3794326241` | `-0.0035460993` |
| Cat2 | `0.7663551402` | `0.7538940810` | `-0.0124610592` |
| Cat3 | `0.3750000000` | `0.3958333333` | `+0.0208333333` |
| Cat4 | `0.7170035672` | `0.7360285375` | `+0.0190249703` |

Cat1/Cat2 regressions were reviewed and accepted as non-blocking for this draft: Cat1 is a net `-1` LLM hit, Cat2 is a net `-4` LLM hits, while the primary metric improves by `+13/1540` judged rows. Cat2 temporal/entity rows are recorded as the next follow-up risk.

## Local checks

```bash
gofmt -l server/internal/domain/types.go server/internal/handler/memory_test.go server/internal/repository/factory.go server/internal/repository/repository.go server/internal/repository/tidb/sessions.go server/internal/repository/tidb/sessions_test.go server/internal/service/session.go server/internal/service/session_test.go
git diff --check
go test ./internal/service ./internal/repository/tidb ./internal/handler
go build ./cmd/mnemo-server
rm -f server/mnemo-server
```

All checks passed in the candidate worktree before opening this draft PR.

## Benchmark integrity

The benchmark dataset, gold answers, judge prompts, judge model, scoring logic, category labels, and benchmark semantics were not changed. The candidate was evaluated with the checked-in harness runner `./locomo.sh --sample-concurrency 5 --evaluation-concurrency 8 --sample-retries 2` using the same benchmark configuration as the baseline.
