### PR TITLE
feat(local): local dev stack via docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,8 @@
 # Keep secrets and git history out of the Docker build context. The
 # compose build sends the repo root to the builder; with a remote
 # builder/BuildKit these files would otherwise leave the machine.
-.env
+# .env* covers .env, .env.local, and .publish.env (the three secret
+# files .gitignore knows about); .env.example is also matched but the
+# build doesn't need it.
+.env*
 .git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,8 @@
 # Keep secrets and git history out of the Docker build context. The
 # compose build sends the repo root to the builder; with a remote
 # builder/BuildKit these files would otherwise leave the machine.
-# .env* covers .env, .env.local, and .publish.env (the three secret
-# files .gitignore knows about); .env.example is also matched but the
-# build doesn't need it.
-.env*
+# The three .env entries match the secret files .gitignore knows about.
+.env
+.env.local
+.publish.env
 .git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Keep secrets and git history out of the Docker build context. The
+# compose build sends the repo root to the builder; with a remote
+# builder/BuildKit these files would otherwise leave the machine.
+.env
+.git

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,82 @@
+# Local mem9 docker-compose overrides. Copy to `.env` and edit as needed.
+#
+# Variables here are picked up automatically by `docker compose` from the
+# `.env` file at the repo root. Anything left commented uses the default
+# baked into docker-compose.yml.
+
+# --- Image selection -----------------------------------------------------
+
+# Tag the in-place compose build (or set to a prebuilt image and skip the
+# build step entirely).
+MEM9_IMAGE=mem9:local
+# Examples: pin to a CI artifact instead of rebuilding locally
+# MEM9_IMAGE=ghcr.io/mem9-ai/mnemo-server:1.2.3
+
+# --- Host ports / bind --------------------------------------------------
+
+# Override if 8080 / 4000 are already in use on your machine.
+MEM9_PORT=8080
+TIDB_PORT=4000
+
+# Bind address for published ports. Default 127.0.0.1 keeps the dev stack
+# loopback-only — the TiDB runs as root with no password and the seeded
+# API key is public, so do NOT bind 0.0.0.0 on machines with public/LAN
+# interfaces unless you've hardened both.
+MEM9_BIND=127.0.0.1
+TIDB_BIND=127.0.0.1
+
+# --- Local DB + API key -------------------------------------------------
+
+# Database name created in the in-compose TiDB. Must match the DSN.
+MEM9_DB_NAME=mem9
+
+# X-API-Key value for the seeded local-dev tenant. The smoke commands in
+# the README use this value; change both if you want a non-default key.
+MEM9_LOCAL_API_KEY=local-dev
+
+# --- Core DB / search toggles -------------------------------------------
+
+MNEMO_DB_BACKEND=tidb
+
+# The server's TiDB Zero provisioner is ON by default (config.go:182) and
+# would call out to https://zero.tidbapi.com on every POST /v1alpha1/mem9s.
+# The local compose stack pre-seeds a single tenant (schema-init), so this
+# MUST stay false — flipping it true here will make provisioning calls hit
+# an external API and the local stack will stop being self-contained.
+MNEMO_TIDB_ZERO_ENABLED=false
+
+# Full-text search index. Defaults false (FTS_MATCH_WORD requires the
+# TiDB Cloud Serverless MULTILINGUAL parser; local pingcap/tidb usually
+# does not have it).
+MNEMO_FTS_ENABLED=false
+
+# Skip writing raw conversation turns to the `sessions` table. Keep false
+# during local debugging so you can inspect what reached the server; flip
+# true to save space on long-running ingests.
+MNEMO_DISABLE_SESSION_SAVE=false
+
+# --- Ingest mode --------------------------------------------------------
+
+# raw  = store turn-by-turn, no LLM call (default, works without API keys).
+# smart = extract facts via LLM during ingest (requires MNEMO_LLM_* below).
+MNEMO_INGEST_MODE=raw
+
+# --- LLM (only needed when MNEMO_INGEST_MODE=smart) ---------------------
+
+# MNEMO_LLM_API_KEY=sk-...
+# MNEMO_LLM_BASE_URL=https://api.openai.com/v1
+# MNEMO_LLM_MODEL=gpt-4o-mini
+
+# --- Embedding (only needed for vector recall) --------------------------
+
+# OpenAI-compatible embedding endpoint:
+# MNEMO_EMBED_API_KEY=sk-...
+# MNEMO_EMBED_BASE_URL=https://api.openai.com/v1
+# MNEMO_EMBED_MODEL=text-embedding-3-small
+# MNEMO_EMBED_DIMS=1536
+
+# TiDB Cloud Serverless built-in embedding (requires the generated-column
+# schema variant — see comments in server/schema.sql). NOT supported on the
+# local pingcap/tidb container in this compose; leave empty for local.
+# MNEMO_EMBED_AUTO_MODEL=tidbcloud_free/amazon/titan-embed-text-v2
+MNEMO_EMBED_AUTO_DIMS=1024

