### PR TITLE
docs: sync README and AGENTS.md with current server implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,14 @@ MNEMO_DSN="user:pass@tcp(host:4000)/db?parseTime=true" make dev
 | -------------------- | ------------------------------------------- |
 | Add/change route     | `server/internal/handler/handler.go`        |
 | Memory CRUD / search | `server/internal/service/memory.go`         |
+| Confidence recall    | `server/internal/handler/recall.go`         |
+| Space Chain routing  | `server/internal/handler/chain_runtime.go`  |
+| Webhook dispatch     | `server/internal/handler/webhook.go`, `server/internal/handler/webhook_events.go` |
 | Ingest pipeline      | `server/internal/service/ingest.go`         |
+| Session storage      | `server/internal/service/session.go`        |
+| Source turn decoration | `server/internal/service/search_source_turns.go` |
+| Temporal facts       | `server/internal/service/temporal_fact.go`  |
+| Activity tracking    | `server/internal/service/activity.go`       |
 | TiDB SQL             | `server/internal/repository/tidb/memory.go` |
 | Tenant provisioning  | `server/internal/service/tenant.go`         |
 | Runtime usage quota  | `server/internal/runtimeusage/`             |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Space Chains let you compose ordered multi-space recall and routing pipelines. U
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/v1alpha2/space-chains` | Create a Space Chain. Requires `X-API-Key` (the management key is returned in the response) |
+| `POST` | `/v1alpha2/space-chains` | Create a Space Chain. No `X-API-Key` required — the management key (`chain_` prefix) is returned in the response body. All subsequent management endpoints require this key |
 | `GET` | `/v1alpha2/space-chains/by-key` | Look up a Space Chain by its management key. Requires the `chain_` key in `X-API-Key` |
 | `GET` | `/v1alpha2/space-chains/{chainID}` | Get Space Chain details. Requires `chain_` management key |
 | `PATCH` | `/v1alpha2/space-chains/{chainID}` | Update Space Chain name/description. Requires `chain_` management key |
@@ -220,8 +220,8 @@ Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only appli
 | `MNEMO_UPLOAD_DIR` | No | `./uploads` | Directory used for uploaded file storage |
 | `MNEMO_WORKER_CONCURRENCY` | No | `5` | Parallelism for async upload ingest workers |
 | `MNEMO_UTM_ENABLED` | No | `false` | Enable UTM campaign tracking. When enabled, `utm_*` query params on provisioning requests are stored in the control-plane DB. Requires the `tenant_utm` table to exist |
-| `MNEMO_ENV` | No | `development` | Deployment environment. `development` allows all CORS origins; `production` requires `MNEMO_CORS_ALLOWED_ORIGINS`. Also settable via `APP_ENV` |
-| `MNEMO_CORS_ALLOWED_ORIGINS` | No | all origins in `development`, none in `production` | Comma-separated allowed CORS origins. Only applies when `MNEMO_ENV=production` |
+| `MNEMO_ENV` | No | `development` | Deployment environment. Controls the default CORS origin set (`https://mem9.ai` in production; `https://mem9.ai,http://localhost:4321,http://127.0.0.1:4321` in development). Also settable via `APP_ENV` |
+| `MNEMO_CORS_ALLOWED_ORIGINS` | No | `https://mem9.ai` in production; `https://mem9.ai,http://localhost:4321,http://127.0.0.1:4321` in development | Comma-separated allowed CORS origins. Overrides the `MNEMO_ENV`-based defaults |
 
 #### Embedding And Ingest
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,35 @@ Prefer `v1alpha2` for all new integrations. It uses `X-API-Key` and is the prima
 
 Webhook events and delivery behavior are documented in [docs/webhooks-api-design.md](docs/webhooks-api-design.md). v1 emits `memory.added`, `memory.deleted`, and `space_chain.fact_routed`.
 
