### PR TITLE
[codex] Improve mobile site navigation and pricing

### DIFF
--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -108,19 +108,6 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
             </div>
           </div>
         </div>
-        <a
-          href="/pricing"
-          class:list={['nav-section-link', isActivePath('/pricing') && 'is-active']}
-          aria-current={isActivePath('/pricing') ? 'page' : undefined}
-        >
-          <span class="localized-label">
-            {navLabels('billing').map((label) => (
-              <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
-                {label.value}
-              </span>
-            ))}
-          </span>
-        </a>
         <div
           class="menu-shell nav-docs-dropdown"
           data-menu-shell="docs"
@@ -200,6 +187,19 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
           </div>
         </div>
         <a
+          href="/pricing"
+          class:list={['nav-section-link', isActivePath('/pricing') && 'is-active']}
+          aria-current={isActivePath('/pricing') ? 'page' : undefined}
+        >
+          <span class="localized-label">
+            {navLabels('billing').map((label) => (
+              <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                {label.value}
+              </span>
+            ))}
+          </span>
+        </a>
+        <a
           href="/release-notes"
           class:list={[
             'nav-section-link',
@@ -219,6 +219,222 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
       </div>
 
       <div class="nav-actions">
+        <div class="menu-shell mobile-menu-shell" data-menu-shell="mobile" data-open="false">
+          <button
+            type="button"
+            class="icon-button mobile-menu-toggle"
+            data-menu-trigger="mobile"
+            aria-haspopup="menu"
+            aria-expanded="false"
+            aria-controls="mobile-main-menu"
+            aria-label={aria.mainMenu}
+            title={aria.mainMenu}
+            data-i18n-attr="aria-label:aria.mainMenu;title:aria.mainMenu"
+          >
+            <svg class="mobile-menu-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                class="mobile-menu-line mobile-menu-line-top"
+                d="M5 7h14"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-width="1.8"
+              />
+              <path
+                class="mobile-menu-line mobile-menu-line-middle"
+                d="M5 12h14"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-width="1.8"
+              />
+              <path
+                class="mobile-menu-line mobile-menu-line-bottom"
+                d="M5 17h14"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-width="1.8"
+              />
+            </svg>
+          </button>
+
+          <div
+            id="mobile-main-menu"
+            class="nav-menu mobile-menu surface-card"
+            data-menu="mobile"
+            role="menu"
+            hidden
+          >
+            <div class="mobile-menu-section" role="presentation">
+              <a
+                href="/#top"
+                class:list={['mobile-menu-item', isActivePath('/') && 'is-active']}
+                role="menuitem"
+                aria-current={isActivePath('/') ? 'page' : undefined}
+              >
+                <span class="localized-label">
+                  {navLabels('home').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a href="/#features" class="mobile-menu-item" role="menuitem">
+                <span class="localized-label">
+                  {navLabels('features').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a href="/#benchmark" class="mobile-menu-item" role="menuitem">
+                <span class="localized-label">
+                  {navLabels('benchmark').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a href="/#platforms" class="mobile-menu-item" role="menuitem">
+                <span class="localized-label">
+                  {navLabels('platforms').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a href="/#security" class="mobile-menu-item" role="menuitem">
+                <span class="localized-label">
+                  {navLabels('security').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a href="/#faq" class="mobile-menu-item" role="menuitem">
+                <span class="localized-label">
+                  {navLabels('faq').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+            </div>
+
+            <div class="mobile-menu-section" role="presentation">
+              <a
+                href="/docs"
+                class:list={['mobile-menu-item', isActivePath('/docs') && 'is-active']}
+                role="menuitem"
+                aria-current={isActivePath('/docs') ? 'page' : undefined}
+              >
+                <span class="localized-label">
+                  {navLabels('mem9Docs').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a
+                href="/console-docs"
+                class:list={['mobile-menu-item', isActivePath('/console-docs') && 'is-active']}
+                role="menuitem"
+                aria-current={isActivePath('/console-docs') ? 'page' : undefined}
+              >
+                <span class="localized-label">
+                  {navLabels('consoleDocs').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a
+                href="/api"
+                class:list={['mobile-menu-item', isActivePath('/api') && 'is-active']}
+                role="menuitem"
+                aria-current={isActivePath('/api') ? 'page' : undefined}
+              >
+                <span class="localized-label">
+                  {navLabels('apiReferences').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+            </div>
+
+            <div class="mobile-menu-section" role="presentation">
+              <a
+                href="/pricing"
+                class:list={['mobile-menu-item', isActivePath('/pricing') && 'is-active']}
+                role="menuitem"
+                aria-current={isActivePath('/pricing') ? 'page' : undefined}
+              >
+                <span class="localized-label">
+                  {navLabels('billing').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a
+                href="/release-notes"
+                class:list={['mobile-menu-item', isActivePath('/release-notes') && 'is-active']}
+                role="menuitem"
+                aria-current={isActivePath('/release-notes') ? 'page' : undefined}
+              >
+                <span class="localized-label">
+                  {navLabels('releaseNotes').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a
+                href="https://github.com/mem9-ai/mem9"
+                class="mobile-menu-item"
+                target="_blank"
+                rel="noopener"
+                role="menuitem"
+              >
+                <span class="localized-label">
+                  {navLabels('github').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a
+                href="https://x.com/mem9_ai"
+                class="mobile-menu-item"
+                target="_blank"
+                rel="noopener"
+                role="menuitem"
+              >
+                <span class="localized-label">
+                  {navLabels('xcom').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+            </div>
+          </div>
+        </div>
         <a
           href="https://github.com/mem9-ai/mem9"
           class="nav-section-link nav-social-link nav-github-link"
@@ -774,6 +990,81 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
     flex: 0 0 auto;
   }
 
+  .mobile-menu-shell {
+    display: none;
+  }
+
+  .mobile-menu-icon {
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  .mobile-menu-line {
+    transform-origin: center;
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s ease;
+  }
+
+  .mobile-menu-shell[data-open='true'] .mobile-menu-line-top {
+    transform: translateY(5px) rotate(45deg);
+  }
+
+  .mobile-menu-shell[data-open='true'] .mobile-menu-line-middle {
+    opacity: 0;
+  }
+
+  .mobile-menu-shell[data-open='true'] .mobile-menu-line-bottom {
+    transform: translateY(-5px) rotate(-45deg);
+  }
+
+  .mobile-menu {
+    width: min(26rem, calc(100vw - 2rem));
+    max-height: min(calc(100dvh - 5rem), 34rem);
+    overflow-y: auto;
+    align-content: start;
+    gap: 0.4rem;
+    padding: 0.6rem;
+  }
+
+  .mobile-menu-section {
+    display: grid;
+    gap: 0.15rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .mobile-menu-section:last-child {
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .mobile-menu-item {
+    display: flex;
+    align-items: center;
+    min-height: 2.75rem;
+    border: 1px solid transparent;
+    border-radius: 0.8rem;
+    padding: 0.65rem 0.8rem;
+    color: var(--text-dim);
+    font-size: 0.96rem;
+    font-weight: 600;
+    line-height: 1.2;
+    transition:
+      background-color 0.2s ease,
+      border-color 0.2s ease,
+      color 0.2s ease;
+  }
+
+  .mobile-menu-item:hover,
+  .mobile-menu-item:focus-visible,
+  .mobile-menu-item.is-active {
+    background: var(--button-active-bg);
+    border-color: var(--button-active-border);
+    color: var(--text);
+    opacity: 1;
+  }
+
   .nav-login-link {
     display: inline-flex;
     align-items: center;
@@ -864,6 +1155,7 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
 
   .login-option-tooltip {
     position: absolute;
+    display: block;
     right: calc(100% + 0.55rem);
     top: 50%;
     z-index: 35;
@@ -880,6 +1172,7 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
     font-weight: 500;
     line-height: 1.35;
     white-space: normal;
+    overflow-wrap: anywhere;
     opacity: 0;
     pointer-events: none;
     visibility: hidden;
@@ -887,6 +1180,10 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
       opacity 0.15s ease,
       transform 0.15s ease,
       visibility 0.15s ease;
+  }
+
+  .login-option-tooltip .localized-label-option {
+    white-space: normal;
   }
 
   .login-menu-item:hover .login-option-tooltip,
@@ -949,6 +1246,19 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
     display: none;
   }
 
+  .nav-menu.mobile-menu {
+    position: fixed;
+    top: calc(56px + 0.75rem);
+    right: 1rem;
+    z-index: 40;
+    width: min(26rem, calc(100vw - 2rem));
+    max-height: min(calc(100dvh - 5rem), 34rem);
+    overflow-y: auto;
+    align-content: start;
+    gap: 0.4rem;
+    padding: 0.6rem;
+  }
+
   .language-menu {
     min-width: 11.5rem;
   }
@@ -979,37 +1289,28 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
     color: var(--text);
   }
 
-  @media (max-width: 780px) {
+  @media (max-width: 900px) {
     .nav-inner {
       min-height: 56px;
-      gap: 1.1rem;
+      gap: 0.85rem;
     }
 
     .nav-links {
-      gap: 0.9rem;
-      font-size: 0.87rem;
+      display: none;
     }
 
     .nav-actions {
       gap: 0.55rem;
+    }
+
+    .mobile-menu-shell {
+      display: block;
     }
   }
 
   @media (max-width: 560px) {
     .nav-right {
       gap: 0.7rem;
-    }
-
-    .nav-links .nav-section-link:not(.nav-docs-link):not(.nav-social-link),
-    .nav-dropdown {
-      display: none;
-    }
-
-    .nav-links .nav-docs-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.25rem;
-      font-size: 0.84rem;
     }
 
     .nav-actions {
@@ -1057,7 +1358,7 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
   }
 
   @media (max-width: 460px) {
-    .nav-docs-dropdown {
+    .nav-social-link {
       display: none;
     }
   }

--- a/site/src/components/Pricing.astro
+++ b/site/src/components/Pricing.astro
@@ -92,6 +92,68 @@ const { billing } = Astro.props;
         </tbody>
       </table>
     </div>
+
+    <div class="pricing-mobile-list">
+      {billing.tiers.map((tier, tierIndex) => (
+        <article class:list={['pricing-mobile-tier', 'surface-card', tier.highlighted && 'is-highlighted']}>
+          <div class="mobile-tier-header">
+            <h3 class="tier-name" data-i18n={`billing.tiers.${tierIndex}.name`}>{tier.name}</h3>
+            <div class="tier-price-row">
+              <span
+                class:list={['tier-price', tier.promoPrice && 'is-crossed']}
+                data-i18n={`billing.tiers.${tierIndex}.price`}
+              >
+                {tier.price}
+              </span>
+              {tier.promoPrice && (
+                <span class="tier-price tier-price-promo" data-i18n={`billing.tiers.${tierIndex}.promoPrice`}>
+                  {tier.promoPrice}
+                </span>
+              )}
+              {tier.period && (
+                <span class="tier-period" data-i18n={`billing.tiers.${tierIndex}.period`}>{tier.period}</span>
+              )}
+            </div>
+            {tier.ctaAction === 'mailto' ? (
+              <button
+                type="button"
+                class="cta-button"
+                data-billing-contact
+                data-billing-track
+                data-tier={tier.name}
+                data-i18n={`billing.tiers.${tierIndex}.ctaLabel`}
+              >
+                {tier.ctaLabel}
+              </button>
+            ) : (
+              <button
+                type="button"
+                class="cta-button"
+                data-billing-alert
+                data-billing-track
+                data-tier={tier.name}
+                data-i18n={`billing.tiers.${tierIndex}.ctaLabel`}
+              >
+                {tier.ctaLabel}
+              </button>
+            )}
+          </div>
+
+          <dl class="mobile-feature-list">
+            {billing.featureLabels.map((label, featureIndex) => (
+              <div class="mobile-feature-row">
+                <dt class="feature-label" data-i18n={`billing.featureLabels.${featureIndex}`}>
+                  {label}
+                </dt>
+                <dd class="mobile-feature-value" data-i18n={`billing.tiers.${tierIndex}.features.${featureIndex}`}>
+                  {tier.features[featureIndex]}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        </article>
+      ))}
+    </div>
   </div>
 
   <div
@@ -291,6 +353,10 @@ const { billing } = Astro.props;
     min-width: 920px;
     border-collapse: collapse;
     table-layout: fixed;
+  }
+
+  .pricing-mobile-list {
+    display: none;
   }
 
   .card-header {
@@ -577,22 +643,94 @@ const { billing } = Astro.props;
       padding-bottom: 4rem;
     }
 
-    .pricing-table {
-      min-width: 780px;
+    .pricing-table-wrap {
+      display: none;
+    }
+
+    .pricing-mobile-list {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .pricing-mobile-tier {
+      display: grid;
+      gap: 1.1rem;
+      overflow: hidden;
+      border-radius: 0.7rem;
+    }
+
+    .pricing-mobile-tier.is-highlighted {
+      border-color: var(--border-strong);
+      background:
+        linear-gradient(180deg, color-mix(in srgb, var(--accent) 10%, transparent), transparent 42%),
+        linear-gradient(180deg, var(--surface-gradient-start), var(--surface-gradient-end));
+      box-shadow:
+        inset 0 2px 0 var(--accent),
+        var(--surface-inset),
+        var(--surface-shadow);
+    }
+
+    .mobile-tier-header {
+      display: grid;
+      gap: 0.9rem;
+      padding: 1.15rem 1rem 0;
+    }
+
+    .pricing-mobile-tier .tier-price-row {
+      flex-wrap: wrap;
+      row-gap: 0.25rem;
+    }
+
+    .pricing-mobile-tier .cta-button {
+      width: 100%;
+      max-width: none;
     }
 
     .tier-price {
       font-size: 2rem;
     }
 
-    .card-header {
-      min-height: 10.75rem;
-      padding: 1.25rem 0.85rem 1rem;
+    .tier-price.is-crossed {
+      font-size: 1.75rem;
     }
 
-    .feature-label,
-    .pricing-table td {
-      padding: 0.85rem;
+    .mobile-feature-list {
+      display: grid;
+      margin: 0;
+    }
+
+    .mobile-feature-row {
+      display: grid;
+      grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+      gap: 0.8rem;
+      align-items: start;
+      padding: 0.95rem 1rem;
+      border-top: 1px solid var(--border);
+    }
+
+    .pricing-mobile-tier .feature-label {
+      padding: 0;
+      border-bottom: 0;
+      background: transparent;
+      font-size: 0.72rem;
+      line-height: 1.35;
+      overflow-wrap: anywhere;
+    }
+
+    .mobile-feature-value {
+      margin: 0;
+      color: var(--text);
+      font-family: var(--font-mono);
+      font-size: 0.88rem;
+      line-height: 1.45;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  @media (max-width: 420px) {
+    .mobile-feature-row {
+      grid-template-columns: 1fr;
+      gap: 0.35rem;
     }
   }
 </style>

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -393,6 +393,7 @@ export interface SiteFooterCopy {
 
 export interface SiteAriaCopy {
   home: string;
+  mainMenu: string;
   changeLanguage: string;
   changeTheme: string;
   themeModeLight: string;
@@ -5599,6 +5600,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'mem9 home',
+      mainMenu: 'Open main menu',
       changeLanguage: 'Change language',
       changeTheme: 'Change theme',
       themeModeLight: 'Theme mode: Light',
@@ -5941,6 +5943,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'mem9 首页',
+      mainMenu: '打开主菜单',
       changeLanguage: '切换语言',
       changeTheme: '切换主题',
       themeModeLight: '主题模式：浅色',
@@ -6288,6 +6291,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'mem9 首頁',
+      mainMenu: '開啟主選單',
       changeLanguage: '切換語言',
       changeTheme: '切換主題',
       themeModeLight: '主題模式：淺色',
@@ -6640,6 +6644,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'mem9 ホーム',
+      mainMenu: 'メインメニューを開く',
       changeLanguage: '言語を切り替える',
       changeTheme: 'テーマを切り替える',
       themeModeLight: 'テーマモード: ライト',
@@ -6989,6 +6994,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'mem9 홈',
+      mainMenu: '메인 메뉴 열기',
       changeLanguage: '언어 변경',
       changeTheme: '테마 변경',
       themeModeLight: '테마 모드: 라이트',
@@ -7341,6 +7347,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'beranda mem9',
+      mainMenu: 'Buka menu utama',
       changeLanguage: 'Ganti bahasa',
       changeTheme: 'Ganti tema',
       themeModeLight: 'Mode tema: Terang',
@@ -7693,6 +7700,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     },
     aria: {
       home: 'หน้าแรก mem9',
+      mainMenu: 'เปิดเมนูหลัก',
       changeLanguage: 'เปลี่ยนภาษา',
       changeTheme: 'เปลี่ยนธีม',
       themeModeLight: 'โหมดธีม: สว่าง',

--- a/site/src/scripts/site-ui.ts
+++ b/site/src/scripts/site-ui.ts
@@ -13,7 +13,7 @@ import {
   type SiteThemePreference,
 } from '../content/site';
 
-type MenuName = 'docs' | 'login' | 'language' | 'theme';
+type MenuName = 'docs' | 'login' | 'language' | 'theme' | 'mobile';
 type DocsLocale = 'en' | 'zh' | 'ja' | 'ko' | 'id' | 'th';
 type OnboardingVersion = 'stable' | 'beta';
 type OnboardingCommandParts = {
@@ -693,6 +693,12 @@ function initMenuControls(): void {
 
       const isOpen = shell.dataset.open === 'true';
       setOpenMenu(isOpen ? null : menuName);
+    });
+  });
+
+  document.querySelectorAll<HTMLAnchorElement>('[data-menu="mobile"] a').forEach((link) => {
+    link.addEventListener('click', () => {
+      setOpenMenu(null);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a collapsible mobile navigation menu so docs, API, pricing, release notes, and social links remain reachable on small screens.
- Convert the Pricing page to vertical tier cards on mobile while keeping the desktop comparison table.
- Add localized accessibility copy for the mobile menu control.

## Why
On mobile, key navigation links were hidden and the Pricing comparison table required horizontal scrolling, making docs/API and plan details hard to access.

## Validation
- npm run build
- npx tsc --noEmit
- Verified at 430x932 mobile viewport: no horizontal overflow, menu links visible, and all four pricing tiers render as cards.