--- a/README.md
+++ b/README.md
@@ -175,6 +175,46 @@ make docker REGISTRY=local COMMIT=dev
 docker run -e MNEMO_DSN="..." -e MNEMO_DB_BACKEND="tidb" -p 8080:8080 local/mnemo-server:dev
 ```
 
+### Local Quickstart with Docker Compose
+
+The `docker-compose.yml` at the repo root spins up a self-contained TiDB + mem9
+stack so you can hack against a real (non-Cloud) mem9 server without managing
+the database yourself. It runs three services:
+
+- `tidb` — `pingcap/tidb:v8.5.6` in `unistore` single-process mode, exposed on
+  `localhost:4000`. Good enough for local dev including the `VECTOR(N)` column
+  types used in `server/schema.sql`. (Vector *indexes* still need TiFlash and
+  remain commented out in the schema.)
+- `schema-init` — one-shot job that waits for TiDB to accept connections, then
+  pipes `server/schema.sql` through the `mysql` client.
+- `mem9` — built in-place from `server/Dockerfile.local` (multi-stage Go
+  build), tagged `mem9:local` by default, started after `schema-init`
+  completes, on `localhost:8080`. No Go toolchain needed on the host.
+
+```bash
+cp .env.example .env                   # optional — defaults are sane
+docker compose up --build              # bring everything up
+
+# smoke check (in another terminal). The X-API-Key matches the local-dev
+# tenant row that schema-init seeds; without it, v1alpha2 routes 401.
+curl -s http://localhost:8080/healthz
+curl -s -X POST http://localhost:8080/v1alpha2/mem9s/memories \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: local-dev' \
+  -d '{"content":"local smoke memory","memory_type":"pinned","agent_id":"smoke"}'
+curl -s 'http://localhost:8080/v1alpha2/mem9s/memories?q=smoke' \
+  -H 'X-API-Key: local-dev'
+```
+
+`.env.example` documents the knobs an operator typically wants:
+`MEM9_IMAGE` (use a prebuilt image instead of the in-place build),
+`MEM9_PORT` / `TIDB_PORT` (re-map host ports if 8080/4000 are in use),
+`MEM9_LOCAL_API_KEY` (rename the seeded key), `MNEMO_INGEST_MODE`
+(switch to `smart` for LLM-extracted ingest — also requires
+`MNEMO_LLM_*`), and the `MNEMO_EMBED_*` keys for vector recall.
+
+To wipe state and start clean: `docker compose down -v && docker compose up --build`.
+
 ### Environment Variables
 
 Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only applies to specific deployment modes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,142 @@
+# Local mem9 development stack: TiDB + auto schema bootstrap + mem9 server.
+#
+# Usage (clean checkout, only Docker required — no Go toolchain on host):
+#   cp .env.example .env   # optional — defaults are sane
+#   docker compose up --build
+#
+# Then mem9 is at http://localhost:${MEM9_PORT:-8080} and TiDB at
+# localhost:${TIDB_PORT:-4000}. The seeded API key is `${MEM9_LOCAL_API_KEY:-local-dev}`
+# (matches the tenant row that schema-init inserts). See README "Local
+# Quickstart with Docker Compose" and .env.example for the full knob list.
+#
+# Schema bootstrap: the `schema-init` service runs once per stack start, waits for
+# TiDB to accept connections, then pipes server/schema.sql through the mysql client.
+# It exits 0 on success; the `mem9` service waits for that completion via
+# `service_completed_successfully` before starting.
+#
+# Tracked in #mem9-discussion:efde4126 (2026-06-09). Targets the v0 code memory
+# spike — single-command local mem9 for dogfooding without external TiDB Cloud.
+
+services:
+  tidb:
+    image: pingcap/tidb:v8.5.6
+    # unistore is TiDB's embedded single-process storage backend — no separate
+    # PD/TiKV containers needed. Sufficient for local dev including the VECTOR
+    # column types in schema.sql. (Vector INDEX would still need TiFlash, but
+    # those are commented out in schema.sql.)
+    command:
+      - --store=unistore
+      - --path=
+      - --host=0.0.0.0
+      - --advertise-address=tidb
+    ports:
+      # Bound to loopback on purpose: this TiDB runs as root with no
+      # password, so exposing it on all interfaces would hand the DB to
+      # anyone on the same network if the host has a public/LAN NIC.
+      # Override TIDB_BIND if you genuinely need remote access.
+      - "${TIDB_BIND:-127.0.0.1}:${TIDB_PORT:-4000}:4000"
+    # No healthcheck on this service: the official pingcap/tidb image ships
+    # without mysqladmin / mysql client. schema-init does its own ready-poll
+    # below using the mysql client baked into the mysql:8.0 image.
+
+  schema-init:
+    # Single-shot job: poll tidb until it accepts connections, create the
+    # mem9 database, load server/schema.sql, seed a local-dev tenant row so
+    # the v1alpha2 X-API-Key path resolves on the first request, then exit.
+    # The mem9 service waits for this via `service_completed_successfully`
+    # so it never starts against an empty or half-loaded schema.
+    image: mysql:8.0
+    depends_on:
+      - tidb
+    volumes:
+      - ./server/schema.sql:/schema.sql:ro
+    environment:
+      # Expose .env-driven knobs into the entrypoint script. Compose's
+      # ${VAR:-default} substitution happens at YAML parse time, but the
+      # script's heredoc embeds them as literal values at that point.
+      DB_NAME: ${MEM9_DB_NAME:-mem9}
+      API_KEY: ${MEM9_LOCAL_API_KEY:-local-dev}
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        set -eu
+        # Poll TiDB for readiness — mysqladmin is in the mysql:8.0 image, and
+        # the official pingcap/tidb image isn't, so the wait lives here.
+        echo "schema-init: waiting for tidb:4000 to accept connections..."
+        for i in $$(seq 1 60); do
+          if mysqladmin ping -h tidb -P 4000 -u root --silent >/dev/null 2>&1; then
+            echo "schema-init: tidb is up after $${i}s"
+            break
+          fi
+          sleep 1
+        done
+        mysql -h tidb -P 4000 -u root -e "CREATE DATABASE IF NOT EXISTS \`$$DB_NAME\`;"
+        mysql -h tidb -P 4000 -u root -D "$$DB_NAME" < /schema.sql
+        # Seed a tenant row. The v1alpha2 routes resolve the X-API-Key
+        # header to a row in `tenants`; without an active tenant every API
+        # call would 401. db_password is stored encrypted in production
+        # but with default MNEMO_ENCRYPT_TYPE=plain the encryptor is a
+        # no-op, so the empty string survives the decrypt path. Both id
+        # and db_name come from .env so they stay in sync with the MNEMO_DSN
+        # that the mem9 service is configured with.
+        mysql -h tidb -P 4000 -u root -D "$$DB_NAME" -e "
+          INSERT INTO tenants (id, name, db_host, db_port, db_user, db_password,
+            db_name, db_tls, provider, cluster_id, status, schema_version)
+          VALUES ('$$API_KEY', '$$API_KEY', 'tidb', 4000, 'root', '',
+            '$$DB_NAME', 0, 'local', 'local-dev', 'active', 1)
+          ON DUPLICATE KEY UPDATE name=VALUES(name), status='active';
+        "
+        echo "schema-init: loaded server/schema.sql + seeded '$$API_KEY' tenant"
+    restart: "no"
+
+  mem9:
+    # Built in-place by `docker compose up --build` from server/Dockerfile.local
+    # (multi-stage Go build → minimal alpine runtime). No Go toolchain needed
+    # on the host. The default image tag is `mem9:local`; set MEM9_IMAGE to
+    # use a pre-built image instead and Docker will skip the build step.
+    image: ${MEM9_IMAGE:-mem9:local}
+    build:
+      context: .
+      dockerfile: server/Dockerfile.local
+    depends_on:
+      schema-init:
+        condition: service_completed_successfully
+    environment:
+      # Point mem9 at the in-compose tidb container. `parseTime=true` is
+      # required by the Go MySQL driver for TIMESTAMP / DATETIME → time.Time.
+      MNEMO_DSN: "root:@tcp(tidb:4000)/${MEM9_DB_NAME:-mem9}?parseTime=true"
+      MNEMO_DB_BACKEND: ${MNEMO_DB_BACKEND:-tidb}
+      MNEMO_PORT: "8080"
+      MNEMO_FTS_ENABLED: ${MNEMO_FTS_ENABLED:-false}
+      MNEMO_DISABLE_SESSION_SAVE: ${MNEMO_DISABLE_SESSION_SAVE:-false}
+      # Disable the TiDB Zero provisioner — it's on by default and would try
+      # to call out to https://zero.tidbapi.com on startup, which is the
+      # wrong behavior for a local single-tenant compose stack (we seeded
+      # the tenant ourselves in schema-init). .env.example carries the
+      # same default with the "do not flip" caveat in case operators look
+      # there first.
+      MNEMO_TIDB_ZERO_ENABLED: ${MNEMO_TIDB_ZERO_ENABLED:-false}
+      # Default ingest mode is `raw` (store turn-by-turn, no LLM call).
+      # Override via .env to `smart` for LLM-extracted ingest; that mode
+      # additionally requires MNEMO_LLM_* below.
+      MNEMO_INGEST_MODE: ${MNEMO_INGEST_MODE:-raw}
+      # Pass through optional LLM / embedding config from .env. Empty
+      # defaults keep mem9 in its no-key code paths (config.go treats
+      # an empty MNEMO_LLM_API_KEY as "LLM unavailable" — see ingest.go's
+      # llm.New() nil-branch handling).
+      MNEMO_LLM_API_KEY: ${MNEMO_LLM_API_KEY:-}
+      MNEMO_LLM_BASE_URL: ${MNEMO_LLM_BASE_URL:-}
+      MNEMO_LLM_MODEL: ${MNEMO_LLM_MODEL:-gpt-4o-mini}
+      MNEMO_EMBED_API_KEY: ${MNEMO_EMBED_API_KEY:-}
+      MNEMO_EMBED_BASE_URL: ${MNEMO_EMBED_BASE_URL:-}
+      MNEMO_EMBED_MODEL: ${MNEMO_EMBED_MODEL:-}
+      MNEMO_EMBED_DIMS: ${MNEMO_EMBED_DIMS:-1536}
+      MNEMO_EMBED_AUTO_MODEL: ${MNEMO_EMBED_AUTO_MODEL:-}
+      MNEMO_EMBED_AUTO_DIMS: ${MNEMO_EMBED_AUTO_DIMS:-1024}
+    ports:
+      # Loopback-bound for the same reason as tidb above — the seeded
+      # local-dev API key is public knowledge (it's in this repo), so the
+      # API must not listen on non-local interfaces by default.
+      - "${MEM9_BIND:-127.0.0.1}:${MEM9_PORT:-8080}:8080"
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,6 @@
 # TiDB to accept connections, then pipes server/schema.sql through the mysql client.
 # It exits 0 on success; the `mem9` service waits for that completion via
 # `service_completed_successfully` before starting.
-#
-# Tracked in #mem9-discussion:efde4126 (2026-06-09). Targets the v0 code memory
-# spike — single-command local mem9 for dogfooding without external TiDB Cloud.
 
 services:
   tidb:

--- a/server/Dockerfile.local
+++ b/server/Dockerfile.local
@@ -1,0 +1,24 @@
+# Self-contained multi-stage Dockerfile for the local dev compose stack.
+#
+# Unlike server/Dockerfile (which expects server/bin/mnemo-server to be
+# pre-built via `make build-linux` on the host and is wired into the
+# `make docker` release pipeline), this one builds the binary inside the
+# image so an operator with only Docker installed can run
+# `docker compose up --build` from a clean checkout.
+#
+# Added in #mem9-discussion:efde4126 (2026-06-09) per @Rossi / @tmgg06.
+# Kept as a separate file rather than rewriting server/Dockerfile so the
+# release pipeline's expectations don't change.
+
+FROM golang:1.24 AS builder
+WORKDIR /src/server
+COPY server/go.mod server/go.sum ./
+RUN go mod download
+COPY server/ ./
+RUN CGO_ENABLED=0 GOOS=linux go build -o /mnemo-server ./cmd/mnemo-server
+
+FROM alpine:3.19
+RUN apk add --no-cache ca-certificates
+COPY --from=builder /mnemo-server /mnemo-server
+EXPOSE 8080
+ENTRYPOINT ["/mnemo-server"]

--- a/server/Dockerfile.local
+++ b/server/Dockerfile.local
@@ -5,10 +5,6 @@
 # `make docker` release pipeline), this one builds the binary inside the
 # image so an operator with only Docker installed can run
 # `docker compose up --build` from a clean checkout.
-#
-# Added in #mem9-discussion:efde4126 (2026-06-09) per @Rossi / @tmgg06.
-# Kept as a separate file rather than rewriting server/Dockerfile so the
-# release pipeline's expectations don't change.
 
 FROM golang:1.24 AS builder
 WORKDIR /src/server


### PR DESCRIPTION
## Summary

Adds a self-contained local development stack so anyone can run a real
mem9 server with one command — no Go toolchain, no external TiDB Cloud:

```
cp .env.example .env
# edit .env
docker compose up --build
curl http://127.0.0.1:8080/healthz
```

Services:
- `tidb` — pingcap/tidb:v8.5.6, unistore single-process mode
- `schema-init` — one-shot job: waits for TiDB, loads server/schema.sql,
  seeds a `local-dev` tenant so the v1alpha2 X-API-Key path works
  immediately
- `mem9` — built in-place from the new server/Dockerfile.local
  (multi-stage Go build; release pipeline's server/Dockerfile untouched)

Security defaults: published ports bind to 127.0.0.1 only (root
no-password TiDB + a public seed key must not face a network), TiDB
Zero provisioning disabled, ingest mode `raw` so no LLM key is needed.

All operator knobs (image, ports, bind address, DB name, API key,
ingest/LLM/embedding config) are documented in .env.example.
