### PR TITLE
feat: add webhook-only space chain routing

### DIFF
--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -131,16 +131,17 @@ type SpaceChainBinding struct {
 }
 
 type SpaceChainNode struct {
-	ID                   string    `json:"id"`
-	ChainID              string    `json:"chain_id"`
-	TenantID             string    `json:"tenant_id"`
-	ExternalSpaceID      string    `json:"external_space_id,omitempty"`
-	DisplayName          string    `json:"display_name,omitempty"`
-	Position             int       `json:"position"`
-	RoutingPolicyEnabled bool      `json:"routing_policy_enabled"`
-	RoutingPolicyPrompt  string    `json:"routing_policy_prompt,omitempty"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
+	ID                       string    `json:"id"`
+	ChainID                  string    `json:"chain_id"`
+	TenantID                 string    `json:"tenant_id"`
+	ExternalSpaceID          string    `json:"external_space_id,omitempty"`
+	DisplayName              string    `json:"display_name,omitempty"`
+	Position                 int       `json:"position"`
+	RoutingPolicyEnabled     bool      `json:"routing_policy_enabled"`
+	RoutingPolicyPrompt      string    `json:"routing_policy_prompt,omitempty"`
+	RoutingPolicyWebhookOnly bool      `json:"routing_policy_webhook_only"`
+	CreatedAt                time.Time `json:"created_at"`
+	UpdatedAt                time.Time `json:"updated_at"`
 }
 
 // MemoryFilter encapsulates search/list query parameters.

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -115,6 +115,10 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 			defer func() { <-sem }()
 
 			nodeAuth := chainNodeAuth(auth, node)
+			if node.RoutingPolicyWebhookOnly {
+				s.enqueueRoutedFactWebhook(ctx, auth, nodeAuth, node, factsForTarget, nil, req.AgentID, req.AppID, req.SessionID)
+				return
+			}
 			targetSvc := s.resolveServices(nodeAuth)
 			var lease *runtimeusage.OperationLease
 			if s.runtimeUsageEnabled() {
@@ -203,7 +207,7 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 					)
 					continue
 				}
-				s.enqueueRoutedFactWebhook(ctx, auth, nodeAuth, node, factsForTarget, mem)
+				s.enqueueRoutedFactWebhook(ctx, auth, nodeAuth, node, factsForTarget, mem, mem.AgentID, mem.AppID, mem.SessionID)
 			}
 			mu.Lock()
 			out.memoriesChanged += result.MemoriesChanged

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
+	"github.com/qiffang/mnemos/server/internal/webhook"
 )
 
 // testMemoryRepo is a minimal MemoryRepo mock for handler tests.
@@ -601,6 +602,46 @@ func storeTestTenantServices(srv *Server, tenantID string, memRepo *testMemoryRe
 	srv.svcCache.Store(tenantSvcKey(fmt.Sprintf("%s-0x0", tenantID)), svc)
 }
 
+type captureWebhookStore struct {
+	mu     sync.Mutex
+	events []webhook.EventRecord
+}
+
+func (s *captureWebhookStore) EnsureSchema(context.Context) error                     { return nil }
+func (s *captureWebhookStore) CreateEndpoint(context.Context, webhook.Endpoint) error { return nil }
+func (s *captureWebhookStore) ListEndpoints(context.Context, string, string) ([]webhook.Endpoint, error) {
+	return nil, nil
+}
+func (s *captureWebhookStore) GetEndpoint(context.Context, string, string, string) (*webhook.Endpoint, error) {
+	return nil, domain.ErrNotFound
+}
+func (s *captureWebhookStore) UpdateEndpoint(context.Context, webhook.Endpoint) error { return nil }
+func (s *captureWebhookStore) UpdateEndpointSecret(context.Context, webhook.Endpoint) error {
+	return nil
+}
+func (s *captureWebhookStore) SoftDeleteEndpoint(context.Context, string, string, string) error {
+	return nil
+}
+func (s *captureWebhookStore) EnqueueEvent(_ context.Context, event webhook.EventRecord) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+func (s *captureWebhookStore) EnqueueTestEvent(context.Context, webhook.Endpoint, webhook.EventRecord) (webhook.Delivery, error) {
+	return webhook.Delivery{}, nil
+}
+func (s *captureWebhookStore) ListDeliveries(context.Context, string, string, int) ([]webhook.Delivery, error) {
+	return nil, nil
+}
+func (s *captureWebhookStore) FetchDueDeliveries(context.Context, int) ([]webhook.DeliveryJob, error) {
+	return nil, nil
+}
+func (s *captureWebhookStore) MarkDeliveryDelivered(context.Context, string, int) error { return nil }
+func (s *captureWebhookStore) MarkDeliveryFailedAttempt(context.Context, string, bool, time.Time, *int, string) error {
+	return nil
+}
+
 func TestResolveServicesDoesNotCacheAfterAppIDSchemaMigrationFailure(t *testing.T) {
 	db := openHandlerErrorDB(t)
 	defer db.Close()
@@ -768,6 +809,100 @@ func TestReconcileRoutedChainFactsSkipsTargetWhenRuntimeUsageDenied(t *testing.T
 	}
 	if runtimeUsage.afterCreateSuccessCalls != 0 || runtimeUsage.afterCreateFailureCalls != 0 {
 		t.Fatalf("runtime finalization calls = success:%d failure:%d, want 0/0", runtimeUsage.afterCreateSuccessCalls, runtimeUsage.afterCreateFailureCalls)
+	}
+}
+
+func TestReconcileRoutedChainFactsWebhookOnlySkipsTargetWrite(t *testing.T) {
+	targetRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	webhookStore := &captureWebhookStore{}
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).
+		WithRuntimeUsage(runtimeUsage).
+		WithWebhookService(webhook.NewService(webhookStore, nil, true))
+	storeTestTenantServices(srv, "tenant-target-a", targetRepo)
+
+	auth := &domain.AuthInfo{
+		AgentName: "chain-agent",
+		Chain: &domain.ChainAuth{
+			ChainID: "chain-a",
+			APIKey:  "chain-key-a",
+			Nodes: []domain.ChainAuthNode{
+				{
+					SpaceChainNode: domain.SpaceChainNode{TenantID: "tenant-source", ExternalSpaceID: "space-source", Position: 0},
+					ClusterID:      "cluster-source",
+				},
+				{
+					SpaceChainNode: domain.SpaceChainNode{
+						ID:                       "node-target-a",
+						TenantID:                 "tenant-target-a",
+						ExternalSpaceID:          "space-target-a",
+						Position:                 1,
+						RoutingPolicyEnabled:     true,
+						RoutingPolicyPrompt:      "facts about mem9",
+						RoutingPolicyWebhookOnly: true,
+					},
+					ClusterID: "cluster-target-a",
+				},
+			},
+		},
+	}
+
+	result := srv.reconcileRoutedChainFacts(context.Background(), auth, service.IngestRequest{
+		AgentID:   "actor-agent",
+		AppID:     "app-a",
+		SessionID: "session-a",
+	}, []service.ExtractedFact{
+		{Text: "mem9 uses webhooks for review", Tags: []string{"tech"}, RouteTargets: []string{"space-target-a"}},
+	})
+
+	if result.memoriesChanged != 0 || len(result.insightIDs) != 0 || result.warnings != 0 {
+		t.Fatalf("result = %+v, want no memory changes or warnings", result)
+	}
+	if len(targetRepo.createCalls) != 0 {
+		t.Fatalf("target writes = %d, want 0", len(targetRepo.createCalls))
+	}
+	if runtimeUsage.beforeCreateCalls != 0 || runtimeUsage.afterCreateSuccessCalls != 0 || runtimeUsage.afterCreateFailureCalls != 0 {
+		t.Fatalf("runtime create calls = before:%d success:%d failure:%d, want 0/0/0", runtimeUsage.beforeCreateCalls, runtimeUsage.afterCreateSuccessCalls, runtimeUsage.afterCreateFailureCalls)
+	}
+
+	webhookStore.mu.Lock()
+	events := append([]webhook.EventRecord(nil), webhookStore.events...)
+	webhookStore.mu.Unlock()
+	if len(events) != 1 {
+		t.Fatalf("webhook events = %d, want 1", len(events))
+	}
+	if events[0].ScopeType != webhook.ScopeChain || events[0].ScopeID != "chain-a" || events[0].EventType != webhook.EventSpaceChainFactRouted {
+		t.Fatalf("webhook event = %+v, want chain fact routed for chain-a", events[0])
+	}
+	var envelope webhook.EventEnvelope
+	if err := json.Unmarshal(events[0].Payload, &envelope); err != nil {
+		t.Fatalf("decode webhook envelope: %v", err)
+	}
+	var data struct {
+		WebhookOnly           bool                    `json:"webhook_only"`
+		TargetTenantID        string                  `json:"target_tenant_id"`
+		TargetExternalSpaceID string                  `json:"target_external_space_id"`
+		RoutingPolicyNodeID   string                  `json:"routing_policy_node_id"`
+		SourceFacts           []service.ExtractedFact `json:"source_facts"`
+		TargetMemory          *domain.Memory          `json:"target_memory"`
+		AgentID               string                  `json:"agent_id"`
+		AppID                 string                  `json:"appId"`
+		SessionID             string                  `json:"session_id"`
+	}
+	if err := json.Unmarshal(envelope.Data, &data); err != nil {
+		t.Fatalf("decode webhook data: %v", err)
+	}
+	if !data.WebhookOnly || data.TargetMemory != nil {
+		t.Fatalf("webhook data target memory/webhook_only = %v/%#v, want true/nil", data.WebhookOnly, data.TargetMemory)
+	}
+	if data.TargetTenantID != "tenant-target-a" || data.TargetExternalSpaceID != "space-target-a" || data.RoutingPolicyNodeID != "node-target-a" {
+		t.Fatalf("webhook target data = %+v, want target node identifiers", data)
+	}
+	if len(data.SourceFacts) != 1 || data.SourceFacts[0].Text != "mem9 uses webhooks for review" {
+		t.Fatalf("source facts = %+v, want original routed fact", data.SourceFacts)
+	}
+	if data.AgentID != "actor-agent" || data.AppID != "app-a" || data.SessionID != "session-a" {
+		t.Fatalf("actor data = %+v, want request actor fields", data)
 	}
 }
 

--- a/server/internal/handler/webhook_events.go
+++ b/server/internal/handler/webhook_events.go
@@ -67,9 +67,14 @@ func (s *Server) enqueueMemoryDeletedWebhook(ctx context.Context, auth *domain.A
 	}
 }
 
-func (s *Server) enqueueRoutedFactWebhook(ctx context.Context, chainAuth *domain.AuthInfo, targetAuth *domain.AuthInfo, node domain.ChainAuthNode, facts []service.ExtractedFact, mem *domain.Memory) {
-	if s == nil || s.webhooks == nil || chainAuth == nil || chainAuth.Chain == nil || targetAuth == nil || mem == nil {
+func (s *Server) enqueueRoutedFactWebhook(ctx context.Context, chainAuth *domain.AuthInfo, targetAuth *domain.AuthInfo, node domain.ChainAuthNode, facts []service.ExtractedFact, mem *domain.Memory, agentID, appID, sessionID string) {
+	if s == nil || s.webhooks == nil || chainAuth == nil || chainAuth.Chain == nil || targetAuth == nil || len(facts) == 0 {
 		return
+	}
+	if mem != nil {
+		agentID = mem.AgentID
+		appID = mem.AppID
+		sessionID = mem.SessionID
 	}
 	data := map[string]any{
 		"route_id":                 uuid.NewString(),
@@ -78,11 +83,12 @@ func (s *Server) enqueueRoutedFactWebhook(ctx context.Context, chainAuth *domain
 		"target_tenant_id":         targetAuth.TenantID,
 		"target_external_space_id": node.ExternalSpaceID,
 		"routing_policy_node_id":   node.ID,
+		"webhook_only":             node.RoutingPolicyWebhookOnly,
 		"source_facts":             facts,
 		"target_memory":            mem,
-		"agent_id":                 mem.AgentID,
-		"appId":                    mem.AppID,
-		"session_id":               mem.SessionID,
+		"agent_id":                 agentID,
+		"appId":                    appID,
+		"session_id":               sessionID,
 	}
 	s.enqueueWebhook(ctx, webhook.EventScope{Type: webhook.ScopeChain, ChainID: chainAuth.Chain.ChainID}, webhook.EventSpaceChainFactRouted, data)
 }

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -788,7 +788,7 @@ func (r *stubSpaceChainRepo) ReplaceNodes(_ context.Context, _ string, nodes []d
 	return nil
 }
 
-func (r *stubSpaceChainRepo) UpdateNodeRoutingPolicy(_ context.Context, _, nodeID string, enabled bool, prompt string) (*domain.SpaceChainNode, error) {
+func (r *stubSpaceChainRepo) UpdateNodeRoutingPolicy(_ context.Context, _, nodeID string, enabled bool, prompt string, webhookOnly bool) (*domain.SpaceChainNode, error) {
 	if r.chain == nil {
 		return nil, domain.ErrNotFound
 	}
@@ -798,6 +798,7 @@ func (r *stubSpaceChainRepo) UpdateNodeRoutingPolicy(_ context.Context, _, nodeI
 		}
 		r.chain.Nodes[i].RoutingPolicyEnabled = enabled
 		r.chain.Nodes[i].RoutingPolicyPrompt = prompt
+		r.chain.Nodes[i].RoutingPolicyWebhookOnly = webhookOnly
 		return &r.chain.Nodes[i], nil
 	}
 	return nil, domain.ErrNotFound

--- a/server/internal/repository/postgres/space_chain.go
+++ b/server/internal/repository/postgres/space_chain.go
@@ -31,6 +31,9 @@ func (r *SpaceChainRepoImpl) ensureRoutingPolicyColumns(ctx context.Context) err
 	if _, err := r.db.ExecContext(ctx, `ALTER TABLE space_chain_nodes ADD COLUMN IF NOT EXISTS routing_policy_prompt TEXT NULL`); err != nil {
 		return fmt.Errorf("add space chain routing policy prompt column: %w", err)
 	}
+	if _, err := r.db.ExecContext(ctx, `ALTER TABLE space_chain_nodes ADD COLUMN IF NOT EXISTS routing_policy_webhook_only BOOLEAN NOT NULL DEFAULT FALSE`); err != nil {
+		return fmt.Errorf("add space chain routing policy webhook only column: %w", err)
+	}
 	r.routingPolicySchemaReady = true
 	return nil
 }
@@ -208,7 +211,7 @@ func (r *SpaceChainRepoImpl) ListNodes(ctx context.Context, chainID string) ([]d
 		return nil, err
 	}
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, created_at, updated_at
+		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, routing_policy_webhook_only, created_at, updated_at
 		 FROM space_chain_nodes
 		 WHERE chain_id = $1
 		 ORDER BY position ASC, id ASC`,
@@ -236,9 +239,9 @@ func (r *SpaceChainRepoImpl) ReplaceNodes(ctx context.Context, chainID string, n
 	}
 	for _, node := range nodes {
 		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO space_chain_nodes (id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())`,
-			node.ID, chainID, node.TenantID, nullString(node.ExternalSpaceID), nullString(node.DisplayName), node.Position, node.RoutingPolicyEnabled, nullString(node.RoutingPolicyPrompt),
+			`INSERT INTO space_chain_nodes (id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, routing_policy_webhook_only, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())`,
+			node.ID, chainID, node.TenantID, nullString(node.ExternalSpaceID), nullString(node.DisplayName), node.Position, node.RoutingPolicyEnabled, nullString(node.RoutingPolicyPrompt), node.RoutingPolicyWebhookOnly,
 		); err != nil {
 			return fmt.Errorf("insert space chain node: %w", err)
 		}
@@ -249,15 +252,15 @@ func (r *SpaceChainRepoImpl) ReplaceNodes(ctx context.Context, chainID string, n
 	return nil
 }
 
-func (r *SpaceChainRepoImpl) UpdateNodeRoutingPolicy(ctx context.Context, chainID, nodeID string, enabled bool, prompt string) (*domain.SpaceChainNode, error) {
+func (r *SpaceChainRepoImpl) UpdateNodeRoutingPolicy(ctx context.Context, chainID, nodeID string, enabled bool, prompt string, webhookOnly bool) (*domain.SpaceChainNode, error) {
 	if err := r.ensureRoutingPolicyColumns(ctx); err != nil {
 		return nil, err
 	}
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE space_chain_nodes
-		 SET routing_policy_enabled = $1, routing_policy_prompt = $2, updated_at = NOW()
-		 WHERE chain_id = $3 AND id = $4`,
-		enabled, nullString(prompt), chainID, nodeID,
+		 SET routing_policy_enabled = $1, routing_policy_prompt = $2, routing_policy_webhook_only = $3, updated_at = NOW()
+		 WHERE chain_id = $4 AND id = $5`,
+		enabled, nullString(prompt), webhookOnly, chainID, nodeID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("update space chain node routing policy: %w", err)
@@ -270,7 +273,7 @@ func (r *SpaceChainRepoImpl) UpdateNodeRoutingPolicy(ctx context.Context, chainI
 		return nil, domain.ErrNotFound
 	}
 	row := r.db.QueryRowContext(ctx,
-		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, created_at, updated_at
+		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, routing_policy_webhook_only, created_at, updated_at
 		 FROM space_chain_nodes
 		 WHERE chain_id = $1 AND id = $2`,
 		chainID, nodeID,
@@ -397,6 +400,7 @@ func scanSpaceChainNode(row interface{ Scan(dest ...any) error }) (*domain.Space
 		&node.Position,
 		&node.RoutingPolicyEnabled,
 		&routingPolicyPrompt,
+		&node.RoutingPolicyWebhookOnly,
 		&node.CreatedAt,
 		&node.UpdatedAt,
 	); err != nil {

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -75,7 +75,7 @@ type SpaceChainRepo interface {
 
 	ListNodes(ctx context.Context, chainID string) ([]domain.SpaceChainNode, error)
 	ReplaceNodes(ctx context.Context, chainID string, nodes []domain.SpaceChainNode) error
-	UpdateNodeRoutingPolicy(ctx context.Context, chainID, nodeID string, enabled bool, prompt string) (*domain.SpaceChainNode, error)
+	UpdateNodeRoutingPolicy(ctx context.Context, chainID, nodeID string, enabled bool, prompt string, webhookOnly bool) (*domain.SpaceChainNode, error)
 	RemoveNodeByExternalSpaceID(ctx context.Context, externalSpaceID string) error
 
 	KeyStatus(ctx context.Context, key string) (domain.KeyStatus, error)

--- a/server/internal/repository/tidb/space_chain.go
+++ b/server/internal/repository/tidb/space_chain.go
@@ -32,7 +32,7 @@ func (r *SpaceChainRepoImpl) ensureRoutingPolicyColumns(ctx context.Context) err
 		   FROM information_schema.COLUMNS
 		  WHERE TABLE_SCHEMA = DATABASE()
 		    AND TABLE_NAME = 'space_chain_nodes'
-		    AND COLUMN_NAME IN ('routing_policy_enabled', 'routing_policy_prompt')`,
+		    AND COLUMN_NAME IN ('routing_policy_enabled', 'routing_policy_prompt', 'routing_policy_webhook_only')`,
 	)
 	if err != nil {
 		return fmt.Errorf("check space chain routing policy schema: %w", err)
@@ -59,6 +59,11 @@ func (r *SpaceChainRepoImpl) ensureRoutingPolicyColumns(ctx context.Context) err
 	if !found["routing_policy_prompt"] {
 		if _, err := r.db.ExecContext(ctx, `ALTER TABLE space_chain_nodes ADD COLUMN routing_policy_prompt TEXT NULL`); err != nil && !isDuplicateColumnError(err) {
 			return fmt.Errorf("add space chain routing policy prompt column: %w", err)
+		}
+	}
+	if !found["routing_policy_webhook_only"] {
+		if _, err := r.db.ExecContext(ctx, `ALTER TABLE space_chain_nodes ADD COLUMN routing_policy_webhook_only TINYINT(1) NOT NULL DEFAULT 0`); err != nil && !isDuplicateColumnError(err) {
+			return fmt.Errorf("add space chain routing policy webhook only column: %w", err)
 		}
 	}
 
@@ -244,7 +249,7 @@ func (r *SpaceChainRepoImpl) ListNodes(ctx context.Context, chainID string) ([]d
 		return nil, err
 	}
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, created_at, updated_at
+		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, routing_policy_webhook_only, created_at, updated_at
 		 FROM space_chain_nodes
 		 WHERE chain_id = ?
 		 ORDER BY position ASC, id ASC`,
@@ -274,9 +279,9 @@ func (r *SpaceChainRepoImpl) ReplaceNodes(ctx context.Context, chainID string, n
 	_ = res
 	for _, node := range nodes {
 		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO space_chain_nodes (id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, created_at, updated_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
-			node.ID, chainID, node.TenantID, nullString(node.ExternalSpaceID), nullString(node.DisplayName), node.Position, node.RoutingPolicyEnabled, nullString(node.RoutingPolicyPrompt),
+			`INSERT INTO space_chain_nodes (id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, routing_policy_webhook_only, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())`,
+			node.ID, chainID, node.TenantID, nullString(node.ExternalSpaceID), nullString(node.DisplayName), node.Position, node.RoutingPolicyEnabled, nullString(node.RoutingPolicyPrompt), node.RoutingPolicyWebhookOnly,
 		); err != nil {
 			return fmt.Errorf("insert space chain node: %w", err)
 		}
@@ -287,15 +292,15 @@ func (r *SpaceChainRepoImpl) ReplaceNodes(ctx context.Context, chainID string, n
 	return nil
 }
 
-func (r *SpaceChainRepoImpl) UpdateNodeRoutingPolicy(ctx context.Context, chainID, nodeID string, enabled bool, prompt string) (*domain.SpaceChainNode, error) {
+func (r *SpaceChainRepoImpl) UpdateNodeRoutingPolicy(ctx context.Context, chainID, nodeID string, enabled bool, prompt string, webhookOnly bool) (*domain.SpaceChainNode, error) {
 	if err := r.ensureRoutingPolicyColumns(ctx); err != nil {
 		return nil, err
 	}
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE space_chain_nodes
-		 SET routing_policy_enabled = ?, routing_policy_prompt = ?, updated_at = NOW()
+		 SET routing_policy_enabled = ?, routing_policy_prompt = ?, routing_policy_webhook_only = ?, updated_at = NOW()
 		 WHERE chain_id = ? AND id = ?`,
-		enabled, nullString(prompt), chainID, nodeID,
+		enabled, nullString(prompt), webhookOnly, chainID, nodeID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("update space chain node routing policy: %w", err)
@@ -308,7 +313,7 @@ func (r *SpaceChainRepoImpl) UpdateNodeRoutingPolicy(ctx context.Context, chainI
 		return nil, domain.ErrNotFound
 	}
 	row := r.db.QueryRowContext(ctx,
-		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, created_at, updated_at
+		`SELECT id, chain_id, tenant_id, external_space_id, display_name, position, routing_policy_enabled, routing_policy_prompt, routing_policy_webhook_only, created_at, updated_at
 		 FROM space_chain_nodes
 		 WHERE chain_id = ? AND id = ?`,
 		chainID, nodeID,
@@ -435,6 +440,7 @@ func scanSpaceChainNode(row interface{ Scan(dest ...any) error }) (*domain.Space
 		&node.Position,
 		&node.RoutingPolicyEnabled,
 		&routingPolicyPrompt,
+		&node.RoutingPolicyWebhookOnly,
 		&node.CreatedAt,
 		&node.UpdatedAt,
 	); err != nil {

--- a/server/internal/service/space_chain.go
+++ b/server/internal/service/space_chain.go
@@ -59,8 +59,9 @@ type CreateSpaceChainBindingRequest struct {
 }
 
 type UpdateSpaceChainNodeRoutingPolicyRequest struct {
-	Enabled bool   `json:"enabled"`
-	Prompt  string `json:"prompt,omitempty"`
+	Enabled     bool   `json:"enabled"`
+	Prompt      string `json:"prompt,omitempty"`
+	WebhookOnly bool   `json:"webhook_only"`
 }
 
 const maxRoutingPolicyPromptRunes = 1200
@@ -283,6 +284,7 @@ func (s *SpaceChainService) ReplaceNodes(ctx context.Context, chainID string, re
 		if existing, ok := existingPolicies[stableNodePolicyKey(node)]; ok {
 			node.RoutingPolicyEnabled = existing.RoutingPolicyEnabled
 			node.RoutingPolicyPrompt = existing.RoutingPolicyPrompt
+			node.RoutingPolicyWebhookOnly = existing.RoutingPolicyWebhookOnly
 		}
 		nodes = append(nodes, node)
 	}
@@ -343,7 +345,7 @@ func (s *SpaceChainService) UpdateNodeRoutingPolicy(ctx context.Context, chainID
 		if node.Position == 0 {
 			return nil, &domain.ValidationError{Field: "node_id", Message: "routing policy cannot be configured on the first Space Chain node"}
 		}
-		return s.chains.UpdateNodeRoutingPolicy(ctx, chainID, nodeID, req.Enabled, prompt)
+		return s.chains.UpdateNodeRoutingPolicy(ctx, chainID, nodeID, req.Enabled, prompt, req.WebhookOnly)
 	}
 	return nil, domain.ErrNotFound
 }

--- a/server/internal/service/space_chain_test.go
+++ b/server/internal/service/space_chain_test.go
@@ -89,13 +89,14 @@ func TestSpaceChainReplaceNodesPreservesRoutingPolicyForSameSpace(t *testing.T) 
 	repo := &fakeSpaceChainRepo{
 		nodes: []domain.SpaceChainNode{
 			{
-				ID:                   "node-1",
-				ChainID:              "chain-1",
-				TenantID:             "tenant-1",
-				ExternalSpaceID:      "space-1",
-				Position:             1,
-				RoutingPolicyEnabled: true,
-				RoutingPolicyPrompt:  "facts about mem9",
+				ID:                       "node-1",
+				ChainID:                  "chain-1",
+				TenantID:                 "tenant-1",
+				ExternalSpaceID:          "space-1",
+				Position:                 1,
+				RoutingPolicyEnabled:     true,
+				RoutingPolicyPrompt:      "facts about mem9",
+				RoutingPolicyWebhookOnly: true,
 			},
 		},
 	}
@@ -113,7 +114,7 @@ func TestSpaceChainReplaceNodesPreservesRoutingPolicyForSameSpace(t *testing.T) 
 	if len(nodes) != 2 {
 		t.Fatalf("expected 2 nodes, got %d", len(nodes))
 	}
-	if !nodes[1].RoutingPolicyEnabled || nodes[1].RoutingPolicyPrompt != "facts about mem9" {
+	if !nodes[1].RoutingPolicyEnabled || nodes[1].RoutingPolicyPrompt != "facts about mem9" || !nodes[1].RoutingPolicyWebhookOnly {
 		t.Fatalf("routing policy was not preserved: %#v", nodes[1])
 	}
 }
@@ -254,13 +255,14 @@ func (r *fakeSpaceChainRepo) ReplaceNodes(_ context.Context, _ string, nodes []d
 	return nil
 }
 
-func (r *fakeSpaceChainRepo) UpdateNodeRoutingPolicy(_ context.Context, _, nodeID string, enabled bool, prompt string) (*domain.SpaceChainNode, error) {
+func (r *fakeSpaceChainRepo) UpdateNodeRoutingPolicy(_ context.Context, _, nodeID string, enabled bool, prompt string, webhookOnly bool) (*domain.SpaceChainNode, error) {
 	for i := range r.nodes {
 		if r.nodes[i].ID != nodeID {
 			continue
 		}
 		r.nodes[i].RoutingPolicyEnabled = enabled
 		r.nodes[i].RoutingPolicyPrompt = prompt
+		r.nodes[i].RoutingPolicyWebhookOnly = webhookOnly
 		return &r.nodes[i], nil
 	}
 	return nil, domain.ErrNotFound

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS space_chain_nodes (
   position            INT           NOT NULL,
   routing_policy_enabled TINYINT(1) NOT NULL DEFAULT 0,
   routing_policy_prompt  TEXT       NULL,
+  routing_policy_webhook_only TINYINT(1) NOT NULL DEFAULT 0,
   created_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
   updated_at          TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   UNIQUE INDEX idx_space_chain_nodes_tenant (chain_id, tenant_id),

--- a/server/schema_db9.sql
+++ b/server/schema_db9.sql
@@ -89,6 +89,7 @@ CREATE TABLE IF NOT EXISTS space_chain_nodes (
     position            INT           NOT NULL,
     routing_policy_enabled BOOLEAN    NOT NULL DEFAULT FALSE,
     routing_policy_prompt  TEXT       NULL,
+    routing_policy_webhook_only BOOLEAN NOT NULL DEFAULT FALSE,
     created_at          TIMESTAMPTZ   DEFAULT NOW(),
     updated_at          TIMESTAMPTZ   DEFAULT NOW(),
     CONSTRAINT uniq_space_chain_nodes_tenant UNIQUE (chain_id, tenant_id),

--- a/server/schema_pg.sql
+++ b/server/schema_pg.sql
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS space_chain_nodes (
     position            INT           NOT NULL,
     routing_policy_enabled BOOLEAN    NOT NULL DEFAULT FALSE,
     routing_policy_prompt  TEXT       NULL,
+    routing_policy_webhook_only BOOLEAN NOT NULL DEFAULT FALSE,
     created_at          TIMESTAMPTZ   DEFAULT NOW(),
     updated_at          TIMESTAMPTZ   DEFAULT NOW(),
     CONSTRAINT uniq_space_chain_nodes_tenant UNIQUE (chain_id, tenant_id),


### PR DESCRIPTION
## Summary
- add routing_policy_webhook_only to Space Chain nodes and schemas
- skip target Space persistence for webhook-only routed facts while enqueueing space_chain.fact_routed
- cover webhook-only routing behavior with handler tests

## Tests
- cd server && go test -race -count=1 ./internal/service ./internal/handler ./internal/middleware ./internal/repository/tidb ./internal/repository/postgres