### PR TITLE
Fix sessions index naming

### DIFF
--- a/docs/design/raw-session-storage-proposal.md
+++ b/docs/design/raw-session-storage-proposal.md
@@ -954,7 +954,7 @@ for i, msg := range req.Messages {
 }
 ```
 
-No signature change to `BulkCreate`. `UNIQUE INDEX idx_sessions_dedup
+No signature change to `BulkCreate`. `UNIQUE INDEX idx_sess_dedup
 (session_id, content_hash)` serves as both dedup key and update key.
 
 **D6 — Tags on sessions only; memories table untouched**

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -130,7 +130,7 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		if cached, ok := s.svcCache.Load(key); ok {
 			return cached.(resolvedSvc)
 		}
-		schemaReady := s.ensureTenantAppIDSchema(auth)
+		schemaReady := s.ensureTenantRuntimeSchema(auth)
 		memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		svc := resolvedSvc{
@@ -148,7 +148,7 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	if cached, ok := s.svcCache.Load(key); ok {
 		return cached.(resolvedSvc)
 	}
-	schemaReady := s.ensureTenantAppIDSchema(auth)
+	schemaReady := s.ensureTenantRuntimeSchema(auth)
 	memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	svc := resolvedSvc{
@@ -163,18 +163,18 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	return actual.(resolvedSvc)
 }
 
-func (s *Server) ensureTenantAppIDSchema(auth *domain.AuthInfo) bool {
+func (s *Server) ensureTenantRuntimeSchema(auth *domain.AuthInfo) bool {
 	if s.tenant == nil || auth == nil || auth.TenantDB == nil {
 		return true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	if err := s.tenant.EnsureAppIDSchema(ctx, auth.TenantDB); err != nil {
+	if err := s.tenant.EnsureRuntimeSchema(ctx, auth.TenantDB); err != nil {
 		logger := s.logger
 		if logger == nil {
 			logger = slog.Default()
 		}
-		logger.Warn("app_id schema migration failed",
+		logger.Warn("runtime schema ensure failed",
 			"cluster_id", auth.ClusterID,
 			"tenant", auth.TenantID,
 			"err", err)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -642,7 +642,7 @@ func (s *captureWebhookStore) MarkDeliveryFailedAttempt(context.Context, string,
 	return nil
 }
 
-func TestResolveServicesDoesNotCacheAfterAppIDSchemaMigrationFailure(t *testing.T) {
+func TestResolveServicesDoesNotCacheAfterRuntimeSchemaEnsureFailure(t *testing.T) {
 	db := openHandlerErrorDB(t)
 	defer db.Close()
 
@@ -659,12 +659,12 @@ func TestResolveServicesDoesNotCacheAfterAppIDSchemaMigrationFailure(t *testing.
 		t.Fatal("resolveServices returned incomplete services")
 	}
 	if _, ok := srv.svcCache.Load(key); ok {
-		t.Fatal("schema migration failure must not cache services")
+		t.Fatal("runtime schema ensure failure must not cache services")
 	}
 
 	second := srv.resolveServices(auth)
 	if _, ok := srv.svcCache.Load(key); ok {
-		t.Fatal("schema migration retry failure must not cache services")
+		t.Fatal("runtime schema retry failure must not cache services")
 	}
 	if first.memory == second.memory {
 		t.Fatal("expected uncached resolveServices call to build a fresh service bundle")

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -345,7 +345,7 @@ func (s *TenantService) EnsureRuntimeSchema(ctx context.Context, db *sql.DB) err
 	}
 	switch backend {
 	case "tidb":
-		if err := tenant.InitTiDBTenantSchema(ctx, db, s.autoModel, s.autoDims, s.clientDims, s.ftsEnabled); err != nil {
+		if err := tenant.ValidateTiDBTenantRuntimeSchema(ctx, db, s.autoModel, s.ftsEnabled); err != nil {
 			return fmt.Errorf("ensure runtime schema: tidb: %w", err)
 		}
 		return nil
@@ -354,37 +354,6 @@ func (s *TenantService) EnsureRuntimeSchema(ctx context.Context, db *sql.DB) err
 	default:
 		return fmt.Errorf("ensure runtime schema: unsupported backend %q", backend)
 	}
-}
-
-func (s *TenantService) EnsureSessionsTable(ctx context.Context, db *sql.DB) error {
-	if _, err := db.ExecContext(ctx, tenant.BuildSessionsSchema(s.autoModel, s.autoDims, s.clientDims)); err != nil {
-		return fmt.Errorf("ensure sessions table: create: %w", err)
-	}
-	if s.autoModel != "" {
-		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sess_cosine")
-		if err != nil {
-			return fmt.Errorf("ensure sessions table: check vector index: %w", err)
-		}
-		if !exists {
-			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !tenant.IsIndexExistsError(err) {
-				return fmt.Errorf("ensure sessions table: vector index: %w", err)
-			}
-		}
-	}
-	if s.ftsEnabled {
-		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sess_fts")
-		if err != nil {
-			return fmt.Errorf("ensure sessions table: check fts index: %w", err)
-		}
-		if !exists {
-			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE sessions ADD FULLTEXT INDEX idx_sess_fts (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !tenant.IsIndexExistsError(err) {
-				return fmt.Errorf("ensure sessions table: fts index: %w", err)
-			}
-		}
-	}
-	return nil
 }
 
 func utmFromRequest(tenantID string, raw map[string]string) *domain.TenantUTM {

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -350,6 +350,9 @@ func (s *TenantService) EnsureRuntimeSchema(ctx context.Context, db *sql.DB) err
 		}
 		return nil
 	case "postgres", "db9":
+		if err := tenant.ValidatePostgresMemoryRuntimeSchema(ctx, db, backend); err != nil {
+			return fmt.Errorf("ensure runtime schema: %s: %w", backend, err)
+		}
 		return nil
 	default:
 		return fmt.Errorf("ensure runtime schema: unsupported backend %q", backend)

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -366,29 +366,26 @@ func (s *TenantService) EnsureSessionsTable(ctx context.Context, db *sql.DB) err
 	if _, err := db.ExecContext(ctx, tenant.BuildSessionsSchema(s.autoModel, s.autoDims, s.clientDims)); err != nil {
 		return fmt.Errorf("ensure sessions table: create: %w", err)
 	}
-	if err := tenant.EnsureSessionsAppIDSchema(ctx, db); err != nil {
-		return fmt.Errorf("ensure sessions table: app_id schema: %w", err)
-	}
 	if s.autoModel != "" {
-		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sessions_cosine")
+		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sess_cosine")
 		if err != nil {
 			return fmt.Errorf("ensure sessions table: check vector index: %w", err)
 		}
 		if !exists {
 			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !tenant.IsIndexExistsError(err) {
+				`ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine ((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !tenant.IsIndexExistsError(err) {
 				return fmt.Errorf("ensure sessions table: vector index: %w", err)
 			}
 		}
 	}
 	if s.ftsEnabled {
-		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sessions_fts")
+		exists, err := tenant.IndexExists(ctx, db, "sessions", "idx_sess_fts")
 		if err != nil {
 			return fmt.Errorf("ensure sessions table: check fts index: %w", err)
 		}
 		if !exists {
 			if _, err := db.ExecContext(ctx,
-				`ALTER TABLE sessions ADD FULLTEXT INDEX idx_sessions_fts (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !tenant.IsIndexExistsError(err) {
+				`ALTER TABLE sessions ADD FULLTEXT INDEX idx_sess_fts (content) WITH PARSER MULTILINGUAL ADD_COLUMNAR_REPLICA_ON_DEMAND`); err != nil && !tenant.IsIndexExistsError(err) {
 				return fmt.Errorf("ensure sessions table: fts index: %w", err)
 			}
 		}

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -345,7 +345,7 @@ func (s *TenantService) EnsureRuntimeSchema(ctx context.Context, db *sql.DB) err
 	}
 	switch backend {
 	case "tidb":
-		if err := tenant.ValidateTiDBTenantRuntimeSchema(ctx, db, s.autoModel, s.ftsEnabled); err != nil {
+		if err := tenant.EnsureTiDBTenantRuntimeSchema(ctx, db, s.autoModel, s.autoDims, s.clientDims, s.ftsEnabled); err != nil {
 			return fmt.Errorf("ensure runtime schema: tidb: %w", err)
 		}
 		return nil

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -338,27 +338,21 @@ func (s *TenantService) GetInfo(ctx context.Context, tenantID string) (*domain.T
 	}, nil
 }
 
-func (s *TenantService) EnsureAppIDSchema(ctx context.Context, db *sql.DB) error {
+func (s *TenantService) EnsureRuntimeSchema(ctx context.Context, db *sql.DB) error {
 	backend := "tidb"
 	if s.pool != nil {
 		backend = s.pool.Backend()
 	}
 	switch backend {
 	case "tidb":
-		if err := tenant.EnsureMemoryAppIDSchema(ctx, db); err != nil {
-			return fmt.Errorf("ensure app_id schema: memories: %w", err)
-		}
-		if err := s.EnsureSessionsTable(ctx, db); err != nil {
-			return fmt.Errorf("ensure app_id schema: sessions: %w", err)
+		if err := tenant.InitTiDBTenantSchema(ctx, db, s.autoModel, s.autoDims, s.clientDims, s.ftsEnabled); err != nil {
+			return fmt.Errorf("ensure runtime schema: tidb: %w", err)
 		}
 		return nil
 	case "postgres", "db9":
-		if err := tenant.EnsurePostgresMemoryAppIDSchema(ctx, db, backend); err != nil {
-			return fmt.Errorf("ensure app_id schema: memories: %w", err)
-		}
 		return nil
 	default:
-		return fmt.Errorf("ensure app_id schema: unsupported backend %q", backend)
+		return fmt.Errorf("ensure runtime schema: unsupported backend %q", backend)
 	}
 }
 

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -453,7 +453,7 @@ func (w *UploadWorker) ensureRuntimeSchema(ctx context.Context, db *sql.DB) erro
 	}
 	switch backend {
 	case "tidb":
-		return tenant.InitTiDBTenantSchema(ctx, db, w.autoModel, w.autoDims, w.clientDims, w.ftsEnabled)
+		return tenant.ValidateTiDBTenantRuntimeSchema(ctx, db, w.autoModel, w.ftsEnabled)
 	case "postgres", "db9":
 		return nil
 	default:

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -241,8 +241,8 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 	if err != nil {
 		return w.failTask(ctx, task, fmt.Errorf("get tenant db: %w", err), logger)
 	}
-	if err := w.ensureAppIDSchema(taskCtx, db); err != nil {
-		return w.failTask(ctx, task, fmt.Errorf("ensure app_id schema: %w", err), logger)
+	if err := w.ensureRuntimeSchema(taskCtx, db); err != nil {
+		return w.failTask(ctx, task, fmt.Errorf("ensure runtime schema: %w", err), logger)
 	}
 
 	memRepo := repository.NewMemoryRepo(w.pool.Backend(), db, w.autoModel, w.ftsEnabled, tenantInfo.ClusterID)
@@ -446,7 +446,7 @@ func (w *UploadWorker) recordActivity(tenantID string) {
 	w.activity.RecordMemoryActivity(tenantID, time.Now().UTC())
 }
 
-func (w *UploadWorker) ensureAppIDSchema(ctx context.Context, db *sql.DB) error {
+func (w *UploadWorker) ensureRuntimeSchema(ctx context.Context, db *sql.DB) error {
 	backend := "tidb"
 	if w.pool != nil {
 		backend = w.pool.Backend()
@@ -455,7 +455,7 @@ func (w *UploadWorker) ensureAppIDSchema(ctx context.Context, db *sql.DB) error 
 	case "tidb":
 		return tenant.InitTiDBTenantSchema(ctx, db, w.autoModel, w.autoDims, w.clientDims, w.ftsEnabled)
 	case "postgres", "db9":
-		return tenant.EnsurePostgresMemoryAppIDSchema(ctx, db, backend)
+		return nil
 	default:
 		return fmt.Errorf("unsupported backend %q", backend)
 	}

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -242,7 +242,7 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 		return w.failTask(ctx, task, fmt.Errorf("get tenant db: %w", err), logger)
 	}
 	if err := w.ensureRuntimeSchema(taskCtx, db); err != nil {
-		return w.failTask(ctx, task, fmt.Errorf("ensure runtime schema: %w", err), logger)
+		return w.requeueTask(ctx, task, fmt.Errorf("ensure runtime schema: %w", err), logger)
 	}
 
 	memRepo := repository.NewMemoryRepo(w.pool.Backend(), db, w.autoModel, w.ftsEnabled, tenantInfo.ClusterID)
@@ -455,10 +455,22 @@ func (w *UploadWorker) ensureRuntimeSchema(ctx context.Context, db *sql.DB) erro
 	case "tidb":
 		return tenant.ValidateTiDBTenantRuntimeSchema(ctx, db, w.autoModel, w.ftsEnabled)
 	case "postgres", "db9":
-		return nil
+		return tenant.ValidatePostgresMemoryRuntimeSchema(ctx, db, backend)
 	default:
 		return fmt.Errorf("unsupported backend %q", backend)
 	}
+}
+
+func (w *UploadWorker) requeueTask(ctx context.Context, task domain.UploadTask, err error, logger *slog.Logger) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if updateErr := w.tasks.UpdateStatus(ctx, task.TaskID, domain.TaskPending, ""); updateErr != nil {
+		logger.Error("failed to requeue upload task", "task_id", task.TaskID, "err", updateErr)
+		return err
+	}
+	logger.Warn("upload task requeued", "task_id", task.TaskID, "err", err)
+	return err
 }
 
 func (w *UploadWorker) recordActivityOnly(tenantID string) {

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -453,7 +453,7 @@ func (w *UploadWorker) ensureRuntimeSchema(ctx context.Context, db *sql.DB) erro
 	}
 	switch backend {
 	case "tidb":
-		return tenant.ValidateTiDBTenantRuntimeSchema(ctx, db, w.autoModel, w.ftsEnabled)
+		return tenant.EnsureTiDBTenantRuntimeSchema(ctx, db, w.autoModel, w.autoDims, w.clientDims, w.ftsEnabled)
 	case "postgres", "db9":
 		return tenant.ValidatePostgresMemoryRuntimeSchema(ctx, db, backend)
 	default:

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
@@ -430,6 +431,56 @@ func TestUploadWorkerRecordMemoryStatsFallsBackToActivity(t *testing.T) {
 	repo.mu.Unlock()
 	if upsertCalls != 0 || touchCalls != 1 {
 		t.Fatalf("calls = upsert:%d touch:%d, want 0/1", upsertCalls, touchCalls)
+	}
+}
+
+type uploadTaskStatusRepo struct {
+	status   domain.TaskStatus
+	errorMsg string
+}
+
+func (r *uploadTaskStatusRepo) Create(context.Context, *domain.UploadTask) error { return nil }
+
+func (r *uploadTaskStatusRepo) GetByID(context.Context, string) (*domain.UploadTask, error) {
+	return nil, nil
+}
+
+func (r *uploadTaskStatusRepo) ListByTenant(context.Context, string) ([]domain.UploadTask, error) {
+	return nil, nil
+}
+
+func (r *uploadTaskStatusRepo) UpdateStatus(_ context.Context, _ string, status domain.TaskStatus, errorMsg string) error {
+	r.status = status
+	r.errorMsg = errorMsg
+	return nil
+}
+
+func (r *uploadTaskStatusRepo) UpdateProgress(context.Context, string, int) error { return nil }
+
+func (r *uploadTaskStatusRepo) UpdateTotalChunks(context.Context, string, int) error { return nil }
+
+func (r *uploadTaskStatusRepo) FetchPending(context.Context, int) ([]domain.UploadTask, error) {
+	return nil, nil
+}
+
+func (r *uploadTaskStatusRepo) ResetProcessing(context.Context, time.Duration) (int64, error) {
+	return 0, nil
+}
+
+func TestUploadWorkerRequeueTaskKeepsPending(t *testing.T) {
+	repo := &uploadTaskStatusRepo{}
+	worker := &UploadWorker{tasks: repo}
+	task := domain.UploadTask{TaskID: "task-a"}
+
+	err := worker.requeueTask(context.Background(), task, errors.New("schema not ready"), nil)
+	if err == nil {
+		t.Fatal("expected requeueTask to return original error")
+	}
+	if repo.status != domain.TaskPending {
+		t.Fatalf("status = %q, want pending", repo.status)
+	}
+	if repo.errorMsg != "" {
+		t.Fatalf("error message = %q, want empty", repo.errorMsg)
 	}
 }
 

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -72,7 +72,8 @@ func (c *schemaInitConn) ExecContext(_ context.Context, query string, _ []driver
 }
 
 func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
-	if strings.Contains(query, "information_schema.COLUMNS") {
+	lowerQuery := strings.ToLower(query)
+	if strings.Contains(lowerQuery, "information_schema.columns") {
 		if strings.Contains(query, "COUNT(*)") {
 			var count int64
 			if len(args) > 1 {
@@ -86,7 +87,7 @@ func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []dr
 		}
 		return &schemaRows{rows: c.recorder.schemaRows}, nil
 	}
-	if strings.Contains(query, "information_schema.TABLES") {
+	if strings.Contains(lowerQuery, "information_schema.tables") {
 		var count int64
 		if len(args) > 0 {
 			if table, ok := args[0].Value.(string); ok && c.recorder.existingTables[table] {
@@ -95,7 +96,7 @@ func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []dr
 		}
 		return &schemaInitRows{values: [][]driver.Value{{count}}}, nil
 	}
-	if strings.Contains(query, "information_schema.STATISTICS") {
+	if strings.Contains(lowerQuery, "information_schema.statistics") || strings.Contains(lowerQuery, "pg_indexes") {
 		indexName := ""
 		if len(args) > 1 {
 			indexName, _ = args[1].Value.(string)
@@ -454,6 +455,57 @@ func TestValidateTiDBTenantRuntimeSchema_RejectsOldSessionsDedupIndex(t *testing
 	}
 	if len(recorder.execs) != 0 {
 		t.Fatalf("runtime schema validation should not execute DDL, got %v", recorder.execs)
+	}
+}
+
+func TestValidatePostgresMemoryRuntimeSchema_IndexNames(t *testing.T) {
+	tests := []struct {
+		name      string
+		backend   string
+		indexName string
+	}{
+		{name: "postgres", backend: "postgres", indexName: "idx_app"},
+		{name: "db9", backend: "db9", indexName: "idx_memory_app"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := &schemaInitConnector{
+				existingCols: map[string]bool{
+					"memories.app_id": true,
+				},
+				indexColumns: map[string][]string{
+					tt.indexName: {"app_id"},
+				},
+			}
+			db := sql.OpenDB(recorder)
+			defer db.Close()
+
+			if err := ValidatePostgresMemoryRuntimeSchema(context.Background(), db, tt.backend); err != nil {
+				t.Fatalf("ValidatePostgresMemoryRuntimeSchema failed: %v", err)
+			}
+			if len(recorder.execs) != 0 {
+				t.Fatalf("runtime schema validation should not execute DDL, got %v", recorder.execs)
+			}
+		})
+	}
+}
+
+func TestValidatePostgresMemoryRuntimeSchema_RejectsMissingAppID(t *testing.T) {
+	recorder := &schemaInitConnector{
+		indexColumns: map[string][]string{
+			"idx_app": {"app_id"},
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	err := ValidatePostgresMemoryRuntimeSchema(context.Background(), db, "postgres")
+	if err == nil {
+		t.Fatal("expected missing app_id column to fail validation")
+	}
+	if !strings.Contains(err.Error(), "memories app_id column") {
+		t.Fatalf("expected memories app_id column error, got %v", err)
 	}
 }
 

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -33,6 +33,8 @@ func setupTiDBCloudEnv(t *testing.T) func() {
 type schemaInitConnector struct {
 	execs          []string
 	existingTables map[string]bool
+	existingCols   map[string]bool
+	indexColumns   map[string][]string
 	schemaRows     []schemaTestRow
 }
 
@@ -72,7 +74,15 @@ func (c *schemaInitConn) ExecContext(_ context.Context, query string, _ []driver
 func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
 	if strings.Contains(query, "information_schema.COLUMNS") {
 		if strings.Contains(query, "COUNT(*)") {
-			return &schemaInitRows{values: [][]driver.Value{{int64(0)}}}, nil
+			var count int64
+			if len(args) > 1 {
+				table, _ := args[0].Value.(string)
+				column, _ := args[1].Value.(string)
+				if c.recorder.existingCols[table+"."+column] {
+					count = 1
+				}
+			}
+			return &schemaInitRows{values: [][]driver.Value{{count}}}, nil
 		}
 		return &schemaRows{rows: c.recorder.schemaRows}, nil
 	}
@@ -86,7 +96,23 @@ func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []dr
 		return &schemaInitRows{values: [][]driver.Value{{count}}}, nil
 	}
 	if strings.Contains(query, "information_schema.STATISTICS") {
-		return &schemaInitRows{values: [][]driver.Value{{int64(0)}}}, nil
+		indexName := ""
+		if len(args) > 1 {
+			indexName, _ = args[1].Value.(string)
+		}
+		columns := c.recorder.indexColumns[indexName]
+		if strings.Contains(query, "COUNT(*)") {
+			var count int64
+			if len(columns) > 0 {
+				count = 1
+			}
+			return &schemaInitRows{values: [][]driver.Value{{count}}}, nil
+		}
+		values := make([][]driver.Value, 0, len(columns))
+		for _, column := range columns {
+			values = append(values, []driver.Value{column})
+		}
+		return &schemaInitRows{values: values}, nil
 	}
 	return nil, fmt.Errorf("unexpected query %q with args %v", query, args)
 }
@@ -364,6 +390,70 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 		if strings.Contains(executed, unwanted) {
 			t.Fatalf("existing tables should not run online app_id schema migration %q\n%s", unwanted, executed)
 		}
+	}
+}
+
+func TestValidateTiDBTenantRuntimeSchema_SuccessDoesNotMutate(t *testing.T) {
+	recorder := &schemaInitConnector{
+		existingTables: map[string]bool{
+			"memories": true,
+			"sessions": true,
+		},
+		existingCols: map[string]bool{
+			"memories.app_id": true,
+			"sessions.app_id": true,
+		},
+		indexColumns: map[string][]string{
+			"idx_app":         {"app_id"},
+			"idx_cosine":      {"embedding"},
+			"idx_fts_content": {"content"},
+			"idx_sess_app":    {"app_id"},
+			"idx_sess_dedup":  {"app_id", "session_id", "content_hash"},
+			"idx_sess_cosine": {"embedding"},
+			"idx_sess_fts":    {"content"},
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	if err := ValidateTiDBTenantRuntimeSchema(context.Background(), db, "", true); err != nil {
+		t.Fatalf("ValidateTiDBTenantRuntimeSchema failed: %v", err)
+	}
+	if len(recorder.execs) != 0 {
+		t.Fatalf("runtime schema validation should not execute DDL, got %v", recorder.execs)
+	}
+}
+
+func TestValidateTiDBTenantRuntimeSchema_RejectsOldSessionsDedupIndex(t *testing.T) {
+	recorder := &schemaInitConnector{
+		existingTables: map[string]bool{
+			"memories": true,
+			"sessions": true,
+		},
+		existingCols: map[string]bool{
+			"memories.app_id": true,
+			"sessions.app_id": true,
+		},
+		indexColumns: map[string][]string{
+			"idx_app":         {"app_id"},
+			"idx_cosine":      {"embedding"},
+			"idx_sess_app":    {"app_id"},
+			"idx_sess_dedup":  {"session_id", "content_hash"},
+			"idx_sess_cosine": {"embedding"},
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	err := ValidateTiDBTenantRuntimeSchema(context.Background(), db, "", false)
+	if err == nil {
+		t.Fatal("expected old sessions dedup index to fail validation")
+	}
+	if !strings.Contains(err.Error(), "sessions dedup index") {
+		t.Fatalf("expected sessions dedup index error, got %v", err)
+	}
+	if len(recorder.execs) != 0 {
+		t.Fatalf("runtime schema validation should not execute DDL, got %v", recorder.execs)
 	}
 }
 

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -31,11 +31,12 @@ func setupTiDBCloudEnv(t *testing.T) func() {
 }
 
 type schemaInitConnector struct {
-	execs          []string
-	existingTables map[string]bool
-	existingCols   map[string]bool
-	indexColumns   map[string][]string
-	schemaRows     []schemaTestRow
+	execs            []string
+	existingTables   map[string]bool
+	existingCols     map[string]bool
+	indexColumns     map[string][]string
+	nonUniqueIndexes map[string]bool
+	schemaRows       []schemaTestRow
 }
 
 func (c *schemaInitConnector) Connect(context.Context) (driver.Conn, error) {
@@ -68,6 +69,7 @@ func (c *schemaInitConn) Begin() (driver.Tx, error) {
 
 func (c *schemaInitConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
 	c.recorder.execs = append(c.recorder.execs, query)
+	c.recorder.recordDDL(query)
 	return driver.RowsAffected(0), nil
 }
 
@@ -109,21 +111,78 @@ func (c *schemaInitConn) QueryContext(_ context.Context, query string, args []dr
 			}
 			return &schemaInitRows{values: [][]driver.Value{{count}}}, nil
 		}
+		if strings.Contains(lowerQuery, "non_unique") {
+			nonUnique := int64(0)
+			if c.recorder.nonUniqueIndexes[indexName] {
+				nonUnique = 1
+			}
+			values := make([][]driver.Value, 0, len(columns))
+			for _, column := range columns {
+				values = append(values, []driver.Value{column, nonUnique})
+			}
+			return &schemaInitRows{columns: []string{"COLUMN_NAME", "NON_UNIQUE"}, values: values}, nil
+		}
 		values := make([][]driver.Value, 0, len(columns))
 		for _, column := range columns {
 			values = append(values, []driver.Value{column})
 		}
-		return &schemaInitRows{values: values}, nil
+		return &schemaInitRows{columns: []string{"COLUMN_NAME"}, values: values}, nil
 	}
 	return nil, fmt.Errorf("unexpected query %q with args %v", query, args)
 }
 
-type schemaInitRows struct {
-	values [][]driver.Value
-	idx    int
+func (c *schemaInitConnector) recordDDL(query string) {
+	c.ensureMaps()
+	lowerQuery := strings.ToLower(query)
+	switch {
+	case strings.Contains(lowerQuery, "create table if not exists memories"):
+		c.existingTables["memories"] = true
+		c.existingCols["memories.app_id"] = true
+		c.indexColumns["idx_app"] = []string{"app_id"}
+	case strings.Contains(lowerQuery, "create table if not exists sessions"):
+		c.existingTables["sessions"] = true
+		c.existingCols["sessions.app_id"] = true
+		c.indexColumns["idx_sess_app"] = []string{"app_id"}
+		c.indexColumns["idx_sess_dedup"] = []string{"app_id", "session_id", "content_hash"}
+		c.nonUniqueIndexes["idx_sess_dedup"] = false
+	case strings.Contains(lowerQuery, "alter table memories add vector index idx_cosine"):
+		c.indexColumns["idx_cosine"] = []string{"embedding"}
+	case strings.Contains(lowerQuery, "alter table memories add fulltext index idx_fts_content"):
+		c.indexColumns["idx_fts_content"] = []string{"content"}
+	case strings.Contains(lowerQuery, "alter table sessions add vector index idx_sess_cosine"):
+		c.indexColumns["idx_sess_cosine"] = []string{"embedding"}
+	case strings.Contains(lowerQuery, "alter table sessions add fulltext index idx_sess_fts"):
+		c.indexColumns["idx_sess_fts"] = []string{"content"}
+	}
 }
 
-func (*schemaInitRows) Columns() []string { return []string{"COUNT(*)"} }
+func (c *schemaInitConnector) ensureMaps() {
+	if c.existingTables == nil {
+		c.existingTables = map[string]bool{}
+	}
+	if c.existingCols == nil {
+		c.existingCols = map[string]bool{}
+	}
+	if c.indexColumns == nil {
+		c.indexColumns = map[string][]string{}
+	}
+	if c.nonUniqueIndexes == nil {
+		c.nonUniqueIndexes = map[string]bool{}
+	}
+}
+
+type schemaInitRows struct {
+	columns []string
+	values  [][]driver.Value
+	idx     int
+}
+
+func (r *schemaInitRows) Columns() []string {
+	if len(r.columns) > 0 {
+		return r.columns
+	}
+	return []string{"COUNT(*)"}
+}
 
 func (*schemaInitRows) Close() error { return nil }
 
@@ -358,6 +417,15 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 			"memories": true,
 			"sessions": true,
 		},
+		existingCols: map[string]bool{
+			"memories.app_id": true,
+			"sessions.app_id": true,
+		},
+		indexColumns: map[string][]string{
+			"idx_app":        {"app_id"},
+			"idx_sess_app":   {"app_id"},
+			"idx_sess_dedup": {"app_id", "session_id", "content_hash"},
+		},
 	}
 	db := sql.OpenDB(recorder)
 	defer db.Close()
@@ -390,6 +458,91 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 	for _, unwanted := range unwantedSubstrings {
 		if strings.Contains(executed, unwanted) {
 			t.Fatalf("existing tables should not run online app_id schema migration %q\n%s", unwanted, executed)
+		}
+	}
+}
+
+func TestTiDBCloudProvisioner_InitSchema_ExistingTablesRejectsStaleAppSchema(t *testing.T) {
+	p := NewTiDBCloudProvisioner("http://localhost", "pool", "", 1024, 1536, false)
+	recorder := &schemaInitConnector{
+		existingTables: map[string]bool{
+			"memories": true,
+			"sessions": true,
+		},
+		existingCols: map[string]bool{
+			"memories.app_id": true,
+			"sessions.app_id": true,
+		},
+		indexColumns: map[string][]string{
+			"idx_app":          {"app_id"},
+			"idx_sessions_app": {"app_id"},
+			"idx_sess_dedup":   {"session_id", "content_hash"},
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	err := p.InitSchema(context.Background(), db)
+	if err == nil {
+		t.Fatal("expected stale existing sessions schema to fail init")
+	}
+	if !strings.Contains(err.Error(), "sessions app_id index") {
+		t.Fatalf("expected sessions app_id index error, got %v", err)
+	}
+	executed := strings.Join(recorder.execs, "\n")
+	if !strings.Contains(executed, "ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine") {
+		t.Fatalf("expected search index ensure before validation failure:\n%s", executed)
+	}
+	if strings.Contains(executed, "ALTER TABLE sessions ADD COLUMN app_id") ||
+		strings.Contains(executed, "ALTER TABLE sessions ADD UNIQUE INDEX idx_sess_dedup") {
+		t.Fatalf("stale app schema should not be migrated online:\n%s", executed)
+	}
+}
+
+func TestEnsureTiDBTenantRuntimeSchema_CreatesSearchIndexesOnly(t *testing.T) {
+	recorder := &schemaInitConnector{
+		existingTables: map[string]bool{
+			"memories": true,
+			"sessions": true,
+		},
+		existingCols: map[string]bool{
+			"memories.app_id": true,
+			"sessions.app_id": true,
+		},
+		indexColumns: map[string][]string{
+			"idx_app":        {"app_id"},
+			"idx_sess_app":   {"app_id"},
+			"idx_sess_dedup": {"app_id", "session_id", "content_hash"},
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	if err := EnsureTiDBTenantRuntimeSchema(context.Background(), db, "", 1024, 1536, true); err != nil {
+		t.Fatalf("EnsureTiDBTenantRuntimeSchema failed: %v", err)
+	}
+	executed := strings.Join(recorder.execs, "\n")
+	wantSubstrings := []string{
+		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
+		"ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
+		"ALTER TABLE sessions ADD FULLTEXT INDEX idx_sess_fts",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(executed, want) {
+			t.Fatalf("executed DDL missing %q\n%s", want, executed)
+		}
+	}
+	unwantedSubstrings := []string{
+		"ALTER TABLE memories ADD COLUMN app_id",
+		"CREATE INDEX idx_app",
+		"ALTER TABLE sessions ADD COLUMN app_id",
+		"CREATE INDEX idx_sess_app",
+		"ALTER TABLE sessions ADD UNIQUE INDEX idx_sess_dedup",
+	}
+	for _, unwanted := range unwantedSubstrings {
+		if strings.Contains(executed, unwanted) {
+			t.Fatalf("runtime ensure should not run app schema migration %q\n%s", unwanted, executed)
 		}
 	}
 }
@@ -452,6 +605,42 @@ func TestValidateTiDBTenantRuntimeSchema_RejectsOldSessionsDedupIndex(t *testing
 	}
 	if !strings.Contains(err.Error(), "sessions dedup index") {
 		t.Fatalf("expected sessions dedup index error, got %v", err)
+	}
+	if len(recorder.execs) != 0 {
+		t.Fatalf("runtime schema validation should not execute DDL, got %v", recorder.execs)
+	}
+}
+
+func TestValidateTiDBTenantRuntimeSchema_RejectsNonUniqueSessionsDedupIndex(t *testing.T) {
+	recorder := &schemaInitConnector{
+		existingTables: map[string]bool{
+			"memories": true,
+			"sessions": true,
+		},
+		existingCols: map[string]bool{
+			"memories.app_id": true,
+			"sessions.app_id": true,
+		},
+		indexColumns: map[string][]string{
+			"idx_app":         {"app_id"},
+			"idx_cosine":      {"embedding"},
+			"idx_sess_app":    {"app_id"},
+			"idx_sess_dedup":  {"app_id", "session_id", "content_hash"},
+			"idx_sess_cosine": {"embedding"},
+		},
+		nonUniqueIndexes: map[string]bool{
+			"idx_sess_dedup": true,
+		},
+	}
+	db := sql.OpenDB(recorder)
+	defer db.Close()
+
+	err := ValidateTiDBTenantRuntimeSchema(context.Background(), db, "", false)
+	if err == nil {
+		t.Fatal("expected non-unique sessions dedup index to fail validation")
+	}
+	if !strings.Contains(err.Error(), "is not unique") {
+		t.Fatalf("expected non-unique dedup index error, got %v", err)
 	}
 	if len(recorder.execs) != 0 {
 		t.Fatalf("runtime schema validation should not execute DDL, got %v", recorder.execs)

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -279,7 +279,6 @@ func TestTiDBCloudProvisioner_InitSchema_AutoEmbedding(t *testing.T) {
 	wantSubstrings := []string{
 		"CREATE TABLE IF NOT EXISTS memories",
 		"embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{\"dimensions\": 1024}')) STORED",
-		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content",
 		"CREATE TABLE IF NOT EXISTS sessions",
@@ -308,7 +307,6 @@ func TestTiDBCloudProvisioner_InitSchema_ClientEmbedding(t *testing.T) {
 	wantSubstrings := []string{
 		"CREATE TABLE IF NOT EXISTS memories",
 		"embedding VECTOR(1536) NULL",
-		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"CREATE TABLE IF NOT EXISTS sessions",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
@@ -346,7 +344,6 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 		t.Fatalf("existing tables should skip CREATE TABLE:\n%s", executed)
 	}
 	wantSubstrings := []string{
-		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
 	}
@@ -356,6 +353,8 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 		}
 	}
 	unwantedSubstrings := []string{
+		"ALTER TABLE memories ADD COLUMN app_id",
+		"CREATE INDEX idx_app",
 		"ALTER TABLE sessions ADD COLUMN app_id",
 		"CREATE INDEX idx_sess_app",
 		"ALTER TABLE sessions DROP INDEX idx_sess_dedup",
@@ -363,7 +362,7 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 	}
 	for _, unwanted := range unwantedSubstrings {
 		if strings.Contains(executed, unwanted) {
-			t.Fatalf("existing sessions table should not run online app_id schema migration %q\n%s", unwanted, executed)
+			t.Fatalf("existing tables should not run online app_id schema migration %q\n%s", unwanted, executed)
 		}
 	}
 }

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -283,10 +283,9 @@ func TestTiDBCloudProvisioner_InitSchema_AutoEmbedding(t *testing.T) {
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content",
 		"CREATE TABLE IF NOT EXISTS sessions",
-		"ALTER TABLE sessions ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"embedding VECTOR(1024) GENERATED ALWAYS AS (EMBED_TEXT('tidbcloud_free/amazon/titan-embed-text-v2', content, '{\"dimensions\": 1024}')) STORED",
-		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
-		"ALTER TABLE sessions ADD FULLTEXT INDEX idx_sessions_fts",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
+		"ALTER TABLE sessions ADD FULLTEXT INDEX idx_sess_fts",
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(executed, want) {
@@ -312,8 +311,7 @@ func TestTiDBCloudProvisioner_InitSchema_ClientEmbedding(t *testing.T) {
 		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"CREATE TABLE IF NOT EXISTS sessions",
-		"ALTER TABLE sessions ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
-		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(executed, want) {
@@ -350,12 +348,22 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 	wantSubstrings := []string{
 		"ALTER TABLE memories ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
-		"ALTER TABLE sessions ADD COLUMN app_id VARCHAR(100) NOT NULL DEFAULT ''",
-		"ALTER TABLE sessions ADD VECTOR INDEX idx_sessions_cosine",
+		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
 	}
 	for _, want := range wantSubstrings {
 		if !strings.Contains(executed, want) {
 			t.Fatalf("executed DDL missing %q\n%s", want, executed)
+		}
+	}
+	unwantedSubstrings := []string{
+		"ALTER TABLE sessions ADD COLUMN app_id",
+		"CREATE INDEX idx_sess_app",
+		"ALTER TABLE sessions DROP INDEX idx_sess_dedup",
+		"ALTER TABLE sessions ADD UNIQUE INDEX idx_sess_dedup",
+	}
+	for _, unwanted := range unwantedSubstrings {
+		if strings.Contains(executed, unwanted) {
+			t.Fatalf("existing sessions table should not run online app_id schema migration %q\n%s", unwanted, executed)
 		}
 	}
 }

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -264,6 +264,23 @@ func ValidateTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel 
 	return nil
 }
 
+func ValidatePostgresMemoryRuntimeSchema(ctx context.Context, db *sql.DB, backend string) error {
+	if db == nil {
+		return fmt.Errorf("validate schema: db connection is nil")
+	}
+	if err := requirePostgresColumn(ctx, db, "memories", "app_id"); err != nil {
+		return fmt.Errorf("validate schema: memories app_id column: %w", err)
+	}
+	indexName := "idx_app"
+	if backend == "db9" {
+		indexName = "idx_memory_app"
+	}
+	if err := requirePostgresIndex(ctx, db, "memories", indexName); err != nil {
+		return fmt.Errorf("validate schema: memories app_id index: %w", err)
+	}
+	return nil
+}
+
 func requireTable(ctx context.Context, db *sql.DB, table string) error {
 	exists, err := TableExists(ctx, db, table)
 	if err != nil {
@@ -295,6 +312,60 @@ func requireIndex(ctx context.Context, db *sql.DB, table, indexName string) erro
 		return fmt.Errorf("%s.%s is missing", table, indexName)
 	}
 	return nil
+}
+
+func requirePostgresColumn(ctx context.Context, db *sql.DB, table, column string) error {
+	exists, err := postgresColumnExists(ctx, db, table, column)
+	if err != nil {
+		return fmt.Errorf("check column: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%s.%s is missing", table, column)
+	}
+	return nil
+}
+
+func postgresColumnExists(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		   FROM information_schema.columns
+		  WHERE table_schema = current_schema()
+		    AND table_name = $1
+		    AND column_name = $2`,
+		table, column,
+	).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func requirePostgresIndex(ctx context.Context, db *sql.DB, table, indexName string) error {
+	exists, err := postgresIndexExists(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check index: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%s.%s is missing", table, indexName)
+	}
+	return nil
+}
+
+func postgresIndexExists(ctx context.Context, db *sql.DB, table, indexName string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*)
+		   FROM pg_indexes
+		  WHERE schemaname = current_schema()
+		    AND tablename = $1
+		    AND indexname = $2`,
+		table, indexName,
+	).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func requireIndexColumns(ctx context.Context, db *sql.DB, table, indexName string, want []string) error {

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -213,6 +213,127 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 	return nil
 }
 
+// ValidateTiDBTenantRuntimeSchema checks the tenant schema expected after
+// provisioning or offline migration without mutating existing tables.
+func ValidateTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel string, ftsEnabled bool) error {
+	if db == nil {
+		return fmt.Errorf("validate schema: db connection is nil")
+	}
+	if err := CheckEmbeddingSchemaCompatibility(ctx, db, autoModel); err != nil {
+		return fmt.Errorf("validate schema: embedding schema compatibility: %w", err)
+	}
+
+	if err := requireTable(ctx, db, "memories"); err != nil {
+		return fmt.Errorf("validate schema: memories table: %w", err)
+	}
+	if err := requireColumn(ctx, db, "memories", "app_id"); err != nil {
+		return fmt.Errorf("validate schema: memories app_id column: %w", err)
+	}
+	if err := requireIndex(ctx, db, "memories", "idx_app"); err != nil {
+		return fmt.Errorf("validate schema: memories app_id index: %w", err)
+	}
+	if err := requireIndex(ctx, db, "memories", "idx_cosine"); err != nil {
+		return fmt.Errorf("validate schema: memories vector index: %w", err)
+	}
+	if ftsEnabled {
+		if err := requireIndex(ctx, db, "memories", "idx_fts_content"); err != nil {
+			return fmt.Errorf("validate schema: memories fulltext index: %w", err)
+		}
+	}
+
+	if err := requireTable(ctx, db, "sessions"); err != nil {
+		return fmt.Errorf("validate schema: sessions table: %w", err)
+	}
+	if err := requireColumn(ctx, db, "sessions", "app_id"); err != nil {
+		return fmt.Errorf("validate schema: sessions app_id column: %w", err)
+	}
+	if err := requireIndex(ctx, db, "sessions", "idx_sess_app"); err != nil {
+		return fmt.Errorf("validate schema: sessions app_id index: %w", err)
+	}
+	if err := requireIndexColumns(ctx, db, "sessions", "idx_sess_dedup", []string{"app_id", "session_id", "content_hash"}); err != nil {
+		return fmt.Errorf("validate schema: sessions dedup index: %w", err)
+	}
+	if err := requireIndex(ctx, db, "sessions", "idx_sess_cosine"); err != nil {
+		return fmt.Errorf("validate schema: sessions vector index: %w", err)
+	}
+	if ftsEnabled {
+		if err := requireIndex(ctx, db, "sessions", "idx_sess_fts"); err != nil {
+			return fmt.Errorf("validate schema: sessions fulltext index: %w", err)
+		}
+	}
+	return nil
+}
+
+func requireTable(ctx context.Context, db *sql.DB, table string) error {
+	exists, err := TableExists(ctx, db, table)
+	if err != nil {
+		return fmt.Errorf("check table: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%s table is missing", table)
+	}
+	return nil
+}
+
+func requireColumn(ctx context.Context, db *sql.DB, table, column string) error {
+	exists, err := ColumnExists(ctx, db, table, column)
+	if err != nil {
+		return fmt.Errorf("check column: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%s.%s is missing", table, column)
+	}
+	return nil
+}
+
+func requireIndex(ctx context.Context, db *sql.DB, table, indexName string) error {
+	exists, err := IndexExists(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check index: %w", err)
+	}
+	if !exists {
+		return fmt.Errorf("%s.%s is missing", table, indexName)
+	}
+	return nil
+}
+
+func requireIndexColumns(ctx context.Context, db *sql.DB, table, indexName string, want []string) error {
+	columns, err := indexColumns(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check index columns: %w", err)
+	}
+	if strings.Join(columns, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("%s.%s columns = %q, want %q", table, indexName, strings.Join(columns, ","), strings.Join(want, ","))
+	}
+	return nil
+}
+
+func indexColumns(ctx context.Context, db *sql.DB, table, indexName string) ([]string, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT COLUMN_NAME
+		   FROM information_schema.STATISTICS
+		  WHERE TABLE_SCHEMA = DATABASE()
+		    AND TABLE_NAME = ?
+		    AND INDEX_NAME = ?
+		  ORDER BY SEQ_IN_INDEX`,
+		table, indexName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var column string
+		if err := rows.Scan(&column); err != nil {
+			return nil, err
+		}
+		columns = append(columns, column)
+	}
+	return columns, rows.Err()
+}
+
 func ensureTable(ctx context.Context, db *sql.DB, table, createSQL string) error {
 	exists, err := TableExists(ctx, db, table)
 	if err != nil {

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -190,12 +190,6 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 	if err := ensureTable(ctx, db, "memories", BuildMemorySchema(autoModel, autoDims, clientDims)); err != nil {
 		return fmt.Errorf("init schema: memories table: %w", err)
 	}
-	if err := ensureColumn(ctx, db, "memories", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
-		return fmt.Errorf("init schema: memories app_id column: %w", err)
-	}
-	if err := ensurePlainIndex(ctx, db, "memories", "idx_app", "app_id"); err != nil {
-		return fmt.Errorf("init schema: memories app_id index: %w", err)
-	}
 	if err := ensureVectorIndex(ctx, db, "memories", "idx_cosine"); err != nil {
 		return fmt.Errorf("init schema: memories vector index: %w", err)
 	}
@@ -215,64 +209,6 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 		if err := ensureFullTextIndex(ctx, db, "sessions", "idx_sess_fts"); err != nil {
 			return fmt.Errorf("init schema: sessions fulltext index: %w", err)
 		}
-	}
-	return nil
-}
-
-func ensureColumn(ctx context.Context, db *sql.DB, table, column, definition string) error {
-	exists, err := ColumnExists(ctx, db, table, column)
-	if err != nil {
-		return fmt.Errorf("check column: %w", err)
-	}
-	if exists {
-		return nil
-	}
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(
-		"ALTER TABLE %s ADD COLUMN %s %s",
-		table, column, definition,
-	)); err != nil && !IsDuplicateColumnError(err) {
-		return fmt.Errorf("add column: %w", err)
-	}
-	return nil
-}
-
-func ensurePlainIndex(ctx context.Context, db *sql.DB, table, indexName, columns string) error {
-	exists, err := IndexExists(ctx, db, table, indexName)
-	if err != nil {
-		return fmt.Errorf("check index: %w", err)
-	}
-	if exists {
-		return nil
-	}
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(
-		"CREATE INDEX %s ON %s(%s)",
-		indexName, table, columns,
-	)); err != nil && !IsIndexExistsError(err) {
-		return fmt.Errorf("create index: %w", err)
-	}
-	return nil
-}
-
-// EnsureMemoryAppIDSchema completes the app-scoped memory schema for existing tenants.
-func EnsureMemoryAppIDSchema(ctx context.Context, db *sql.DB) error {
-	if err := ensureColumn(ctx, db, "memories", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
-		return err
-	}
-	return ensurePlainIndex(ctx, db, "memories", "idx_app", "app_id")
-}
-
-// EnsurePostgresMemoryAppIDSchema completes the app-scoped memory schema for
-// PostgreSQL-compatible tenant databases.
-func EnsurePostgresMemoryAppIDSchema(ctx context.Context, db *sql.DB, backend string) error {
-	if _, err := db.ExecContext(ctx, `ALTER TABLE memories ADD COLUMN IF NOT EXISTS app_id VARCHAR(100) NOT NULL DEFAULT ''`); err != nil {
-		return fmt.Errorf("memories app_id column: %w", err)
-	}
-	indexName := "idx_app"
-	if backend == "db9" {
-		indexName = "idx_memory_app"
-	}
-	if _, err := db.ExecContext(ctx, fmt.Sprintf(`CREATE INDEX IF NOT EXISTS %s ON memories(app_id)`, indexName)); err != nil {
-		return fmt.Errorf("memories app_id index: %w", err)
 	}
 	return nil
 }

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -179,35 +179,54 @@ func BuildSessionsSchema(autoModel string, autoDims int, clientDims int) string 
 
 // InitTiDBTenantSchema creates or completes the TiDB tenant data-plane schema.
 func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
+	if err := EnsureTiDBTenantRuntimeSchema(ctx, db, autoModel, autoDims, clientDims, ftsEnabled); err != nil {
+		return fmt.Errorf("init schema: %w", err)
+	}
+	return nil
+}
+
+// EnsureTiDBTenantRuntimeSchema creates missing tenant tables and search indexes,
+// then validates the offline-migrated app-scoped schema without mutating it.
+func EnsureTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
+	if err := ensureTiDBTenantTablesAndSearchIndexes(ctx, db, autoModel, autoDims, clientDims, ftsEnabled); err != nil {
+		return err
+	}
+	if err := ValidateTiDBTenantRuntimeSchema(ctx, db, autoModel, ftsEnabled); err != nil {
+		return fmt.Errorf("runtime validation: %w", err)
+	}
+	return nil
+}
+
+func ensureTiDBTenantTablesAndSearchIndexes(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
 	if db == nil {
-		return fmt.Errorf("init schema: db connection is nil")
+		return fmt.Errorf("db connection is nil")
 	}
 
 	if err := CheckEmbeddingSchemaCompatibility(ctx, db, autoModel); err != nil {
-		return fmt.Errorf("init schema: embedding schema compatibility: %w", err)
+		return fmt.Errorf("embedding schema compatibility: %w", err)
 	}
 
 	if err := ensureTable(ctx, db, "memories", BuildMemorySchema(autoModel, autoDims, clientDims)); err != nil {
-		return fmt.Errorf("init schema: memories table: %w", err)
+		return fmt.Errorf("memories table: %w", err)
 	}
 	if err := ensureVectorIndex(ctx, db, "memories", "idx_cosine"); err != nil {
-		return fmt.Errorf("init schema: memories vector index: %w", err)
+		return fmt.Errorf("memories vector index: %w", err)
 	}
 	if ftsEnabled {
 		if err := ensureFullTextIndex(ctx, db, "memories", "idx_fts_content"); err != nil {
-			return fmt.Errorf("init schema: memories fulltext index: %w", err)
+			return fmt.Errorf("memories fulltext index: %w", err)
 		}
 	}
 
 	if err := ensureTable(ctx, db, "sessions", BuildSessionsSchema(autoModel, autoDims, clientDims)); err != nil {
-		return fmt.Errorf("init schema: sessions table: %w", err)
+		return fmt.Errorf("sessions table: %w", err)
 	}
 	if err := ensureVectorIndex(ctx, db, "sessions", "idx_sess_cosine"); err != nil {
-		return fmt.Errorf("init schema: sessions vector index: %w", err)
+		return fmt.Errorf("sessions vector index: %w", err)
 	}
 	if ftsEnabled {
 		if err := ensureFullTextIndex(ctx, db, "sessions", "idx_sess_fts"); err != nil {
-			return fmt.Errorf("init schema: sessions fulltext index: %w", err)
+			return fmt.Errorf("sessions fulltext index: %w", err)
 		}
 	}
 	return nil
@@ -250,7 +269,7 @@ func ValidateTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel 
 	if err := requireIndex(ctx, db, "sessions", "idx_sess_app"); err != nil {
 		return fmt.Errorf("validate schema: sessions app_id index: %w", err)
 	}
-	if err := requireIndexColumns(ctx, db, "sessions", "idx_sess_dedup", []string{"app_id", "session_id", "content_hash"}); err != nil {
+	if err := requireUniqueIndexColumns(ctx, db, "sessions", "idx_sess_dedup", []string{"app_id", "session_id", "content_hash"}); err != nil {
 		return fmt.Errorf("validate schema: sessions dedup index: %w", err)
 	}
 	if err := requireIndex(ctx, db, "sessions", "idx_sess_cosine"); err != nil {
@@ -368,20 +387,23 @@ func postgresIndexExists(ctx context.Context, db *sql.DB, table, indexName strin
 	return count > 0, nil
 }
 
-func requireIndexColumns(ctx context.Context, db *sql.DB, table, indexName string, want []string) error {
-	columns, err := indexColumns(ctx, db, table, indexName)
+func requireUniqueIndexColumns(ctx context.Context, db *sql.DB, table, indexName string, want []string) error {
+	columns, unique, err := indexDefinition(ctx, db, table, indexName)
 	if err != nil {
 		return fmt.Errorf("check index columns: %w", err)
 	}
 	if strings.Join(columns, ",") != strings.Join(want, ",") {
 		return fmt.Errorf("%s.%s columns = %q, want %q", table, indexName, strings.Join(columns, ","), strings.Join(want, ","))
 	}
+	if !unique {
+		return fmt.Errorf("%s.%s is not unique", table, indexName)
+	}
 	return nil
 }
 
-func indexColumns(ctx context.Context, db *sql.DB, table, indexName string) ([]string, error) {
+func indexDefinition(ctx context.Context, db *sql.DB, table, indexName string) ([]string, bool, error) {
 	rows, err := db.QueryContext(ctx,
-		`SELECT COLUMN_NAME
+		`SELECT COLUMN_NAME, NON_UNIQUE
 		   FROM information_schema.STATISTICS
 		  WHERE TABLE_SCHEMA = DATABASE()
 		    AND TABLE_NAME = ?
@@ -390,19 +412,24 @@ func indexColumns(ctx context.Context, db *sql.DB, table, indexName string) ([]s
 		table, indexName,
 	)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer rows.Close()
 
 	var columns []string
+	unique := true
 	for rows.Next() {
 		var column string
-		if err := rows.Scan(&column); err != nil {
-			return nil, err
+		var nonUnique int
+		if err := rows.Scan(&column, &nonUnique); err != nil {
+			return nil, false, err
 		}
 		columns = append(columns, column)
+		if nonUnique != 0 {
+			unique = false
+		}
 	}
-	return columns, rows.Err()
+	return columns, unique, rows.Err()
 }
 
 func ensureTable(ctx context.Context, db *sql.DB, table, createSQL string) error {

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -150,12 +150,12 @@ const TenantSessionsSchemaBase = `CREATE TABLE IF NOT EXISTS sessions (
     state        VARCHAR(20)     NOT NULL DEFAULT 'active',
     created_at   TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
     updated_at   TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    INDEX        idx_sessions_session (session_id),
-    INDEX        idx_sessions_agent   (agent_id),
-    INDEX        idx_sessions_app     (app_id),
-    INDEX        idx_sessions_state   (state),
-    INDEX        idx_sessions_created (created_at),
-    UNIQUE INDEX idx_sessions_dedup   (app_id, session_id, content_hash)
+    INDEX        idx_sess_session (session_id),
+    INDEX        idx_sess_agent   (agent_id),
+    INDEX        idx_sess_app     (app_id),
+    INDEX        idx_sess_state   (state),
+    INDEX        idx_sess_created (created_at),
+    UNIQUE INDEX idx_sess_dedup   (app_id, session_id, content_hash)
 )`
 
 // BuildSessionsSchema builds the TiDB sessions schema with optional auto-embedding.
@@ -208,20 +208,11 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 	if err := ensureTable(ctx, db, "sessions", BuildSessionsSchema(autoModel, autoDims, clientDims)); err != nil {
 		return fmt.Errorf("init schema: sessions table: %w", err)
 	}
-	if err := ensureColumn(ctx, db, "sessions", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
-		return fmt.Errorf("init schema: sessions app_id column: %w", err)
-	}
-	if err := ensurePlainIndex(ctx, db, "sessions", "idx_sessions_app", "app_id"); err != nil {
-		return fmt.Errorf("init schema: sessions app_id index: %w", err)
-	}
-	if err := ensureSessionsDedupIndex(ctx, db); err != nil {
-		return fmt.Errorf("init schema: sessions app_id dedup index: %w", err)
-	}
-	if err := ensureVectorIndex(ctx, db, "sessions", "idx_sessions_cosine"); err != nil {
+	if err := ensureVectorIndex(ctx, db, "sessions", "idx_sess_cosine"); err != nil {
 		return fmt.Errorf("init schema: sessions vector index: %w", err)
 	}
 	if ftsEnabled {
-		if err := ensureFullTextIndex(ctx, db, "sessions", "idx_sessions_fts"); err != nil {
+		if err := ensureFullTextIndex(ctx, db, "sessions", "idx_sess_fts"); err != nil {
 			return fmt.Errorf("init schema: sessions fulltext index: %w", err)
 		}
 	}
@@ -262,49 +253,6 @@ func ensurePlainIndex(ctx context.Context, db *sql.DB, table, indexName, columns
 	return nil
 }
 
-func ensureSessionsDedupIndex(ctx context.Context, db *sql.DB) error {
-	columns, err := indexColumns(ctx, db, "sessions", "idx_sessions_dedup")
-	if err != nil {
-		return fmt.Errorf("check dedup index columns: %w", err)
-	}
-	if strings.Join(columns, ",") == "app_id,session_id,content_hash" {
-		return nil
-	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE sessions DROP INDEX idx_sessions_dedup`); err != nil && !IsIndexNotFoundError(err) {
-		return fmt.Errorf("drop old dedup index: %w", err)
-	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE sessions ADD UNIQUE INDEX idx_sessions_dedup (app_id, session_id, content_hash)`); err != nil && !IsIndexExistsError(err) {
-		return fmt.Errorf("add app scoped dedup index: %w", err)
-	}
-	return nil
-}
-
-func indexColumns(ctx context.Context, db *sql.DB, table, indexName string) ([]string, error) {
-	rows, err := db.QueryContext(ctx,
-		`SELECT COLUMN_NAME
-		   FROM information_schema.STATISTICS
-		  WHERE TABLE_SCHEMA = DATABASE()
-		    AND TABLE_NAME = ?
-		    AND INDEX_NAME = ?
-		  ORDER BY SEQ_IN_INDEX`,
-		table, indexName,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var columns []string
-	for rows.Next() {
-		var column string
-		if err := rows.Scan(&column); err != nil {
-			return nil, err
-		}
-		columns = append(columns, column)
-	}
-	return columns, rows.Err()
-}
-
 // EnsureMemoryAppIDSchema completes the app-scoped memory schema for existing tenants.
 func EnsureMemoryAppIDSchema(ctx context.Context, db *sql.DB) error {
 	if err := ensureColumn(ctx, db, "memories", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
@@ -327,17 +275,6 @@ func EnsurePostgresMemoryAppIDSchema(ctx context.Context, db *sql.DB, backend st
 		return fmt.Errorf("memories app_id index: %w", err)
 	}
 	return nil
-}
-
-// EnsureSessionsAppIDSchema completes the app-scoped raw session schema for existing tenants.
-func EnsureSessionsAppIDSchema(ctx context.Context, db *sql.DB) error {
-	if err := ensureColumn(ctx, db, "sessions", "app_id", "VARCHAR(100) NOT NULL DEFAULT ''"); err != nil {
-		return err
-	}
-	if err := ensurePlainIndex(ctx, db, "sessions", "idx_sessions_app", "app_id"); err != nil {
-		return err
-	}
-	return ensureSessionsDedupIndex(ctx, db)
 }
 
 func ensureTable(ctx context.Context, db *sql.DB, table, createSQL string) error {


### PR DESCRIPTION
## Summary
- align sessions table index names with production idx_sess_* convention
- remove runtime sessions app_id/index/dedup ensure logic now owned by offline migration
- keep runtime vector and fulltext ensure using idx_sess_cosine and idx_sess_fts

Fixes #352

## Tests
- make vet
- make test