### PR TITLE
feat(site): add crawler entrypoints

### DIFF
--- a/site/src/pages/robots.txt.ts
+++ b/site/src/pages/robots.txt.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+const fallbackSiteUrl = 'https://mem9.ai';
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL(fallbackSiteUrl);
+  const robotsText = [
+    'User-agent: *',
+    'Allow: /',
+    '',
+    `Sitemap: ${new URL('/sitemap.xml', siteUrl).toString()}`,
+  ].join('\n');
+
+  return new Response(robotsText, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/site/src/pages/sitemap.xml.ts
+++ b/site/src/pages/sitemap.xml.ts
@@ -1,0 +1,29 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+const fallbackSiteUrl = 'https://mem9.ai';
+const publicPages = ['/', '/api', '/docs', '/openclaw-memory', '/pricing'];
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL(fallbackSiteUrl);
+  const lastModified = new Date().toISOString();
+  const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${publicPages
+  .map(
+    (path) => `  <url>
+    <loc>${new URL(path, siteUrl).toString()}</loc>
+    <lastmod>${lastModified}</lastmod>
+  </url>`
+  )
+  .join('\n')}
+</urlset>
+`;
+
+  return new Response(sitemapXml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+};


### PR DESCRIPTION
## What changed
- Added a prerendered `/robots.txt` endpoint for the mem9 Astro site.
- Added a prerendered `/sitemap.xml` endpoint covering the current public site pages: `/`, `/api`, `/docs`, `/openclaw-memory`, and `/pricing`.

## Context
- Background: the mem9 site currently builds static Astro pages and public assets without crawler entrypoint files.
- Why this approach: Astro endpoints keep crawler files in source control beside the page routes and use the configured canonical site URL.
- How it works: both endpoints are prerendered during `astro build`; `robots.txt` advertises the sitemap, and `sitemap.xml` emits absolute canonical URLs.

## Validation
- `npm run build`
- `npx tsc --noEmit`
- Checked generated `dist/robots.txt` and `dist/sitemap.xml` contents.