+#### Space Chain Management
+
+Space Chains let you compose ordered multi-space recall and routing pipelines. Use the `chain_` management key returned at creation time as the `X-API-Key` for all management endpoints below. Read nodes via their own Space `X-API-Key`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1alpha2/space-chains` | Create a Space Chain. Requires `X-API-Key` (the management key is returned in the response) |
+| `GET` | `/v1alpha2/space-chains/by-key` | Look up a Space Chain by its management key. Requires the `chain_` key in `X-API-Key` |
+| `GET` | `/v1alpha2/space-chains/{chainID}` | Get Space Chain details. Requires `chain_` management key |
+| `PATCH` | `/v1alpha2/space-chains/{chainID}` | Update Space Chain name/description. Requires `chain_` management key |
+| `DELETE` | `/v1alpha2/space-chains/{chainID}` | Soft-delete a Space Chain. Requires `chain_` management key |
+| `GET` | `/v1alpha2/space-chains/{chainID}/nodes` | List all nodes in the chain (ordered by position). Requires `chain_` management key |
+| `PUT` | `/v1alpha2/space-chains/{chainID}/nodes` | Replace all nodes in the chain (full replacement). Requires `chain_` management key |
+| `PUT` | `/v1alpha2/space-chains/{chainID}/nodes/{nodeID}/routing-policy` | Update routing policy for a specific chain node. Requires `chain_` management key |
+| `GET` | `/v1alpha2/space-chains/{chainID}/bindings` | List all API key bindings for the chain. Requires `chain_` management key |
+| `POST` | `/v1alpha2/space-chains/{chainID}/bindings` | Create a new API key binding for the chain. Requires `chain_` management key |
+| `PATCH` | `/v1alpha2/space-chains/{chainID}/bindings/{bindingID}` | Disable an API key binding. Requires `chain_` management key |
+
+#### Additional v1alpha2 Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/v1alpha2/mem9s/memories/batch-delete` | Bulk soft-delete memories (max 1000). Accepts `{"ids": ["..."]}`. Requires `X-API-Key` |
+| `GET` | `/v1alpha2/mem9s/session-messages` | List persisted session messages. Requires `X-API-Key`. Query: `session_id`, `limit_per_session` |
+| `POST` | `/v1alpha2/mem9s/imports` | Upload a JSON file for async ingest (multipart, 50MB max). `file_type`: `memory` or `session`. Requires `X-API-Key` |
+| `GET` | `/v1alpha2/mem9s/imports` | List upload tasks with aggregate status. Requires `X-API-Key` |
+| `GET` | `/v1alpha2/mem9s/imports/{id}` | Get single upload task detail. Requires `X-API-Key` |
+| `GET` | `/v1alpha2/status` | Validate the `X-API-Key` header. Returns key status (`active`/`inactive`) without resolving a tenant |
+
 ### Legacy Tenant-Path API (`v1alpha1`)
 
 Use these endpoints only when you need compatibility with older tenant-ID-in-path clients.
@@ -191,6 +220,8 @@ Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only appli
 | `MNEMO_UPLOAD_DIR` | No | `./uploads` | Directory used for uploaded file storage |
 | `MNEMO_WORKER_CONCURRENCY` | No | `5` | Parallelism for async upload ingest workers |
 | `MNEMO_UTM_ENABLED` | No | `false` | Enable UTM campaign tracking. When enabled, `utm_*` query params on provisioning requests are stored in the control-plane DB. Requires the `tenant_utm` table to exist |
+| `MNEMO_ENV` | No | `development` | Deployment environment. `development` allows all CORS origins; `production` requires `MNEMO_CORS_ALLOWED_ORIGINS`. Also settable via `APP_ENV` |
+| `MNEMO_CORS_ALLOWED_ORIGINS` | No | all origins in `development`, none in `production` | Comma-separated allowed CORS origins. Only applies when `MNEMO_ENV=production` |
 
 #### Embedding And Ingest
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -2,6 +2,8 @@
 
 Command-line tool for testing mnemo-server REST API endpoints.
 
