### PR TITLE
feat: add webhooks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,15 @@ Prefer `v1alpha2` for all new integrations. It uses `X-API-Key` and is the prima
 | `GET` | `/v1alpha2/mem9s/memories/{id}` | Preferred get-by-id endpoint. Requires `X-API-Key` header |
 | `PUT` | `/v1alpha2/mem9s/memories/{id}` | Preferred update endpoint. Requires `X-API-Key` header |
 | `DELETE` | `/v1alpha2/mem9s/memories/{id}` | Preferred delete endpoint. Requires `X-API-Key` header |
+| `GET/POST` | `/v1alpha2/mem9s/webhooks` | Space webhook management. Requires a Space `X-API-Key` |
+| `GET/PATCH/DELETE` | `/v1alpha2/mem9s/webhooks/{webhookID}` | Get, update, or delete a Space webhook |
+| `POST` | `/v1alpha2/mem9s/webhooks/{webhookID}/test` | Queue a signed test delivery |
+| `POST` | `/v1alpha2/mem9s/webhooks/{webhookID}/rotate-secret` | Rotate the webhook signing secret. The new secret is returned once |
+| `GET` | `/v1alpha2/mem9s/webhook-deliveries` | List recent Space webhook deliveries |
+| `GET/POST` | `/v1alpha2/space-chains/{chainID}/webhooks` | Space Chain webhook management. Requires the `chain_` management key in `X-API-Key` |
+| `GET` | `/v1alpha2/space-chains/{chainID}/webhook-deliveries` | List recent Space Chain webhook deliveries |
+
+Webhook events and delivery behavior are documented in [docs/webhooks-api-design.md](docs/webhooks-api-design.md). v1 emits `memory.added`, `memory.deleted`, and `space_chain.fact_routed`.
 
 ### Legacy Tenant-Path API (`v1alpha1`)
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -55,6 +55,10 @@
     {
       "name": "Sessions v1alpha2",
       "description": "API-key raw session message API."
+    },
+    {
+      "name": "Webhooks v1alpha2",
+      "description": "API-key and Space Chain webhook management endpoints."
     }
   ],
   "paths": {
@@ -1133,6 +1137,671 @@
           }
         }
       }
+    },
+    "/v1alpha2/mem9s/webhooks": {
+      "get": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "List Space webhooks",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook endpoint list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Create Space webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created webhook endpoint and one-time signing secret.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpointWithSecret"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1alpha2/mem9s/webhooks/{webhookID}": {
+      "get": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Get Space webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Update Space webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated webhook endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Delete Space webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WebhookID"
+        }
+      ]
+    },
+    "/v1alpha2/mem9s/webhooks/{webhookID}/test": {
+      "post": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Test Space webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Queued test delivery.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDelivery"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WebhookID"
+        }
+      ]
+    },
+    "/v1alpha2/mem9s/webhooks/{webhookID}/rotate-secret": {
+      "post": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Rotate secret for Space webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook endpoint and one-time signing secret.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpointWithSecret"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/WebhookID"
+        }
+      ]
+    },
+    "/v1alpha2/mem9s/webhook-deliveries": {
+      "get": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "List Space webhook deliveries",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookDeliveryLimit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook delivery list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDeliveryListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/v1alpha2/space-chains/{chainID}/webhooks": {
+      "get": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "List Space Chain webhooks",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook endpoint list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Create Space Chain webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created webhook endpoint and one-time signing secret.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpointWithSecret"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ChainID"
+        }
+      ]
+    },
+    "/v1alpha2/space-chains/{chainID}/webhooks/{webhookID}": {
+      "get": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Get Space Chain webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Update Space Chain webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated webhook endpoint.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpoint"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Delete Space Chain webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "204": {
+            "$ref": "#/components/responses/NoContent"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ChainID"
+        },
+        {
+          "$ref": "#/components/parameters/WebhookID"
+        }
+      ]
+    },
+    "/v1alpha2/space-chains/{chainID}/webhooks/{webhookID}/test": {
+      "post": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Test Space Chain webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Queued test delivery.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDelivery"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ChainID"
+        },
+        {
+          "$ref": "#/components/parameters/WebhookID"
+        }
+      ]
+    },
+    "/v1alpha2/space-chains/{chainID}/webhooks/{webhookID}/rotate-secret": {
+      "post": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "Rotate secret for Space Chain webhook",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook endpoint and one-time signing secret.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookEndpointWithSecret"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ChainID"
+        },
+        {
+          "$ref": "#/components/parameters/WebhookID"
+        }
+      ]
+    },
+    "/v1alpha2/space-chains/{chainID}/webhook-deliveries": {
+      "get": {
+        "tags": [
+          "Webhooks v1alpha2"
+        ],
+        "summary": "List Space Chain webhook deliveries",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/WebhookDeliveryLimit"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook delivery list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WebhookDeliveryListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/ChainID"
+        }
+      ]
     }
   },
   "components": {
@@ -1398,6 +2067,33 @@
           "maxLength": 100
         },
         "description": "Optional application isolation filter. Omit appId to search across all appIds. Use appId=<value> for an exact appId, and appId=null or appId= to search only the default/global appId stored as an empty string."
+      },
+      "WebhookID": {
+        "name": "webhookID",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "ChainID": {
+        "name": "chainID",
+        "in": "path",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "WebhookDeliveryLimit": {
+        "name": "limit",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 200,
+          "default": 50
+        }
       }
     },
     "headers": {
@@ -1676,6 +2372,9 @@
             }
           }
         }
+      },
+      "NoContent": {
+        "description": "No content."
       }
     },
     "schemas": {
@@ -2234,6 +2933,232 @@
           "session",
           "memory"
         ]
+      },
+      "WebhookEventType": {
+        "type": "string",
+        "enum": [
+          "memory.added",
+          "memory.deleted",
+          "space_chain.fact_routed"
+        ]
+      },
+      "WebhookEndpoint": {
+        "type": "object",
+        "required": [
+          "id",
+          "scope_type",
+          "scope_id",
+          "name",
+          "url",
+          "enabled",
+          "events",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "scope_type": {
+            "type": "string",
+            "enum": [
+              "tenant",
+              "chain"
+            ]
+          },
+          "scope_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "WebhookEndpointWithSecret": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/WebhookEndpoint"
+          },
+          {
+            "type": "object",
+            "required": [
+              "signing_secret"
+            ],
+            "properties": {
+              "signing_secret": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "WebhookListResponse": {
+        "type": "object",
+        "required": [
+          "webhooks"
+        ],
+        "properties": {
+          "webhooks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEndpoint"
+            }
+          }
+        }
+      },
+      "WebhookCreateRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "url",
+          "events"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          }
+        }
+      },
+      "WebhookUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookEventType"
+            }
+          }
+        }
+      },
+      "WebhookDelivery": {
+        "type": "object",
+        "required": [
+          "id",
+          "event_id",
+          "endpoint_id",
+          "event_type",
+          "scope_type",
+          "scope_id",
+          "status",
+          "attempt_count",
+          "next_attempt_at",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "event_id": {
+            "type": "string"
+          },
+          "endpoint_id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string"
+          },
+          "scope_type": {
+            "type": "string"
+          },
+          "scope_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "delivered",
+              "failed"
+            ]
+          },
+          "attempt_count": {
+            "type": "integer"
+          },
+          "next_attempt_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_http_status": {
+            "type": "integer",
+            "nullable": true
+          },
+          "last_error": {
+            "type": "string"
+          },
+          "delivered_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "WebhookDeliveryListResponse": {
+        "type": "object",
+        "required": [
+          "deliveries"
+        ],
+        "properties": {
+          "deliveries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WebhookDelivery"
+            }
+          }
+        }
       }
     }
   }