+> **API version note**: The CLI currently uses the legacy `v1alpha1` tenant-path API (`/v1alpha1/mem9s/{tenantID}/...`) exclusively. All other integrations (plugins, dashboard, e2e) have migrated to `v1alpha2` with `X-API-Key` header auth. The CLI should be updated to support `v1alpha2` for consistency.
+
 ## Installation
 
 ```bash

--- a/server/internal/handler/AGENTS.md
+++ b/server/internal/handler/AGENTS.md
@@ -18,12 +18,41 @@ cd server && go test -race -count=1 -run TestFunctionName ./internal/handler/
 | Task | File |
 |------|------|
 | Router, middleware order, response helpers | `handler.go` |
-| Memory CRUD endpoints | `memory.go` |
-| Recall endpoint | `recall.go` |
+| Memory CRUD, search dispatch, batch delete | `memory.go` |
+| Confidence recall scoring and query classification | `recall.go` |
+| Space Chain runtime routing and recall | `chain_runtime.go` |
+| Webhook CRUD (Space + Chain scoped) | `webhook.go` |
+| Webhook event enqueueing | `webhook_events.go` |
 | Tenant endpoints | `tenant.go` |
 | Import task endpoints | `task.go` |
 | Metering admin endpoints | `metering.go` |
 | Runtime usage helpers and error mapping | `runtime_usage.go` |
+
+## Unwired handlers
+
+The following handlers are defined in `memory.go` and `tenant.go` but are NOT registered in `Router()`:
+
+| Handler | File | Note |
+|---------|------|------|
+| `bulkCreateMemories` | `memory.go` | Defined, no route. Use `POST /memories` with `messages[]` array instead |
+| `bootstrapMemories` | `memory.go` | Defined, no route. Use `GET /memories?scan_all=true&limit=N&sort_by=created_at&sort_dir=desc` instead |
+| `getTenantInfo` | `tenant.go` | Defined, no route. Tenant info is available via `GET /v1alpha2/status` |
+
+These may be wired up or removed in a future cleanup pass.
+
+## Search dispatch in `listMemories`
+
+`memory.go:listMemories()` dispatches to one of these search paths based on query parameters:
+
+| Path | Trigger | Description |
+|------|---------|-------------|
+| `content-keyword` | `search_mode=keyword` or query is short/needs substring match | Direct keyword substring search against content |
+| `scan-all` | `scan_all=true`, no query | Return all memories in insertion order (paginated) |
+| `default-confidence-recall` | No `search_mode`, no special params | 3-pool confidence recall: pinned + insight + session memories scored and deduplicated |
+| `single-pool-confidence-recall` | `memory_type` filter + query | Recall from a single pool (pinned/insight/session only) |
+| `session-list` | `session_id` param present, no search query | List memories by session ID(s) |
+| `memory-search` | `search_mode=memory-search` | Standard hybrid/keyword search (bypasses confidence recall) |
+| `chain` | Chain auth context | Ordered Space Chain recall with stop-score threshold |
 
 ## Local conventions
 

--- a/server/internal/handler/AGENTS.md
+++ b/server/internal/handler/AGENTS.md
@@ -35,8 +35,8 @@ The following handlers are defined in `memory.go` and `tenant.go` but are NOT re
 | Handler | File | Note |
 |---------|------|------|
 | `bulkCreateMemories` | `memory.go` | Defined, no route. Use `POST /memories` with `messages[]` array instead |
-| `bootstrapMemories` | `memory.go` | Defined, no route. Use `GET /memories?scan_all=true&limit=N&sort_by=created_at&sort_dir=desc` instead |
-| `getTenantInfo` | `tenant.go` | Defined, no route. Tenant info is available via `GET /v1alpha2/status` |
+| `bootstrapMemories` | `memory.go` | Defined, no route. No direct replacement; the scan-all path (`scanAll=true` + non-empty `q`) differs from this handler's behavior |
+| `getTenantInfo` | `tenant.go` | Defined, no route. Would return full tenant metadata (name, provider, memory_count, etc.) if wired. Not equivalent to `GET /v1alpha2/status` which only returns `{"status": "active"}` |
 
 These may be wired up or removed in a future cleanup pass.
 
@@ -46,12 +46,11 @@ These may be wired up or removed in a future cleanup pass.
 
 | Path | Trigger | Description |
 |------|---------|-------------|
-| `content-keyword` | `search_mode=keyword` or query is short/needs substring match | Direct keyword substring search against content |
-| `scan-all` | `scan_all=true`, no query | Return all memories in insertion order (paginated) |
-| `default-confidence-recall` | No `search_mode`, no special params | 3-pool confidence recall: pinned + insight + session memories scored and deduplicated |
-| `single-pool-confidence-recall` | `memory_type` filter + query | Recall from a single pool (pinned/insight/session only) |
-| `session-list` | `session_id` param present, no search query | List memories by session ID(s) |
-| `memory-search` | `search_mode=memory-search` | Standard hybrid/keyword search (bypasses confidence recall) |
+| `content-keyword` | `search_mode=keyword` or `search_mode=content_keyword` (explicit only) + non-empty `q` | Direct keyword substring search against content |
+| `scan-all` | `scanAll=true` + non-empty `q` | Fetch all memories across types with keyword filter |
+| `default-confidence-recall` | Non-empty `q` + `memory_type` not set | 3-pool confidence recall: pinned + insight + session memories scored and deduplicated |
+| `single-pool-confidence-recall` | Non-empty `q` + `memory_type` set to `pinned`, `insight`, or `session` | Recall from a single pool |
+| `session-list` | `memory_type=session` | List memories from session storage (query optional) |
 | `chain` | Chain auth context | Ordered Space Chain recall with stop-score threshold |
 
 ## Local conventions


### PR DESCRIPTION
## Summary

Audited all documentation against the current server implementation and fixed high + medium priority gaps.

### Changes

**README.md** (+31 lines):
- Added 6 missing v1alpha2 endpoints: `batch-delete`, `session-messages`, `imports` (3), `/status`
- Added Space Chain management CRUD section (11 endpoints)
- Added `MNEMO_ENV` / `APP_ENV` and `MNEMO_CORS_ALLOWED_ORIGINS` env vars

**AGENTS.md** (+7 lines):
- Expanded file map with: recall, chain_runtime, webhook dispatch, session storage, source turn decoration, temporal facts, activity tracking

**AGENTS.local.md** (+2 lines):
- Added CRDT branch disclaimer: features only on `shenjun/add-crdt` branch, not on `main`

**server/internal/handler/AGENTS.md** (+31 lines):
- Updated file map with all current handler files
- Documented 3 unwired handlers (`bulkCreateMemories`, `bootstrapMemories`, `getTenantInfo`)
- Added search dispatch table (7 search paths in `listMemories`)

**cli/README.md** (+2 lines):
- Added note that CLI uses legacy v1alpha1 API