--- a/docs/webhooks-api-design.md
+++ b/docs/webhooks-api-design.md
@@ -1,0 +1,255 @@
+# mem9 Webhooks API Design
+
+## Background
+
+mem9 webhooks let external systems react to memory lifecycle and Space Chain routing events without polling. The implementation keeps mem9 as the source of truth: endpoint configuration, signing secrets, event records, delivery outbox, delivery attempts, retry state, and logs all live in the mem9 control-plane database.
+
+Console products only proxy and aggregate this API. They must not persist webhook endpoint state or delivery state.
+
+## Requirements
+
+- Support Space-scoped webhook endpoints authenticated with the existing `X-API-Key`.
+- Support Space Chain-scoped webhook endpoints authenticated with the `chain_` management key.
+- Emit v1 events only:
+  - `memory.added`
+  - `memory.deleted`
+  - `space_chain.fact_routed`
+- Deliver signed JSON payloads to HTTPS URLs. Local HTTP is allowed only outside production.
+- Retry transient delivery failures with backoff and preserve delivery history.
+- Return `signing_secret` only on create and rotate-secret responses.
+
+## Event Model
+
+Each event is stored once in `webhook_events` and faned out to enabled matching endpoints through `webhook_deliveries`.
+
+```json
+{
+  "id": "evt_...",
+  "type": "memory.added",
+  "api_version": "2026-06-08",
+  "created_at": "2026-06-08T00:00:00Z",
+  "scope": {
+    "type": "tenant",
+    "tenant_id": "...",
+    "external_space_id": "...",
+    "chain_id": "..."
+  },
+  "data": {}
+}
+```
+
+### memory.added
+
+Emitted after a memory create path succeeds:
+
+- direct content create
+- pinned create
+- smart ingest ADD action
+- routed Space Chain target ADD action
+
+Smart ingest UPDATE actions do not emit `memory.added`.
+
+Payload:
+
+```json
+{
+  "memory": {
+    "id": "...",
+    "content": "...",
+    "memory_type": "insight",
+    "agent_id": "...",
+    "appId": "...",
+    "session_id": "...",
+    "tags": [],
+    "metadata": {},
+    "created_at": "...",
+    "updated_at": "..."
+  }
+}
+```
+
+### memory.deleted
+
+Emitted after a single or batch delete succeeds.
+
+Payload:
+
+```json
+{
+  "memory": {
+    "id": "...",
+    "tenant_id": "...",
+    "deleted_by_agent": "...",
+    "deleted_at": "..."
+  }
+}
+```
+
+### space_chain.fact_routed
+
+Emitted to the Space Chain scope when extracted facts match a target Space routing policy and the target Space write succeeds. Quota-denied or failed target writes do not emit this event.
+
+Payload:
+
+```json
+{
+  "route_id": "...",
+  "chain_id": "...",
+  "source_tenant_id": "...",
+  "target_tenant_id": "...",
+  "target_external_space_id": "...",
+  "routing_policy_node_id": "...",
+  "source_facts": [],
+  "target_memory": {},
+  "agent_id": "...",
+  "appId": "...",
+  "session_id": "..."
+}
+```
+
+## APIs
+
+Space scope, using `X-API-Key`:
+
+- `GET /v1alpha2/mem9s/webhooks`
+- `POST /v1alpha2/mem9s/webhooks`
+- `GET /v1alpha2/mem9s/webhooks/{webhookID}`
+- `PATCH /v1alpha2/mem9s/webhooks/{webhookID}`
+- `DELETE /v1alpha2/mem9s/webhooks/{webhookID}`
+- `POST /v1alpha2/mem9s/webhooks/{webhookID}/test`
+- `POST /v1alpha2/mem9s/webhooks/{webhookID}/rotate-secret`
+- `GET /v1alpha2/mem9s/webhook-deliveries`
+
+Space Chain scope, using `chain_` management key:
+
+- `GET /v1alpha2/space-chains/{chainID}/webhooks`
+- `POST /v1alpha2/space-chains/{chainID}/webhooks`
+- `GET /v1alpha2/space-chains/{chainID}/webhooks/{webhookID}`
+- `PATCH /v1alpha2/space-chains/{chainID}/webhooks/{webhookID}`
+- `DELETE /v1alpha2/space-chains/{chainID}/webhooks/{webhookID}`
+- `POST /v1alpha2/space-chains/{chainID}/webhooks/{webhookID}/test`
+- `POST /v1alpha2/space-chains/{chainID}/webhooks/{webhookID}/rotate-secret`
+- `GET /v1alpha2/space-chains/{chainID}/webhook-deliveries`
+
+Create request:
+
+```json
+{
+  "name": "Production sync",
+  "url": "https://example.com/mem9/webhook",
+  "enabled": true,
+  "events": ["memory.added", "memory.deleted"]
+}
+```
+
+Create and rotate-secret responses include one-time `signing_secret`; list/get/update responses never include it.
+
+## Signing
+
+Each delivery includes:
+
+- `X-Mem9-Event-Id`
+- `X-Mem9-Event-Type`
+- `X-Mem9-Timestamp`
+- `X-Mem9-Signature`
+
+Signature format:
+
+```text
+v1=<hex_hmac_sha256>
+```
+
+The HMAC input is:
+
+```text
+<timestamp>.<event_id>.<raw_body>
+```
+
+Consumers should verify the timestamp tolerance, recompute with the current signing secret, and compare in constant time.
+
+## URL Validation
+
+- Production requires HTTPS.
+- Development allows HTTP only for `localhost`, `127.0.0.1`, and `::1`.
+- Userinfo URLs are rejected.
+- Literal private, link-local, loopback, and unspecified IP destinations are rejected unless the local-development exception applies.
+
+## Data Tables
+
+`webhook_endpoints`
+
+- endpoint metadata
+- scope type and ID
+- event subscriptions as JSON
+- encrypted signing secret
+- soft-delete marker
+
+`webhook_events`
+
+- immutable event envelope
+- scope and type for filtering
+
+`webhook_deliveries`
+
+- endpoint fanout rows
+- status, attempt count, retry schedule
+- latest HTTP status or error
+- delivered timestamp
+
+## Delivery State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> delivered: 2xx response
+  pending --> pending: failed attempt, attempts remain
+  pending --> failed: max attempts reached
+```
+
+Default backoff:
+
+- attempt 1: 1 minute
+- attempt 2: 5 minutes
+- attempt 3: 30 minutes
+- attempt 4: 2 hours
+- attempt 5: 6 hours
+- later attempts: 24 hours
+
+## Space And Space Chain Boundaries
+
+Space webhooks are bound to a tenant/Space API key and only observe that Space. Space Chain webhooks are bound to a chain management key and observe chain-scope events. When a chain write creates a memory in a target Space, mem9 emits the target Space `memory.added` event and the chain `memory.added` event. Routing-specific metadata is emitted separately as `space_chain.fact_routed`.
+
+## Console Integration
+
+`mem9-console-server` proxies webhook CRUD/test/rotate/delivery calls to mem9 using the current Space API key or Chain management key. It also exposes project-level aggregation endpoints by reading the console project Spaces and Space Chains, then calling mem9 for each resource.
+
+`mem9-console-fe` renders a project-level `/console/webhooks` page from those aggregation APIs. It never calls mem9 directly and never stores webhook secrets.
+
+## Testing And Acceptance
+
+mem9:
+
+- CRUD endpoint validation and one-time secret responses.
+- secret rotation and HMAC signing.
+- URL validation including HTTPS and local development exceptions.
+- `memory.added` for direct, pinned, and smart ADD paths.
+- no `memory.added` for smart UPDATE-only reconciliation.
+- `memory.deleted` for single and batch delete.
+- `space_chain.fact_routed` for successful routed target ADDs.
+- no routing event when runtime usage denies or target write fails.
+- dispatcher success, retry, backoff, and terminal failure.
+
+console-server:
+
+- Space and Space Chain proxy auth and error mapping.
+- project aggregation limited to current principal/project resources.
+- one-time secret passthrough with no logging.
+- no webhook DB migration.
+
+console-fe:
+
+- sidebar entry order: Space, Space Chain, Webhooks, Memories.
+- create/edit/test/rotate/disable/delete flows.
+- one-time secret reveal modal.
+- deliveries drawer/table.
+- generated API client is used for all webhook requests.

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
 	"github.com/qiffang/mnemos/server/internal/tenant"
+	"github.com/qiffang/mnemos/server/internal/webhook"
 )
 
 func main() {
@@ -95,6 +96,23 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("encryption configured", "type", cfg.EncryptType)
+
+	webhookStore := webhook.NewSQLStore(db, cfg.DBBackend)
+	if err := webhookStore.EnsureSchema(context.Background()); err != nil {
+		logger.Error("failed to initialize webhook tables", "err", err)
+		os.Exit(1)
+	}
+	allowLocalWebhookHTTP := cfg.Env != "prod" && cfg.Env != "production"
+	webhookSvc := webhook.NewService(webhookStore, encryptor, allowLocalWebhookHTTP)
+	webhookWorkerCtx, webhookWorkerCancel := context.WithCancel(context.Background())
+	defer webhookWorkerCancel()
+	go func() {
+		err := webhook.NewDispatcher(webhookStore, webhookSvc, webhook.DispatcherConfig{}, logger).Run(webhookWorkerCtx)
+		if err != nil && err != context.Canceled {
+			logger.Error("webhook dispatcher stopped", "err", err)
+		}
+	}()
+	logger.Info("webhook dispatcher initialized", "allow_local_http", allowLocalWebhookHTTP)
 
 	// Repositories.
 	tenantRepo := repository.NewTenantRepo(cfg.DBBackend, db)
@@ -262,6 +280,7 @@ func main() {
 		WithSpaceChainService(spaceChainSvc, cfg.ChainRecallStopScore).
 		WithMetering(meteringWriter).
 		WithRuntimeUsage(runtimeUsageManager).
+		WithWebhookService(webhookSvc).
 		WithActivityTracker(activityTracker).
 		WithDisableSessionSave(cfg.DisableSessionSave)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW, middleware.CORS(cfg.CORSAllowedOrigins))
@@ -309,6 +328,7 @@ func main() {
 		if runtimeUsageWorkerCancel != nil {
 			runtimeUsageWorkerCancel()
 		}
+		webhookWorkerCancel()
 		workerCancel() // Stop upload worker first.
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -187,6 +187,24 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 					return
 				}
 			}
+			source := chainSource(auth, node)
+			s.enqueueMemoryAddedIDWebhooks(ctx, nodeAuth, targetSvc, source, auth, result)
+			for _, change := range result.Changes {
+				if change.Type != service.MemoryChangeAdd || change.MemoryID == "" {
+					continue
+				}
+				mem, err := targetSvc.memory.Get(ctx, change.MemoryID)
+				if err != nil {
+					logger.WarnContext(ctx, "space chain routed webhook payload lookup failed",
+						"chain_id", auth.Chain.ChainID,
+						"target_space_id", targetID,
+						"memory_id", change.MemoryID,
+						"err", err,
+					)
+					continue
+				}
+				s.enqueueRoutedFactWebhook(ctx, auth, nodeAuth, node, factsForTarget, mem)
+			}
 			mu.Lock()
 			out.memoriesChanged += result.MemoriesChanged
 			out.insightIDs = append(out.insightIDs, result.InsightIDs...)

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/reqid"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
+	"github.com/qiffang/mnemos/server/internal/webhook"
 )
 
 // Server holds the HTTP handlers and their dependencies.
@@ -42,6 +43,7 @@ type Server struct {
 	logger               *slog.Logger
 	metering             metering.Writer
 	runtimeUsage         runtimeusage.Manager
+	webhooks             *webhook.Service
 	activity             *service.ActivityTracker
 	startedAt            time.Time
 	svcCache             sync.Map
@@ -93,6 +95,11 @@ func (s *Server) WithMetering(writer metering.Writer) *Server {
 
 func (s *Server) WithRuntimeUsage(manager runtimeusage.Manager) *Server {
 	s.runtimeUsage = manager
+	return s
+}
+
+func (s *Server) WithWebhookService(service *webhook.Service) *Server {
+	s.webhooks = service
 	return s
 }
 
@@ -225,6 +232,14 @@ func (s *Server) Router(
 		r.Get("/bindings", s.listSpaceChainBindings)
 		r.Post("/bindings", s.createSpaceChainBinding)
 		r.Patch("/bindings/{bindingID}", s.disableSpaceChainBinding)
+		r.Get("/webhooks", s.listSpaceChainWebhooks)
+		r.Post("/webhooks", s.createSpaceChainWebhook)
+		r.Get("/webhooks/{webhookID}", s.getSpaceChainWebhook)
+		r.Patch("/webhooks/{webhookID}", s.updateSpaceChainWebhook)
+		r.Delete("/webhooks/{webhookID}", s.deleteSpaceChainWebhook)
+		r.Post("/webhooks/{webhookID}/test", s.testSpaceChainWebhook)
+		r.Post("/webhooks/{webhookID}/rotate-secret", s.rotateSpaceChainWebhookSecret)
+		r.Get("/webhook-deliveries", s.listSpaceChainWebhookDeliveries)
 	})
 
 	// Tenant-scoped routes — tenantMW resolves {tenantID} to DB connection.
@@ -256,6 +271,14 @@ func (s *Server) Router(
 		r.Put("/memories/{id}", s.updateMemory)
 		r.Delete("/memories/{id}", s.deleteMemory)
 		r.Post("/memories/batch-delete", s.batchDeleteMemories)
+		r.Get("/webhooks", s.listTenantWebhooks)
+		r.Post("/webhooks", s.createTenantWebhook)
+		r.Get("/webhooks/{webhookID}", s.getTenantWebhook)
+		r.Patch("/webhooks/{webhookID}", s.updateTenantWebhook)
+		r.Delete("/webhooks/{webhookID}", s.deleteTenantWebhook)
+		r.Post("/webhooks/{webhookID}/test", s.testTenantWebhook)
+		r.Post("/webhooks/{webhookID}/rotate-secret", s.rotateTenantWebhookSecret)
+		r.Get("/webhook-deliveries", s.listTenantWebhookDeliveries)
 
 		r.Post("/imports", s.createTask)
 		r.Get("/imports", s.listTasks)

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -174,6 +174,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				finalized = true
 			}
 			s.recordIngestMetering(auth, svc)
+			s.enqueueMemoryAddedIDWebhooks(syncCtx, auth, svc, writeChainSource, chainAuth, result)
 			go s.afterSuccessfulWrite(auth, svc, written)
 			respond(w, http.StatusOK, map[string]string{"status": "ok"})
 		} else {
@@ -224,6 +225,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 				}
+				s.enqueueMemoryAddedIDWebhooks(context.Background(), auth, svc, writeChainSource, chainAuth, result)
 				s.afterSuccessfulIngest(auth, svc, written)
 			}(lease)
 			respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
@@ -310,6 +312,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			}
 			finalized = true
 		}
+		s.enqueueMemoryAddedWebhook(r.Context(), auth, writeChainSource, chainAuth, mem)
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusCreated, mem)
 		return
@@ -377,6 +380,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				}
 				finalized = true
 			}
+			s.enqueueMemoryAddedIDWebhooks(r.Context(), auth, svc, writeChainSource, chainAuth, result)
 			go s.afterSuccessfulWrite(auth, svc, written)
 			respond(w, http.StatusOK, map[string]string{"status": "ok"})
 			return
@@ -415,6 +419,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			}
 			finalized = true
 		}
+		s.enqueueMemoryAddedWebhook(r.Context(), auth, writeChainSource, chainAuth, mem)
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
 		respond(w, http.StatusOK, map[string]string{"status": "ok"})
 	} else {
@@ -466,6 +471,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 				}
+				s.enqueueMemoryAddedIDWebhooks(context.Background(), auth, svc, writeChainSource, chainAuth, result)
 				s.afterSuccessfulWrite(auth, svc, written)
 				return
 			}
@@ -500,6 +506,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					return
 				}
 			}
+			s.enqueueMemoryAddedWebhook(context.Background(), auth, writeChainSource, chainAuth, mem)
 			s.afterSuccessfulWrite(auth, svc, int64(written))
 		}(auth, chainAuth, lease, auth.AgentName, agentID, appID, req.SessionID, content, tags, metadata, routingTargets)
 
@@ -1242,6 +1249,9 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 			}
 			finalized = true
 		}
+		if deleted > 0 {
+			s.enqueueMemoryDeletedWebhook(r.Context(), target.nodeAuth, target.source, auth, id, auth.AgentName)
+		}
 		go s.afterSuccessfulWrite(target.nodeAuth, target.svc, 0)
 		w.WriteHeader(http.StatusNoContent)
 		return
@@ -1299,6 +1309,9 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		finalized = true
 	}
 
+	if deleted > 0 {
+		s.enqueueMemoryDeletedWebhook(r.Context(), auth, nil, nil, id, auth.AgentName)
+	}
 	go s.afterSuccessfulWrite(auth, svc, 0)
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -1327,6 +1340,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		}
 		var deleted int64
 		for _, group := range groups {
+			webhookDeleteIDs := s.existingBatchDeleteWebhookIDs(r.Context(), group.target.svc, group.ids)
 			var lease *runtimeusage.OperationLease
 			finalized := false
 			if s.runtimeUsageEnabled() {
@@ -1378,6 +1392,9 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
 			}
 			if groupDeleted > 0 {
+				for _, id := range webhookDeleteIDs {
+					s.enqueueMemoryDeletedWebhook(r.Context(), group.target.nodeAuth, group.target.source, auth, id, auth.AgentName)
+				}
 				go s.afterSuccessfulWrite(group.target.nodeAuth, group.target.svc, 0)
 			}
 			deleted += groupDeleted
@@ -1394,6 +1411,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		s.handleError(r.Context(), w, err)
 		return
 	}
+	webhookDeleteIDs := s.existingBatchDeleteWebhookIDs(r.Context(), svc, deleteIDs)
 	var lease *runtimeusage.OperationLease
 	finalized := false
 	if s.runtimeUsageEnabled() {
@@ -1448,10 +1466,40 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		finalized = true
 	}
 
+	if deleted > 0 {
+		for _, id := range webhookDeleteIDs {
+			s.enqueueMemoryDeletedWebhook(r.Context(), auth, nil, nil, id, auth.AgentName)
+		}
+	}
 	go s.afterSuccessfulWrite(auth, svc, 0)
 	respond(w, http.StatusOK, map[string]any{
 		"deleted": deleted,
 	})
+}
+
+func (s *Server) existingBatchDeleteWebhookIDs(ctx context.Context, svc resolvedSvc, ids []string) []string {
+	existing := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if _, err := svc.memory.Get(ctx, id); err == nil {
+			existing = append(existing, id)
+			continue
+		} else if !errors.Is(err, domain.ErrNotFound) {
+			s.logger.WarnContext(ctx, "memory delete webhook precheck failed",
+				"memory_id", id,
+				"err", err,
+			)
+		}
+
+		if _, err := svc.session.Get(ctx, id); err == nil {
+			existing = append(existing, id)
+		} else if !errors.Is(err, domain.ErrNotFound) && !errors.Is(err, domain.ErrNotSupported) {
+			s.logger.WarnContext(ctx, "session delete webhook precheck failed",
+				"memory_id", id,
+				"err", err,
+			)
+		}
+	}
+	return existing
 }
 
 type bulkCreateRequest struct {

--- a/server/internal/handler/webhook.go
+++ b/server/internal/handler/webhook.go
@@ -1,0 +1,311 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/webhook"
+)
+
+type webhookCreateRequest struct {
+	Name    string   `json:"name"`
+	URL     string   `json:"url"`
+	Enabled *bool    `json:"enabled,omitempty"`
+	Events  []string `json:"events"`
+}
+
+type webhookUpdateRequest struct {
+	Name    *string   `json:"name,omitempty"`
+	URL     *string   `json:"url,omitempty"`
+	Enabled *bool     `json:"enabled,omitempty"`
+	Events  *[]string `json:"events,omitempty"`
+}
+
+func (s *Server) listTenantWebhooks(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.listWebhooks(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) createTenantWebhook(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.createWebhook(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) getTenantWebhook(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.getWebhook(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) updateTenantWebhook(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.updateWebhook(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) deleteTenantWebhook(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.deleteWebhook(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) testTenantWebhook(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.testWebhook(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) rotateTenantWebhookSecret(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.rotateWebhookSecret(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) listTenantWebhookDeliveries(w http.ResponseWriter, r *http.Request) {
+	scopeID, ok := s.tenantWebhookScope(w, r)
+	if !ok {
+		return
+	}
+	s.listWebhookDeliveries(w, r, webhook.ScopeTenant, scopeID)
+}
+
+func (s *Server) listSpaceChainWebhooks(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.listWebhooks(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) createSpaceChainWebhook(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.createWebhook(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) getSpaceChainWebhook(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.getWebhook(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) updateSpaceChainWebhook(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.updateWebhook(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) deleteSpaceChainWebhook(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.deleteWebhook(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) testSpaceChainWebhook(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.testWebhook(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) rotateSpaceChainWebhookSecret(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.rotateWebhookSecret(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) listSpaceChainWebhookDeliveries(w http.ResponseWriter, r *http.Request) {
+	chain, ok := s.authorizeSpaceChainManagement(w, r)
+	if !ok {
+		return
+	}
+	s.listWebhookDeliveries(w, r, webhook.ScopeChain, chain.ID)
+}
+
+func (s *Server) listWebhooks(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	endpoints, err := s.webhooks.ListEndpoints(r.Context(), scopeType, scopeID)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, map[string]any{"webhooks": endpoints})
+}
+
+func (s *Server) createWebhook(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	var req webhookCreateRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	endpoint, err := s.webhooks.CreateEndpoint(r.Context(), webhook.CreateEndpointInput{
+		ScopeType: scopeType,
+		ScopeID:   scopeID,
+		Name:      req.Name,
+		URL:       req.URL,
+		Enabled:   enabled,
+		Events:    req.Events,
+	})
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusCreated, endpoint)
+}
+
+func (s *Server) getWebhook(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	endpoint, err := s.webhooks.GetEndpoint(r.Context(), scopeType, scopeID, chi.URLParam(r, "webhookID"))
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, endpoint)
+}
+
+func (s *Server) updateWebhook(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	var req webhookUpdateRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	endpoint, err := s.webhooks.UpdateEndpoint(r.Context(), webhook.UpdateEndpointInput{
+		ScopeType:  scopeType,
+		ScopeID:    scopeID,
+		EndpointID: chi.URLParam(r, "webhookID"),
+		Name:       req.Name,
+		URL:        req.URL,
+		Enabled:    req.Enabled,
+		Events:     req.Events,
+	})
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, endpoint)
+}
+
+func (s *Server) deleteWebhook(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	if err := s.webhooks.DeleteEndpoint(r.Context(), scopeType, scopeID, chi.URLParam(r, "webhookID")); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) testWebhook(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	delivery, err := s.webhooks.TestEndpoint(r.Context(), scopeType, scopeID, chi.URLParam(r, "webhookID"))
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusAccepted, map[string]any{"delivery": delivery})
+}
+
+func (s *Server) rotateWebhookSecret(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	endpoint, err := s.webhooks.RotateSecret(r.Context(), scopeType, scopeID, chi.URLParam(r, "webhookID"))
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, endpoint)
+}
+
+func (s *Server) listWebhookDeliveries(w http.ResponseWriter, r *http.Request, scopeType, scopeID string) {
+	if !s.requireWebhookService(w) {
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	deliveries, err := s.webhooks.ListDeliveries(r.Context(), scopeType, scopeID, limit)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, map[string]any{"deliveries": deliveries})
+}
+
+func (s *Server) tenantWebhookScope(w http.ResponseWriter, r *http.Request) (string, bool) {
+	auth := authInfo(r)
+	if auth == nil || auth.IsChain() || strings.TrimSpace(auth.TenantID) == "" {
+		respondError(w, http.StatusBadRequest, "tenant API key required")
+		return "", false
+	}
+	return auth.TenantID, true
+}
+
+func (s *Server) requireWebhookService(w http.ResponseWriter) bool {
+	if s.webhooks == nil {
+		respondError(w, http.StatusServiceUnavailable, "webhook service unavailable")
+		return false
+	}
+	return true
+}
+
+func webhookScopeForAuth(auth *domain.AuthInfo, source *domain.ChainSource) webhook.EventScope {
+	if source != nil {
+		return webhook.EventScope{
+			Type:            webhook.ScopeTenant,
+			TenantID:        source.TenantID,
+			ExternalSpaceID: source.ExternalSpaceID,
+			ChainID:         source.ChainID,
+		}
+	}
+	return webhook.EventScope{
+		Type:     webhook.ScopeTenant,
+		TenantID: auth.TenantID,
+	}
+}

--- a/server/internal/handler/webhook_events.go
+++ b/server/internal/handler/webhook_events.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/service"
+	"github.com/qiffang/mnemos/server/internal/webhook"
+)
+
+func (s *Server) enqueueMemoryAddedWebhook(ctx context.Context, auth *domain.AuthInfo, source *domain.ChainSource, chainAuth *domain.AuthInfo, mem *domain.Memory) {
+	if s == nil || s.webhooks == nil || auth == nil || mem == nil || mem.ID == "" {
+		return
+	}
+	data := map[string]any{"memory": mem}
+	s.enqueueWebhook(ctx, webhookScopeForAuth(auth, source), webhook.EventMemoryAdded, data)
+	if chainAuth != nil && chainAuth.Chain != nil {
+		s.enqueueWebhook(ctx, webhook.EventScope{Type: webhook.ScopeChain, ChainID: chainAuth.Chain.ChainID}, webhook.EventMemoryAdded, data)
+	}
+}
+
+func (s *Server) enqueueMemoryAddedIDWebhooks(ctx context.Context, auth *domain.AuthInfo, svc resolvedSvc, source *domain.ChainSource, chainAuth *domain.AuthInfo, result *service.IngestResult) {
+	if s == nil || s.webhooks == nil || result == nil {
+		return
+	}
+	for _, change := range result.Changes {
+		if change.Type != service.MemoryChangeAdd || change.MemoryID == "" {
+			continue
+		}
+		mem, err := svc.memory.Get(ctx, change.MemoryID)
+		if err != nil {
+			slog.WarnContext(ctx, "webhook memory.added payload lookup failed", "memory_id", change.MemoryID, "err", err)
+			continue
+		}
+		s.enqueueMemoryAddedWebhook(ctx, auth, source, chainAuth, mem)
+	}
+}
+
+func (s *Server) enqueueMemoryDeletedWebhook(ctx context.Context, auth *domain.AuthInfo, source *domain.ChainSource, chainAuth *domain.AuthInfo, memoryID, agentName string) {
+	if s == nil || s.webhooks == nil || auth == nil || memoryID == "" {
+		return
+	}
+	data := map[string]any{
+		"memory": map[string]any{
+			"id":               memoryID,
+			"tenant_id":        auth.TenantID,
+			"deleted_by_agent": agentName,
+			"deleted_at":       time.Now().UTC(),
+		},
+	}
+	s.enqueueWebhook(ctx, webhookScopeForAuth(auth, source), webhook.EventMemoryDeleted, data)
+	if chainAuth != nil && chainAuth.Chain != nil {
+		s.enqueueWebhook(ctx, webhook.EventScope{Type: webhook.ScopeChain, ChainID: chainAuth.Chain.ChainID}, webhook.EventMemoryDeleted, data)
+	}
+}
+
+func (s *Server) enqueueRoutedFactWebhook(ctx context.Context, chainAuth *domain.AuthInfo, targetAuth *domain.AuthInfo, node domain.ChainAuthNode, facts []service.ExtractedFact, mem *domain.Memory) {
+	if s == nil || s.webhooks == nil || chainAuth == nil || chainAuth.Chain == nil || targetAuth == nil || mem == nil {
+		return
+	}
+	data := map[string]any{
+		"route_id":                 uuid.NewString(),
+		"chain_id":                 chainAuth.Chain.ChainID,
+		"source_tenant_id":         firstChainTenantID(chainAuth),
+		"target_tenant_id":         targetAuth.TenantID,
+		"target_external_space_id": node.ExternalSpaceID,
+		"routing_policy_node_id":   node.ID,
+		"source_facts":             facts,
+		"target_memory":            mem,
+		"agent_id":                 mem.AgentID,
+		"appId":                    mem.AppID,
+		"session_id":               mem.SessionID,
+	}
+	s.enqueueWebhook(ctx, webhook.EventScope{Type: webhook.ScopeChain, ChainID: chainAuth.Chain.ChainID}, webhook.EventSpaceChainFactRouted, data)
+}
+
+func (s *Server) enqueueWebhook(ctx context.Context, scope webhook.EventScope, eventType string, data any) {
+	if err := s.webhooks.Enqueue(context.Background(), scope, eventType, data); err != nil {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.WarnContext(ctx, "webhook enqueue failed", "event_type", eventType, "scope_type", scope.Type, "err", err)
+	}
+}
+
+func firstChainTenantID(auth *domain.AuthInfo) string {
+	if auth == nil || auth.Chain == nil || len(auth.Chain.Nodes) == 0 {
+		return ""
+	}
+	return auth.Chain.Nodes[0].TenantID
+}

--- a/server/internal/handler/webhook_events.go
+++ b/server/internal/handler/webhook_events.go
@@ -28,15 +28,24 @@ func (s *Server) enqueueMemoryAddedIDWebhooks(ctx context.Context, auth *domain.
 		return
 	}
 	for _, change := range result.Changes {
-		if change.Type != service.MemoryChangeAdd || change.MemoryID == "" {
+		if change.MemoryID == "" {
 			continue
 		}
-		mem, err := svc.memory.Get(ctx, change.MemoryID)
-		if err != nil {
-			slog.WarnContext(ctx, "webhook memory.added payload lookup failed", "memory_id", change.MemoryID, "err", err)
-			continue
+		switch change.Type {
+		case service.MemoryChangeAdd:
+			mem, err := svc.memory.Get(ctx, change.MemoryID)
+			if err != nil {
+				slog.WarnContext(ctx, "webhook memory.added payload lookup failed", "memory_id", change.MemoryID, "err", err)
+				continue
+			}
+			s.enqueueMemoryAddedWebhook(ctx, auth, source, chainAuth, mem)
+		case service.MemoryChangeDelete:
+			agentName := ""
+			if auth != nil {
+				agentName = auth.AgentName
+			}
+			s.enqueueMemoryDeletedWebhook(ctx, auth, source, chainAuth, change.MemoryID, agentName)
 		}
-		s.enqueueMemoryAddedWebhook(ctx, auth, source, chainAuth, mem)
 	}
 }
 

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -57,11 +57,24 @@ type IngestMessage struct {
 
 // IngestResult is the output of the ingest pipeline.
 type IngestResult struct {
-	Status          string   `json:"status"`           // complete | partial | failed
-	MemoriesChanged int      `json:"memories_changed"` // count of ADD + UPDATE actions executed
-	InsightIDs      []string `json:"insight_ids,omitempty"`
-	Warnings        int      `json:"warnings,omitempty"`
-	Error           string   `json:"error,omitempty"`
+	Status          string         `json:"status"`           // complete | partial | failed
+	MemoriesChanged int            `json:"memories_changed"` // count of ADD + UPDATE actions executed
+	InsightIDs      []string       `json:"insight_ids,omitempty"`
+	Changes         []MemoryChange `json:"changes,omitempty"`
+	Warnings        int            `json:"warnings,omitempty"`
+	Error           string         `json:"error,omitempty"`
+}
+
+const (
+	MemoryChangeAdd    = "add"
+	MemoryChangeUpdate = "update"
+	MemoryChangeDelete = "delete"
+)
+
+type MemoryChange struct {
+	Type        string `json:"type"`
+	MemoryID    string `json:"memory_id,omitempty"`
+	OldMemoryID string `json:"old_memory_id,omitempty"`
 }
 
 // IngestService orchestrates the two-phase smart memory pipeline.
@@ -126,11 +139,12 @@ func (s *IngestService) Ingest(ctx context.Context, agentName string, req Ingest
 	// Cap conversation size to avoid blowing LLM token limits.
 	formatted = truncateRunes(formatted, maxExtractionConversationRunes)
 
-	insightIDs, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted)
+	changes, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted)
 	if err != nil {
 		slog.Error("insight extraction failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
 	}
+	insightIDs := insightIDsFromChanges(changes)
 
 	status := "complete"
 	if warnings > 0 && len(insightIDs) == 0 {
@@ -141,6 +155,7 @@ func (s *IngestService) Ingest(ctx context.Context, agentName string, req Ingest
 		Status:          status,
 		MemoriesChanged: len(insightIDs),
 		InsightIDs:      insightIDs,
+		Changes:         changes,
 		Warnings:        warnings,
 	}, nil
 }
@@ -397,11 +412,12 @@ func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID,
 		slog.Warn("ReconcilePhase2: truncating facts", "count", len(facts), "max", maxFacts)
 		facts = facts[:maxFacts]
 	}
-	insightIDs, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, facts)
+	changes, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, facts)
 	if err != nil {
 		slog.Error("ReconcilePhase2: reconciliation failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
 	}
+	insightIDs := insightIDsFromChanges(changes)
 	status := "complete"
 	if warnings > 0 && len(insightIDs) == 0 {
 		status = "partial"
@@ -410,6 +426,7 @@ func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID,
 		Status:          status,
 		MemoriesChanged: len(insightIDs),
 		InsightIDs:      insightIDs,
+		Changes:         changes,
 		Warnings:        warnings,
 	}, nil
 }
@@ -468,7 +485,7 @@ func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID
 		}, nil
 	}
 
-	insightIDs, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, allFacts)
+	changes, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, allFacts)
 	totalWarnings += warnings
 	if err != nil {
 		slog.Error("reconcile content: batched reconciliation failed", "err", err)
@@ -478,6 +495,7 @@ func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID
 			Warnings:        totalWarnings + 1,
 		}, nil
 	}
+	insightIDs := insightIDsFromChanges(changes)
 
 	status := "complete"
 	if failures > 0 && len(insightIDs) == 0 {
@@ -490,6 +508,7 @@ func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID
 		Status:          status,
 		MemoriesChanged: len(insightIDs),
 		InsightIDs:      insightIDs,
+		Changes:         changes,
 		Warnings:        totalWarnings,
 	}, nil
 }
@@ -551,11 +570,12 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 		Status:          "complete",
 		MemoriesChanged: 1,
 		InsightIDs:      []string{m.ID},
+		Changes:         []MemoryChange{{Type: MemoryChangeAdd, MemoryID: m.ID}},
 	}, nil
 }
 
 // extractAndReconcile runs Phase 1a (extraction) + Phase 2 (reconciliation).
-func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string) ([]string, int, error) {
+func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string) ([]MemoryChange, int, error) {
 	const maxFacts = 50 // Cap extracted facts to bound reconciliation prompt size
 
 	// Phase 1a: Extract facts only — no message_tags needed here (smart-ingest / raw-ingest path).
@@ -992,7 +1012,7 @@ Return ONLY valid JSON. No markdown fences, no explanation.
 // all facts and all retrieved memories to the LLM in a single call for batch
 // decision-making. This gives the LLM a complete view of both the new facts and
 // the existing knowledge base, enabling better ADD/UPDATE/DELETE/NOOP decisions.
-func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]string, int, error) {
+func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]MemoryChange, int, error) {
 	start := time.Now()
 	var (
 		applyActionsDuration   time.Duration
@@ -1047,7 +1067,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID
 
 	if len(existingMemories) == 0 {
 		applyActionsStart := time.Now()
-		resultIDs, warningCount, err := s.addAllFacts(ctx, agentName, agentID, appID, sessionID, facts)
+		changes, warningCount, err := s.addAllFacts(ctx, agentName, agentID, appID, sessionID, facts)
 		applyActionsDuration = time.Since(applyActionsStart)
 		warnings = warningCount
 		if err != nil {
@@ -1055,7 +1075,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID
 			return nil, warningCount, err
 		}
 		status = "add_all"
-		return resultIDs, warningCount, nil
+		return changes, warningCount, nil
 	}
 
 	// Step 2: Map real UUIDs to integer IDs to prevent LLM hallucination.
@@ -1218,7 +1238,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 
 	// Step 4: Execute each action.
 	applyActionsStart := time.Now()
-	var resultIDs []string
+	var changes []MemoryChange
 
 	for _, event := range parsed.Memory {
 		switch strings.ToUpper(event.Event) {
@@ -1244,7 +1264,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				warnings++
 				continue
 			}
-			resultIDs = append(resultIDs, newID)
+			changes = append(changes, MemoryChange{Type: MemoryChangeAdd, MemoryID: newID})
 
 		case "UPDATE":
 			intID := parseIntID(event.ID)
@@ -1277,7 +1297,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 					warnings++
 					continue
 				}
-				resultIDs = append(resultIDs, newID)
+				changes = append(changes, MemoryChange{Type: MemoryChangeAdd, MemoryID: newID})
 				continue
 			}
 			newID, updateErr := s.updateInsight(ctx, agentName, agentID, appID, sessionID, realID, normalizedText, effectiveTags, metadata)
@@ -1286,7 +1306,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				warnings++
 				continue
 			}
-			resultIDs = append(resultIDs, newID)
+			changes = append(changes, MemoryChange{Type: MemoryChangeUpdate, MemoryID: newID, OldMemoryID: realID})
 
 		case "DELETE":
 			intID := parseIntID(event.ID)
@@ -1310,6 +1330,8 @@ Analyze the new facts and determine whether each should be added, updated, or de
 					slog.Warn("failed to delete memory", "err", delErr, "id", event.ID)
 					warnings++
 				}
+			} else {
+				changes = append(changes, MemoryChange{Type: MemoryChangeDelete, MemoryID: realID})
 			}
 
 		case "NOOP", "NONE":
@@ -1321,7 +1343,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 	}
 	applyActionsDuration = time.Since(applyActionsStart)
 
-	return resultIDs, warnings, nil
+	return changes, warnings, nil
 }
 
 const gatherExistingMemoriesConcurrency = 4
@@ -1521,8 +1543,8 @@ func (s *IngestService) searchExistingMemoriesForFact(
 
 // addAllFacts adds all facts as new insights when no existing memories are
 // found (i.e., all facts are guaranteed new). Called only when gatherExistingMemories returns empty.
-func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]string, int, error) {
-	var ids []string
+func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]MemoryChange, int, error) {
+	var changes []MemoryChange
 	var warnings int
 	for _, fact := range facts {
 		id, err := s.addInsight(ctx, agentName, agentID, appID, sessionID, fact.Text, fact.Tags, metadataForExtractedFact(fact))
@@ -1531,9 +1553,22 @@ func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, app
 			warnings++
 			continue
 		}
-		ids = append(ids, id)
+		changes = append(changes, MemoryChange{Type: MemoryChangeAdd, MemoryID: id})
 	}
-	return ids, warnings, nil
+	return changes, warnings, nil
+}
+
+func insightIDsFromChanges(changes []MemoryChange) []string {
+	ids := make([]string, 0, len(changes))
+	for _, change := range changes {
+		if change.MemoryID == "" {
+			continue
+		}
+		if change.Type == MemoryChangeAdd || change.Type == MemoryChangeUpdate {
+			ids = append(ids, change.MemoryID)
+		}
+	}
+	return ids
 }
 
 // addInsight creates a new insight memory with the given content and tags.

--- a/server/internal/webhook/dispatcher.go
+++ b/server/internal/webhook/dispatcher.go
@@ -1,0 +1,138 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+type DispatcherConfig struct {
+	PollInterval time.Duration
+	BatchSize    int
+	Timeout      time.Duration
+	MaxAttempts  int
+}
+
+type Dispatcher struct {
+	store  Store
+	svc    *Service
+	client *http.Client
+	cfg    DispatcherConfig
+	logger *slog.Logger
+}
+
+func NewDispatcher(store Store, svc *Service, cfg DispatcherConfig, logger *slog.Logger) *Dispatcher {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = 2 * time.Second
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 25
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 8
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Dispatcher{
+		store:  store,
+		svc:    svc,
+		client: &http.Client{Timeout: cfg.Timeout},
+		cfg:    cfg,
+		logger: logger,
+	}
+}
+
+func (d *Dispatcher) Run(ctx context.Context) error {
+	ticker := time.NewTicker(d.cfg.PollInterval)
+	defer ticker.Stop()
+	for {
+		if err := d.drain(ctx); err != nil && err != context.Canceled {
+			d.logger.WarnContext(ctx, "webhook dispatcher drain failed", "err", err)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (d *Dispatcher) drain(ctx context.Context) error {
+	jobs, err := d.store.FetchDueDeliveries(ctx, d.cfg.BatchSize)
+	if err != nil {
+		return err
+	}
+	for _, job := range jobs {
+		if err := d.deliver(ctx, job); err != nil {
+			d.logger.WarnContext(ctx, "webhook delivery failed", "delivery_id", job.ID, "event_id", job.EventID, "err", err)
+		}
+	}
+	return nil
+}
+
+func (d *Dispatcher) deliver(ctx context.Context, job DeliveryJob) error {
+	secret, err := d.svc.DecryptSecret(ctx, job.SecretCiphertext)
+	if err != nil {
+		return d.recordFailure(ctx, job, nil, fmt.Errorf("decrypt webhook secret: %w", err))
+	}
+	timestamp := time.Now().Unix()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, job.URL, bytes.NewReader(job.Payload))
+	if err != nil {
+		return d.recordFailure(ctx, job, nil, fmt.Errorf("build webhook request: %w", err))
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "mem9-webhooks/1")
+	req.Header.Set("X-Mem9-Event-Id", job.EventID)
+	req.Header.Set("X-Mem9-Event-Type", job.EventType)
+	req.Header.Set("X-Mem9-Timestamp", fmt.Sprintf("%d", timestamp))
+	req.Header.Set("X-Mem9-Signature", SignPayload(secret, timestamp, job.EventID, job.Payload))
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return d.recordFailure(ctx, job, nil, err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return d.store.MarkDeliveryDelivered(ctx, job.ID, resp.StatusCode)
+	}
+	return d.recordFailure(ctx, job, &resp.StatusCode, fmt.Errorf("webhook returned status %d", resp.StatusCode))
+}
+
+func (d *Dispatcher) recordFailure(ctx context.Context, job DeliveryJob, httpStatus *int, err error) error {
+	nextAttempt := job.AttemptCount + 1
+	terminal := nextAttempt >= d.cfg.MaxAttempts
+	next := time.Now().UTC().Add(backoff(nextAttempt))
+	if terminal {
+		next = time.Now().UTC()
+	}
+	if markErr := d.store.MarkDeliveryFailedAttempt(ctx, job.ID, terminal, next, httpStatus, err.Error()); markErr != nil {
+		return markErr
+	}
+	return err
+}
+
+func backoff(attempt int) time.Duration {
+	switch {
+	case attempt <= 1:
+		return time.Minute
+	case attempt == 2:
+		return 5 * time.Minute
+	case attempt == 3:
+		return 30 * time.Minute
+	case attempt == 4:
+		return 2 * time.Hour
+	case attempt == 5:
+		return 6 * time.Hour
+	default:
+		return 24 * time.Hour
+	}
+}

--- a/server/internal/webhook/dispatcher.go
+++ b/server/internal/webhook/dispatcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"time"
 )
@@ -41,10 +42,28 @@ func NewDispatcher(store Store, svc *Service, cfg DispatcherConfig, logger *slog
 	if logger == nil {
 		logger = slog.Default()
 	}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: guardedDialContext(
+			&net.Dialer{
+				Timeout:   cfg.Timeout,
+				KeepAlive: 30 * time.Second,
+			},
+			svc != nil && svc.allowLocalHTTP,
+		),
+		TLSHandshakeTimeout:   cfg.Timeout,
+		ResponseHeaderTimeout: cfg.Timeout,
+	}
 	return &Dispatcher{
-		store:  store,
-		svc:    svc,
-		client: &http.Client{Timeout: cfg.Timeout},
+		store: store,
+		svc:   svc,
+		client: &http.Client{
+			Timeout:   cfg.Timeout,
+			Transport: transport,
+			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+				return validateDeliveryURL(req.Context(), req.URL.String(), svc != nil && svc.allowLocalHTTP)
+			},
+		},
 		cfg:    cfg,
 		logger: logger,
 	}
@@ -83,6 +102,9 @@ func (d *Dispatcher) deliver(ctx context.Context, job DeliveryJob) error {
 	if err != nil {
 		return d.recordFailure(ctx, job, nil, fmt.Errorf("decrypt webhook secret: %w", err))
 	}
+	if err := validateDeliveryURL(ctx, job.URL, d.svc != nil && d.svc.allowLocalHTTP); err != nil {
+		return d.recordFailure(ctx, job, nil, err)
+	}
 	timestamp := time.Now().Unix()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, job.URL, bytes.NewReader(job.Payload))
 	if err != nil {
@@ -105,6 +127,31 @@ func (d *Dispatcher) deliver(ctx context.Context, job DeliveryJob) error {
 		return d.store.MarkDeliveryDelivered(ctx, job.ID, resp.StatusCode)
 	}
 	return d.recordFailure(ctx, job, &resp.StatusCode, fmt.Errorf("webhook returned status %d", resp.StatusCode))
+}
+
+func guardedDialContext(dialer *net.Dialer, allowLocalHTTP bool) func(context.Context, string, string) (net.Conn, error) {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(address)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := allowedDestinationIPs(ctx, host, allowLocalHTTP)
+		if err != nil {
+			return nil, err
+		}
+		var lastErr error
+		for _, ip := range ips {
+			conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, fmt.Errorf("webhook destination has no allowed IPs")
+	}
 }
 
 func (d *Dispatcher) recordFailure(ctx context.Context, job DeliveryJob, httpStatus *int, err error) error {

--- a/server/internal/webhook/service.go
+++ b/server/internal/webhook/service.go
@@ -347,6 +347,47 @@ func validateEndpointURL(rawURL string, allowLocalHTTP bool) (string, error) {
 	return parsed.String(), nil
 }
 
+func validateDeliveryURL(ctx context.Context, rawURL string, allowLocalHTTP bool) error {
+	endpointURL, err := validateEndpointURL(rawURL, allowLocalHTTP)
+	if err != nil {
+		return err
+	}
+	parsed, err := url.Parse(endpointURL)
+	if err != nil {
+		return &domain.ValidationError{Field: "url", Message: "invalid"}
+	}
+	host := strings.Trim(parsed.Hostname(), "[]")
+	if _, err := allowedDestinationIPs(ctx, host, allowLocalHTTP); err != nil {
+		return err
+	}
+	return nil
+}
+
+func allowedDestinationIPs(ctx context.Context, host string, allowLocalHTTP bool) ([]net.IP, error) {
+	if ip := net.ParseIP(host); ip != nil {
+		if !isAllowedIP(ip, allowLocalHTTP) {
+			return nil, &domain.ValidationError{Field: "url", Message: "private IP destinations are not allowed"}
+		}
+		return []net.IP{ip}, nil
+	}
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("resolve webhook destination: %w", err)
+	}
+	ips := make([]net.IP, 0, len(addrs))
+	for _, addr := range addrs {
+		if !isAllowedIP(addr.IP, allowLocalHTTP) {
+			return nil, &domain.ValidationError{Field: "url", Message: "private IP destinations are not allowed"}
+		}
+		ips = append(ips, addr.IP)
+	}
+	if len(ips) == 0 {
+		return nil, &domain.ValidationError{Field: "url", Message: "destination has no IP addresses"}
+	}
+	return ips, nil
+}
+
 func normalizeEvents(events []string) ([]string, error) {
 	seen := map[string]struct{}{}
 	out := make([]string, 0, len(events))

--- a/server/internal/webhook/service.go
+++ b/server/internal/webhook/service.go
@@ -1,0 +1,403 @@
+package webhook
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+const APIVersion = "2026-06-08"
+
+type secretProtector interface {
+	Encrypt(ctx context.Context, plaintext string) (string, error)
+	Decrypt(ctx context.Context, ciphertext string) (string, error)
+}
+
+type Store interface {
+	EnsureSchema(ctx context.Context) error
+	CreateEndpoint(ctx context.Context, endpoint Endpoint) error
+	ListEndpoints(ctx context.Context, scopeType, scopeID string) ([]Endpoint, error)
+	GetEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) (*Endpoint, error)
+	UpdateEndpoint(ctx context.Context, endpoint Endpoint) error
+	UpdateEndpointSecret(ctx context.Context, endpoint Endpoint) error
+	SoftDeleteEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) error
+	EnqueueEvent(ctx context.Context, event EventRecord) error
+	EnqueueTestEvent(ctx context.Context, endpoint Endpoint, event EventRecord) error
+	ListDeliveries(ctx context.Context, scopeType, scopeID string, limit int) ([]Delivery, error)
+	FetchDueDeliveries(ctx context.Context, limit int) ([]DeliveryJob, error)
+	MarkDeliveryDelivered(ctx context.Context, deliveryID string, httpStatus int) error
+	MarkDeliveryFailedAttempt(ctx context.Context, deliveryID string, terminal bool, nextAttemptAt time.Time, httpStatus *int, message string) error
+}
+
+type Service struct {
+	store          Store
+	protector      secretProtector
+	allowLocalHTTP bool
+}
+
+func NewService(store Store, protector secretProtector, allowLocalHTTP bool) *Service {
+	return &Service{store: store, protector: protector, allowLocalHTTP: allowLocalHTTP}
+}
+
+func (s *Service) CreateEndpoint(ctx context.Context, input CreateEndpointInput) (EndpointSecretResponse, error) {
+	if err := validateScope(input.ScopeType, input.ScopeID); err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	name, err := validateName(input.Name)
+	if err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	endpointURL, err := validateEndpointURL(input.URL, s.allowLocalHTTP)
+	if err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	events, err := normalizeEvents(input.Events)
+	if err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	secret, err := generateSigningSecret()
+	if err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	encrypted, err := s.protector.Encrypt(ctx, secret)
+	if err != nil {
+		return EndpointSecretResponse{}, fmt.Errorf("encrypt webhook secret: %w", err)
+	}
+	now := time.Now().UTC()
+	endpoint := Endpoint{
+		ID:               uuid.NewString(),
+		ScopeType:        input.ScopeType,
+		ScopeID:          input.ScopeID,
+		Name:             name,
+		URL:              endpointURL,
+		Enabled:          input.Enabled,
+		Events:           events,
+		SecretCiphertext: encrypted,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := s.store.CreateEndpoint(ctx, endpoint); err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	return EndpointSecretResponse{
+		EndpointResponse: ToEndpointResponse(endpoint),
+		SigningSecret:    secret,
+	}, nil
+}
+
+func (s *Service) ListEndpoints(ctx context.Context, scopeType, scopeID string) ([]EndpointResponse, error) {
+	if err := validateScope(scopeType, scopeID); err != nil {
+		return nil, err
+	}
+	endpoints, err := s.store.ListEndpoints(ctx, scopeType, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]EndpointResponse, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		out = append(out, ToEndpointResponse(endpoint))
+	}
+	return out, nil
+}
+
+func (s *Service) GetEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) (EndpointResponse, error) {
+	endpoint, err := s.getEndpoint(ctx, scopeType, scopeID, endpointID)
+	if err != nil {
+		return EndpointResponse{}, err
+	}
+	return ToEndpointResponse(*endpoint), nil
+}
+
+func (s *Service) UpdateEndpoint(ctx context.Context, input UpdateEndpointInput) (EndpointResponse, error) {
+	endpoint, err := s.getEndpoint(ctx, input.ScopeType, input.ScopeID, input.EndpointID)
+	if err != nil {
+		return EndpointResponse{}, err
+	}
+	if input.Name != nil {
+		name, err := validateName(*input.Name)
+		if err != nil {
+			return EndpointResponse{}, err
+		}
+		endpoint.Name = name
+	}
+	if input.URL != nil {
+		endpointURL, err := validateEndpointURL(*input.URL, s.allowLocalHTTP)
+		if err != nil {
+			return EndpointResponse{}, err
+		}
+		endpoint.URL = endpointURL
+	}
+	if input.Enabled != nil {
+		endpoint.Enabled = *input.Enabled
+	}
+	if input.Events != nil {
+		events, err := normalizeEvents(*input.Events)
+		if err != nil {
+			return EndpointResponse{}, err
+		}
+		endpoint.Events = events
+	}
+	endpoint.UpdatedAt = time.Now().UTC()
+	if err := s.store.UpdateEndpoint(ctx, *endpoint); err != nil {
+		return EndpointResponse{}, err
+	}
+	return ToEndpointResponse(*endpoint), nil
+}
+
+func (s *Service) DeleteEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) error {
+	if err := validateScope(scopeType, scopeID); err != nil {
+		return err
+	}
+	if strings.TrimSpace(endpointID) == "" {
+		return &domain.ValidationError{Field: "webhook_id", Message: "required"}
+	}
+	return s.store.SoftDeleteEndpoint(ctx, scopeType, scopeID, endpointID)
+}
+
+func (s *Service) RotateSecret(ctx context.Context, scopeType, scopeID, endpointID string) (EndpointSecretResponse, error) {
+	endpoint, err := s.getEndpoint(ctx, scopeType, scopeID, endpointID)
+	if err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	secret, err := generateSigningSecret()
+	if err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	encrypted, err := s.protector.Encrypt(ctx, secret)
+	if err != nil {
+		return EndpointSecretResponse{}, fmt.Errorf("encrypt webhook secret: %w", err)
+	}
+	endpoint.SecretCiphertext = encrypted
+	endpoint.UpdatedAt = time.Now().UTC()
+	if err := s.store.UpdateEndpointSecret(ctx, *endpoint); err != nil {
+		return EndpointSecretResponse{}, err
+	}
+	return EndpointSecretResponse{
+		EndpointResponse: ToEndpointResponse(*endpoint),
+		SigningSecret:    secret,
+	}, nil
+}
+
+func (s *Service) TestEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) (Delivery, error) {
+	endpoint, err := s.getEndpoint(ctx, scopeType, scopeID, endpointID)
+	if err != nil {
+		return Delivery{}, err
+	}
+	id := eventID()
+	payload, err := s.buildPayload(id, EventTest, eventScope(scopeType, scopeID, "", ""), map[string]any{
+		"message": "mem9 webhook test event",
+	})
+	if err != nil {
+		return Delivery{}, err
+	}
+	event := EventRecord{
+		ID:        id,
+		ScopeType: scopeType,
+		ScopeID:   scopeID,
+		EventType: EventTest,
+		Payload:   payload,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.store.EnqueueTestEvent(ctx, *endpoint, event); err != nil {
+		return Delivery{}, err
+	}
+	deliveries, err := s.store.ListDeliveries(ctx, scopeType, scopeID, 1)
+	if err != nil {
+		return Delivery{}, err
+	}
+	if len(deliveries) == 0 {
+		return Delivery{}, domain.ErrNotFound
+	}
+	return deliveries[0], nil
+}
+
+func (s *Service) ListDeliveries(ctx context.Context, scopeType, scopeID string, limit int) ([]Delivery, error) {
+	if err := validateScope(scopeType, scopeID); err != nil {
+		return nil, err
+	}
+	return s.store.ListDeliveries(ctx, scopeType, scopeID, limit)
+}
+
+func (s *Service) Enqueue(ctx context.Context, scope EventScope, eventType string, data any) error {
+	if s == nil || s.store == nil {
+		return nil
+	}
+	scopeType := scope.Type
+	scopeID := scope.TenantID
+	if scopeType == ScopeChain {
+		scopeID = scope.ChainID
+	}
+	if err := validateScope(scopeType, scopeID); err != nil {
+		return err
+	}
+	if eventType != EventTest && !isSupportedEvent(eventType) {
+		return &domain.ValidationError{Field: "type", Message: "unsupported event"}
+	}
+	id := eventID()
+	payload, err := s.buildPayload(id, eventType, scope, data)
+	if err != nil {
+		return err
+	}
+	return s.store.EnqueueEvent(ctx, EventRecord{
+		ID:        id,
+		ScopeType: scopeType,
+		ScopeID:   scopeID,
+		EventType: eventType,
+		Payload:   payload,
+		CreatedAt: time.Now().UTC(),
+	})
+}
+
+func (s *Service) DecryptSecret(ctx context.Context, ciphertext string) (string, error) {
+	return s.protector.Decrypt(ctx, ciphertext)
+}
+
+func (s *Service) getEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) (*Endpoint, error) {
+	if err := validateScope(scopeType, scopeID); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(endpointID) == "" {
+		return nil, &domain.ValidationError{Field: "webhook_id", Message: "required"}
+	}
+	return s.store.GetEndpoint(ctx, scopeType, scopeID, endpointID)
+}
+
+func (s *Service) buildPayload(id, eventType string, scope EventScope, data any) (json.RawMessage, error) {
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal webhook data: %w", err)
+	}
+	payload, err := json.Marshal(EventEnvelope{
+		ID:         id,
+		Type:       eventType,
+		APIVersion: APIVersion,
+		CreatedAt:  time.Now().UTC(),
+		Scope:      scope,
+		Data:       dataJSON,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal webhook payload: %w", err)
+	}
+	return payload, nil
+}
+
+func eventScope(scopeType, scopeID, externalSpaceID, chainID string) EventScope {
+	switch scopeType {
+	case ScopeChain:
+		return EventScope{Type: ScopeChain, ChainID: scopeID}
+	default:
+		return EventScope{Type: ScopeTenant, TenantID: scopeID, ExternalSpaceID: externalSpaceID, ChainID: chainID}
+	}
+}
+
+func validateScope(scopeType, scopeID string) error {
+	scopeType = strings.TrimSpace(scopeType)
+	scopeID = strings.TrimSpace(scopeID)
+	if scopeType != ScopeTenant && scopeType != ScopeChain {
+		return &domain.ValidationError{Field: "scope_type", Message: "unsupported"}
+	}
+	if scopeID == "" {
+		return &domain.ValidationError{Field: "scope_id", Message: "required"}
+	}
+	return nil
+}
+
+func validateName(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", &domain.ValidationError{Field: "name", Message: "required"}
+	}
+	if len(name) > 255 {
+		return "", &domain.ValidationError{Field: "name", Message: "too long (max 255)"}
+	}
+	return name, nil
+}
+
+func validateEndpointURL(rawURL string, allowLocalHTTP bool) (string, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", &domain.ValidationError{Field: "url", Message: "required"}
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", &domain.ValidationError{Field: "url", Message: "invalid"}
+	}
+	if parsed.User != nil {
+		return "", &domain.ValidationError{Field: "url", Message: "userinfo is not allowed"}
+	}
+	host := strings.Trim(parsed.Hostname(), "[]")
+	if parsed.Scheme != "https" {
+		if !(allowLocalHTTP && parsed.Scheme == "http" && isLocalhost(host)) {
+			return "", &domain.ValidationError{Field: "url", Message: "https is required"}
+		}
+	}
+	if ip := net.ParseIP(host); ip != nil && !isAllowedIP(ip, allowLocalHTTP) {
+		return "", &domain.ValidationError{Field: "url", Message: "private IP destinations are not allowed"}
+	}
+	return parsed.String(), nil
+}
+
+func normalizeEvents(events []string) ([]string, error) {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(events))
+	for _, event := range events {
+		event = strings.TrimSpace(event)
+		if event == "" {
+			continue
+		}
+		if !isSupportedEvent(event) {
+			return nil, &domain.ValidationError{Field: "events", Message: "unsupported event: " + event}
+		}
+		if _, ok := seen[event]; ok {
+			continue
+		}
+		seen[event] = struct{}{}
+		out = append(out, event)
+	}
+	if len(out) == 0 {
+		return nil, &domain.ValidationError{Field: "events", Message: "required"}
+	}
+	return out, nil
+}
+
+func isSupportedEvent(event string) bool {
+	for _, supported := range SupportedEvents {
+		if event == supported {
+			return true
+		}
+	}
+	return false
+}
+
+func generateSigningSecret() (string, error) {
+	var raw [32]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "whsec_" + base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}
+
+func eventID() string {
+	return "evt_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+}
+
+func isLocalhost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func isAllowedIP(ip net.IP, allowLocal bool) bool {
+	if allowLocal && ip.IsLoopback() {
+		return true
+	}
+	return !(ip.IsPrivate() || ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified())
+}

--- a/server/internal/webhook/service.go
+++ b/server/internal/webhook/service.go
@@ -32,7 +32,7 @@ type Store interface {
 	UpdateEndpointSecret(ctx context.Context, endpoint Endpoint) error
 	SoftDeleteEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) error
 	EnqueueEvent(ctx context.Context, event EventRecord) error
-	EnqueueTestEvent(ctx context.Context, endpoint Endpoint, event EventRecord) error
+	EnqueueTestEvent(ctx context.Context, endpoint Endpoint, event EventRecord) (Delivery, error)
 	ListDeliveries(ctx context.Context, scopeType, scopeID string, limit int) ([]Delivery, error)
 	FetchDueDeliveries(ctx context.Context, limit int) ([]DeliveryJob, error)
 	MarkDeliveryDelivered(ctx context.Context, deliveryID string, httpStatus int) error
@@ -193,6 +193,9 @@ func (s *Service) TestEndpoint(ctx context.Context, scopeType, scopeID, endpoint
 	if err != nil {
 		return Delivery{}, err
 	}
+	if !endpoint.Enabled {
+		return Delivery{}, &domain.ValidationError{Field: "enabled", Message: "webhook endpoint is disabled"}
+	}
 	id := eventID()
 	payload, err := s.buildPayload(id, EventTest, eventScope(scopeType, scopeID, "", ""), map[string]any{
 		"message": "mem9 webhook test event",
@@ -208,17 +211,7 @@ func (s *Service) TestEndpoint(ctx context.Context, scopeType, scopeID, endpoint
 		Payload:   payload,
 		CreatedAt: time.Now().UTC(),
 	}
-	if err := s.store.EnqueueTestEvent(ctx, *endpoint, event); err != nil {
-		return Delivery{}, err
-	}
-	deliveries, err := s.store.ListDeliveries(ctx, scopeType, scopeID, 1)
-	if err != nil {
-		return Delivery{}, err
-	}
-	if len(deliveries) == 0 {
-		return Delivery{}, domain.ErrNotFound
-	}
-	return deliveries[0], nil
+	return s.store.EnqueueTestEvent(ctx, *endpoint, event)
 }
 
 func (s *Service) ListDeliveries(ctx context.Context, scopeType, scopeID string, limit int) ([]Delivery, error) {

--- a/server/internal/webhook/service_test.go
+++ b/server/internal/webhook/service_test.go
@@ -58,6 +58,19 @@ func TestCreateEndpointAllowsLocalHTTPOnlyWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestValidateDeliveryURLRejectsPrivateDestinations(t *testing.T) {
+	ctx := context.Background()
+	if err := validateDeliveryURL(ctx, "https://127.0.0.1/hooks", false); !isValidationError(err) {
+		t.Fatalf("validateDeliveryURL(loopback, production) error = %v, want validation error", err)
+	}
+	if err := validateDeliveryURL(ctx, "http://localhost:3000/hooks", true); err != nil {
+		t.Fatalf("validateDeliveryURL(localhost, dev) error = %v", err)
+	}
+	if err := validateDeliveryURL(ctx, "http://127.0.0.1:3000/hooks", false); !isValidationError(err) {
+		t.Fatalf("validateDeliveryURL(http loopback, production) error = %v, want validation error", err)
+	}
+}
+
 func TestRotateSecretUpdatesCiphertextAndReturnsSecretOnce(t *testing.T) {
 	ctx := context.Background()
 	store := newFakeStore()

--- a/server/internal/webhook/service_test.go
+++ b/server/internal/webhook/service_test.go
@@ -1,0 +1,177 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestSignPayload(t *testing.T) {
+	got := SignPayload("whsec_test", 1710000000, "evt_123", []byte(`{"hello":"world"}`))
+	want := "v1=e8b3a71f736fa023d7b77e89bbe33bbd9706c17e91b6d7b1ba539e635cfc6e72"
+	if got != want {
+		t.Fatalf("SignPayload() = %q, want %q", got, want)
+	}
+}
+
+func TestCreateEndpointAllowsLocalHTTPOnlyWhenConfigured(t *testing.T) {
+	ctx := context.Background()
+	input := CreateEndpointInput{
+		ScopeType: ScopeTenant,
+		ScopeID:   "tenant-1",
+		Name:      " Local hook ",
+		URL:       " http://localhost:3000/hooks ",
+		Enabled:   true,
+		Events:    []string{EventMemoryAdded, EventMemoryAdded},
+	}
+
+	lockedDown := NewService(newFakeStore(), fakeProtector{}, false)
+	if _, err := lockedDown.CreateEndpoint(ctx, input); !isValidationError(err) {
+		t.Fatalf("CreateEndpoint() error = %v, want validation error", err)
+	}
+
+	store := newFakeStore()
+	localDev := NewService(store, fakeProtector{}, true)
+	resp, err := localDev.CreateEndpoint(ctx, input)
+	if err != nil {
+		t.Fatalf("CreateEndpoint() error = %v", err)
+	}
+	if resp.Name != "Local hook" {
+		t.Fatalf("endpoint name = %q, want trimmed name", resp.Name)
+	}
+	if resp.URL != "http://localhost:3000/hooks" {
+		t.Fatalf("endpoint url = %q", resp.URL)
+	}
+	if got := len(resp.Events); got != 1 || resp.Events[0] != EventMemoryAdded {
+		t.Fatalf("endpoint events = %#v, want single memory.added", resp.Events)
+	}
+	if !strings.HasPrefix(resp.SigningSecret, "whsec_") {
+		t.Fatalf("signing secret = %q, want whsec_ prefix", resp.SigningSecret)
+	}
+	stored := store.endpoints[resp.ID]
+	if stored.SecretCiphertext != "enc:"+resp.SigningSecret {
+		t.Fatalf("stored ciphertext = %q, want encrypted response secret", stored.SecretCiphertext)
+	}
+}
+
+func TestRotateSecretUpdatesCiphertextAndReturnsSecretOnce(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeStore()
+	svc := NewService(store, fakeProtector{}, true)
+
+	created, err := svc.CreateEndpoint(ctx, CreateEndpointInput{
+		ScopeType: ScopeTenant,
+		ScopeID:   "tenant-1",
+		Name:      "hook",
+		URL:       "https://example.com/hooks",
+		Enabled:   true,
+		Events:    []string{EventMemoryDeleted},
+	})
+	if err != nil {
+		t.Fatalf("CreateEndpoint() error = %v", err)
+	}
+
+	rotated, err := svc.RotateSecret(ctx, ScopeTenant, "tenant-1", created.ID)
+	if err != nil {
+		t.Fatalf("RotateSecret() error = %v", err)
+	}
+	if rotated.SigningSecret == "" || rotated.SigningSecret == created.SigningSecret {
+		t.Fatalf("rotated signing secret = %q, original = %q", rotated.SigningSecret, created.SigningSecret)
+	}
+	if store.endpoints[created.ID].SecretCiphertext != "enc:"+rotated.SigningSecret {
+		t.Fatalf("stored ciphertext was not updated")
+	}
+}
+
+func isValidationError(err error) bool {
+	var validationErr *domain.ValidationError
+	return errors.As(err, &validationErr)
+}
+
+type fakeProtector struct{}
+
+func (fakeProtector) Encrypt(_ context.Context, plaintext string) (string, error) {
+	return "enc:" + plaintext, nil
+}
+
+func (fakeProtector) Decrypt(_ context.Context, ciphertext string) (string, error) {
+	return strings.TrimPrefix(ciphertext, "enc:"), nil
+}
+
+type fakeStore struct {
+	endpoints map[string]Endpoint
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{endpoints: map[string]Endpoint{}}
+}
+
+func (s *fakeStore) EnsureSchema(context.Context) error { return nil }
+
+func (s *fakeStore) CreateEndpoint(_ context.Context, endpoint Endpoint) error {
+	s.endpoints[endpoint.ID] = endpoint
+	return nil
+}
+
+func (s *fakeStore) ListEndpoints(_ context.Context, scopeType, scopeID string) ([]Endpoint, error) {
+	var endpoints []Endpoint
+	for _, endpoint := range s.endpoints {
+		if endpoint.ScopeType == scopeType && endpoint.ScopeID == scopeID && endpoint.DeletedAt == nil {
+			endpoints = append(endpoints, endpoint)
+		}
+	}
+	return endpoints, nil
+}
+
+func (s *fakeStore) GetEndpoint(_ context.Context, scopeType, scopeID, endpointID string) (*Endpoint, error) {
+	endpoint, ok := s.endpoints[endpointID]
+	if !ok || endpoint.ScopeType != scopeType || endpoint.ScopeID != scopeID || endpoint.DeletedAt != nil {
+		return nil, domain.ErrNotFound
+	}
+	return &endpoint, nil
+}
+
+func (s *fakeStore) UpdateEndpoint(_ context.Context, endpoint Endpoint) error {
+	if _, ok := s.endpoints[endpoint.ID]; !ok {
+		return domain.ErrNotFound
+	}
+	s.endpoints[endpoint.ID] = endpoint
+	return nil
+}
+
+func (s *fakeStore) UpdateEndpointSecret(_ context.Context, endpoint Endpoint) error {
+	return s.UpdateEndpoint(context.Background(), endpoint)
+}
+
+func (s *fakeStore) SoftDeleteEndpoint(_ context.Context, scopeType, scopeID, endpointID string) error {
+	endpoint, err := s.GetEndpoint(context.Background(), scopeType, scopeID, endpointID)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	endpoint.DeletedAt = &now
+	s.endpoints[endpointID] = *endpoint
+	return nil
+}
+
+func (s *fakeStore) EnqueueEvent(context.Context, EventRecord) error { return nil }
+
+func (s *fakeStore) EnqueueTestEvent(context.Context, Endpoint, EventRecord) error { return nil }
+
+func (s *fakeStore) ListDeliveries(context.Context, string, string, int) ([]Delivery, error) {
+	return nil, nil
+}
+
+func (s *fakeStore) FetchDueDeliveries(context.Context, int) ([]DeliveryJob, error) {
+	return nil, nil
+}
+
+func (s *fakeStore) MarkDeliveryDelivered(context.Context, string, int) error { return nil }
+
+func (s *fakeStore) MarkDeliveryFailedAttempt(context.Context, string, bool, time.Time, *int, string) error {
+	return nil
+}

--- a/server/internal/webhook/service_test.go
+++ b/server/internal/webhook/service_test.go
@@ -100,6 +100,60 @@ func TestRotateSecretUpdatesCiphertextAndReturnsSecretOnce(t *testing.T) {
 	}
 }
 
+func TestTestEndpointRejectsDisabledEndpoint(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeStore()
+	svc := NewService(store, fakeProtector{}, true)
+
+	created, err := svc.CreateEndpoint(ctx, CreateEndpointInput{
+		ScopeType: ScopeTenant,
+		ScopeID:   "tenant-1",
+		Name:      "hook",
+		URL:       "https://example.com/hooks",
+		Enabled:   false,
+		Events:    []string{EventMemoryAdded},
+	})
+	if err != nil {
+		t.Fatalf("CreateEndpoint() error = %v", err)
+	}
+
+	if _, err := svc.TestEndpoint(ctx, ScopeTenant, "tenant-1", created.ID); !isValidationError(err) {
+		t.Fatalf("TestEndpoint(disabled) error = %v, want validation error", err)
+	}
+	if store.testDelivery.ID != "" {
+		t.Fatalf("test delivery was enqueued for disabled endpoint: %#v", store.testDelivery)
+	}
+}
+
+func TestTestEndpointReturnsCreatedDelivery(t *testing.T) {
+	ctx := context.Background()
+	store := newFakeStore()
+	svc := NewService(store, fakeProtector{}, true)
+
+	created, err := svc.CreateEndpoint(ctx, CreateEndpointInput{
+		ScopeType: ScopeTenant,
+		ScopeID:   "tenant-1",
+		Name:      "hook",
+		URL:       "https://example.com/hooks",
+		Enabled:   true,
+		Events:    []string{EventMemoryAdded},
+	})
+	if err != nil {
+		t.Fatalf("CreateEndpoint() error = %v", err)
+	}
+
+	delivery, err := svc.TestEndpoint(ctx, ScopeTenant, "tenant-1", created.ID)
+	if err != nil {
+		t.Fatalf("TestEndpoint() error = %v", err)
+	}
+	if delivery.ID != "test-delivery" {
+		t.Fatalf("delivery id = %q, want store-created delivery", delivery.ID)
+	}
+	if delivery.EndpointID != created.ID || delivery.EventType != EventTest {
+		t.Fatalf("delivery = %#v, want created endpoint test delivery", delivery)
+	}
+}
+
 func isValidationError(err error) bool {
 	var validationErr *domain.ValidationError
 	return errors.As(err, &validationErr)
@@ -116,7 +170,8 @@ func (fakeProtector) Decrypt(_ context.Context, ciphertext string) (string, erro
 }
 
 type fakeStore struct {
-	endpoints map[string]Endpoint
+	endpoints    map[string]Endpoint
+	testDelivery Delivery
 }
 
 func newFakeStore() *fakeStore {
@@ -173,7 +228,23 @@ func (s *fakeStore) SoftDeleteEndpoint(_ context.Context, scopeType, scopeID, en
 
 func (s *fakeStore) EnqueueEvent(context.Context, EventRecord) error { return nil }
 
-func (s *fakeStore) EnqueueTestEvent(context.Context, Endpoint, EventRecord) error { return nil }
+func (s *fakeStore) EnqueueTestEvent(_ context.Context, endpoint Endpoint, event EventRecord) (Delivery, error) {
+	delivery := Delivery{
+		ID:            "test-delivery",
+		EventID:       event.ID,
+		EndpointID:    endpoint.ID,
+		EventType:     event.EventType,
+		ScopeType:     event.ScopeType,
+		ScopeID:       event.ScopeID,
+		Status:        StatusPending,
+		AttemptCount:  0,
+		NextAttemptAt: event.CreatedAt,
+		CreatedAt:     event.CreatedAt,
+		UpdatedAt:     event.CreatedAt,
+	}
+	s.testDelivery = delivery
+	return delivery, nil
+}
 
 func (s *fakeStore) ListDeliveries(context.Context, string, string, int) ([]Delivery, error) {
 	return nil, nil

--- a/server/internal/webhook/signer.go
+++ b/server/internal/webhook/signer.go
@@ -1,0 +1,18 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+)
+
+func SignPayload(secret string, timestamp int64, eventID string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(strconv.FormatInt(timestamp, 10)))
+	mac.Write([]byte("."))
+	mac.Write([]byte(eventID))
+	mac.Write([]byte("."))
+	mac.Write(payload)
+	return "v1=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/server/internal/webhook/store.go
+++ b/server/internal/webhook/store.go
@@ -173,11 +173,19 @@ func (s *SQLStore) EnqueueEvent(ctx context.Context, event EventRecord) error {
 			matching = append(matching, endpoint)
 		}
 	}
-	return s.insertEventAndDeliveries(ctx, event, matching)
+	_, err = s.insertEventAndDeliveries(ctx, event, matching)
+	return err
 }
 
-func (s *SQLStore) EnqueueTestEvent(ctx context.Context, endpoint Endpoint, event EventRecord) error {
-	return s.insertEventAndDeliveries(ctx, event, []Endpoint{endpoint})
+func (s *SQLStore) EnqueueTestEvent(ctx context.Context, endpoint Endpoint, event EventRecord) (Delivery, error) {
+	deliveries, err := s.insertEventAndDeliveries(ctx, event, []Endpoint{endpoint})
+	if err != nil {
+		return Delivery{}, err
+	}
+	if len(deliveries) == 0 {
+		return Delivery{}, domain.ErrNotFound
+	}
+	return deliveries[0], nil
 }
 
 func (s *SQLStore) ListDeliveries(ctx context.Context, scopeType, scopeID string, limit int) ([]Delivery, error) {
@@ -335,10 +343,10 @@ func (s *SQLStore) MarkDeliveryFailedAttempt(ctx context.Context, deliveryID str
 	return nil
 }
 
-func (s *SQLStore) insertEventAndDeliveries(ctx context.Context, event EventRecord, endpoints []Endpoint) error {
+func (s *SQLStore) insertEventAndDeliveries(ctx context.Context, event EventRecord, endpoints []Endpoint) ([]Delivery, error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("begin webhook enqueue: %w", err)
+		return nil, fmt.Errorf("begin webhook enqueue: %w", err)
 	}
 	defer tx.Rollback()
 
@@ -353,29 +361,44 @@ func (s *SQLStore) insertEventAndDeliveries(ctx context.Context, event EventReco
 		string(event.Payload),
 		event.CreatedAt,
 	); err != nil {
-		return fmt.Errorf("insert webhook event: %w", err)
+		return nil, fmt.Errorf("insert webhook event: %w", err)
 	}
+	deliveries := make([]Delivery, 0, len(endpoints))
 	for _, endpoint := range endpoints {
 		now := time.Now().UTC()
+		delivery := Delivery{
+			ID:            uuid.NewString(),
+			EventID:       event.ID,
+			EndpointID:    endpoint.ID,
+			EventType:     event.EventType,
+			ScopeType:     event.ScopeType,
+			ScopeID:       event.ScopeID,
+			Status:        StatusPending,
+			AttemptCount:  0,
+			NextAttemptAt: now,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
 		if _, err := tx.ExecContext(ctx,
 			s.rebind(`INSERT INTO webhook_deliveries
 				(id, event_id, endpoint_id, status, attempt_count, next_attempt_at, created_at, updated_at)
 				VALUES (?, ?, ?, ?, 0, ?, ?, ?)`),
-			uuid.NewString(),
-			event.ID,
-			endpoint.ID,
-			StatusPending,
-			now,
-			now,
-			now,
+			delivery.ID,
+			delivery.EventID,
+			delivery.EndpointID,
+			delivery.Status,
+			delivery.NextAttemptAt,
+			delivery.CreatedAt,
+			delivery.UpdatedAt,
 		); err != nil {
-			return fmt.Errorf("insert webhook delivery: %w", err)
+			return nil, fmt.Errorf("insert webhook delivery: %w", err)
 		}
+		deliveries = append(deliveries, delivery)
 	}
 	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit webhook enqueue: %w", err)
+		return nil, fmt.Errorf("commit webhook enqueue: %w", err)
 	}
-	return nil
+	return deliveries, nil
 }
 
 func (s *SQLStore) schemaStatements() []string {

--- a/server/internal/webhook/store.go
+++ b/server/internal/webhook/store.go
@@ -1,0 +1,613 @@
+package webhook
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+type SQLStore struct {
+	db      *sql.DB
+	backend string
+}
+
+func NewSQLStore(db *sql.DB, backend string) *SQLStore {
+	return &SQLStore{db: db, backend: strings.TrimSpace(backend)}
+}
+
+func (s *SQLStore) EnsureSchema(ctx context.Context) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("webhook store unavailable")
+	}
+	for _, stmt := range s.schemaStatements() {
+		if _, err := s.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("ensure webhook schema: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *SQLStore) CreateEndpoint(ctx context.Context, endpoint Endpoint) error {
+	eventsJSON, err := json.Marshal(endpoint.Events)
+	if err != nil {
+		return fmt.Errorf("marshal webhook events: %w", err)
+	}
+	_, err = s.db.ExecContext(ctx,
+		s.rebind(`INSERT INTO webhook_endpoints
+			(id, scope_type, scope_id, name, url, enabled, events_json, secret_ciphertext, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		endpoint.ID,
+		endpoint.ScopeType,
+		endpoint.ScopeID,
+		endpoint.Name,
+		endpoint.URL,
+		boolValue(endpoint.Enabled),
+		string(eventsJSON),
+		endpoint.SecretCiphertext,
+		endpoint.CreatedAt,
+		endpoint.UpdatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("create webhook endpoint: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) ListEndpoints(ctx context.Context, scopeType, scopeID string) ([]Endpoint, error) {
+	rows, err := s.db.QueryContext(ctx,
+		s.rebind(`SELECT id, scope_type, scope_id, name, url, enabled, events_json, secret_ciphertext, created_at, updated_at, deleted_at
+			FROM webhook_endpoints
+			WHERE scope_type = ? AND scope_id = ? AND deleted_at IS NULL
+			ORDER BY created_at DESC, id DESC`),
+		scopeType,
+		scopeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list webhook endpoints: %w", err)
+	}
+	defer rows.Close()
+	return scanEndpoints(rows)
+}
+
+func (s *SQLStore) GetEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) (*Endpoint, error) {
+	row := s.db.QueryRowContext(ctx,
+		s.rebind(`SELECT id, scope_type, scope_id, name, url, enabled, events_json, secret_ciphertext, created_at, updated_at, deleted_at
+			FROM webhook_endpoints
+			WHERE id = ? AND scope_type = ? AND scope_id = ? AND deleted_at IS NULL`),
+		endpointID,
+		scopeType,
+		scopeID,
+	)
+	endpoint, err := scanEndpoint(row)
+	if err != nil {
+		return nil, err
+	}
+	return endpoint, nil
+}
+
+func (s *SQLStore) UpdateEndpoint(ctx context.Context, endpoint Endpoint) error {
+	eventsJSON, err := json.Marshal(endpoint.Events)
+	if err != nil {
+		return fmt.Errorf("marshal webhook events: %w", err)
+	}
+	res, err := s.db.ExecContext(ctx,
+		s.rebind(`UPDATE webhook_endpoints
+			SET name = ?, url = ?, enabled = ?, events_json = ?, updated_at = ?
+			WHERE id = ? AND scope_type = ? AND scope_id = ? AND deleted_at IS NULL`),
+		endpoint.Name,
+		endpoint.URL,
+		boolValue(endpoint.Enabled),
+		string(eventsJSON),
+		endpoint.UpdatedAt,
+		endpoint.ID,
+		endpoint.ScopeType,
+		endpoint.ScopeID,
+	)
+	if err != nil {
+		return fmt.Errorf("update webhook endpoint: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLStore) UpdateEndpointSecret(ctx context.Context, endpoint Endpoint) error {
+	res, err := s.db.ExecContext(ctx,
+		s.rebind(`UPDATE webhook_endpoints
+			SET secret_ciphertext = ?, updated_at = ?
+			WHERE id = ? AND scope_type = ? AND scope_id = ? AND deleted_at IS NULL`),
+		endpoint.SecretCiphertext,
+		endpoint.UpdatedAt,
+		endpoint.ID,
+		endpoint.ScopeType,
+		endpoint.ScopeID,
+	)
+	if err != nil {
+		return fmt.Errorf("rotate webhook endpoint secret: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLStore) SoftDeleteEndpoint(ctx context.Context, scopeType, scopeID, endpointID string) error {
+	res, err := s.db.ExecContext(ctx,
+		s.rebind(`UPDATE webhook_endpoints
+			SET deleted_at = ?, updated_at = ?
+			WHERE id = ? AND scope_type = ? AND scope_id = ? AND deleted_at IS NULL`),
+		time.Now().UTC(),
+		time.Now().UTC(),
+		endpointID,
+		scopeType,
+		scopeID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete webhook endpoint: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+func (s *SQLStore) EnqueueEvent(ctx context.Context, event EventRecord) error {
+	endpoints, err := s.ListEndpoints(ctx, event.ScopeType, event.ScopeID)
+	if err != nil {
+		return err
+	}
+	matching := make([]Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		if endpoint.Enabled && endpointAcceptsEvent(endpoint, event.EventType) {
+			matching = append(matching, endpoint)
+		}
+	}
+	return s.insertEventAndDeliveries(ctx, event, matching)
+}
+
+func (s *SQLStore) EnqueueTestEvent(ctx context.Context, endpoint Endpoint, event EventRecord) error {
+	return s.insertEventAndDeliveries(ctx, event, []Endpoint{endpoint})
+}
+
+func (s *SQLStore) ListDeliveries(ctx context.Context, scopeType, scopeID string, limit int) ([]Delivery, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	rows, err := s.db.QueryContext(ctx,
+		s.rebind(`SELECT d.id, d.event_id, d.endpoint_id, e.event_type, e.scope_type, e.scope_id,
+				d.status, d.attempt_count, d.next_attempt_at, d.last_http_status, d.last_error,
+				d.delivered_at, d.created_at, d.updated_at
+			FROM webhook_deliveries AS d
+			INNER JOIN webhook_events AS e ON e.id = d.event_id
+			WHERE e.scope_type = ? AND e.scope_id = ?
+			ORDER BY d.created_at DESC, d.id DESC
+			LIMIT ?`),
+		scopeType,
+		scopeID,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list webhook deliveries: %w", err)
+	}
+	defer rows.Close()
+	return scanDeliveries(rows)
+}
+
+func (s *SQLStore) FetchDueDeliveries(ctx context.Context, limit int) ([]DeliveryJob, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	rows, err := s.db.QueryContext(ctx,
+		s.rebind(`SELECT d.id, d.event_id, d.endpoint_id, e.event_type, e.scope_type, e.scope_id,
+				d.status, d.attempt_count, d.next_attempt_at, d.last_http_status, d.last_error,
+				d.delivered_at, d.created_at, d.updated_at, ep.url, ep.secret_ciphertext, e.payload_json
+			FROM webhook_deliveries AS d
+			INNER JOIN webhook_events AS e ON e.id = d.event_id
+			INNER JOIN webhook_endpoints AS ep ON ep.id = d.endpoint_id
+			WHERE d.status = ? AND d.next_attempt_at <= ? AND ep.enabled = ? AND ep.deleted_at IS NULL
+			ORDER BY d.next_attempt_at ASC, d.created_at ASC, d.id ASC
+			LIMIT ?`),
+		StatusPending,
+		time.Now().UTC(),
+		boolValue(true),
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("fetch due webhook deliveries: %w", err)
+	}
+	defer rows.Close()
+	return scanDeliveryJobs(rows)
+}
+
+func (s *SQLStore) MarkDeliveryDelivered(ctx context.Context, deliveryID string, httpStatus int) error {
+	now := time.Now().UTC()
+	_, err := s.db.ExecContext(ctx,
+		s.rebind(`UPDATE webhook_deliveries
+			SET status = ?, attempt_count = attempt_count + 1, last_http_status = ?, last_error = '',
+				delivered_at = ?, updated_at = ?
+			WHERE id = ?`),
+		StatusDelivered,
+		httpStatus,
+		now,
+		now,
+		deliveryID,
+	)
+	if err != nil {
+		return fmt.Errorf("mark webhook delivery delivered: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) MarkDeliveryFailedAttempt(ctx context.Context, deliveryID string, terminal bool, nextAttemptAt time.Time, httpStatus *int, message string) error {
+	status := StatusPending
+	if terminal {
+		status = StatusFailed
+	}
+	_, err := s.db.ExecContext(ctx,
+		s.rebind(`UPDATE webhook_deliveries
+			SET status = ?, attempt_count = attempt_count + 1, next_attempt_at = ?, last_http_status = ?,
+				last_error = ?, updated_at = ?
+			WHERE id = ?`),
+		status,
+		nextAttemptAt.UTC(),
+		nullableInt(httpStatus),
+		truncate(message, 2000),
+		time.Now().UTC(),
+		deliveryID,
+	)
+	if err != nil {
+		return fmt.Errorf("mark webhook delivery failed attempt: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) insertEventAndDeliveries(ctx context.Context, event EventRecord, endpoints []Endpoint) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin webhook enqueue: %w", err)
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx,
+		s.rebind(`INSERT INTO webhook_events
+			(id, scope_type, scope_id, event_type, payload_json, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`),
+		event.ID,
+		event.ScopeType,
+		event.ScopeID,
+		event.EventType,
+		string(event.Payload),
+		event.CreatedAt,
+	); err != nil {
+		return fmt.Errorf("insert webhook event: %w", err)
+	}
+	for _, endpoint := range endpoints {
+		now := time.Now().UTC()
+		if _, err := tx.ExecContext(ctx,
+			s.rebind(`INSERT INTO webhook_deliveries
+				(id, event_id, endpoint_id, status, attempt_count, next_attempt_at, created_at, updated_at)
+				VALUES (?, ?, ?, ?, 0, ?, ?, ?)`),
+			uuid.NewString(),
+			event.ID,
+			endpoint.ID,
+			StatusPending,
+			now,
+			now,
+			now,
+		); err != nil {
+			return fmt.Errorf("insert webhook delivery: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit webhook enqueue: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLStore) schemaStatements() []string {
+	if s.backend == "postgres" || s.backend == "db9" {
+		return []string{
+			`CREATE TABLE IF NOT EXISTS webhook_endpoints (
+				id VARCHAR(36) PRIMARY KEY,
+				scope_type VARCHAR(20) NOT NULL,
+				scope_id VARCHAR(255) NOT NULL,
+				name VARCHAR(255) NOT NULL,
+				url TEXT NOT NULL,
+				enabled BOOLEAN NOT NULL DEFAULT TRUE,
+				events_json JSONB NOT NULL,
+				secret_ciphertext TEXT NOT NULL,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				deleted_at TIMESTAMPTZ NULL
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_scope ON webhook_endpoints(scope_type, scope_id, deleted_at)`,
+			`CREATE TABLE IF NOT EXISTS webhook_events (
+				id VARCHAR(36) PRIMARY KEY,
+				scope_type VARCHAR(20) NOT NULL,
+				scope_id VARCHAR(255) NOT NULL,
+				event_type VARCHAR(100) NOT NULL,
+				payload_json JSONB NOT NULL,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_webhook_events_scope ON webhook_events(scope_type, scope_id, created_at)`,
+			`CREATE TABLE IF NOT EXISTS webhook_deliveries (
+				id VARCHAR(36) PRIMARY KEY,
+				event_id VARCHAR(36) NOT NULL REFERENCES webhook_events(id),
+				endpoint_id VARCHAR(36) NOT NULL REFERENCES webhook_endpoints(id),
+				status VARCHAR(20) NOT NULL DEFAULT 'pending',
+				attempt_count INT NOT NULL DEFAULT 0,
+				next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				last_http_status INT NULL,
+				last_error TEXT NULL,
+				delivered_at TIMESTAMPTZ NULL,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_poll ON webhook_deliveries(status, next_attempt_at)`,
+			`CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_event ON webhook_deliveries(event_id)`,
+		}
+	}
+	return []string{
+		`CREATE TABLE IF NOT EXISTS webhook_endpoints (
+			id VARCHAR(36) PRIMARY KEY,
+			scope_type VARCHAR(20) NOT NULL,
+			scope_id VARCHAR(255) NOT NULL,
+			name VARCHAR(255) NOT NULL,
+			url TEXT NOT NULL,
+			enabled TINYINT(1) NOT NULL DEFAULT 1,
+			events_json JSON NOT NULL,
+			secret_ciphertext TEXT NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			deleted_at TIMESTAMP NULL,
+			INDEX idx_webhook_endpoints_scope (scope_type, scope_id, deleted_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS webhook_events (
+			id VARCHAR(36) PRIMARY KEY,
+			scope_type VARCHAR(20) NOT NULL,
+			scope_id VARCHAR(255) NOT NULL,
+			event_type VARCHAR(100) NOT NULL,
+			payload_json JSON NOT NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			INDEX idx_webhook_events_scope (scope_type, scope_id, created_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS webhook_deliveries (
+			id VARCHAR(36) PRIMARY KEY,
+			event_id VARCHAR(36) NOT NULL,
+			endpoint_id VARCHAR(36) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'pending',
+			attempt_count INT NOT NULL DEFAULT 0,
+			next_attempt_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			last_http_status INT NULL,
+			last_error TEXT NULL,
+			delivered_at TIMESTAMP NULL,
+			created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+			INDEX idx_webhook_deliveries_poll (status, next_attempt_at),
+			INDEX idx_webhook_deliveries_event (event_id),
+			CONSTRAINT fk_webhook_deliveries_event FOREIGN KEY (event_id) REFERENCES webhook_events(id),
+			CONSTRAINT fk_webhook_deliveries_endpoint FOREIGN KEY (endpoint_id) REFERENCES webhook_endpoints(id)
+		)`,
+	}
+}
+
+func (s *SQLStore) rebind(query string) string {
+	if s.backend != "postgres" && s.backend != "db9" {
+		return query
+	}
+	var b strings.Builder
+	arg := 1
+	for _, r := range query {
+		if r == '?' {
+			b.WriteString(fmt.Sprintf("$%d", arg))
+			arg++
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanEndpoint(row scanner) (*Endpoint, error) {
+	var endpoint Endpoint
+	var eventsRaw []byte
+	var deletedAt sql.NullTime
+	var enabled any
+	if err := row.Scan(
+		&endpoint.ID,
+		&endpoint.ScopeType,
+		&endpoint.ScopeID,
+		&endpoint.Name,
+		&endpoint.URL,
+		&enabled,
+		&eventsRaw,
+		&endpoint.SecretCiphertext,
+		&endpoint.CreatedAt,
+		&endpoint.UpdatedAt,
+		&deletedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+	endpoint.Enabled = scanBool(enabled)
+	if deletedAt.Valid {
+		endpoint.DeletedAt = &deletedAt.Time
+	}
+	if len(eventsRaw) > 0 {
+		_ = json.Unmarshal(eventsRaw, &endpoint.Events)
+	}
+	if endpoint.Events == nil {
+		endpoint.Events = []string{}
+	}
+	return &endpoint, nil
+}
+
+func scanEndpoints(rows *sql.Rows) ([]Endpoint, error) {
+	out := []Endpoint{}
+	for rows.Next() {
+		endpoint, err := scanEndpoint(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *endpoint)
+	}
+	return out, rows.Err()
+}
+
+func scanDeliveries(rows *sql.Rows) ([]Delivery, error) {
+	out := []Delivery{}
+	for rows.Next() {
+		d, err := scanDelivery(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+func scanDelivery(row scanner) (Delivery, error) {
+	var delivery Delivery
+	var lastHTTPStatus sql.NullInt64
+	var lastError sql.NullString
+	var deliveredAt sql.NullTime
+	if err := row.Scan(
+		&delivery.ID,
+		&delivery.EventID,
+		&delivery.EndpointID,
+		&delivery.EventType,
+		&delivery.ScopeType,
+		&delivery.ScopeID,
+		&delivery.Status,
+		&delivery.AttemptCount,
+		&delivery.NextAttemptAt,
+		&lastHTTPStatus,
+		&lastError,
+		&deliveredAt,
+		&delivery.CreatedAt,
+		&delivery.UpdatedAt,
+	); err != nil {
+		return Delivery{}, err
+	}
+	if lastHTTPStatus.Valid {
+		value := int(lastHTTPStatus.Int64)
+		delivery.LastHTTPStatus = &value
+	}
+	if lastError.Valid {
+		delivery.LastError = lastError.String
+	}
+	if deliveredAt.Valid {
+		delivery.DeliveredAt = &deliveredAt.Time
+	}
+	return delivery, nil
+}
+
+func scanDeliveryJobs(rows *sql.Rows) ([]DeliveryJob, error) {
+	out := []DeliveryJob{}
+	for rows.Next() {
+		job, err := scanDeliveryJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, job)
+	}
+	return out, rows.Err()
+}
+
+func scanDeliveryJob(row scanner) (DeliveryJob, error) {
+	var job DeliveryJob
+	var lastHTTPStatus sql.NullInt64
+	var lastError sql.NullString
+	var deliveredAt sql.NullTime
+	if err := row.Scan(
+		&job.ID,
+		&job.EventID,
+		&job.EndpointID,
+		&job.EventType,
+		&job.ScopeType,
+		&job.ScopeID,
+		&job.Status,
+		&job.AttemptCount,
+		&job.NextAttemptAt,
+		&lastHTTPStatus,
+		&lastError,
+		&deliveredAt,
+		&job.CreatedAt,
+		&job.UpdatedAt,
+		&job.URL,
+		&job.SecretCiphertext,
+		&job.Payload,
+	); err != nil {
+		return DeliveryJob{}, err
+	}
+	if lastHTTPStatus.Valid {
+		value := int(lastHTTPStatus.Int64)
+		job.LastHTTPStatus = &value
+	}
+	if lastError.Valid {
+		job.LastError = lastError.String
+	}
+	if deliveredAt.Valid {
+		job.DeliveredAt = &deliveredAt.Time
+	}
+	return job, nil
+}
+
+func endpointAcceptsEvent(endpoint Endpoint, eventType string) bool {
+	for _, candidate := range endpoint.Events {
+		if candidate == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func boolValue(value bool) any {
+	return value
+}
+
+func scanBool(value any) bool {
+	switch v := value.(type) {
+	case bool:
+		return v
+	case int64:
+		return v != 0
+	case int:
+		return v != 0
+	case []byte:
+		return string(v) == "1" || strings.EqualFold(string(v), "true")
+	case string:
+		return v == "1" || strings.EqualFold(v, "true")
+	default:
+		return false
+	}
+}
+
+func nullableInt(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func truncate(value string, maxLen int) string {
+	if len(value) <= maxLen {
+		return value
+	}
+	return value[:maxLen]
+}

--- a/server/internal/webhook/store.go
+++ b/server/internal/webhook/store.go
@@ -173,6 +173,9 @@ func (s *SQLStore) EnqueueEvent(ctx context.Context, event EventRecord) error {
 			matching = append(matching, endpoint)
 		}
 	}
+	if len(matching) == 0 {
+		return nil
+	}
 	_, err = s.insertEventAndDeliveries(ctx, event, matching)
 	return err
 }

--- a/server/internal/webhook/store.go
+++ b/server/internal/webhook/store.go
@@ -19,6 +19,8 @@ type SQLStore struct {
 	backend string
 }
 
+const deliveryClaimDuration = 5 * time.Minute
+
 func NewSQLStore(db *sql.DB, backend string) *SQLStore {
 	return &SQLStore{db: db, backend: strings.TrimSpace(backend)}
 }
@@ -206,26 +208,89 @@ func (s *SQLStore) FetchDueDeliveries(ctx context.Context, limit int) ([]Deliver
 	if limit <= 0 || limit > 100 {
 		limit = 25
 	}
-	rows, err := s.db.QueryContext(ctx,
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin webhook delivery claim: %w", err)
+	}
+	defer tx.Rollback()
+
+	now := time.Now().UTC()
+	rows, err := tx.QueryContext(ctx,
+		s.rebind(`SELECT d.id
+			FROM webhook_deliveries AS d
+			INNER JOIN webhook_events AS e ON e.id = d.event_id
+			INNER JOIN webhook_endpoints AS ep ON ep.id = d.endpoint_id
+			WHERE d.status = ? AND d.next_attempt_at <= ? AND ep.enabled = ? AND ep.deleted_at IS NULL
+			ORDER BY d.next_attempt_at ASC, d.created_at ASC, d.id ASC
+			LIMIT ?
+			FOR UPDATE`),
+		StatusPending,
+		now,
+		boolValue(true),
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("select due webhook deliveries: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan due webhook delivery id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return nil, fmt.Errorf("iterate due webhook deliveries: %w", err)
+	}
+	rows.Close()
+
+	if len(ids) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit empty webhook delivery claim: %w", err)
+		}
+		return nil, nil
+	}
+
+	claimUntil := now.Add(deliveryClaimDuration)
+	inClause, idArgs := placeholders(ids)
+	updateArgs := append([]any{claimUntil, now}, idArgs...)
+	updateArgs = append(updateArgs, StatusPending)
+	if _, err := tx.ExecContext(ctx,
+		s.rebind(`UPDATE webhook_deliveries
+			SET next_attempt_at = ?, updated_at = ?
+			WHERE id IN (`+inClause+`) AND status = ?`),
+		updateArgs...,
+	); err != nil {
+		return nil, fmt.Errorf("claim webhook deliveries: %w", err)
+	}
+
+	selectArgs := idArgs
+	rows, err = tx.QueryContext(ctx,
 		s.rebind(`SELECT d.id, d.event_id, d.endpoint_id, e.event_type, e.scope_type, e.scope_id,
 				d.status, d.attempt_count, d.next_attempt_at, d.last_http_status, d.last_error,
 				d.delivered_at, d.created_at, d.updated_at, ep.url, ep.secret_ciphertext, e.payload_json
 			FROM webhook_deliveries AS d
 			INNER JOIN webhook_events AS e ON e.id = d.event_id
 			INNER JOIN webhook_endpoints AS ep ON ep.id = d.endpoint_id
-			WHERE d.status = ? AND d.next_attempt_at <= ? AND ep.enabled = ? AND ep.deleted_at IS NULL
-			ORDER BY d.next_attempt_at ASC, d.created_at ASC, d.id ASC
-			LIMIT ?`),
-		StatusPending,
-		time.Now().UTC(),
-		boolValue(true),
-		limit,
+			WHERE d.id IN (`+inClause+`)
+			ORDER BY d.next_attempt_at ASC, d.created_at ASC, d.id ASC`),
+		selectArgs...,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("fetch due webhook deliveries: %w", err)
+		return nil, fmt.Errorf("fetch claimed webhook deliveries: %w", err)
 	}
-	defer rows.Close()
-	return scanDeliveryJobs(rows)
+	jobs, err := scanDeliveryJobs(rows)
+	rows.Close()
+	if err != nil {
+		return nil, fmt.Errorf("scan claimed webhook deliveries: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit webhook delivery claim: %w", err)
+	}
+	return jobs, nil
 }
 
 func (s *SQLStore) MarkDeliveryDelivered(ctx context.Context, deliveryID string, httpStatus int) error {
@@ -610,4 +675,14 @@ func truncate(value string, maxLen int) string {
 		return value
 	}
 	return value[:maxLen]
+}
+
+func placeholders(values []string) (string, []any) {
+	parts := make([]string, len(values))
+	args := make([]any, len(values))
+	for i, value := range values {
+		parts[i] = "?"
+		args[i] = value
+	}
+	return strings.Join(parts, ","), args
 }

--- a/server/internal/webhook/types.go
+++ b/server/internal/webhook/types.go
@@ -1,0 +1,139 @@
+package webhook
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	EventMemoryAdded          = "memory.added"
+	EventMemoryDeleted        = "memory.deleted"
+	EventSpaceChainFactRouted = "space_chain.fact_routed"
+	EventTest                 = "webhook.test"
+
+	ScopeTenant = "tenant"
+	ScopeChain  = "chain"
+
+	StatusPending   = "pending"
+	StatusDelivered = "delivered"
+	StatusFailed    = "failed"
+)
+
+var SupportedEvents = []string{
+	EventMemoryAdded,
+	EventMemoryDeleted,
+	EventSpaceChainFactRouted,
+}
+
+type Endpoint struct {
+	ID               string     `json:"id"`
+	ScopeType        string     `json:"scope_type"`
+	ScopeID          string     `json:"scope_id"`
+	Name             string     `json:"name"`
+	URL              string     `json:"url"`
+	Enabled          bool       `json:"enabled"`
+	Events           []string   `json:"events"`
+	SecretCiphertext string     `json:"-"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	DeletedAt        *time.Time `json:"deleted_at,omitempty"`
+}
+
+type EndpointResponse struct {
+	ID        string    `json:"id"`
+	ScopeType string    `json:"scope_type"`
+	ScopeID   string    `json:"scope_id"`
+	Name      string    `json:"name"`
+	URL       string    `json:"url"`
+	Enabled   bool      `json:"enabled"`
+	Events    []string  `json:"events"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type EndpointSecretResponse struct {
+	EndpointResponse
+	SigningSecret string `json:"signing_secret,omitempty"`
+}
+
+type EventEnvelope struct {
+	ID         string          `json:"id"`
+	Type       string          `json:"type"`
+	APIVersion string          `json:"api_version"`
+	CreatedAt  time.Time       `json:"created_at"`
+	Scope      EventScope      `json:"scope"`
+	Data       json.RawMessage `json:"data"`
+}
+
+type EventScope struct {
+	Type            string `json:"type"`
+	TenantID        string `json:"tenant_id,omitempty"`
+	ChainID         string `json:"chain_id,omitempty"`
+	ExternalSpaceID string `json:"external_space_id,omitempty"`
+}
+
+type EventRecord struct {
+	ID        string
+	ScopeType string
+	ScopeID   string
+	EventType string
+	Payload   json.RawMessage
+	CreatedAt time.Time
+}
+
+type Delivery struct {
+	ID             string     `json:"id"`
+	EventID        string     `json:"event_id"`
+	EndpointID     string     `json:"endpoint_id"`
+	EventType      string     `json:"event_type"`
+	ScopeType      string     `json:"scope_type"`
+	ScopeID        string     `json:"scope_id"`
+	Status         string     `json:"status"`
+	AttemptCount   int        `json:"attempt_count"`
+	NextAttemptAt  time.Time  `json:"next_attempt_at"`
+	LastHTTPStatus *int       `json:"last_http_status,omitempty"`
+	LastError      string     `json:"last_error,omitempty"`
+	DeliveredAt    *time.Time `json:"delivered_at,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+type DeliveryJob struct {
+	Delivery
+	URL              string
+	SecretCiphertext string
+	Payload          json.RawMessage
+}
+
+type CreateEndpointInput struct {
+	ScopeType string
+	ScopeID   string
+	Name      string
+	URL       string
+	Enabled   bool
+	Events    []string
+}
+
+type UpdateEndpointInput struct {
+	ScopeType  string
+	ScopeID    string
+	EndpointID string
+	Name       *string
+	URL        *string
+	Enabled    *bool
+	Events     *[]string
+}
+
+func ToEndpointResponse(endpoint Endpoint) EndpointResponse {
+	return EndpointResponse{
+		ID:        endpoint.ID,
+		ScopeType: endpoint.ScopeType,
+		ScopeID:   endpoint.ScopeID,
+		Name:      endpoint.Name,
+		URL:       endpoint.URL,
+		Enabled:   endpoint.Enabled,
+		Events:    append([]string(nil), endpoint.Events...),
+		CreatedAt: endpoint.CreatedAt,
+		UpdatedAt: endpoint.UpdatedAt,
+	}
+}

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -211,3 +211,46 @@ CREATE TABLE IF NOT EXISTS runtime_usage_outbox (
   updated_at        TIMESTAMP   DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   INDEX idx_runtime_usage_outbox_poll (status, next_attempt_at)
 );
+
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+  id                VARCHAR(36)  PRIMARY KEY,
+  scope_type        VARCHAR(20)  NOT NULL,
+  scope_id          VARCHAR(255) NOT NULL,
+  name              VARCHAR(255) NOT NULL,
+  url               TEXT         NOT NULL,
+  enabled           TINYINT(1)   NOT NULL DEFAULT 1,
+  events_json       JSON         NOT NULL,
+  secret_ciphertext TEXT         NOT NULL,
+  created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at        TIMESTAMP    NULL,
+  INDEX idx_webhook_endpoints_scope (scope_type, scope_id, deleted_at)
+);
+
+CREATE TABLE IF NOT EXISTS webhook_events (
+  id           VARCHAR(36)  PRIMARY KEY,
+  scope_type   VARCHAR(20)  NOT NULL,
+  scope_id     VARCHAR(255) NOT NULL,
+  event_type   VARCHAR(100) NOT NULL,
+  payload_json JSON         NOT NULL,
+  created_at   TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_webhook_events_scope (scope_type, scope_id, created_at)
+);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+  id               VARCHAR(36) PRIMARY KEY,
+  event_id         VARCHAR(36) NOT NULL,
+  endpoint_id      VARCHAR(36) NOT NULL,
+  status           VARCHAR(20) NOT NULL DEFAULT 'pending',
+  attempt_count    INT         NOT NULL DEFAULT 0,
+  next_attempt_at  TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_http_status INT         NULL,
+  last_error       TEXT        NULL,
+  delivered_at     TIMESTAMP   NULL,
+  created_at       TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at       TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_webhook_deliveries_poll (status, next_attempt_at),
+  INDEX idx_webhook_deliveries_event (event_id),
+  CONSTRAINT fk_webhook_deliveries_event FOREIGN KEY (event_id) REFERENCES webhook_events(id),
+  CONSTRAINT fk_webhook_deliveries_endpoint FOREIGN KEY (endpoint_id) REFERENCES webhook_endpoints(id)
+);

--- a/server/schema_db9.sql
+++ b/server/schema_db9.sql
@@ -156,6 +156,47 @@ CREATE TABLE IF NOT EXISTS upload_tasks (
 CREATE INDEX IF NOT EXISTS idx_upload_tenant ON upload_tasks(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_upload_poll ON upload_tasks(status, created_at);
 
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+    id                VARCHAR(36)  PRIMARY KEY,
+    scope_type        VARCHAR(20)  NOT NULL,
+    scope_id          VARCHAR(255) NOT NULL,
+    name              VARCHAR(255) NOT NULL,
+    url               TEXT         NOT NULL,
+    enabled           BOOLEAN      NOT NULL DEFAULT TRUE,
+    events_json       JSONB        NOT NULL,
+    secret_ciphertext TEXT         NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    deleted_at        TIMESTAMPTZ  NULL
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_scope ON webhook_endpoints(scope_type, scope_id, deleted_at);
+
+CREATE TABLE IF NOT EXISTS webhook_events (
+    id           VARCHAR(36)  PRIMARY KEY,
+    scope_type   VARCHAR(20)  NOT NULL,
+    scope_id     VARCHAR(255) NOT NULL,
+    event_type   VARCHAR(100) NOT NULL,
+    payload_json JSONB        NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_events_scope ON webhook_events(scope_type, scope_id, created_at);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id               VARCHAR(36) PRIMARY KEY,
+    event_id         VARCHAR(36) NOT NULL REFERENCES webhook_events(id),
+    endpoint_id      VARCHAR(36) NOT NULL REFERENCES webhook_endpoints(id),
+    status           VARCHAR(20) NOT NULL DEFAULT 'pending',
+    attempt_count    INT         NOT NULL DEFAULT 0,
+    next_attempt_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_http_status INT         NULL,
+    last_error       TEXT        NULL,
+    delivered_at     TIMESTAMPTZ NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_poll ON webhook_deliveries(status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_event ON webhook_deliveries(event_id);
+
 CREATE OR REPLACE FUNCTION update_updated_at()
 RETURNS TRIGGER AS $$ BEGIN NEW.updated_at = NOW(); RETURN NEW; END; $$ LANGUAGE plpgsql;
 
@@ -167,6 +208,12 @@ CREATE TRIGGER trg_memories_updated BEFORE UPDATE ON memories FOR EACH ROW EXECU
 
 DROP TRIGGER IF EXISTS trg_upload_tasks_updated ON upload_tasks;
 CREATE TRIGGER trg_upload_tasks_updated BEFORE UPDATE ON upload_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_webhook_endpoints_updated ON webhook_endpoints;
+CREATE TRIGGER trg_webhook_endpoints_updated BEFORE UPDATE ON webhook_endpoints FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_webhook_deliveries_updated ON webhook_deliveries;
+CREATE TRIGGER trg_webhook_deliveries_updated BEFORE UPDATE ON webhook_deliveries FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 DROP TRIGGER IF EXISTS trg_space_chains_updated ON space_chains;
 CREATE TRIGGER trg_space_chains_updated BEFORE UPDATE ON space_chains FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/server/schema_pg.sql
+++ b/server/schema_pg.sql
@@ -125,6 +125,47 @@ CREATE TABLE IF NOT EXISTS upload_tasks (
 CREATE INDEX IF NOT EXISTS idx_upload_tenant ON upload_tasks(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_upload_poll ON upload_tasks(status, created_at);
 
+CREATE TABLE IF NOT EXISTS webhook_endpoints (
+    id                VARCHAR(36)  PRIMARY KEY,
+    scope_type        VARCHAR(20)  NOT NULL,
+    scope_id          VARCHAR(255) NOT NULL,
+    name              VARCHAR(255) NOT NULL,
+    url               TEXT         NOT NULL,
+    enabled           BOOLEAN      NOT NULL DEFAULT TRUE,
+    events_json       JSONB        NOT NULL,
+    secret_ciphertext TEXT         NOT NULL,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    deleted_at        TIMESTAMPTZ  NULL
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_endpoints_scope ON webhook_endpoints(scope_type, scope_id, deleted_at);
+
+CREATE TABLE IF NOT EXISTS webhook_events (
+    id           VARCHAR(36)  PRIMARY KEY,
+    scope_type   VARCHAR(20)  NOT NULL,
+    scope_id     VARCHAR(255) NOT NULL,
+    event_type   VARCHAR(100) NOT NULL,
+    payload_json JSONB        NOT NULL,
+    created_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_events_scope ON webhook_events(scope_type, scope_id, created_at);
+
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id               VARCHAR(36) PRIMARY KEY,
+    event_id         VARCHAR(36) NOT NULL REFERENCES webhook_events(id),
+    endpoint_id      VARCHAR(36) NOT NULL REFERENCES webhook_endpoints(id),
+    status           VARCHAR(20) NOT NULL DEFAULT 'pending',
+    attempt_count    INT         NOT NULL DEFAULT 0,
+    next_attempt_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_http_status INT         NULL,
+    last_error       TEXT        NULL,
+    delivered_at     TIMESTAMPTZ NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_poll ON webhook_deliveries(status, next_attempt_at);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_event ON webhook_deliveries(event_id);
+
 CREATE OR REPLACE FUNCTION update_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -141,6 +182,12 @@ CREATE TRIGGER trg_memories_updated BEFORE UPDATE ON memories FOR EACH ROW EXECU
 
 DROP TRIGGER IF EXISTS trg_upload_tasks_updated ON upload_tasks;
 CREATE TRIGGER trg_upload_tasks_updated BEFORE UPDATE ON upload_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_webhook_endpoints_updated ON webhook_endpoints;
+CREATE TRIGGER trg_webhook_endpoints_updated BEFORE UPDATE ON webhook_endpoints FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+DROP TRIGGER IF EXISTS trg_webhook_deliveries_updated ON webhook_deliveries;
+CREATE TRIGGER trg_webhook_deliveries_updated BEFORE UPDATE ON webhook_deliveries FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 DROP TRIGGER IF EXISTS trg_space_chains_updated ON space_chains;
 CREATE TRIGGER trg_space_chains_updated BEFORE UPDATE ON space_chains FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/site/src/content/console-docs.ts
+++ b/site/src/content/console-docs.ts
@@ -30,7 +30,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
     ],
     sections: [
       {
@@ -189,8 +189,41 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       {
-        id: 'usage-billing-settings',
+        id: 'webhooks',
         label: '08',
+        title: 'Webhooks',
+        intro: 'The Webhooks page manages event subscriptions for Spaces and Space Chains in the current project.',
+        subsections: [
+          {
+            title: 'Project view',
+            bullets: [
+              'Open Webhooks from the Activity sidebar.',
+              'Use All, Space, or Space Chain filters to narrow the project-level list.',
+              'The table shows the endpoint name, scope, URL host, enabled state, subscribed events, last delivery status, and update time.',
+              'If one Space is not usable, the project list continues to show reachable scopes instead of blocking the whole page.',
+            ],
+          },
+          {
+            title: 'Create and edit',
+            bullets: [
+              'Create Webhook opens a modal where you choose Space or Space Chain, pick the resource, enter the URL, select events, and enable or disable the endpoint.',
+              'Production endpoints should use HTTPS. Local HTTP URLs are only for local development receivers.',
+              'The signing secret is shown only after create or rotate-secret. Copy it before closing the modal.',
+            ],
+          },
+          {
+            title: 'Actions and deliveries',
+            bullets: [
+              'Use the row menu to edit, test, view deliveries, rotate the signing secret, enable or disable, or delete an endpoint.',
+              'Test queues a `webhook.test` delivery so you can verify the receiver before relying on live events.',
+              'The deliveries drawer shows event type, event id, delivery status, attempt count, HTTP status, last error, retry time, and delivered time.',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'usage-billing-settings',
+        label: '09',
         title: 'Usage, Billing, and Settings',
         intro: 'These pages operate at the organization level.',
         subsections: [
@@ -220,7 +253,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'safe-operations',
-        label: '09',
+        label: '10',
         title: 'Safe Operations',
         intro: 'Console exposes powerful controls, so treat changes deliberately.',
         bullets: [
@@ -262,7 +295,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: '开始', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: '记忆工作流', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: '高级工作流', sectionIDs: ['space-chains', 'usage-billing-settings', 'safe-operations'] },
+      { title: '高级工作流', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
     ],
     sections: [
       {
@@ -421,8 +454,41 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       {
-        id: 'usage-billing-settings',
+        id: 'webhooks',
         label: '08',
+        title: 'Webhooks',
+        intro: 'Webhooks 页面用于管理当前 project 下 Space 和 Space Chain 的事件订阅。',
+        subsections: [
+          {
+            title: 'Project 视图',
+            bullets: [
+              '从 Activity 侧边栏进入 Webhooks。',
+              '用 All、Space、Space Chain filter 缩小项目级列表。',
+              '表格会显示 endpoint 名称、scope、URL host、启用状态、订阅事件、最近投递状态和更新时间。',
+              '如果某个 Space 暂时不可用，项目列表会继续显示其它可访问 scope，而不是卡住整页。',
+            ],
+          },
+          {
+            title: '创建和编辑',
+            bullets: [
+              'Create Webhook 会打开表单，选择 Space 或 Space Chain、选择资源、填写 URL、选择事件，并设置是否启用。',
+              '生产环境 endpoint 应使用 HTTPS。本地 HTTP URL 只用于本地开发 receiver。',
+              'Signing secret 只会在 create 或 rotate-secret 后显示一次，关闭弹窗前需要复制保存。',
+            ],
+          },
+          {
+            title: '操作和投递记录',
+            bullets: [
+              '行菜单支持 edit、test、view deliveries、rotate secret、enable / disable 和 delete。',
+              'Test 会排队一个 `webhook.test` delivery，方便你在依赖真实事件之前验证 receiver。',
+              'Deliveries drawer 会显示 event type、event id、状态、尝试次数、HTTP 状态、最近错误、下次重试时间和成功投递时间。',
+            ],
+          },
+        ],
+      },
+      {
+        id: 'usage-billing-settings',
+        label: '09',
         title: 'Usage、Billing 和 Settings',
         intro: '这些页面作用在 organization 层级。',
         subsections: [
@@ -452,7 +518,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'safe-operations',
-        label: '09',
+        label: '10',
         title: '安全操作建议',
         intro: 'Console 暴露了关键控制能力，操作时要有明确意图。',
         bullets: [
@@ -494,7 +560,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
     ],
     sections: [
       {
@@ -577,8 +643,18 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       {
-        id: 'usage-billing-settings',
+        id: 'webhooks',
         label: '08',
+        title: 'Webhooks',
+        subsections: [
+          { title: 'Project view', bullets: ['Activity sidebar から Webhooks を開きます。', 'All、Space、Space Chain filter で project-level list を絞り込みます。', 'table で endpoint、scope、URL host、enabled、events、last delivery を確認します。'] },
+          { title: 'Create and edit', bullets: ['Space または Space Chain、resource、URL、events、enabled state を設定します。', 'production endpoint は HTTPS を使います。local HTTP は development 用です。', 'signing secret は create / rotate-secret の後に一度だけ表示されます。'] },
+          { title: 'Actions and deliveries', bullets: ['row menu で edit、test、deliveries、rotate secret、enable / disable、delete を実行します。', 'deliveries drawer で status、attempts、HTTP status、last error、retry time を確認します。'] },
+        ],
+      },
+      {
+        id: 'usage-billing-settings',
+        label: '09',
         title: 'Usage, Billing, Settings',
         subsections: [
           { title: 'Usage', bullets: ['recall / write request usage を確認します。', 'date range、daily trend、usage events を見ます。'] },
@@ -588,7 +664,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'safe-operations',
-        label: '09',
+        label: '10',
         title: 'Safe Operations',
         bullets: [
           'API key は信頼できる client に設定する時だけ reveal します。',
@@ -628,7 +704,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
     ],
     sections: [
       { id: 'quick-start', label: '01', title: 'Quick Start', bullets: ['Log in 메뉴에서 mem9 Console 에 로그인합니다.', '변경 전에 organization 과 project 를 확인합니다.', '공식 OpenClaw onboarding prompt 는 Install mem9 에서 복사합니다.', '기존 mem9 API key 는 Claim API key 로 Space 에 연결합니다.', 'Space 또는 Memories 에서 agent 가 저장한 memory 를 확인합니다.'] },
@@ -638,8 +714,9 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-detail', label: '05', title: 'Space Detail', subsections: [{ title: 'Tenant key', bullets: ['memory data 를 보기 전에 key 를 설정합니다.', '필요할 때만 key 를 reveal / copy 합니다.', 'Console 은 기본적으로 masked key 를 보여줍니다.'] }, { title: 'Metrics and imports', bullets: ['total, pinned, insight memories 를 확인합니다.', 'latest import 상태를 확인합니다.', 'Space switcher 로 다른 Space 를 봅니다.'] }, { title: 'Memory workbench', bullets: ['memory 를 생성, 편집, 삭제합니다.', 'Smart ingest 는 pasted message 에서 durable facts 를 추출합니다.', 'appId 로 같은 key 안의 용도를 분리합니다.'] }] },
       { id: 'memories', label: '06', title: 'Memories', bullets: ['Space 를 선택해 memory 를 봅니다.', 'text, type, state, agent, tags, appId 로 필터합니다.', 'detail 에서 content, metadata, tags, score, confidence, session, agent, version, timestamps 를 확인합니다.', 'Space 에 key 가 없으면 key settings 를 먼저 설정합니다.'] },
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['새 chain 을 만들거나 기존 chain key 를 import 합니다.', 'detail 에서 key, nodes, memory tools 를 관리합니다.'] }, { title: 'Nodes and routing', bullets: ['active key 가 있는 Space 를 추가합니다.', 'node order 가 recall order 입니다.', 'routing policy prompt 로 검색 조건을 제한할 수 있습니다.'] }, { title: 'Chain keys', bullets: ['chain key 를 만들거나 bind 합니다.', '필요 없는 key 는 disable 합니다.', 'recall tools 로 single Space 와 비교합니다.'] }] },
-      { id: 'usage-billing-settings', label: '08', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['recall / write request usage 를 확인합니다.', 'date range, daily trend, usage events 를 봅니다.'] }, { title: 'Billing', bullets: ['current plan, period, included access, on-demand settings 를 확인합니다.'] }, { title: 'Settings', bullets: ['account 와 organization 관리, theme, language, logout 에 사용합니다.'] }] },
-      { id: 'safe-operations', label: '09', title: 'Safe Operations', bullets: ['API key 는 trusted client 설정 시에만 reveal 합니다.', 'delete 전에 preview 와 confirmation 을 확인합니다.', '섞이면 안 되는 data 는 별도 Space 로 나눕니다.', '결과가 이상하면 org, project, Space, key, appId filter 를 확인합니다.'] },
+      { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['Activity sidebar 에서 Webhooks 를 엽니다.', 'All, Space, Space Chain filter 로 project list 를 좁힙니다.', 'table 에서 endpoint, scope, URL host, enabled, events, last delivery 를 확인합니다.'] }, { title: 'Create and edit', bullets: ['Space 또는 Space Chain, resource, URL, events, enabled state 를 설정합니다.', 'production endpoint 는 HTTPS 를 사용합니다.', 'signing secret 은 create / rotate-secret 뒤 한 번만 표시됩니다.'] }, { title: 'Actions and deliveries', bullets: ['row menu 에서 edit, test, deliveries, rotate secret, enable / disable, delete 를 실행합니다.', 'deliveries drawer 에서 status, attempts, HTTP status, last error, retry time 을 확인합니다.'] }] },
+      { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['recall / write request usage 를 확인합니다.', 'date range, daily trend, usage events 를 봅니다.'] }, { title: 'Billing', bullets: ['current plan, period, included access, on-demand settings 를 확인합니다.'] }, { title: 'Settings', bullets: ['account 와 organization 관리, theme, language, logout 에 사용합니다.'] }] },
+      { id: 'safe-operations', label: '10', title: 'Safe Operations', bullets: ['API key 는 trusted client 설정 시에만 reveal 합니다.', 'delete 전에 preview 와 confirmation 을 확인합니다.', '섞이면 안 되는 data 는 별도 Space 로 나눕니다.', '결과가 이상하면 org, project, Space, key, appId filter 를 확인합니다.'] },
     ],
   },
   id: {
@@ -671,7 +748,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
     ],
     sections: [
       { id: 'quick-start', label: '01', title: 'Quick Start', bullets: ['Buka mem9 Console dari menu Log in lalu masuk.', 'Pastikan organization dan project sebelum mengubah resource.', 'Gunakan Install mem9 untuk prompt onboarding OpenClaw resmi.', 'Gunakan Claim API key untuk menautkan key lama ke Space.', 'Buka Space atau Memories untuk melihat memory yang disimpan agent.'] },
@@ -681,8 +758,9 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-detail', label: '05', title: 'Space Detail', subsections: [{ title: 'Tenant key', bullets: ['Set key sebelum melihat data memory.', 'Reveal / copy key hanya saat perlu.', 'Console menampilkan masked key secara default.'] }, { title: 'Metrics and imports', bullets: ['Cek total, pinned, dan insight memories.', 'Pantau latest import.', 'Gunakan Space switcher untuk pindah Space.'] }, { title: 'Memory workbench', bullets: ['Buat, edit, dan hapus memory.', 'Smart ingest mengekstrak durable facts dari pesan.', 'Gunakan appId untuk isolasi di dalam key yang sama.'] }] },
       { id: 'memories', label: '06', title: 'Memories', bullets: ['Pilih Space untuk melihat memory.', 'Filter berdasarkan text, type, state, agent, tags, atau appId.', 'Buka detail untuk content, metadata, tags, score, confidence, session, agent, version, dan timestamps.', 'Jika Space belum punya key, konfigurasi key dulu.'] },
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['Buat chain baru atau import chain key yang ada.', 'Detail page mengelola key, nodes, dan memory tools.'] }, { title: 'Nodes and routing', bullets: ['Tambahkan Space yang punya active key.', 'Node order menentukan recall order.', 'Routing policy prompt membatasi kapan node dicari.'] }, { title: 'Chain keys', bullets: ['Create atau bind chain key.', 'Disable key yang tidak dipakai.', 'Bandingkan chain dengan single Space memakai recall tools.'] }] },
-      { id: 'usage-billing-settings', label: '08', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['Pantau recall / write request usage.', 'Lihat date range, daily trend, dan usage events.'] }, { title: 'Billing', bullets: ['Lihat current plan, period, included access, dan on-demand settings.'] }, { title: 'Settings', bullets: ['Untuk account, organization, theme, language, dan logout.'] }] },
-      { id: 'safe-operations', label: '09', title: 'Safe Operations', bullets: ['Reveal API key hanya untuk trusted client.', 'Baca preview dan confirmation sebelum delete.', 'Pisahkan data sensitif ke Space berbeda.', 'Jika hasil aneh, cek org, project, Space, key, dan appId filter.'] },
+      { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['Buka Webhooks dari Activity sidebar.', 'Gunakan filter All, Space, atau Space Chain.', 'Tabel menampilkan endpoint, scope, URL host, enabled, events, dan last delivery.'] }, { title: 'Create and edit', bullets: ['Pilih Space atau Space Chain, resource, URL, events, dan enabled state.', 'Endpoint production harus HTTPS.', 'signing secret hanya muncul sekali setelah create atau rotate-secret.'] }, { title: 'Actions and deliveries', bullets: ['Row menu mendukung edit, test, deliveries, rotate secret, enable / disable, dan delete.', 'Drawer deliveries menampilkan status, attempts, HTTP status, last error, dan retry time.'] }] },
+      { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['Pantau recall / write request usage.', 'Lihat date range, daily trend, dan usage events.'] }, { title: 'Billing', bullets: ['Lihat current plan, period, included access, dan on-demand settings.'] }, { title: 'Settings', bullets: ['Untuk account, organization, theme, language, dan logout.'] }] },
+      { id: 'safe-operations', label: '10', title: 'Safe Operations', bullets: ['Reveal API key hanya untuk trusted client.', 'Baca preview dan confirmation sebelum delete.', 'Pisahkan data sensitif ke Space berbeda.', 'Jika hasil aneh, cek org, project, Space, key, dan appId filter.'] },
     ],
   },
   th: {
@@ -714,7 +792,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
     ],
     sections: [
       { id: 'quick-start', label: '01', title: 'Quick Start', bullets: ['เปิด mem9 Console จากเมนู Log in แล้วเข้าสู่ระบบ', 'ตรวจ organization และ project ก่อนแก้ resource', 'ใช้ Install mem9 เพื่อคัดลอก OpenClaw onboarding prompt', 'ใช้ Claim API key เพื่อผูก key เดิมเข้ากับ Space', 'เปิด Space หรือ Memories เพื่อดู memory ที่ agent บันทึก'] },
@@ -724,8 +802,9 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-detail', label: '05', title: 'Space Detail', subsections: [{ title: 'Tenant key', bullets: ['ตั้ง key ก่อนดู memory data', 'Reveal / copy key เฉพาะเมื่อจำเป็น', 'Console แสดง masked key เป็นค่าเริ่มต้น'] }, { title: 'Metrics and imports', bullets: ['ตรวจ total, pinned และ insight memories', 'ดูสถานะ latest import', 'ใช้ Space switcher เพื่อเปลี่ยน Space'] }, { title: 'Memory workbench', bullets: ['สร้าง แก้ไข และลบ memory', 'Smart ingest ดึง durable facts จากข้อความ', 'ใช้ appId เพื่อแยกการใช้งานใน key เดียวกัน'] }] },
       { id: 'memories', label: '06', title: 'Memories', bullets: ['เลือก Space เพื่อดู memory', 'Filter ด้วย text, type, state, agent, tags หรือ appId', 'เปิด detail เพื่อดู content, metadata, tags, score, confidence, session, agent, version และ timestamps', 'ถ้า Space ไม่มี key ให้ตั้งค่า key ก่อน'] },
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['สร้าง chain ใหม่หรือ import chain key เดิม', 'หน้า detail ใช้จัดการ key, nodes และ memory tools'] }, { title: 'Nodes and routing', bullets: ['เพิ่ม Space ที่มี active key', 'node order คือ recall order', 'routing policy prompt จำกัดว่า node ควรถูกค้นหาเมื่อใด'] }, { title: 'Chain keys', bullets: ['Create หรือ bind chain key', 'Disable key ที่ไม่ใช้แล้ว', 'ใช้ recall tools เปรียบเทียบ chain กับ Space เดี่ยว'] }] },
-      { id: 'usage-billing-settings', label: '08', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['ดู recall / write request usage', 'ดู date range, daily trend และ usage events'] }, { title: 'Billing', bullets: ['ดู current plan, period, included access และ on-demand settings'] }, { title: 'Settings', bullets: ['สำหรับ account, organization, theme, language และ logout'] }] },
-      { id: 'safe-operations', label: '09', title: 'Safe Operations', bullets: ['Reveal API key เฉพาะ trusted client', 'อ่าน preview และ confirmation ก่อน delete', 'แยกข้อมูลที่ไม่ควรรวมกันไว้คนละ Space', 'ถ้าผลลัพธ์ผิดปกติ ให้ตรวจ org, project, Space, key และ appId filter'] },
+      { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['เปิด Webhooks จาก Activity sidebar', 'ใช้ filter All, Space หรือ Space Chain', 'ตารางแสดง endpoint, scope, URL host, enabled, events และ last delivery'] }, { title: 'Create and edit', bullets: ['เลือก Space หรือ Space Chain, resource, URL, events และ enabled state', 'production endpoint ต้องใช้ HTTPS', 'signing secret แสดงเพียงครั้งเดียวหลัง create หรือ rotate-secret'] }, { title: 'Actions and deliveries', bullets: ['row menu ใช้ edit, test, deliveries, rotate secret, enable / disable และ delete', 'deliveries drawer แสดง status, attempts, HTTP status, last error และ retry time'] }] },
+      { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['ดู recall / write request usage', 'ดู date range, daily trend และ usage events'] }, { title: 'Billing', bullets: ['ดู current plan, period, included access และ on-demand settings'] }, { title: 'Settings', bullets: ['สำหรับ account, organization, theme, language และ logout'] }] },
+      { id: 'safe-operations', label: '10', title: 'Safe Operations', bullets: ['Reveal API key เฉพาะ trusted client', 'อ่าน preview และ confirmation ก่อน delete', 'แยกข้อมูลที่ไม่ควรรวมกันไว้คนละ Space', 'ถ้าผลลัพธ์ผิดปกติ ให้ตรวจ org, project, Space, key และ appId filter'] },
     ],
   },
 };

--- a/site/src/content/docs.ts
+++ b/site/src/content/docs.ts
@@ -278,6 +278,297 @@ const spaceChainDocsSections: Record<DocsLocale, DocsSection> = {
   },
 };
 
+const webhookDocsSections: Record<DocsLocale, DocsSection> = {
+  en: {
+    id: 'webhooks',
+    label: '11',
+    title: 'Webhooks',
+    intro: 'Webhooks let external systems react when mem9 creates, deletes, or routes memory.',
+    paragraphs: [
+      'Use Webhooks when you need mem9 activity to update another system without polling the memory API. A webhook endpoint subscribes to events for one Space or one Space Chain, and mem9 delivers signed JSON payloads to the URL you configure.',
+      'mem9 remains the source of truth for endpoint configuration, signing secrets, event records, delivery attempts, retry state, and delivery history. Console and other products proxy or aggregate that state; they do not store webhook secrets or delivery logs separately.',
+    ],
+    bullets: [
+      'Subscribe to `memory.added`, `memory.deleted`, and `space_chain.fact_routed`.',
+      'Create Space webhooks with a normal Space API key.',
+      'Create Space Chain webhooks with the `chain_` management key for that chain.',
+      'Use deliveries to audit attempts, HTTP responses, retry timing, and terminal failures.',
+    ],
+    subsections: [
+      {
+        title: 'Event payloads',
+        bullets: [
+          '`memory.added` is emitted after direct writes, pinned writes, smart ingest ADD actions, and successful routed target writes.',
+          '`memory.deleted` is emitted after single-memory and batch delete operations succeed.',
+          '`space_chain.fact_routed` is emitted on the Space Chain scope after a routing policy writes a matched fact to a target Space.',
+          'Smart ingest UPDATE-only reconciliation does not emit `memory.added`.',
+        ],
+      },
+      {
+        title: 'Signing and delivery',
+        bullets: [
+          'Every delivery includes `X-Mem9-Event-Id`, `X-Mem9-Event-Type`, `X-Mem9-Timestamp`, and `X-Mem9-Signature`.',
+          'The signature format is `v1=<hex_hmac_sha256>` over `<timestamp>.<event_id>.<raw_body>`.',
+          'Verify the timestamp tolerance, recompute the HMAC with the current signing secret, and compare in constant time.',
+          'mem9 retries transient failures with backoff and keeps delivery history for inspection.',
+        ],
+      },
+      {
+        title: 'Managing endpoints',
+        bullets: [
+          'Create and rotate responses show `signing_secret` once. List, get, and update responses never include it.',
+          'Production endpoints must use HTTPS. Development local HTTP is allowed only for localhost-style addresses.',
+          'Rotate the signing secret when a receiver is compromised or the secret was stored incorrectly.',
+        ],
+        links: [
+          { label: 'Open API reference', href: '/api#api-webhooks' },
+          { label: 'Open Console guide', href: '/console-docs#webhooks' },
+        ],
+      },
+    ],
+  },
+  zh: {
+    id: 'webhooks',
+    label: '11',
+    title: 'Webhooks',
+    intro: 'Webhooks 让外部系统在 mem9 创建、删除或路由记忆时自动响应。',
+    paragraphs: [
+      '当你希望其它系统感知 mem9 活动，又不想轮询 memory API 时，可以使用 Webhooks。一个 webhook endpoint 订阅某个 Space 或某条 Space Chain 的事件，mem9 会把带签名的 JSON payload 投递到你配置的 URL。',
+      'mem9 是 webhook 状态的 source of truth：endpoint 配置、签名密钥、事件记录、投递 outbox、重试状态和投递历史都保存在 mem9 内。Console 只代理或聚合这些状态，不单独保存 webhook secret 或投递日志。',
+    ],
+    bullets: [
+      '支持订阅 `memory.added`、`memory.deleted` 和 `space_chain.fact_routed`。',
+      'Space webhook 使用普通 Space API key 创建和管理。',
+      'Space Chain webhook 使用该 chain 的 `chain_` management key 创建和管理。',
+      '通过 deliveries 查看投递尝试、HTTP 响应、重试时间和最终失败状态。',
+    ],
+    subsections: [
+      {
+        title: '事件 payload',
+        bullets: [
+          '`memory.added` 会在直接写入、pinned 写入、smart ingest ADD action，以及成功的 routed target 写入之后发出。',
+          '`memory.deleted` 会在单条或批量删除成功之后发出。',
+          '`space_chain.fact_routed` 会在路由策略把匹配事实写入目标 Space 成功后，在 Space Chain scope 发出。',
+          'Smart ingest 的 UPDATE-only reconcile 不会发出 `memory.added`。',
+        ],
+      },
+      {
+        title: '签名与投递',
+        bullets: [
+          '每次投递都会带上 `X-Mem9-Event-Id`、`X-Mem9-Event-Type`、`X-Mem9-Timestamp` 和 `X-Mem9-Signature`。',
+          '签名格式是 `v1=<hex_hmac_sha256>`，HMAC 输入为 `<timestamp>.<event_id>.<raw_body>`。',
+          '接收方应校验 timestamp tolerance，用当前 signing secret 重新计算 HMAC，并用 constant-time comparison 比较。',
+          'mem9 会对临时失败做 backoff retry，并保留投递历史供排查。',
+        ],
+      },
+      {
+        title: '管理 endpoint',
+        bullets: [
+          'Create 和 rotate-secret 响应只展示一次 `signing_secret`；list、get、update 响应不会包含它。',
+          '生产环境 URL 必须是 HTTPS。开发环境只允许 localhost 类地址使用本地 HTTP。',
+          '当 receiver 泄露、secret 保存错误或需要轮换时，使用 rotate-secret 生成新签名密钥。',
+        ],
+        links: [
+          { label: '查看 API 文档', href: '/api#api-webhooks' },
+          { label: '查看 Console 指南', href: '/console-docs#webhooks' },
+        ],
+      },
+    ],
+  },
+  ja: {
+    id: 'webhooks',
+    label: '11',
+    title: 'Webhooks',
+    intro: 'Webhooks は、mem9 が memory を作成・削除・ルーティングした時に外部システムへ通知します。',
+    paragraphs: [
+      'memory API をポーリングせずに mem9 の活動を別システムへ反映したい場合に使います。endpoint は 1 つの Space または Space Chain のイベントを購読し、mem9 は署名付き JSON payload を設定した URL に送信します。',
+      'endpoint 設定、署名 secret、event record、delivery attempt、retry 状態、delivery history は mem9 が保持します。Console はそれらを proxy / aggregate し、secret や delivery log を別保存しません。',
+    ],
+    bullets: [
+      '`memory.added`、`memory.deleted`、`space_chain.fact_routed` を購読できます。',
+      'Space webhook は通常の Space API key で管理します。',
+      'Space Chain webhook はその chain の `chain_` management key で管理します。',
+      'deliveries で attempt、HTTP status、retry timing、最終 failure を確認できます。',
+    ],
+    subsections: [
+      {
+        title: 'Event payload',
+        bullets: [
+          '`memory.added` は direct write、pinned write、smart ingest ADD、成功した routed target write の後に送られます。',
+          '`memory.deleted` は single / batch delete 成功後に送られます。',
+          '`space_chain.fact_routed` は routing policy が target Space へ fact を書き込んだ後、Space Chain scope に送られます。',
+          'smart ingest の UPDATE-only reconcile では `memory.added` は送られません。',
+        ],
+      },
+      {
+        title: 'Signing and delivery',
+        bullets: [
+          '各 delivery は `X-Mem9-Event-Id`、`X-Mem9-Event-Type`、`X-Mem9-Timestamp`、`X-Mem9-Signature` を含みます。',
+          'signature は `<timestamp>.<event_id>.<raw_body>` の HMAC SHA-256 で、形式は `v1=<hex_hmac_sha256>` です。',
+          'receiver は timestamp tolerance を確認し、現在の signing secret で再計算して constant time で比較してください。',
+          'mem9 は一時的な失敗を backoff 付きで retry し、delivery history を残します。',
+        ],
+      },
+      {
+        title: 'Managing endpoints',
+        bullets: [
+          '`signing_secret` は create と rotate-secret response で一度だけ表示されます。',
+          'production endpoint は HTTPS が必要です。development の local HTTP は localhost 系の address に限られます。',
+          'receiver が侵害された場合や secret を誤って保存した場合は secret を rotate してください。',
+        ],
+        links: [
+          { label: 'API reference', href: '/api#api-webhooks' },
+          { label: 'Console guide', href: '/console-docs#webhooks' },
+        ],
+      },
+    ],
+  },
+  ko: {
+    id: 'webhooks',
+    label: '11',
+    title: 'Webhooks',
+    intro: 'Webhooks 는 mem9 가 memory 를 생성, 삭제, 라우팅할 때 외부 시스템이 반응하게 합니다.',
+    paragraphs: [
+      'memory API 를 polling 하지 않고 mem9 활동을 다른 시스템에 반영하고 싶을 때 사용합니다. endpoint 는 하나의 Space 또는 Space Chain 이벤트를 구독하고, mem9 는 signed JSON payload 를 설정한 URL 로 전달합니다.',
+      'endpoint 설정, signing secret, event record, delivery attempt, retry 상태, delivery history 는 mem9 가 source of truth 로 보관합니다. Console 은 이를 proxy / aggregate 하며 secret 이나 delivery log 를 따로 저장하지 않습니다.',
+    ],
+    bullets: [
+      '`memory.added`, `memory.deleted`, `space_chain.fact_routed` 를 구독할 수 있습니다.',
+      'Space webhook 은 일반 Space API key 로 관리합니다.',
+      'Space Chain webhook 은 해당 chain 의 `chain_` management key 로 관리합니다.',
+      'deliveries 에서 attempts, HTTP status, retry timing, terminal failure 를 확인합니다.',
+    ],
+    subsections: [
+      {
+        title: 'Event payload',
+        bullets: [
+          '`memory.added` 는 direct write, pinned write, smart ingest ADD, 성공한 routed target write 뒤에 발행됩니다.',
+          '`memory.deleted` 는 single / batch delete 성공 뒤에 발행됩니다.',
+          '`space_chain.fact_routed` 는 routing policy 가 target Space 에 fact 를 쓴 뒤 Space Chain scope 에 발행됩니다.',
+          'smart ingest UPDATE-only reconcile 은 `memory.added` 를 발행하지 않습니다.',
+        ],
+      },
+      {
+        title: 'Signing and delivery',
+        bullets: [
+          '각 delivery 는 `X-Mem9-Event-Id`, `X-Mem9-Event-Type`, `X-Mem9-Timestamp`, `X-Mem9-Signature` 를 포함합니다.',
+          'signature 형식은 `v1=<hex_hmac_sha256>` 이며 입력은 `<timestamp>.<event_id>.<raw_body>` 입니다.',
+          'receiver 는 timestamp tolerance 를 확인하고 현재 signing secret 으로 HMAC 을 다시 계산한 뒤 constant time 으로 비교해야 합니다.',
+          'mem9 는 transient failure 를 backoff 로 retry 하고 delivery history 를 보관합니다.',
+        ],
+      },
+      {
+        title: 'Managing endpoints',
+        bullets: [
+          '`signing_secret` 은 create 와 rotate-secret response 에서 한 번만 표시됩니다.',
+          'production endpoint 는 HTTPS 여야 합니다. development local HTTP 는 localhost 계열 address 에만 허용됩니다.',
+          'receiver 가 침해됐거나 secret 저장이 잘못됐으면 secret 을 rotate 하세요.',
+        ],
+        links: [
+          { label: 'API reference', href: '/api#api-webhooks' },
+          { label: 'Console guide', href: '/console-docs#webhooks' },
+        ],
+      },
+    ],
+  },
+  id: {
+    id: 'webhooks',
+    label: '11',
+    title: 'Webhooks',
+    intro: 'Webhooks membuat sistem eksternal bereaksi saat mem9 membuat, menghapus, atau merutekan memory.',
+    paragraphs: [
+      'Gunakan Webhooks ketika Anda ingin aktivitas mem9 memperbarui sistem lain tanpa polling memory API. Endpoint berlangganan event dari satu Space atau satu Space Chain, lalu mem9 mengirim payload JSON bertanda tangan ke URL yang Anda atur.',
+      'mem9 tetap menjadi source of truth untuk konfigurasi endpoint, signing secret, event record, delivery attempt, retry state, dan delivery history. Console hanya mem-proxy atau mengagregasi state itu; Console tidak menyimpan secret atau log delivery secara terpisah.',
+    ],
+    bullets: [
+      'Berlangganan `memory.added`, `memory.deleted`, dan `space_chain.fact_routed`.',
+      'Kelola Space webhook dengan Space API key biasa.',
+      'Kelola Space Chain webhook dengan `chain_` management key untuk chain tersebut.',
+      'Gunakan deliveries untuk melihat attempt, HTTP response, jadwal retry, dan kegagalan final.',
+    ],
+    subsections: [
+      {
+        title: 'Event payload',
+        bullets: [
+          '`memory.added` dikirim setelah direct write, pinned write, smart ingest ADD, dan routed target write yang sukses.',
+          '`memory.deleted` dikirim setelah single atau batch delete berhasil.',
+          '`space_chain.fact_routed` dikirim pada Space Chain scope setelah routing policy menulis fact ke target Space.',
+          'Smart ingest UPDATE-only reconciliation tidak mengirim `memory.added`.',
+        ],
+      },
+      {
+        title: 'Signing and delivery',
+        bullets: [
+          'Setiap delivery menyertakan `X-Mem9-Event-Id`, `X-Mem9-Event-Type`, `X-Mem9-Timestamp`, dan `X-Mem9-Signature`.',
+          'Format signature adalah `v1=<hex_hmac_sha256>` atas `<timestamp>.<event_id>.<raw_body>`.',
+          'Receiver sebaiknya memeriksa timestamp tolerance, menghitung ulang HMAC dengan signing secret aktif, lalu membandingkan secara constant time.',
+          'mem9 melakukan retry untuk kegagalan sementara dengan backoff dan menyimpan delivery history.',
+        ],
+      },
+      {
+        title: 'Managing endpoints',
+        bullets: [
+          '`signing_secret` hanya muncul sekali pada response create dan rotate-secret.',
+          'Endpoint production harus HTTPS. HTTP lokal untuk development hanya diizinkan untuk alamat localhost.',
+          'Rotate signing secret ketika receiver bocor atau secret tersimpan dengan cara yang salah.',
+        ],
+        links: [
+          { label: 'API reference', href: '/api#api-webhooks' },
+          { label: 'Console guide', href: '/console-docs#webhooks' },
+        ],
+      },
+    ],
+  },
+  th: {
+    id: 'webhooks',
+    label: '11',
+    title: 'Webhooks',
+    intro: 'Webhooks ทำให้ระบบภายนอกตอบสนองเมื่อ mem9 สร้าง ลบ หรือ route memory',
+    paragraphs: [
+      'ใช้ Webhooks เมื่อคุณต้องการให้กิจกรรมของ mem9 อัปเดตระบบอื่นโดยไม่ต้อง polling memory API endpoint หนึ่งรายการจะ subscribe event ของ Space หรือ Space Chain หนึ่งชุด และ mem9 จะส่ง JSON payload ที่มี signature ไปยัง URL ที่ตั้งไว้',
+      'mem9 เป็น source of truth สำหรับ endpoint configuration, signing secrets, event records, delivery attempts, retry state และ delivery history ส่วน Console จะ proxy หรือ aggregate ข้อมูลเหล่านี้ และไม่เก็บ webhook secret หรือ delivery log แยกต่างหาก',
+    ],
+    bullets: [
+      'subscribe `memory.added`, `memory.deleted` และ `space_chain.fact_routed`',
+      'จัดการ Space webhook ด้วย Space API key ปกติ',
+      'จัดการ Space Chain webhook ด้วย `chain_` management key ของ chain นั้น',
+      'ใช้ deliveries เพื่อตรวจ attempts, HTTP response, เวลา retry และ failure สุดท้าย',
+    ],
+    subsections: [
+      {
+        title: 'Event payload',
+        bullets: [
+          '`memory.added` ถูกส่งหลัง direct write, pinned write, smart ingest ADD และ routed target write ที่สำเร็จ',
+          '`memory.deleted` ถูกส่งหลัง single หรือ batch delete สำเร็จ',
+          '`space_chain.fact_routed` ถูกส่งที่ Space Chain scope หลัง routing policy เขียน fact ไปยัง target Space สำเร็จ',
+          'smart ingest แบบ UPDATE-only reconciliation จะไม่ส่ง `memory.added`',
+        ],
+      },
+      {
+        title: 'Signing and delivery',
+        bullets: [
+          'ทุก delivery มี `X-Mem9-Event-Id`, `X-Mem9-Event-Type`, `X-Mem9-Timestamp` และ `X-Mem9-Signature`',
+          'signature อยู่ในรูป `v1=<hex_hmac_sha256>` โดยคำนวณจาก `<timestamp>.<event_id>.<raw_body>`',
+          'receiver ควรตรวจ timestamp tolerance คำนวณ HMAC ใหม่ด้วย signing secret ปัจจุบัน แล้วเปรียบเทียบแบบ constant time',
+          'mem9 retry ความล้มเหลวชั่วคราวด้วย backoff และเก็บ delivery history ไว้ตรวจสอบ',
+        ],
+      },
+      {
+        title: 'Managing endpoints',
+        bullets: [
+          '`signing_secret` แสดงเพียงครั้งเดียวใน response ของ create และ rotate-secret',
+          'production endpoint ต้องใช้ HTTPS ส่วน local HTTP สำหรับ development อนุญาตเฉพาะ localhost-style address',
+          'rotate signing secret เมื่อ receiver ถูก compromise หรือ secret ถูกเก็บผิดวิธี',
+        ],
+        links: [
+          { label: 'API reference', href: '/api#api-webhooks' },
+          { label: 'Console guide', href: '/console-docs#webhooks' },
+        ],
+      },
+    ],
+  },
+};
+
 export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
   en: {
     meta: {
@@ -321,6 +612,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'what-you-get-after-setup',
           'your-memory-dashboard',
           'space-chains',
+          'webhooks',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -552,9 +844,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       spaceChainDocsSections.en,
+      webhookDocsSections.en,
       {
         id: 'daily-usage-expectations',
-        label: '11',
+        label: '12',
         title: 'Daily Usage Expectations',
         paragraphs: [
           'The most immediate day-to-day change is that users stop repeating the same project background, preferences, and working agreements every session.',
@@ -580,7 +873,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '12',
+        label: '13',
         title: 'Reconnect, New Machine, and API Key Care',
         subsections: [
           {
@@ -608,7 +901,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '13',
+        label: '14',
         title: 'Uninstall Behavior',
         intro: 'Uninstalling mem9 affects the local machine setup, not the remote cloud data.',
         subsections: [
@@ -636,7 +929,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '14',
+        label: '15',
         title: 'Security and Trust',
         paragraphs: [
           'mem9 positions itself as a production-ready memory layer, not an opaque black box. The product story emphasizes clear data handling boundaries and production-grade cloud infrastructure.',
@@ -663,7 +956,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '15',
+        label: '16',
         title: 'Product Expectations and Limits',
         subsections: [
           {
@@ -685,7 +978,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '16',
+        label: '17',
         title: 'Recommended Path and Official Links',
         intro: 'For a new user, the cleanest sequence looks like this.',
         bullets: [
@@ -760,6 +1053,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'what-you-get-after-setup',
           'your-memory-dashboard',
           'space-chains',
+          'webhooks',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -996,9 +1290,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       spaceChainDocsSections.zh,
+      webhookDocsSections.zh,
       {
         id: 'daily-usage-expectations',
-        label: '11',
+        label: '12',
         title: '日常使用时，mem9 会怎样改变体验',
         paragraphs: [
           '最直接的变化通常是：你不需要每次重新解释项目背景，长期知识不会只留在某次聊天里，而且你还能明确要求“把这件事记下来”。',
@@ -1024,7 +1319,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '12',
+        label: '13',
         title: '恢复、重连和 API key 保管',
         subsections: [
           {
@@ -1052,7 +1347,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '13',
+        label: '14',
         title: '卸载时，会发生什么，不会发生什么',
         intro: '卸载影响的是本地配置，不会直接删除远端云数据。',
         subsections: [
@@ -1080,7 +1375,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '14',
+        label: '15',
         title: '安全和信任基础',
         paragraphs: [
           'mem9 对自己的定位是面向生产场景的长期记忆层，而不是一个不可控黑盒。官方叙述强调的是清晰的数据处理边界，以及生产级云基础设施。',
@@ -1107,7 +1402,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '15',
+        label: '16',
         title: '真实使用时，应该有什么预期',
         subsections: [
           {
@@ -1129,7 +1424,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '16',
+        label: '17',
         title: '给新用户的推荐顺序和官方入口',
         intro: '如果你第一次使用 mem9，推荐路径可以很简单。',
         bullets: [
@@ -1204,6 +1499,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'what-you-get-after-setup',
           'your-memory-dashboard',
           'space-chains',
+          'webhooks',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -1427,9 +1723,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       spaceChainDocsSections.ja,
+      webhookDocsSections.ja,
       {
         id: 'daily-usage-expectations',
-        label: '11',
+        label: '12',
         title: '日常利用で mem9 が変えること',
         paragraphs: [
           'もっとも直接的な変化は、毎回同じプロジェクト背景や作業ルールを説明し直さなくてよくなることです。',
@@ -1455,7 +1752,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '12',
+        label: '13',
         title: 'reconnect・復元・API key の管理',
         subsections: [
           {
@@ -1483,7 +1780,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '13',
+        label: '14',
         title: 'uninstall で起きること / 起きないこと',
         intro: 'uninstall はローカル設定に影響しますが、クラウド上のデータは直接削除しません。',
         subsections: [
@@ -1511,7 +1808,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '14',
+        label: '15',
         title: 'セキュリティと信頼の基盤',
         paragraphs: [
           'mem9 は、制御不能なブラックボックスではなく、本番運用を前提とした長期記憶レイヤーとして位置づけられています。説明の中心は、明確なデータ処理境界と本番級クラウド基盤です。',
@@ -1538,7 +1835,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '15',
+        label: '16',
         title: '実運用での期待値',
         subsections: [
           {
@@ -1560,7 +1857,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '16',
+        label: '17',
         title: '新規ユーザー向けおすすめ順序と公式入口',
         intro: '初めて mem9 を使うなら、次の流れがもっともシンプルです。',
         bullets: [
@@ -1635,6 +1932,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'what-you-get-after-setup',
           'your-memory-dashboard',
           'space-chains',
+          'webhooks',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -1858,9 +2156,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       spaceChainDocsSections.ko,
+      webhookDocsSections.ko,
       {
         id: 'daily-usage-expectations',
-        label: '11',
+        label: '12',
         title: '일상 사용에서 어떻게 달라지는가',
         paragraphs: [
           '가장 즉각적인 변화는 프로젝트 배경, 선호, 작업 규칙을 매번 다시 설명하지 않아도 된다는 점입니다.',
@@ -1886,7 +2185,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '12',
+        label: '13',
         title: '복구, reconnect, API key 관리',
         subsections: [
           {
@@ -1914,7 +2213,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '13',
+        label: '14',
         title: '제거 시 일어나는 일과 일어나지 않는 일',
         intro: 'uninstall은 로컬 설정에 영향을 주지만 원격 클라우드 데이터는 직접 삭제하지 않습니다.',
         subsections: [
@@ -1942,7 +2241,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '14',
+        label: '15',
         title: '보안과 신뢰의 기반',
         paragraphs: [
           'mem9는 통제 불가능한 블랙박스가 아니라, 프로덕션 장기 메모리 레이어로 자리매김합니다. 공식 설명의 중심은 명확한 데이터 처리 경계와 프로덕션급 클라우드 인프라입니다.',
@@ -1969,7 +2268,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '15',
+        label: '16',
         title: '실사용에서의 기대치와 한계',
         subsections: [
           {
@@ -1991,7 +2290,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '16',
+        label: '17',
         title: '신규 사용자를 위한 추천 순서와 공식 링크',
         intro: '처음 mem9를 사용하는 사용자에게는 다음 순서가 가장 단순합니다.',
         bullets: [
@@ -2066,6 +2365,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'what-you-get-after-setup',
           'your-memory-dashboard',
           'space-chains',
+          'webhooks',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -2295,9 +2595,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       spaceChainDocsSections.id,
+      webhookDocsSections.id,
       {
         id: 'daily-usage-expectations',
-        label: '11',
+        label: '12',
         title: 'Bagaimana mem9 mengubah pengalaman harian',
         paragraphs: [
           'Perubahan paling langsung biasanya adalah Anda tidak perlu lagi menjelaskan ulang latar belakang proyek, preferensi, dan aturan kerja di setiap sesi.',
@@ -2323,7 +2624,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '12',
+        label: '13',
         title: 'Reconnect, pemulihan, dan penyimpanan API key',
         subsections: [
           {
@@ -2351,7 +2652,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '13',
+        label: '14',
         title: 'Apa yang terjadi dan tidak terjadi saat uninstall',
         intro: 'Uninstall memengaruhi konfigurasi lokal, bukan menghapus data cloud dari jarak jauh.',
         subsections: [
@@ -2379,7 +2680,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '14',
+        label: '15',
         title: 'Fondasi keamanan dan kepercayaan',
         paragraphs: [
           'mem9 memosisikan diri sebagai lapisan memori jangka panjang untuk penggunaan produksi, bukan kotak hitam yang tidak terkontrol. Narasi resminya menekankan batas penanganan data yang jelas dan infrastruktur cloud kelas produksi.',
@@ -2406,7 +2707,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '15',
+        label: '16',
         title: 'Ekspektasi nyata dan batasan produk',
         subsections: [
           {
@@ -2428,7 +2729,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '16',
+        label: '17',
         title: 'Urutan yang direkomendasikan dan tautan resmi',
         intro: 'Untuk pengguna baru, urutan paling sederhana biasanya seperti ini.',
         bullets: [
@@ -2503,6 +2804,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
           'what-you-get-after-setup',
           'your-memory-dashboard',
           'space-chains',
+          'webhooks',
           'daily-usage-expectations',
           'reconnect-and-recovery',
           'uninstall-behavior',
@@ -2732,9 +3034,10 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
         ],
       },
       spaceChainDocsSections.th,
+      webhookDocsSections.th,
       {
         id: 'daily-usage-expectations',
-        label: '11',
+        label: '12',
         title: 'mem9 เปลี่ยนประสบการณ์การใช้งานประจำวันอย่างไร',
         paragraphs: [
           'ความเปลี่ยนแปลงที่ชัดที่สุดคือคุณไม่ต้องอธิบายพื้นหลังโปรเจกต์ ความชอบ และกติกาการทำงานซ้ำในทุก session',
@@ -2760,7 +3063,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'reconnect-and-recovery',
-        label: '12',
+        label: '13',
         title: 'Reconnect การกู้คืน และการเก็บ API key',
         subsections: [
           {
@@ -2788,7 +3091,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'uninstall-behavior',
-        label: '13',
+        label: '14',
         title: 'สิ่งที่จะเกิดขึ้นและไม่เกิดขึ้นเมื่อ uninstall',
         intro: 'การ uninstall มีผลกับการตั้งค่าในเครื่อง แต่ไม่ได้ลบข้อมูลคลาวด์จากระยะไกลโดยตรง',
         subsections: [
@@ -2816,7 +3119,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'security-and-trust',
-        label: '14',
+        label: '15',
         title: 'พื้นฐานด้านความปลอดภัยและความน่าเชื่อถือ',
         paragraphs: [
           'mem9 วางตำแหน่งตัวเองเป็นเลเยอร์หน่วยความจำระยะยาวสำหรับงาน production ไม่ใช่กล่องดำที่ควบคุมไม่ได้ เรื่องราวทางการจึงเน้นขอบเขตการจัดการข้อมูลที่ชัดเจนและโครงสร้างพื้นฐานคลาวด์ระดับ production',
@@ -2843,7 +3146,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'product-expectations-and-limits',
-        label: '15',
+        label: '16',
         title: 'ความคาดหวังจริงและขอบเขตของผลิตภัณฑ์',
         subsections: [
           {
@@ -2865,7 +3168,7 @@ export const docsCopy: Record<DocsLocale, DocsPageCopy> = {
       },
       {
         id: 'recommended-path-and-links',
-        label: '16',
+        label: '17',
         title: 'ลำดับที่แนะนำและลิงก์ทางการ',
         intro: 'สำหรับผู้ใช้ใหม่ ลำดับที่เรียบง่ายที่สุดมักเป็นดังนี้',
         bullets: [

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -546,6 +546,35 @@ const disableSpaceChainBindingCode = `curl -sX PATCH "$CHAIN_API/{chain_id}/bind
   -H "X-API-Key: $CHAIN_API_KEY" \\
   -d '{"disabled":true,"disabled_by_user_id":"user-123"}'`;
 const recallSpaceChainCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$API/memories?q=postgres&scanAll=true&limit=10"';
+const createSpaceWebhookCode = `curl -sX POST "$API/webhooks" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $API_KEY" \\
+  -d '{"name":"Production sync","url":"https://example.com/mem9/webhook","enabled":true,"events":["memory.added","memory.deleted"]}'`;
+const listSpaceWebhooksCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/webhooks"';
+const updateSpaceWebhookCode = `curl -sX PATCH "$API/webhooks/{webhookID}" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $API_KEY" \\
+  -d '{"enabled":false}'`;
+const testSpaceWebhookCode = `curl -sX POST "$API/webhooks/{webhookID}/test" \\
+  -H "X-API-Key: $API_KEY"`;
+const rotateSpaceWebhookSecretCode = `curl -sX POST "$API/webhooks/{webhookID}/rotate-secret" \\
+  -H "X-API-Key: $API_KEY"`;
+const listSpaceWebhookDeliveriesCode = 'curl -s -H "X-API-Key: $API_KEY" "$API/webhook-deliveries?limit=25"';
+const createSpaceChainWebhookCode = `curl -sX POST "$CHAIN_API/{chain_id}/webhooks" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{"name":"Routing audit","url":"https://example.com/mem9/chain-webhook","enabled":true,"events":["space_chain.fact_routed"]}'`;
+const listSpaceChainWebhooksCode = 'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$CHAIN_API/{chain_id}/webhooks"';
+const updateSpaceChainWebhookCode = `curl -sX PATCH "$CHAIN_API/{chain_id}/webhooks/{webhookID}" \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: $CHAIN_API_KEY" \\
+  -d '{"events":["memory.added","space_chain.fact_routed"]}'`;
+const testSpaceChainWebhookCode = `curl -sX POST "$CHAIN_API/{chain_id}/webhooks/{webhookID}/test" \\
+  -H "X-API-Key: $CHAIN_API_KEY"`;
+const rotateSpaceChainWebhookSecretCode = `curl -sX POST "$CHAIN_API/{chain_id}/webhooks/{webhookID}/rotate-secret" \\
+  -H "X-API-Key: $CHAIN_API_KEY"`;
+const listSpaceChainWebhookDeliveriesCode =
+  'curl -s -H "X-API-Key: $CHAIN_API_KEY" "$CHAIN_API/{chain_id}/webhook-deliveries?limit=25"';
 
 const faqCopyByLocale: Record<SiteLocale, SiteFaqCopy> = {
   en: {
@@ -1256,6 +1285,81 @@ const spaceChainRuntimeResponseFields: SiteApiFieldCopy[] = [
   { name: 'offset', description: 'Applied page offset.', required: true },
 ];
 
+const webhookCreateBodyFields: SiteApiFieldCopy[] = [
+  { name: 'name', description: 'Human-readable endpoint name.', required: true },
+  { name: 'url', description: 'Receiver URL. Production deployments require HTTPS.', required: true },
+  { name: 'enabled', description: 'Whether the endpoint accepts matching events. Defaults to true on create.' },
+  {
+    name: 'events',
+    description: 'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.',
+    required: true,
+  },
+];
+
+const webhookUpdateBodyFields: SiteApiFieldCopy[] = [
+  { name: 'name', description: 'Updated endpoint name.' },
+  { name: 'url', description: 'Updated receiver URL.' },
+  { name: 'enabled', description: 'Whether the endpoint accepts matching events.' },
+  {
+    name: 'events',
+    description: 'Replacement array of subscribed event types.',
+  },
+];
+
+const webhookDeliveryQueryParams: SiteApiFieldCopy[] = [
+  { name: 'limit', description: 'Maximum number of deliveries to return. Defaults to 50 and caps at 200.' },
+];
+
+const webhookEndpointResponseFields: SiteApiFieldCopy[] = [
+  { name: 'id', description: 'Webhook endpoint id.', required: true },
+  { name: 'scope_type', description: 'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.', required: true },
+  { name: 'scope_id', description: 'Tenant id for Space webhooks or chain id for Space Chain webhooks.', required: true },
+  { name: 'name', description: 'Human-readable endpoint name.', required: true },
+  { name: 'url', description: 'Receiver URL.', required: true },
+  { name: 'enabled', description: 'Whether the endpoint accepts matching events.', required: true },
+  { name: 'events', description: 'Subscribed event type array.', required: true },
+  { name: 'created_at', description: 'Creation timestamp.', required: true },
+  { name: 'updated_at', description: 'Last update timestamp.', required: true },
+];
+
+const webhookEndpointListResponseFields: SiteApiFieldCopy[] = [
+  { name: 'webhooks', description: 'Array of webhook endpoints.', required: true },
+];
+
+const webhookEndpointSecretResponseFields: SiteApiFieldCopy[] = [
+  ...webhookEndpointResponseFields,
+  {
+    name: 'signing_secret',
+    description: 'One-time signing secret returned only by create and rotate-secret responses.',
+    required: true,
+  },
+];
+
+const webhookDeliveryResponseFields: SiteApiFieldCopy[] = [
+  { name: 'id', description: 'Delivery id.', required: true },
+  { name: 'event_id', description: 'Event id.', required: true },
+  { name: 'endpoint_id', description: 'Webhook endpoint id for this delivery.', required: true },
+  { name: 'event_type', description: 'Event type delivered to the receiver.', required: true },
+  { name: 'scope_type', description: 'Delivery scope type.', required: true },
+  { name: 'scope_id', description: 'Delivery scope id.', required: true },
+  { name: 'status', description: 'Delivery status: `pending`, `delivered`, or `failed`.', required: true },
+  { name: 'attempt_count', description: 'Delivery attempt count.', required: true },
+  { name: 'next_attempt_at', description: 'Next retry timestamp for pending deliveries.', required: true },
+  { name: 'last_http_status', description: 'Most recent HTTP status returned by the receiver.' },
+  { name: 'last_error', description: 'Most recent delivery error message.' },
+  { name: 'delivered_at', description: 'Timestamp when delivery reached a 2xx response.' },
+  { name: 'created_at', description: 'Creation timestamp.', required: true },
+  { name: 'updated_at', description: 'Last update timestamp.', required: true },
+];
+
+const webhookDeliveryListResponseFields: SiteApiFieldCopy[] = [
+  { name: 'deliveries', description: 'Array of webhook delivery records.', required: true },
+];
+
+const webhookTestResponseFields: SiteApiFieldCopy[] = [
+  { name: 'delivery', description: 'Queued test delivery record.', required: true },
+];
+
 const keyStatusEndpointGroup: SiteApiEndpointGroupCopy = {
   id: 'key-status',
   title: 'Key Status',
@@ -1403,6 +1507,161 @@ const spaceChainEndpointGroup: SiteApiEndpointGroupCopy = {
       queryParams: memoryListQueryParams,
       responseFields: spaceChainRuntimeResponseFields,
       examples: [{ label: 'Recall with scanAll', code: recallSpaceChainCode }],
+    },
+  ],
+};
+
+const webhookEndpointGroup: SiteApiEndpointGroupCopy = {
+  id: 'webhooks',
+  title: 'Webhooks',
+  description:
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.',
+  endpoints: [
+    {
+      method: 'GET',
+      path: '/v1alpha2/mem9s/webhooks',
+      summary: 'List Space webhooks.',
+      description: 'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.',
+      headers: hostedReadHeaders,
+      responseFields: webhookEndpointListResponseFields,
+      examples: [{ label: 'List Space webhooks', code: listSpaceWebhooksCode }],
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/mem9s/webhooks',
+      summary: 'Create a Space webhook.',
+      description:
+        'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.',
+      headers: hostedJSONWriteHeaders,
+      bodyFields: webhookCreateBodyFields,
+      responseFields: webhookEndpointSecretResponseFields,
+      examples: [{ label: 'Create Space webhook', code: createSpaceWebhookCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/mem9s/webhooks/{webhookID}',
+      summary: 'Read one Space webhook.',
+      description: 'Returns one Space-scoped webhook endpoint without the signing secret.',
+      headers: hostedReadHeaders,
+      responseFields: webhookEndpointResponseFields,
+    },
+    {
+      method: 'PATCH',
+      path: '/v1alpha2/mem9s/webhooks/{webhookID}',
+      summary: 'Update a Space webhook.',
+      description: 'Updates endpoint name, URL, enabled state, or subscribed events.',
+      headers: hostedJSONWriteHeaders,
+      bodyFields: webhookUpdateBodyFields,
+      responseFields: webhookEndpointResponseFields,
+      examples: [{ label: 'Disable Space webhook', code: updateSpaceWebhookCode }],
+    },
+    {
+      method: 'DELETE',
+      path: '/v1alpha2/mem9s/webhooks/{webhookID}',
+      summary: 'Delete a Space webhook.',
+      description: 'Soft-deletes the endpoint. A successful delete returns `204 No Content`.',
+      headers: hostedReadHeaders,
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/mem9s/webhooks/{webhookID}/test',
+      summary: 'Test a Space webhook.',
+      description: 'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.',
+      headers: hostedReadHeaders,
+      responseFields: webhookTestResponseFields,
+      examples: [{ label: 'Test Space webhook', code: testSpaceWebhookCode }],
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/mem9s/webhooks/{webhookID}/rotate-secret',
+      summary: 'Rotate a Space webhook secret.',
+      description: 'Replaces the signing secret and returns the new `signing_secret` once.',
+      headers: hostedReadHeaders,
+      responseFields: webhookEndpointSecretResponseFields,
+      examples: [{ label: 'Rotate Space webhook secret', code: rotateSpaceWebhookSecretCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/mem9s/webhook-deliveries',
+      summary: 'List Space webhook deliveries.',
+      description: 'Returns recent delivery records for the current Space scope.',
+      headers: hostedReadHeaders,
+      queryParams: webhookDeliveryQueryParams,
+      responseFields: webhookDeliveryListResponseFields,
+      examples: [{ label: 'List Space deliveries', code: listSpaceWebhookDeliveriesCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks',
+      summary: 'List Space Chain webhooks.',
+      description: 'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.',
+      headers: chainManagementHeaders,
+      responseFields: webhookEndpointListResponseFields,
+      examples: [{ label: 'List Space Chain webhooks', code: listSpaceChainWebhooksCode }],
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks',
+      summary: 'Create a Space Chain webhook.',
+      description:
+        'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: webhookCreateBodyFields,
+      responseFields: webhookEndpointSecretResponseFields,
+      examples: [{ label: 'Create Space Chain webhook', code: createSpaceChainWebhookCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks/{webhookID}',
+      summary: 'Read one Space Chain webhook.',
+      description: 'Returns one chain-scoped webhook endpoint without the signing secret.',
+      headers: chainManagementHeaders,
+      responseFields: webhookEndpointResponseFields,
+    },
+    {
+      method: 'PATCH',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks/{webhookID}',
+      summary: 'Update a Space Chain webhook.',
+      description: 'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.',
+      headers: chainJSONWriteHeaders,
+      bodyFields: webhookUpdateBodyFields,
+      responseFields: webhookEndpointResponseFields,
+      examples: [{ label: 'Update Space Chain webhook', code: updateSpaceChainWebhookCode }],
+    },
+    {
+      method: 'DELETE',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks/{webhookID}',
+      summary: 'Delete a Space Chain webhook.',
+      description: 'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.',
+      headers: chainManagementHeaders,
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks/{webhookID}/test',
+      summary: 'Test a Space Chain webhook.',
+      description: 'Queues a `webhook.test` delivery for a chain-scoped endpoint.',
+      headers: chainManagementHeaders,
+      responseFields: webhookTestResponseFields,
+      examples: [{ label: 'Test Space Chain webhook', code: testSpaceChainWebhookCode }],
+    },
+    {
+      method: 'POST',
+      path: '/v1alpha2/space-chains/{chain_id}/webhooks/{webhookID}/rotate-secret',
+      summary: 'Rotate a Space Chain webhook secret.',
+      description: 'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.',
+      headers: chainManagementHeaders,
+      responseFields: webhookEndpointSecretResponseFields,
+      examples: [{ label: 'Rotate Space Chain webhook secret', code: rotateSpaceChainWebhookSecretCode }],
+    },
+    {
+      method: 'GET',
+      path: '/v1alpha2/space-chains/{chain_id}/webhook-deliveries',
+      summary: 'List Space Chain webhook deliveries.',
+      description: 'Returns recent delivery records for the Space Chain scope.',
+      headers: chainManagementHeaders,
+      queryParams: webhookDeliveryQueryParams,
+      responseFields: webhookDeliveryListResponseFields,
+      examples: [{ label: 'List Space Chain deliveries', code: listSpaceChainWebhookDeliveriesCode }],
     },
   ],
 };
@@ -1582,6 +1841,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -1821,6 +2081,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2051,6 +2312,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2282,6 +2544,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2513,6 +2776,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2744,6 +3008,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -2975,6 +3240,7 @@ const apiPageByLocale: Record<SiteLocale, SiteApiPageCopy> = {
         ],
       },
       spaceChainEndpointGroup,
+      webhookEndpointGroup,
       {
         id: 'imports',
         title: 'Imports',
@@ -5230,12 +5496,553 @@ const apiSharedTextTranslations: Partial<Record<SiteLocale, Record<string, strin
   },
 };
 
+const webhookApiSharedTextTranslations: Partial<Record<SiteLocale, Record<string, string>>> = {
+  zh: {
+    Webhooks: 'Webhooks',
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.':
+      '为 Space 和 Space Chain 创建带签名的事件订阅。mem9 会保存 endpoint 状态、delivery 尝试、重试状态和 delivery 历史。',
+    'List Space webhooks.': '列出 Space webhooks。',
+    'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.': '列出 `X-API-Key` 中 Space API key 作用域下的 webhook endpoints。',
+    'List Space webhooks': '列出 Space webhooks',
+    'Create a Space webhook.': '创建 Space webhook。',
+    'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.':
+      '创建 Space 作用域的 webhook endpoint。响应只会包含一次 `signing_secret`；请在关闭响应前保存。',
+    'Create Space webhook': '创建 Space webhook',
+    'Read one Space webhook.': '读取单个 Space webhook。',
+    'Returns one Space-scoped webhook endpoint without the signing secret.': '返回一个 Space 作用域的 webhook endpoint，不包含 signing secret。',
+    'Update a Space webhook.': '更新 Space webhook。',
+    'Updates endpoint name, URL, enabled state, or subscribed events.': '更新 endpoint 名称、URL、enabled 状态或订阅事件。',
+    'Disable Space webhook': '禁用 Space webhook',
+    'Delete a Space webhook.': '删除 Space webhook。',
+    'Soft-deletes the endpoint. A successful delete returns `204 No Content`.': '软删除 endpoint。删除成功时返回 `204 No Content`。',
+    'Test a Space webhook.': '测试 Space webhook。',
+    'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.':
+      '向 endpoint 排队一个 `webhook.test` delivery，便于验证 receiver 和签名处理。',
+    'Test Space webhook': '测试 Space webhook',
+    'Rotate a Space webhook secret.': '轮换 Space webhook secret。',
+    'Replaces the signing secret and returns the new `signing_secret` once.': '替换 signing secret，并且只返回一次新的 `signing_secret`。',
+    'Rotate Space webhook secret': '轮换 Space webhook secret',
+    'List Space webhook deliveries.': '列出 Space webhook deliveries。',
+    'Returns recent delivery records for the current Space scope.': '返回当前 Space 作用域最近的 delivery records。',
+    'List Space deliveries': '列出 Space deliveries',
+    'List Space Chain webhooks.': '列出 Space Chain webhooks。',
+    'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.':
+      '列出 Space Chain 作用域下的 webhook endpoints。需要在 `X-API-Key` 中提供 chain management key。',
+    'List Space Chain webhooks': '列出 Space Chain webhooks',
+    'Create a Space Chain webhook.': '创建 Space Chain webhook。',
+    'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.':
+      '创建 chain 作用域的 webhook endpoint。可用于 chain-level memory 事件和 `space_chain.fact_routed` 路由事件。',
+    'Create Space Chain webhook': '创建 Space Chain webhook',
+    'Read one Space Chain webhook.': '读取单个 Space Chain webhook。',
+    'Returns one chain-scoped webhook endpoint without the signing secret.': '返回一个 chain 作用域的 webhook endpoint，不包含 signing secret。',
+    'Update a Space Chain webhook.': '更新 Space Chain webhook。',
+    'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.':
+      '更新 chain 作用域 endpoint 的名称、URL、enabled 状态或订阅事件。',
+    'Update Space Chain webhook': '更新 Space Chain webhook',
+    'Delete a Space Chain webhook.': '删除 Space Chain webhook。',
+    'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.':
+      '软删除 chain 作用域 endpoint。删除成功时返回 `204 No Content`。',
+    'Test a Space Chain webhook.': '测试 Space Chain webhook。',
+    'Queues a `webhook.test` delivery for a chain-scoped endpoint.': '为 chain 作用域 endpoint 排队一个 `webhook.test` delivery。',
+    'Test Space Chain webhook': '测试 Space Chain webhook',
+    'Rotate a Space Chain webhook secret.': '轮换 Space Chain webhook secret。',
+    'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.':
+      '替换 chain 作用域 endpoint 的 signing secret，并且只返回一次新的 `signing_secret`。',
+    'Rotate Space Chain webhook secret': '轮换 Space Chain webhook secret',
+    'List Space Chain webhook deliveries.': '列出 Space Chain webhook deliveries。',
+    'Returns recent delivery records for the Space Chain scope.': '返回 Space Chain 作用域最近的 delivery records。',
+    'List Space Chain deliveries': '列出 Space Chain deliveries',
+    'Human-readable endpoint name.': '人类可读的 endpoint 名称。',
+    'Receiver URL. Production deployments require HTTPS.': '接收方 URL。生产部署要求 HTTPS。',
+    'Whether the endpoint accepts matching events. Defaults to true on create.': 'endpoint 是否接收匹配事件。创建时默认是 true。',
+    'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.':
+      '要订阅的事件类型数组：`memory.added`、`memory.deleted` 或 `space_chain.fact_routed`。',
+    'Updated endpoint name.': '更新后的 endpoint 名称。',
+    'Updated receiver URL.': '更新后的接收方 URL。',
+    'Whether the endpoint accepts matching events.': 'endpoint 是否接收匹配事件。',
+    'Replacement array of subscribed event types.': '用于替换的订阅事件类型数组。',
+    'Maximum number of deliveries to return. Defaults to 50 and caps at 200.': '要返回的最大 delivery 数量。默认 50，上限 200。',
+    'Webhook endpoint id.': 'Webhook endpoint id。',
+    'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.':
+      '作用域类型。Space endpoint 返回 `tenant`；Space Chain endpoint 返回 `chain`。',
+    'Tenant id for Space webhooks or chain id for Space Chain webhooks.': 'Space webhook 的 tenant id，或 Space Chain webhook 的 chain id。',
+    'Receiver URL.': '接收方 URL。',
+    'Subscribed event type array.': '已订阅的事件类型数组。',
+    'Array of webhook endpoints.': 'Webhook endpoint 数组。',
+    'One-time signing secret returned only by create and rotate-secret responses.': '一次性 signing secret，只会在 create 和 rotate-secret 响应中返回。',
+    'Delivery id.': 'Delivery id。',
+    'Event id.': 'Event id。',
+    'Webhook endpoint id for this delivery.': '本次 delivery 对应的 webhook endpoint id。',
+    'Event type delivered to the receiver.': '发送给 receiver 的事件类型。',
+    'Delivery scope type.': 'Delivery 作用域类型。',
+    'Delivery scope id.': 'Delivery 作用域 id。',
+    'Delivery status: `pending`, `delivered`, or `failed`.': 'Delivery 状态：`pending`、`delivered` 或 `failed`。',
+    'Delivery attempt count.': 'Delivery 尝试次数。',
+    'Next retry timestamp for pending deliveries.': 'pending delivery 的下一次重试时间戳。',
+    'Most recent HTTP status returned by the receiver.': 'receiver 最近返回的 HTTP 状态。',
+    'Most recent delivery error message.': '最近的 delivery 错误消息。',
+    'Timestamp when delivery reached a 2xx response.': 'delivery 收到 2xx 响应时的时间戳。',
+    'Array of webhook delivery records.': 'Webhook delivery record 数组。',
+    'Queued test delivery record.': '已排队的测试 delivery record。',
+  },
+  'zh-Hant': {
+    Webhooks: 'Webhooks',
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.':
+      '為 Space 和 Space Chain 建立帶簽名的事件訂閱。mem9 會保存 endpoint 狀態、delivery 嘗試、重試狀態和 delivery 歷史。',
+    'List Space webhooks.': '列出 Space webhooks。',
+    'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.': '列出 `X-API-Key` 中 Space API key 作用域下的 webhook endpoints。',
+    'List Space webhooks': '列出 Space webhooks',
+    'Create a Space webhook.': '建立 Space webhook。',
+    'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.':
+      '建立 Space 作用域的 webhook endpoint。回應只會包含一次 `signing_secret`；請在關閉回應前保存。',
+    'Create Space webhook': '建立 Space webhook',
+    'Read one Space webhook.': '讀取單個 Space webhook。',
+    'Returns one Space-scoped webhook endpoint without the signing secret.': '回傳一個 Space 作用域的 webhook endpoint，不包含 signing secret。',
+    'Update a Space webhook.': '更新 Space webhook。',
+    'Updates endpoint name, URL, enabled state, or subscribed events.': '更新 endpoint 名稱、URL、enabled 狀態或訂閱事件。',
+    'Disable Space webhook': '停用 Space webhook',
+    'Delete a Space webhook.': '刪除 Space webhook。',
+    'Soft-deletes the endpoint. A successful delete returns `204 No Content`.': '軟刪除 endpoint。刪除成功時回傳 `204 No Content`。',
+    'Test a Space webhook.': '測試 Space webhook。',
+    'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.':
+      '向 endpoint 排入一筆 `webhook.test` delivery，方便驗證 receiver 和簽名處理。',
+    'Test Space webhook': '測試 Space webhook',
+    'Rotate a Space webhook secret.': '輪換 Space webhook secret。',
+    'Replaces the signing secret and returns the new `signing_secret` once.': '替換 signing secret，並且只回傳一次新的 `signing_secret`。',
+    'Rotate Space webhook secret': '輪換 Space webhook secret',
+    'List Space webhook deliveries.': '列出 Space webhook deliveries。',
+    'Returns recent delivery records for the current Space scope.': '回傳目前 Space 作用域最近的 delivery records。',
+    'List Space deliveries': '列出 Space deliveries',
+    'List Space Chain webhooks.': '列出 Space Chain webhooks。',
+    'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.':
+      '列出 Space Chain 作用域下的 webhook endpoints。需要在 `X-API-Key` 中提供 chain management key。',
+    'List Space Chain webhooks': '列出 Space Chain webhooks',
+    'Create a Space Chain webhook.': '建立 Space Chain webhook。',
+    'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.':
+      '建立 chain 作用域的 webhook endpoint。可用於 chain-level memory 事件和 `space_chain.fact_routed` 路由事件。',
+    'Create Space Chain webhook': '建立 Space Chain webhook',
+    'Read one Space Chain webhook.': '讀取單個 Space Chain webhook。',
+    'Returns one chain-scoped webhook endpoint without the signing secret.': '回傳一個 chain 作用域的 webhook endpoint，不包含 signing secret。',
+    'Update a Space Chain webhook.': '更新 Space Chain webhook。',
+    'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.':
+      '更新 chain 作用域 endpoint 的名稱、URL、enabled 狀態或訂閱事件。',
+    'Update Space Chain webhook': '更新 Space Chain webhook',
+    'Delete a Space Chain webhook.': '刪除 Space Chain webhook。',
+    'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.':
+      '軟刪除 chain 作用域 endpoint。刪除成功時回傳 `204 No Content`。',
+    'Test a Space Chain webhook.': '測試 Space Chain webhook。',
+    'Queues a `webhook.test` delivery for a chain-scoped endpoint.': '為 chain 作用域 endpoint 排入一筆 `webhook.test` delivery。',
+    'Test Space Chain webhook': '測試 Space Chain webhook',
+    'Rotate a Space Chain webhook secret.': '輪換 Space Chain webhook secret。',
+    'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.':
+      '替換 chain 作用域 endpoint 的 signing secret，並且只回傳一次新的 `signing_secret`。',
+    'Rotate Space Chain webhook secret': '輪換 Space Chain webhook secret',
+    'List Space Chain webhook deliveries.': '列出 Space Chain webhook deliveries。',
+    'Returns recent delivery records for the Space Chain scope.': '回傳 Space Chain 作用域最近的 delivery records。',
+    'List Space Chain deliveries': '列出 Space Chain deliveries',
+    'Human-readable endpoint name.': '人類可讀的 endpoint 名稱。',
+    'Receiver URL. Production deployments require HTTPS.': '接收方 URL。production 部署要求 HTTPS。',
+    'Whether the endpoint accepts matching events. Defaults to true on create.': 'endpoint 是否接收匹配事件。建立時預設是 true。',
+    'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.':
+      '要訂閱的事件類型陣列：`memory.added`、`memory.deleted` 或 `space_chain.fact_routed`。',
+    'Updated endpoint name.': '更新後的 endpoint 名稱。',
+    'Updated receiver URL.': '更新後的接收方 URL。',
+    'Whether the endpoint accepts matching events.': 'endpoint 是否接收匹配事件。',
+    'Replacement array of subscribed event types.': '用於替換的訂閱事件類型陣列。',
+    'Maximum number of deliveries to return. Defaults to 50 and caps at 200.': '要回傳的最大 delivery 數量。預設 50，上限 200。',
+    'Webhook endpoint id.': 'Webhook endpoint id。',
+    'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.':
+      '作用域類型。Space endpoint 回傳 `tenant`；Space Chain endpoint 回傳 `chain`。',
+    'Tenant id for Space webhooks or chain id for Space Chain webhooks.': 'Space webhook 的 tenant id，或 Space Chain webhook 的 chain id。',
+    'Receiver URL.': '接收方 URL。',
+    'Subscribed event type array.': '已訂閱的事件類型陣列。',
+    'Creation timestamp.': '建立時間戳。',
+    'Last update timestamp.': '最後更新時間戳。',
+    'Array of webhook endpoints.': 'Webhook endpoint 陣列。',
+    'One-time signing secret returned only by create and rotate-secret responses.': '一次性 signing secret，只會在 create 和 rotate-secret 回應中回傳。',
+    'Delivery id.': 'Delivery id。',
+    'Event id.': 'Event id。',
+    'Webhook endpoint id for this delivery.': '本次 delivery 對應的 webhook endpoint id。',
+    'Event type delivered to the receiver.': '送給 receiver 的事件類型。',
+    'Delivery scope type.': 'Delivery 作用域類型。',
+    'Delivery scope id.': 'Delivery 作用域 id。',
+    'Delivery status: `pending`, `delivered`, or `failed`.': 'Delivery 狀態：`pending`、`delivered` 或 `failed`。',
+    'Delivery attempt count.': 'Delivery 嘗試次數。',
+    'Next retry timestamp for pending deliveries.': 'pending delivery 的下一次重試時間戳。',
+    'Most recent HTTP status returned by the receiver.': 'receiver 最近回傳的 HTTP 狀態。',
+    'Most recent delivery error message.': '最近的 delivery 錯誤訊息。',
+    'Timestamp when delivery reached a 2xx response.': 'delivery 收到 2xx 回應時的時間戳。',
+    'Array of webhook delivery records.': 'Webhook delivery record 陣列。',
+    'Queued test delivery record.': '已排入的測試 delivery record。',
+  },
+  ja: {
+    Webhooks: 'Webhooks',
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.':
+      'Space と Space Chain の署名付き event subscription を作成します。mem9 は endpoint state、delivery attempts、retry state、delivery history を保存します。',
+    'List Space webhooks.': 'Space webhooks を一覧する。',
+    'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.': '`X-API-Key` の Space API key に scoped された webhook endpoints を一覧します。',
+    'List Space webhooks': 'Space webhooks を一覧',
+    'Create a Space webhook.': 'Space webhook を作成する。',
+    'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.':
+      'Space-scoped webhook endpoint を作成します。response には `signing_secret` が一度だけ含まれるため、閉じる前に保存してください。',
+    'Create Space webhook': 'Space webhook を作成',
+    'Read one Space webhook.': 'Space webhook を 1 件取得する。',
+    'Returns one Space-scoped webhook endpoint without the signing secret.': 'signing secret を含まない Space-scoped webhook endpoint を 1 件返します。',
+    'Update a Space webhook.': 'Space webhook を更新する。',
+    'Updates endpoint name, URL, enabled state, or subscribed events.': 'endpoint name、URL、enabled state、subscribed events を更新します。',
+    'Disable Space webhook': 'Space webhook を無効化',
+    'Delete a Space webhook.': 'Space webhook を削除する。',
+    'Soft-deletes the endpoint. A successful delete returns `204 No Content`.': 'endpoint を soft delete します。成功時は `204 No Content` を返します。',
+    'Test a Space webhook.': 'Space webhook をテストする。',
+    'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.':
+      'receiver と signature handling を検証できるよう、endpoint に `webhook.test` delivery を enqueue します。',
+    'Test Space webhook': 'Space webhook をテスト',
+    'Rotate a Space webhook secret.': 'Space webhook secret を rotate する。',
+    'Replaces the signing secret and returns the new `signing_secret` once.': 'signing secret を置き換え、新しい `signing_secret` を一度だけ返します。',
+    'Rotate Space webhook secret': 'Space webhook secret を rotate',
+    'List Space webhook deliveries.': 'Space webhook deliveries を一覧する。',
+    'Returns recent delivery records for the current Space scope.': '現在の Space scope の最近の delivery records を返します。',
+    'List Space deliveries': 'Space deliveries を一覧',
+    'List Space Chain webhooks.': 'Space Chain webhooks を一覧する。',
+    'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.':
+      'Space Chain に scoped された webhook endpoints を一覧します。`X-API-Key` には chain management key が必要です。',
+    'List Space Chain webhooks': 'Space Chain webhooks を一覧',
+    'Create a Space Chain webhook.': 'Space Chain webhook を作成する。',
+    'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.':
+      'chain-scoped webhook endpoint を作成します。chain-level memory events と `space_chain.fact_routed` routing events に使います。',
+    'Create Space Chain webhook': 'Space Chain webhook を作成',
+    'Read one Space Chain webhook.': 'Space Chain webhook を 1 件取得する。',
+    'Returns one chain-scoped webhook endpoint without the signing secret.': 'signing secret を含まない chain-scoped webhook endpoint を 1 件返します。',
+    'Update a Space Chain webhook.': 'Space Chain webhook を更新する。',
+    'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.':
+      'chain-scoped endpoint の name、URL、enabled state、subscribed events を更新します。',
+    'Update Space Chain webhook': 'Space Chain webhook を更新',
+    'Delete a Space Chain webhook.': 'Space Chain webhook を削除する。',
+    'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.':
+      'chain-scoped endpoint を soft delete します。成功時は `204 No Content` を返します。',
+    'Test a Space Chain webhook.': 'Space Chain webhook をテストする。',
+    'Queues a `webhook.test` delivery for a chain-scoped endpoint.': 'chain-scoped endpoint に `webhook.test` delivery を enqueue します。',
+    'Test Space Chain webhook': 'Space Chain webhook をテスト',
+    'Rotate a Space Chain webhook secret.': 'Space Chain webhook secret を rotate する。',
+    'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.':
+      'chain-scoped endpoint の signing secret を置き換え、新しい `signing_secret` を一度だけ返します。',
+    'Rotate Space Chain webhook secret': 'Space Chain webhook secret を rotate',
+    'List Space Chain webhook deliveries.': 'Space Chain webhook deliveries を一覧する。',
+    'Returns recent delivery records for the Space Chain scope.': 'Space Chain scope の最近の delivery records を返します。',
+    'List Space Chain deliveries': 'Space Chain deliveries を一覧',
+    'Human-readable endpoint name.': '人が読める endpoint name。',
+    'Receiver URL. Production deployments require HTTPS.': 'receiver URL。production deployment では HTTPS が必要です。',
+    'Whether the endpoint accepts matching events. Defaults to true on create.': 'endpoint が matching events を受け付けるかどうか。create 時の default は true です。',
+    'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.':
+      'subscribe する event type の配列: `memory.added`、`memory.deleted`、`space_chain.fact_routed`。',
+    'Updated endpoint name.': '更新後の endpoint name。',
+    'Updated receiver URL.': '更新後の receiver URL。',
+    'Whether the endpoint accepts matching events.': 'endpoint が matching events を受け付けるかどうか。',
+    'Replacement array of subscribed event types.': 'subscribed event types を置き換える配列。',
+    'Maximum number of deliveries to return. Defaults to 50 and caps at 200.': '返す delivery の最大数。default は 50、上限は 200 です。',
+    'Webhook endpoint id.': 'Webhook endpoint id。',
+    'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.':
+      'scope type。Space endpoints は `tenant`、Space Chain endpoints は `chain` を返します。',
+    'Tenant id for Space webhooks or chain id for Space Chain webhooks.': 'Space webhooks の tenant id、または Space Chain webhooks の chain id。',
+    'Receiver URL.': 'receiver URL。',
+    'Subscribed event type array.': 'subscribed event type 配列。',
+    'Creation timestamp.': '作成 timestamp。',
+    'Last update timestamp.': '最終更新 timestamp。',
+    'Array of webhook endpoints.': 'webhook endpoint の配列。',
+    'One-time signing secret returned only by create and rotate-secret responses.': 'create と rotate-secret responses でのみ返る一度限りの signing secret。',
+    'Delivery id.': 'Delivery id。',
+    'Event id.': 'Event id。',
+    'Webhook endpoint id for this delivery.': 'この delivery の webhook endpoint id。',
+    'Event type delivered to the receiver.': 'receiver に送信された event type。',
+    'Delivery scope type.': 'Delivery scope type。',
+    'Delivery scope id.': 'Delivery scope id。',
+    'Delivery status: `pending`, `delivered`, or `failed`.': 'Delivery status: `pending`、`delivered`、`failed`。',
+    'Delivery attempt count.': 'Delivery attempt count。',
+    'Next retry timestamp for pending deliveries.': 'pending deliveries の次回 retry timestamp。',
+    'Most recent HTTP status returned by the receiver.': 'receiver が返した最新の HTTP status。',
+    'Most recent delivery error message.': '最新の delivery error message。',
+    'Timestamp when delivery reached a 2xx response.': 'delivery が 2xx response に到達した timestamp。',
+    'Array of webhook delivery records.': 'webhook delivery record の配列。',
+    'Queued test delivery record.': 'enqueue 済みの test delivery record。',
+  },
+  ko: {
+    Webhooks: 'Webhooks',
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.':
+      'Space 와 Space Chain 의 signed event subscription 을 생성합니다. mem9 는 endpoint state, delivery attempts, retry state, delivery history 를 저장합니다.',
+    'List Space webhooks.': 'Space webhooks 를 조회합니다.',
+    'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.': '`X-API-Key` 의 Space API key scope 에 해당하는 webhook endpoints 를 조회합니다.',
+    'List Space webhooks': 'Space webhooks 조회',
+    'Create a Space webhook.': 'Space webhook 을 생성합니다.',
+    'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.':
+      'Space-scoped webhook endpoint 를 생성합니다. response 에는 `signing_secret` 이 한 번만 포함되므로 response 를 닫기 전에 저장하세요.',
+    'Create Space webhook': 'Space webhook 생성',
+    'Read one Space webhook.': 'Space webhook 하나를 조회합니다.',
+    'Returns one Space-scoped webhook endpoint without the signing secret.': 'signing secret 없이 Space-scoped webhook endpoint 하나를 반환합니다.',
+    'Update a Space webhook.': 'Space webhook 을 업데이트합니다.',
+    'Updates endpoint name, URL, enabled state, or subscribed events.': 'endpoint name, URL, enabled state, subscribed events 를 업데이트합니다.',
+    'Disable Space webhook': 'Space webhook 비활성화',
+    'Delete a Space webhook.': 'Space webhook 을 삭제합니다.',
+    'Soft-deletes the endpoint. A successful delete returns `204 No Content`.': 'endpoint 를 soft delete 합니다. 성공하면 `204 No Content` 를 반환합니다.',
+    'Test a Space webhook.': 'Space webhook 을 테스트합니다.',
+    'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.':
+      'receiver 와 signature handling 을 검증할 수 있도록 endpoint 에 `webhook.test` delivery 를 queue 합니다.',
+    'Test Space webhook': 'Space webhook 테스트',
+    'Rotate a Space webhook secret.': 'Space webhook secret 을 rotate 합니다.',
+    'Replaces the signing secret and returns the new `signing_secret` once.': 'signing secret 을 교체하고 새 `signing_secret` 을 한 번만 반환합니다.',
+    'Rotate Space webhook secret': 'Space webhook secret rotate',
+    'List Space webhook deliveries.': 'Space webhook deliveries 를 조회합니다.',
+    'Returns recent delivery records for the current Space scope.': '현재 Space scope 의 최근 delivery records 를 반환합니다.',
+    'List Space deliveries': 'Space deliveries 조회',
+    'List Space Chain webhooks.': 'Space Chain webhooks 를 조회합니다.',
+    'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.':
+      'Space Chain scope 의 webhook endpoints 를 조회합니다. `X-API-Key` 에 chain management key 가 필요합니다.',
+    'List Space Chain webhooks': 'Space Chain webhooks 조회',
+    'Create a Space Chain webhook.': 'Space Chain webhook 을 생성합니다.',
+    'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.':
+      'chain-scoped webhook endpoint 를 생성합니다. chain-level memory events 와 `space_chain.fact_routed` routing events 에 사용합니다.',
+    'Create Space Chain webhook': 'Space Chain webhook 생성',
+    'Read one Space Chain webhook.': 'Space Chain webhook 하나를 조회합니다.',
+    'Returns one chain-scoped webhook endpoint without the signing secret.': 'signing secret 없이 chain-scoped webhook endpoint 하나를 반환합니다.',
+    'Update a Space Chain webhook.': 'Space Chain webhook 을 업데이트합니다.',
+    'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.':
+      'chain-scoped endpoint 의 name, URL, enabled state, subscribed events 를 업데이트합니다.',
+    'Update Space Chain webhook': 'Space Chain webhook 업데이트',
+    'Delete a Space Chain webhook.': 'Space Chain webhook 을 삭제합니다.',
+    'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.':
+      'chain-scoped endpoint 를 soft delete 합니다. 성공하면 `204 No Content` 를 반환합니다.',
+    'Test a Space Chain webhook.': 'Space Chain webhook 을 테스트합니다.',
+    'Queues a `webhook.test` delivery for a chain-scoped endpoint.': 'chain-scoped endpoint 에 `webhook.test` delivery 를 queue 합니다.',
+    'Test Space Chain webhook': 'Space Chain webhook 테스트',
+    'Rotate a Space Chain webhook secret.': 'Space Chain webhook secret 을 rotate 합니다.',
+    'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.':
+      'chain-scoped endpoint signing secret 을 교체하고 새 `signing_secret` 을 한 번만 반환합니다.',
+    'Rotate Space Chain webhook secret': 'Space Chain webhook secret rotate',
+    'List Space Chain webhook deliveries.': 'Space Chain webhook deliveries 를 조회합니다.',
+    'Returns recent delivery records for the Space Chain scope.': 'Space Chain scope 의 최근 delivery records 를 반환합니다.',
+    'List Space Chain deliveries': 'Space Chain deliveries 조회',
+    'Human-readable endpoint name.': '사람이 읽을 수 있는 endpoint name.',
+    'Receiver URL. Production deployments require HTTPS.': 'receiver URL. production deployment 에서는 HTTPS 가 필요합니다.',
+    'Whether the endpoint accepts matching events. Defaults to true on create.': 'endpoint 가 matching events 를 받을지 여부. create 시 기본값은 true 입니다.',
+    'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.':
+      'subscribe 할 event type 배열: `memory.added`, `memory.deleted`, `space_chain.fact_routed`.',
+    'Updated endpoint name.': '업데이트된 endpoint name.',
+    'Updated receiver URL.': '업데이트된 receiver URL.',
+    'Whether the endpoint accepts matching events.': 'endpoint 가 matching events 를 받을지 여부.',
+    'Replacement array of subscribed event types.': 'subscribed event types 를 교체할 배열.',
+    'Maximum number of deliveries to return. Defaults to 50 and caps at 200.': '반환할 delivery 최대 수. 기본값은 50, 상한은 200 입니다.',
+    'Webhook endpoint id.': 'Webhook endpoint id.',
+    'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.':
+      'scope type. Space endpoints 는 `tenant`, Space Chain endpoints 는 `chain` 을 반환합니다.',
+    'Tenant id for Space webhooks or chain id for Space Chain webhooks.': 'Space webhooks 의 tenant id 또는 Space Chain webhooks 의 chain id.',
+    'Receiver URL.': 'receiver URL.',
+    'Subscribed event type array.': 'subscribed event type 배열.',
+    'Creation timestamp.': '생성 timestamp.',
+    'Last update timestamp.': '마지막 업데이트 timestamp.',
+    'Array of webhook endpoints.': 'webhook endpoint 배열.',
+    'One-time signing secret returned only by create and rotate-secret responses.': 'create 와 rotate-secret responses 에서만 반환되는 one-time signing secret.',
+    'Delivery id.': 'Delivery id.',
+    'Event id.': 'Event id.',
+    'Webhook endpoint id for this delivery.': '이 delivery 의 webhook endpoint id.',
+    'Event type delivered to the receiver.': 'receiver 로 전달된 event type.',
+    'Delivery scope type.': 'Delivery scope type.',
+    'Delivery scope id.': 'Delivery scope id.',
+    'Delivery status: `pending`, `delivered`, or `failed`.': 'Delivery status: `pending`, `delivered`, `failed`.',
+    'Delivery attempt count.': 'Delivery attempt count.',
+    'Next retry timestamp for pending deliveries.': 'pending deliveries 의 다음 retry timestamp.',
+    'Most recent HTTP status returned by the receiver.': 'receiver 가 반환한 가장 최근 HTTP status.',
+    'Most recent delivery error message.': '가장 최근 delivery error message.',
+    'Timestamp when delivery reached a 2xx response.': 'delivery 가 2xx response 에 도달한 timestamp.',
+    'Array of webhook delivery records.': 'webhook delivery record 배열.',
+    'Queued test delivery record.': 'queue 된 test delivery record.',
+  },
+  id: {
+    Webhooks: 'Webhooks',
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.':
+      'Buat langganan event bertanda tangan untuk Space dan Space Chain. mem9 menyimpan endpoint state, delivery attempts, retry state, dan delivery history.',
+    'List Space webhooks.': 'List Space webhooks.',
+    'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.': 'Menampilkan webhook endpoints dalam scope Space API key di `X-API-Key`.',
+    'List Space webhooks': 'List Space webhooks',
+    'Create a Space webhook.': 'Buat Space webhook.',
+    'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.':
+      'Membuat webhook endpoint dalam scope Space. Response menyertakan `signing_secret` sekali saja; simpan sebelum response ditutup.',
+    'Create Space webhook': 'Buat Space webhook',
+    'Read one Space webhook.': 'Baca satu Space webhook.',
+    'Returns one Space-scoped webhook endpoint without the signing secret.': 'Mengembalikan satu Space-scoped webhook endpoint tanpa signing secret.',
+    'Update a Space webhook.': 'Update Space webhook.',
+    'Updates endpoint name, URL, enabled state, or subscribed events.': 'Mengupdate endpoint name, URL, enabled state, atau subscribed events.',
+    'Disable Space webhook': 'Nonaktifkan Space webhook',
+    'Delete a Space webhook.': 'Hapus Space webhook.',
+    'Soft-deletes the endpoint. A successful delete returns `204 No Content`.': 'Melakukan soft-delete endpoint. Delete yang berhasil mengembalikan `204 No Content`.',
+    'Test a Space webhook.': 'Test Space webhook.',
+    'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.':
+      'Mengantrekan `webhook.test` delivery ke endpoint agar Anda dapat memverifikasi receiver dan signature handling.',
+    'Test Space webhook': 'Test Space webhook',
+    'Rotate a Space webhook secret.': 'Rotate Space webhook secret.',
+    'Replaces the signing secret and returns the new `signing_secret` once.': 'Mengganti signing secret dan mengembalikan `signing_secret` baru sekali saja.',
+    'Rotate Space webhook secret': 'Rotate Space webhook secret',
+    'List Space webhook deliveries.': 'List Space webhook deliveries.',
+    'Returns recent delivery records for the current Space scope.': 'Mengembalikan delivery records terbaru untuk scope Space saat ini.',
+    'List Space deliveries': 'List Space deliveries',
+    'List Space Chain webhooks.': 'List Space Chain webhooks.',
+    'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.':
+      'Menampilkan webhook endpoints dalam scope Space Chain. Memerlukan chain management key di `X-API-Key`.',
+    'List Space Chain webhooks': 'List Space Chain webhooks',
+    'Create a Space Chain webhook.': 'Buat Space Chain webhook.',
+    'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.':
+      'Membuat chain-scoped webhook endpoint. Gunakan untuk chain-level memory events dan `space_chain.fact_routed` routing events.',
+    'Create Space Chain webhook': 'Buat Space Chain webhook',
+    'Read one Space Chain webhook.': 'Baca satu Space Chain webhook.',
+    'Returns one chain-scoped webhook endpoint without the signing secret.': 'Mengembalikan satu chain-scoped webhook endpoint tanpa signing secret.',
+    'Update a Space Chain webhook.': 'Update Space Chain webhook.',
+    'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.':
+      'Mengupdate endpoint name, URL, enabled state, atau subscribed events untuk chain-scoped endpoint.',
+    'Update Space Chain webhook': 'Update Space Chain webhook',
+    'Delete a Space Chain webhook.': 'Hapus Space Chain webhook.',
+    'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.':
+      'Melakukan soft-delete chain-scoped endpoint. Delete yang berhasil mengembalikan `204 No Content`.',
+    'Test a Space Chain webhook.': 'Test Space Chain webhook.',
+    'Queues a `webhook.test` delivery for a chain-scoped endpoint.': 'Mengantrekan `webhook.test` delivery untuk chain-scoped endpoint.',
+    'Test Space Chain webhook': 'Test Space Chain webhook',
+    'Rotate a Space Chain webhook secret.': 'Rotate Space Chain webhook secret.',
+    'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.':
+      'Mengganti signing secret milik chain-scoped endpoint dan mengembalikan `signing_secret` baru sekali saja.',
+    'Rotate Space Chain webhook secret': 'Rotate Space Chain webhook secret',
+    'List Space Chain webhook deliveries.': 'List Space Chain webhook deliveries.',
+    'Returns recent delivery records for the Space Chain scope.': 'Mengembalikan delivery records terbaru untuk scope Space Chain.',
+    'List Space Chain deliveries': 'List Space Chain deliveries',
+    'Human-readable endpoint name.': 'endpoint name yang mudah dibaca.',
+    'Receiver URL. Production deployments require HTTPS.': 'receiver URL. Production deployment memerlukan HTTPS.',
+    'Whether the endpoint accepts matching events. Defaults to true on create.': 'Apakah endpoint menerima matching events. Default true saat create.',
+    'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.':
+      'Array event type yang disubscribe: `memory.added`, `memory.deleted`, atau `space_chain.fact_routed`.',
+    'Updated endpoint name.': 'endpoint name yang diperbarui.',
+    'Updated receiver URL.': 'receiver URL yang diperbarui.',
+    'Whether the endpoint accepts matching events.': 'Apakah endpoint menerima matching events.',
+    'Replacement array of subscribed event types.': 'Array pengganti untuk subscribed event types.',
+    'Maximum number of deliveries to return. Defaults to 50 and caps at 200.': 'Jumlah maksimum deliveries yang dikembalikan. Default 50 dan batas atas 200.',
+    'Webhook endpoint id.': 'Webhook endpoint id.',
+    'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.':
+      'scope type. Space endpoints mengembalikan `tenant`; Space Chain endpoints mengembalikan `chain`.',
+    'Tenant id for Space webhooks or chain id for Space Chain webhooks.': 'tenant id untuk Space webhooks atau chain id untuk Space Chain webhooks.',
+    'Receiver URL.': 'receiver URL.',
+    'Subscribed event type array.': 'Array subscribed event type.',
+    'Creation timestamp.': 'Timestamp pembuatan.',
+    'Last update timestamp.': 'Timestamp update terakhir.',
+    'Array of webhook endpoints.': 'Array webhook endpoints.',
+    'One-time signing secret returned only by create and rotate-secret responses.': 'One-time signing secret yang hanya dikembalikan oleh response create dan rotate-secret.',
+    'Delivery id.': 'Delivery id.',
+    'Event id.': 'Event id.',
+    'Webhook endpoint id for this delivery.': 'webhook endpoint id untuk delivery ini.',
+    'Event type delivered to the receiver.': 'event type yang dikirim ke receiver.',
+    'Delivery scope type.': 'Delivery scope type.',
+    'Delivery scope id.': 'Delivery scope id.',
+    'Delivery status: `pending`, `delivered`, or `failed`.': 'Delivery status: `pending`, `delivered`, atau `failed`.',
+    'Delivery attempt count.': 'Jumlah delivery attempt.',
+    'Next retry timestamp for pending deliveries.': 'Timestamp retry berikutnya untuk pending deliveries.',
+    'Most recent HTTP status returned by the receiver.': 'HTTP status terbaru yang dikembalikan receiver.',
+    'Most recent delivery error message.': 'delivery error message terbaru.',
+    'Timestamp when delivery reached a 2xx response.': 'Timestamp saat delivery menerima response 2xx.',
+    'Array of webhook delivery records.': 'Array webhook delivery records.',
+    'Queued test delivery record.': 'test delivery record yang sudah diantrekan.',
+  },
+  th: {
+    Webhooks: 'Webhooks',
+    'Create signed event subscriptions for Spaces and Space Chains. mem9 stores endpoint state, delivery attempts, retry state, and delivery history.':
+      'สร้าง event subscriptions พร้อมลายเซ็นสำหรับ Space และ Space Chain โดย mem9 จะเก็บ endpoint state, delivery attempts, retry state และ delivery history',
+    'List Space webhooks.': 'แสดง Space webhooks',
+    'Lists webhook endpoints scoped to the Space API key in `X-API-Key`.': 'แสดง webhook endpoints ใน scope ของ Space API key ที่อยู่ใน `X-API-Key`',
+    'List Space webhooks': 'แสดง Space webhooks',
+    'Create a Space webhook.': 'สร้าง Space webhook',
+    'Creates a Space-scoped webhook endpoint. The response includes `signing_secret` once; store it before closing the response.':
+      'สร้าง webhook endpoint ใน scope ของ Space โดย response มี `signing_secret` เพียงครั้งเดียว โปรดบันทึกไว้ก่อนปิด response',
+    'Create Space webhook': 'สร้าง Space webhook',
+    'Read one Space webhook.': 'อ่าน Space webhook หนึ่งรายการ',
+    'Returns one Space-scoped webhook endpoint without the signing secret.': 'คืน webhook endpoint ใน scope ของ Space หนึ่งรายการโดยไม่มี signing secret',
+    'Update a Space webhook.': 'อัปเดต Space webhook',
+    'Updates endpoint name, URL, enabled state, or subscribed events.': 'อัปเดต endpoint name, URL, enabled state หรือ subscribed events',
+    'Disable Space webhook': 'ปิดใช้งาน Space webhook',
+    'Delete a Space webhook.': 'ลบ Space webhook',
+    'Soft-deletes the endpoint. A successful delete returns `204 No Content`.': 'soft-delete endpoint และคืน `204 No Content` เมื่อสำเร็จ',
+    'Test a Space webhook.': 'ทดสอบ Space webhook',
+    'Queues a `webhook.test` delivery to the endpoint so you can verify the receiver and signature handling.':
+      'คิว `webhook.test` delivery ไปยัง endpoint เพื่อให้ตรวจสอบ receiver และ signature handling ได้',
+    'Test Space webhook': 'ทดสอบ Space webhook',
+    'Rotate a Space webhook secret.': 'rotate Space webhook secret',
+    'Replaces the signing secret and returns the new `signing_secret` once.': 'แทนที่ signing secret และคืน `signing_secret` ใหม่เพียงครั้งเดียว',
+    'Rotate Space webhook secret': 'rotate Space webhook secret',
+    'List Space webhook deliveries.': 'แสดง Space webhook deliveries',
+    'Returns recent delivery records for the current Space scope.': 'คืน delivery records ล่าสุดสำหรับ Space scope ปัจจุบัน',
+    'List Space deliveries': 'แสดง Space deliveries',
+    'List Space Chain webhooks.': 'แสดง Space Chain webhooks',
+    'Lists webhook endpoints scoped to a Space Chain. Requires the chain management key in `X-API-Key`.':
+      'แสดง webhook endpoints ใน scope ของ Space Chain ต้องใช้ chain management key ใน `X-API-Key`',
+    'List Space Chain webhooks': 'แสดง Space Chain webhooks',
+    'Create a Space Chain webhook.': 'สร้าง Space Chain webhook',
+    'Creates a chain-scoped webhook endpoint. Use it for chain-level memory events and `space_chain.fact_routed` routing events.':
+      'สร้าง chain-scoped webhook endpoint ใช้สำหรับ chain-level memory events และ `space_chain.fact_routed` routing events',
+    'Create Space Chain webhook': 'สร้าง Space Chain webhook',
+    'Read one Space Chain webhook.': 'อ่าน Space Chain webhook หนึ่งรายการ',
+    'Returns one chain-scoped webhook endpoint without the signing secret.': 'คืน chain-scoped webhook endpoint หนึ่งรายการโดยไม่มี signing secret',
+    'Update a Space Chain webhook.': 'อัปเดต Space Chain webhook',
+    'Updates endpoint name, URL, enabled state, or subscribed events for a chain-scoped endpoint.':
+      'อัปเดต endpoint name, URL, enabled state หรือ subscribed events สำหรับ chain-scoped endpoint',
+    'Update Space Chain webhook': 'อัปเดต Space Chain webhook',
+    'Delete a Space Chain webhook.': 'ลบ Space Chain webhook',
+    'Soft-deletes the chain-scoped endpoint. A successful delete returns `204 No Content`.':
+      'soft-delete chain-scoped endpoint และคืน `204 No Content` เมื่อสำเร็จ',
+    'Test a Space Chain webhook.': 'ทดสอบ Space Chain webhook',
+    'Queues a `webhook.test` delivery for a chain-scoped endpoint.': 'คิว `webhook.test` delivery สำหรับ chain-scoped endpoint',
+    'Test Space Chain webhook': 'ทดสอบ Space Chain webhook',
+    'Rotate a Space Chain webhook secret.': 'rotate Space Chain webhook secret',
+    'Replaces the chain-scoped endpoint signing secret and returns the new `signing_secret` once.':
+      'แทนที่ signing secret ของ chain-scoped endpoint และคืน `signing_secret` ใหม่เพียงครั้งเดียว',
+    'Rotate Space Chain webhook secret': 'rotate Space Chain webhook secret',
+    'List Space Chain webhook deliveries.': 'แสดง Space Chain webhook deliveries',
+    'Returns recent delivery records for the Space Chain scope.': 'คืน delivery records ล่าสุดสำหรับ Space Chain scope',
+    'List Space Chain deliveries': 'แสดง Space Chain deliveries',
+    'Human-readable endpoint name.': 'endpoint name ที่อ่านเข้าใจง่าย',
+    'Receiver URL. Production deployments require HTTPS.': 'receiver URL โดย production deployment ต้องใช้ HTTPS',
+    'Whether the endpoint accepts matching events. Defaults to true on create.': 'endpoint รับ matching events หรือไม่ ค่าเริ่มต้นตอน create คือ true',
+    'Array of event types to subscribe to: `memory.added`, `memory.deleted`, or `space_chain.fact_routed`.':
+      'array ของ event types ที่ subscribe: `memory.added`, `memory.deleted` หรือ `space_chain.fact_routed`',
+    'Updated endpoint name.': 'endpoint name ที่อัปเดตแล้ว',
+    'Updated receiver URL.': 'receiver URL ที่อัปเดตแล้ว',
+    'Whether the endpoint accepts matching events.': 'endpoint รับ matching events หรือไม่',
+    'Replacement array of subscribed event types.': 'array ใหม่สำหรับ subscribed event types',
+    'Maximum number of deliveries to return. Defaults to 50 and caps at 200.': 'จำนวน deliveries สูงสุดที่จะคืน ค่าเริ่มต้น 50 และสูงสุด 200',
+    'Webhook endpoint id.': 'Webhook endpoint id',
+    'Scope type. Space endpoints return `tenant`; Space Chain endpoints return `chain`.':
+      'scope type โดย Space endpoints คืน `tenant` และ Space Chain endpoints คืน `chain`',
+    'Tenant id for Space webhooks or chain id for Space Chain webhooks.': 'tenant id สำหรับ Space webhooks หรือ chain id สำหรับ Space Chain webhooks',
+    'Receiver URL.': 'receiver URL',
+    'Subscribed event type array.': 'array ของ subscribed event type',
+    'Creation timestamp.': 'timestamp การสร้าง',
+    'Last update timestamp.': 'timestamp การอัปเดตล่าสุด',
+    'Array of webhook endpoints.': 'array ของ webhook endpoints',
+    'One-time signing secret returned only by create and rotate-secret responses.': 'one-time signing secret ที่คืนเฉพาะจาก response ของ create และ rotate-secret',
+    'Delivery id.': 'Delivery id',
+    'Event id.': 'Event id',
+    'Webhook endpoint id for this delivery.': 'webhook endpoint id สำหรับ delivery นี้',
+    'Event type delivered to the receiver.': 'event type ที่ส่งไปยัง receiver',
+    'Delivery scope type.': 'Delivery scope type',
+    'Delivery scope id.': 'Delivery scope id',
+    'Delivery status: `pending`, `delivered`, or `failed`.': 'Delivery status: `pending`, `delivered` หรือ `failed`',
+    'Delivery attempt count.': 'จำนวน delivery attempt',
+    'Next retry timestamp for pending deliveries.': 'timestamp retry ครั้งถัดไปสำหรับ pending deliveries',
+    'Most recent HTTP status returned by the receiver.': 'HTTP status ล่าสุดที่ receiver คืนมา',
+    'Most recent delivery error message.': 'delivery error message ล่าสุด',
+    'Timestamp when delivery reached a 2xx response.': 'timestamp เมื่อ delivery ได้รับ response 2xx',
+    'Array of webhook delivery records.': 'array ของ webhook delivery records',
+    'Queued test delivery record.': 'test delivery record ที่ถูกคิวแล้ว',
+  },
+};
+
 export function localizeApiSharedText(locale: SiteLocale, text: string): string {
   if (locale === 'en') {
     return text;
   }
 
-  return apiSharedTextTranslations[locale]?.[text] ?? text;
+  return apiSharedTextTranslations[locale]?.[text] ?? webhookApiSharedTextTranslations[locale]?.[text] ?? text;
 }
 
 function localizeApiFields(locale: SiteLocale, fields: SiteApiFieldCopy[] | undefined): SiteApiFieldCopy[] | undefined {


### PR DESCRIPTION
## Summary
- Add mem9 Webhooks API, storage schema, dispatcher, signing, and event enqueue paths
- Document webhook design and update OpenAPI/README
- Cover memory.added, memory.deleted, and space_chain.fact_routed

## Tests
- make test