### PR TITLE
fix: preserve user-supplied metadata in messages ingest path

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -39,6 +39,9 @@ MNEMO_BASE=$DEV bash e2e/api-smoke-test-utm.sh
 METADB="<user>:<pass>@tcp(<host>:4000)/<db>"
 MNEMO_BASE=$DEV MNEMO_METADB_DSN=$METADB bash e2e/api-smoke-test-utm.sh
 
+# Metadata preservation (messages ingest + content write)
+MNEMO_BASE=$DEV POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-metadata.sh
+
 # Full smoke suite
 for script in \
   "e2e/api-smoke-test.sh" \
@@ -195,6 +198,22 @@ is not set.
 | 9   | DB: non-UTM params absent  | `foo=bar` values not present in row                                                               |
 | 10  | DB: empty-value param NULL | `medium` column is NULL when `utm_medium=` was sent                                               |
 
+### Metadata preservation (`api-smoke-test-metadata.sh`)
+
+Regression test for metadata round-trip through the messages ingest path (GitHub issue #361).
+Provisions a fresh tenant, sends messages with `mode:smart` and custom `metadata`, polls until
+the insight memory materialises, and verifies the metadata is present. Also tests the content +
+pinned path as a control group.
+
+| #   | Case                                    | What is verified                                                                      |
+| --- | --------------------------------------- | ------------------------------------------------------------------------------------- |
+| 1   | Provision tenant                        | `POST /v1alpha1/mem9s` returns 201 with `id` field                                    |
+| 2   | Messages + metadata write               | `POST /memories` with `messages[]`, `mode:smart`, `sync:true`, `metadata` → 200 ok   |
+| 3   | Poll until insight materialises         | `GET /memories?memory_type=insight` polled until Nebula fact appears                  |
+| 4   | Insight metadata round-trip             | `GET /memories/{id}` returns insight with `metadata.source_kind`, `test_run`, `occurred_at` matching sent values |
+| 5   | Pinned content + metadata write         | `POST /memories` with `content`, `memory_type:pinned`, `metadata` → 201              |
+| 6   | Pinned GET metadata persisted           | `GET /memories/{id}` returns pinned memory with metadata matching sent values         |
+
 ## Commands
 
 ```bash
@@ -241,6 +260,7 @@ python3 e2e/concurrent-real-doc-test.py
 - `api-smoke-test-sessions.sh` — session storage: write, dedup, unified search, type filter, metadata, no-query session list, per-ID get/delete, batch delete, lazy migration (tests 1–17; tests 15–17 require `MNEMO_EXISTING_TENANT_ID`)
 - `api-smoke-test-existing-tenant.sh` — backward-compat: pre-existing tenant read/write/search across v1alpha1 and v1alpha2 (tests 1–12)
 - `api-smoke-test-utm.sh` — UTM attribution: param normalization, filtering, empty-value dropping (tests 1–5 always; tests 6–10 require `MNEMO_METADB_DSN` and `MNEMO_UTM_ENABLED=true` on server)
+- `api-smoke-test-metadata.sh` — metadata preservation: messages + mode:smart metadata round-trip, pinned content metadata round-trip (tests 1–6)
 - `crdt-*` and `plugin-crdt-*` use the CRDT branch `/api/users`, `/api/spaces/provision`, `/api/memories` surface.
 - Check the server branch/API shape before mixing the two sets.
 
@@ -268,6 +288,7 @@ python3 e2e/concurrent-real-doc-test.py
 | `api-smoke-test-sessions.sh`        | v1alpha1 (default) or v1alpha2 | Session storage: write, dedup, unified search, lifecycle             |
 | `api-smoke-test-existing-tenant.sh` | v1alpha1 + v1alpha2            | Backward-compat: pre-existing tenant full lifecycle, both auth modes |
 | `api-smoke-test-utm.sh`             | v1alpha1                       | UTM attribution: param normalization + optional DB row verification  |
+| `api-smoke-test-metadata.sh`         | v1alpha1                       | Metadata preservation: messages ingest + content write               |
 | `crdt-e2e-tests.sh`                 | CRDT branch                    | Core CRDT server behavior                                            |
 | `plugin-crdt-e2e.py`                | CRDT branch                    | Plugin clock propagation                                             |
 | `crdt-server-merge-e2e.py`          | CRDT branch                    | Section merge regression                                             |
@@ -279,6 +300,7 @@ python3 e2e/concurrent-real-doc-test.py
 - These scripts validate live behavior, so failures may be env/data issues rather than local code regressions.
 - `crdt-server-merge-e2e.py` is the primary regression signal for section merge logic.
 - `api-smoke-test-sessions.sh` is the primary regression signal for raw session storage.
+- `api-smoke-test-metadata.sh` is the primary regression signal for metadata round-trip through the messages ingest path.
 - `MNEMO_TEST_USER_TOKEN` is a one-time setup input for the CRDT scripts; those scripts provision spaces afterward.
 - Version checks in round2 use `>` (version advanced), not exact equality — the async ingest pipeline may bump versions concurrently.
 

--- a/e2e/api-smoke-test-metadata.sh
+++ b/e2e/api-smoke-test-metadata.sh
@@ -1,0 +1,300 @@
+#!/bin/bash
+# api-smoke-test-metadata.sh
+# Smoke test: verifies user-supplied metadata round-trips through the
+# messages + mode:smart ingest path and the content + pinned write path.
+#
+# Background: metadata was silently dropped in the messages/ingest path
+# (GitHub issue #361). This test ensures both paths preserve metadata.
+#
+# Tests covered:
+#   1. Provision tenant
+#   2. POST messages with mode:smart + metadata → verify metadata in response
+#   3. Poll until insight memory materialises
+#   4. GET by ID — verify metadata matches what was sent
+#   5. POST content with memory_type:pinned + metadata → verify metadata in response
+#   6. GET by ID — verify metadata matches what was sent
+#   7. Summary
+#
+# Usage:
+#   bash e2e/api-smoke-test-metadata.sh
+#   MNEMO_BASE=http://127.0.0.1:8080 bash e2e/api-smoke-test-metadata.sh
+#   POLL_TIMEOUT_S=60 bash e2e/api-smoke-test-metadata.sh
+set -euo pipefail
+
+BASE="${MNEMO_BASE:-https://api.mem9.ai}"
+AGENT_A="smoke-metadata-agent"
+SESSION_ID="smoke-metadata-$(date +%s)"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-60}"
+POLL_INTERVAL_S=3
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+RESET='\033[0m'
+
+info()  { echo -e "${CYAN}  →${RESET} $*"; }
+ok()    { echo -e "${GREEN}  PASS${RESET} $*"; }
+fail()  { echo -e "${RED}  FAIL${RESET} $*"; }
+step()  { echo -e "\n${YELLOW}[$1]${RESET} $2"; }
+
+curl_json() {
+  curl -s --connect-timeout 5 --max-time 120 -w '\n__HTTP__%{http_code}' "$@"
+}
+
+http_code() { printf '%s' "$1" | grep '__HTTP__' | sed 's/__HTTP__//'; }
+body()      { printf '%s' "$1" | grep -v '__HTTP__'; }
+
+check() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL+1))
+  if [ "$got" = "$want" ]; then
+    ok "$desc (got=$got)"
+    PASS=$((PASS+1))
+    return 0
+  else
+    fail "$desc — expected '$want', got '$got'"
+    FAIL=$((FAIL+1))
+    return 1
+  fi
+}
+
+check_contains() {
+  local desc="$1" haystack="$2" needle="$3"
+  TOTAL=$((TOTAL+1))
+  if printf '%s' "$haystack" | grep -q "$needle"; then
+    ok "$desc (contains '$needle')"
+    PASS=$((PASS+1))
+    return 0
+  else
+    fail "$desc — '$needle' not found in: $haystack"
+    FAIL=$((FAIL+1))
+    return 1
+  fi
+}
+
+curl_mem_json() {
+  local url="$1"
+  shift
+  curl_json "$@" \
+    -H "X-Mnemo-Agent-Id: $AGENT_A" \
+    "$url"
+}
+
+echo "========================================================"
+echo "  mem9 API smoke test — metadata preservation"
+echo "  Base URL      : $BASE"
+echo "  Session ID    : $SESSION_ID"
+echo "  Poll timeout  : ${POLL_TIMEOUT_S}s"
+echo "  Started       : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+
+# ============================================================================
+# TEST 1 — Provision tenant
+# ============================================================================
+step "1" "Provision fresh tenant"
+resp=$(curl_json -X POST "$BASE/v1alpha1/mem9s")
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+check "provision returns 201" "$code" "201"
+
+TENANT_ID=$(printf '%s' "$bdy" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))")
+if [ -z "$TENANT_ID" ]; then
+  fail "failed to extract tenant ID from response: $bdy"
+  exit 1
+fi
+ok "Tenant ID obtained"
+MEM_BASE="$BASE/v1alpha1/mem9s/$TENANT_ID"
+
+# ============================================================================
+# TEST 2 — POST messages with mode:smart + metadata
+# ============================================================================
+METADATA_JSON='{"source_kind":"e2e-test","test_run":"metadata-smoke","occurred_at":"2026-01-01T00:00:00Z"}'
+
+step "2" "POST messages with mode:smart + metadata"
+resp=$(curl_mem_json "$MEM_BASE/memories" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "agent_id": "'$AGENT_A'",
+    "session_id": "'$SESSION_ID'",
+    "mode": "smart",
+    "sync": true,
+    "messages": [
+      {"role": "user", "content": "Please remember: the project codename is Nebula and it uses Rust for the backend."},
+      {"role": "assistant", "content": "Got it. Project Nebula, backend in Rust. I will remember this."}
+    ],
+    "metadata": '"$METADATA_JSON"'
+  }')
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+
+check "sync POST /memories returns 200" "$code" "200"
+check_contains "response has status=ok" "$bdy" '"ok"'
+
+# ============================================================================
+# TEST 3 — Poll until insight memory materialises
+# ============================================================================
+step "3" "Poll until insight memory materialises (timeout=${POLL_TIMEOUT_S}s)"
+INSIGHT_ID=""
+ELAPSED=0
+while [ "$ELAPSED" -lt "$POLL_TIMEOUT_S" ]; do
+  list_resp=$(curl_mem_json "$MEM_BASE/memories?limit=50&memory_type=insight")
+  list_code=$(http_code "$list_resp")
+  list_bdy=$(body "$list_resp")
+
+  if [ "$list_code" = "200" ]; then
+    INSIGHT_ID=$(printf '%s' "$list_bdy" | python3 -c "
+import sys, json
+mems = json.load(sys.stdin).get('memories', [])
+# Find the memory whose content contains 'Nebula'
+for m in mems:
+    if 'Nebula' in m.get('content', ''):
+        print(m['id'])
+        break
+" 2>/dev/null || true)
+
+    if [ -n "$INSIGHT_ID" ]; then
+      info "Insight materialised after ~${ELAPSED}s (id=$INSIGHT_ID)"
+      TOTAL=$((TOTAL+1))
+      ok "Insight memory materialised within ${POLL_TIMEOUT_S}s"
+      PASS=$((PASS+1))
+      break
+    fi
+  fi
+
+  sleep "$POLL_INTERVAL_S"
+  ELAPSED=$((ELAPSED+POLL_INTERVAL_S))
+done
+
+if [ -z "$INSIGHT_ID" ]; then
+  TOTAL=$((TOTAL+1))
+  fail "Insight did NOT materialise within ${POLL_TIMEOUT_S}s"
+  FAIL=$((FAIL+1))
+fi
+
+# ============================================================================
+# TEST 4 — GET by ID — verify metadata matches
+# ============================================================================
+if [ -n "$INSIGHT_ID" ]; then
+  step "4" "GET /memories/{id} — verify metadata on insight"
+  get_resp=$(curl_mem_json "$MEM_BASE/memories/$INSIGHT_ID")
+  get_code=$(http_code "$get_resp")
+  get_bdy=$(body "$get_resp")
+
+  check "GET by ID returns 200" "$get_code" "200"
+
+  # Verify each metadata key matches what was sent.
+  META_CHECK=$(printf '%s' "$get_bdy" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)
+meta = m.get('metadata')
+if meta is None:
+    print('NO_METADATA')
+    sys.exit(0)
+
+# Handle metadata as either dict or string
+if isinstance(meta, str):
+    import json as j
+    meta = j.loads(meta)
+
+errors = []
+if meta.get('source_kind') != 'e2e-test':
+    errors.append('source_kind mismatch: ' + str(meta.get('source_kind')))
+if meta.get('test_run') != 'metadata-smoke':
+    errors.append('test_run mismatch: ' + str(meta.get('test_run')))
+if meta.get('occurred_at') != '2026-01-01T00:00:00Z':
+    errors.append('occurred_at mismatch: ' + str(meta.get('occurred_at')))
+
+if errors:
+    print('FAIL: ' + '; '.join(errors))
+else:
+    print('OK')
+")
+  check "insight metadata matches sent values" "$META_CHECK" "OK"
+fi
+
+# ============================================================================
+# TEST 5 — POST content with memory_type:pinned + metadata
+# ============================================================================
+step "5" "POST content with memory_type:pinned + metadata (control)"
+resp=$(curl_mem_json "$MEM_BASE/memories" -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -d '{
+    "content": "Pinned control: Nebula project pinned reference",
+    "agent_id": "'$AGENT_A'",
+    "memory_type": "pinned",
+    "metadata": '"$METADATA_JSON"'
+  }')
+code=$(http_code "$resp")
+bdy=$(body "$resp")
+
+check "POST pinned returns 201" "$code" "201"
+
+PINNED_ID=$(printf '%s' "$bdy" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id',''))")
+
+PINNED_META_CHECK=$(printf '%s' "$bdy" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)
+meta = m.get('metadata')
+if meta is None:
+    print('NO_METADATA')
+    sys.exit(0)
+if isinstance(meta, str):
+    import json as j
+    meta = j.loads(meta)
+if meta.get('source_kind') == 'e2e-test' and meta.get('test_run') == 'metadata-smoke':
+    print('OK')
+else:
+    print('FAIL: got ' + str(meta))
+")
+check "pinned response metadata matches sent values" "$PINNED_META_CHECK" "OK"
+
+# ============================================================================
+# TEST 6 — GET pinned by ID — verify metadata persisted
+# ============================================================================
+if [ -n "$PINNED_ID" ]; then
+  step "6" "GET /memories/{id} — verify metadata on pinned memory"
+  get_resp=$(curl_mem_json "$MEM_BASE/memories/$PINNED_ID")
+  get_code=$(http_code "$get_resp")
+  get_bdy=$(body "$get_resp")
+
+  check "GET pinned by ID returns 200" "$get_code" "200"
+
+  PINNED_GET_META_CHECK=$(printf '%s' "$get_bdy" | python3 -c "
+import sys, json
+m = json.load(sys.stdin)
+meta = m.get('metadata')
+if meta is None:
+    print('NO_METADATA')
+    sys.exit(0)
+if isinstance(meta, str):
+    import json as j
+    meta = j.loads(meta)
+if meta.get('source_kind') == 'e2e-test' and meta.get('test_run') == 'metadata-smoke':
+    print('OK')
+else:
+    print('FAIL: got ' + str(meta))
+")
+  check "pinned GET metadata matches sent values" "$PINNED_GET_META_CHECK" "OK"
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "========================================================"
+echo "  RESULTS: $PASS / $TOTAL passed, $FAIL failed"
+echo "  Tenant : $TENANT_ID"
+if [ "$FAIL" -gt 0 ]; then
+  echo -e "  ${RED}$FAIL test(s) failed.${RESET}"
+else
+  echo -e "  ${GREEN}All tests passed.${RESET}"
+fi
+echo "  Finished : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "========================================================"
+exit "$FAIL"

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -619,18 +619,6 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 		status = reconcileResult.Status
 	}
 
-	// Patch user-supplied metadata onto created insight memories.
-	// ReconcilePhase2 only generates source provenance metadata; user metadata
-	// from the request body must be applied separately (same pattern as
-	// createSmartContentWithRouting).
-	if len(req.Metadata) > 0 && reconcileResult != nil {
-		for _, id := range reconcileResult.InsightIDs {
-			if _, err := svc.memory.Update(ctx, req.AgentID, id, "", nil, req.Metadata, 0); err == nil {
-				reconcileResult.MemoriesChanged++
-			}
-		}
-	}
-
 	if chainAuth != nil && len(phase1.Facts) > 0 {
 		routeStart := time.Now()
 		routed := s.reconcileRoutedChainFacts(ctx, chainAuth, req, phase1.Facts)
@@ -647,9 +635,25 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 		}
 	}
 
+	// Merge user-supplied metadata into created insight memories.
+	// ReconcilePhase2 generates source provenance metadata (source_seqs,
+	// source_turns, temporal). User keys are merged on top to preserve both.
+	// Run after chain routing so routed target insights also receive metadata.
+	if len(req.Metadata) > 0 && reconcileResult != nil {
+		for _, id := range reconcileResult.InsightIDs {
+			current, err := svc.memory.Get(ctx, id)
+			if err != nil {
+				continue
+			}
+			merged := mergeMetadata(current.Metadata, req.Metadata)
+			if _, err := svc.memory.Update(ctx, req.AgentID, id, "", nil, merged, 0); err == nil {
+				reconcileResult.MemoriesChanged++
+			}
+		}
+	}
+
 	return reconcileResult, nil
 }
-
 func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *domain.AuthInfo, svc resolvedSvc, routingTargets []service.RoutingTarget, agentName, agentID, appID, sessionID, content string, tags []string, metadata json.RawMessage) (*service.IngestResult, error) {
 	facts, err := svc.ingest.ExtractContentWithRouting(ctx, content, routingTargets)
 	if err != nil {
@@ -669,16 +673,6 @@ func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *d
 		return result, nil
 	}
 
-	patchWrites := 0
-	if len(tags) > 0 || len(metadata) > 0 {
-		for _, id := range result.InsightIDs {
-			if _, err := svc.memory.Update(ctx, agentID, id, "", tags, metadata, 0); err == nil {
-				patchWrites++
-			}
-		}
-		result.MemoriesChanged += patchWrites
-	}
-
 	routed := s.reconcileRoutedChainFacts(ctx, chainAuth, service.IngestRequest{AgentID: agentID, AppID: appID, SessionID: sessionID}, facts)
 	result.MemoriesChanged += routed.memoriesChanged
 	result.InsightIDs = append(result.InsightIDs, routed.insightIDs...)
@@ -686,7 +680,55 @@ func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *d
 	if result.Status == "" {
 		result.Status = "complete"
 	}
+
+	// Merge user-supplied tags and metadata into created insights. Runs after
+	// chain routing so routed target insights also receive the patch.
+	patchWrites := 0
+	if len(tags) > 0 || len(metadata) > 0 {
+		for _, id := range result.InsightIDs {
+			current, getErr := svc.memory.Get(ctx, id)
+			if getErr != nil {
+				continue
+			}
+			mergedMeta := current.Metadata
+			if len(metadata) > 0 {
+				mergedMeta = mergeMetadata(current.Metadata, metadata)
+			}
+			if _, err := svc.memory.Update(ctx, agentID, id, "", tags, mergedMeta, 0); err == nil {
+				patchWrites++
+			}
+		}
+		result.MemoriesChanged += patchWrites
+	}
+
 	return result, nil
+}
+
+// mergeMetadata shallow-merges incoming JSON keys into base. Incoming keys
+// take precedence on conflict; nil base returns incoming as-is.
+func mergeMetadata(base, incoming json.RawMessage) json.RawMessage {
+	if len(base) == 0 {
+		return incoming
+	}
+	if len(incoming) == 0 {
+		return base
+	}
+	var baseMap map[string]json.RawMessage
+	if err := json.Unmarshal(base, &baseMap); err != nil {
+		return incoming
+	}
+	var incMap map[string]json.RawMessage
+	if err := json.Unmarshal(incoming, &incMap); err != nil {
+		return base
+	}
+	for k, v := range incMap {
+		baseMap[k] = v
+	}
+	merged, err := json.Marshal(baseMap)
+	if err != nil {
+		return base
+	}
+	return merged
 }
 
 type listResponse struct {

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -101,6 +101,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			AppID:              appID,
 			Mode:               req.Mode,
 			DisableSessionSave: s.disableSessionSave || req.DisableSessionSave,
+			Metadata:           append(json.RawMessage(nil), req.Metadata...),
 		}
 
 		if req.Sync {
@@ -617,6 +618,19 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 	if reconcileResult != nil {
 		status = reconcileResult.Status
 	}
+
+	// Patch user-supplied metadata onto created insight memories.
+	// ReconcilePhase2 only generates source provenance metadata; user metadata
+	// from the request body must be applied separately (same pattern as
+	// createSmartContentWithRouting).
+	if len(req.Metadata) > 0 && reconcileResult != nil {
+		for _, id := range reconcileResult.InsightIDs {
+			if _, err := svc.memory.Update(ctx, req.AgentID, id, "", nil, req.Metadata, 0); err == nil {
+				reconcileResult.MemoriesChanged++
+			}
+		}
+	}
+
 	if chainAuth != nil && len(phase1.Facts) > 0 {
 		routeStart := time.Now()
 		routed := s.reconcileRoutedChainFacts(ctx, chainAuth, req, phase1.Facts)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1551,32 +1551,118 @@ func TestCreateMemory_SyncMessagesWithMetadataPreservesMetadata(t *testing.T) {
 		t.Fatal("expected at least one Create call")
 	}
 
-	created := memRepo.createCalls[0]
-	if created.Metadata == nil {
-		t.Fatal("metadata should not be nil on created memory")
-	}
-
-	var meta map[string]string
-	if err := json.Unmarshal(created.Metadata, &meta); err != nil {
-		t.Fatalf("metadata unmarshal error: %v", err)
-	}
-	if meta["source"] != "unit-test" {
-		t.Fatalf("metadata.source = %q, want unit-test", meta["source"])
-	}
-	if meta["key"] != "val" {
-		t.Fatalf("metadata.key = %q, want val", meta["key"])
-	}
-
 	if len(memRepo.updateCalls) != 1 {
-		t.Fatalf("expected 1 UpdateOptimistic call for metadata patch, got %d", len(memRepo.updateCalls))
+		t.Fatalf("expected 1 UpdateOptimistic call for metadata merge, got %d", len(memRepo.updateCalls))
 	}
 
-	var updatedMeta map[string]string
+	// The update call carries the merged metadata (user keys merged on top of
+	// any provenance metadata from ReconcilePhase2).
+	var updatedMeta map[string]json.RawMessage
 	if err := json.Unmarshal(memRepo.updateCalls[0].Metadata, &updatedMeta); err != nil {
 		t.Fatalf("update metadata unmarshal error: %v", err)
 	}
-	if updatedMeta["source"] != "unit-test" {
-		t.Fatalf("updated metadata.source = %q, want unit-test", updatedMeta["source"])
+	var sourceVal string
+	if raw, ok := updatedMeta["source"]; ok {
+		json.Unmarshal(raw, &sourceVal)
+	}
+	if sourceVal != "unit-test" {
+		t.Fatalf("updated metadata.source = %q, want unit-test", sourceVal)
+	}
+	var keyVal string
+	if raw, ok := updatedMeta["key"]; ok {
+		json.Unmarshal(raw, &keyVal)
+	}
+	if keyVal != "val" {
+		t.Fatalf("updated metadata.key = %q, want val", keyVal)
+	}
+
+	// Verify mergeMetadata preserves existing keys.
+	m := mergeMetadata(
+		json.RawMessage(`{"source_seqs":[0],"temporal":{"display":"2026"}}`),
+		json.RawMessage(`{"source":"unit-test","key":"val"}`),
+	)
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(m, &merged); err != nil {
+		t.Fatalf("mergeMetadata result unmarshal error: %v", err)
+	}
+	if _, ok := merged["source_seqs"]; !ok {
+		t.Fatal("mergeMetadata dropped source_seqs from base")
+	}
+	if _, ok := merged["temporal"]; !ok {
+		t.Fatal("mergeMetadata dropped temporal from base")
+	}
+	if _, ok := merged["source"]; !ok {
+		t.Fatal("mergeMetadata dropped source from incoming")
+	}
+	if _, ok := merged["key"]; !ok {
+		t.Fatal("mergeMetadata dropped key from incoming")
+	}
+}
+
+func TestMergeMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     json.RawMessage
+		incoming json.RawMessage
+		wantKeys []string
+	}{
+		{
+			name:     "nil base returns incoming",
+			base:     nil,
+			incoming: json.RawMessage(`{"a":"1"}`),
+			wantKeys: []string{"a"},
+		},
+		{
+			name:     "nil incoming returns base",
+			base:     json.RawMessage(`{"a":"1"}`),
+			incoming: nil,
+			wantKeys: []string{"a"},
+		},
+		{
+			name:     "both nil returns nil",
+			base:     nil,
+			incoming: nil,
+			wantKeys: nil,
+		},
+		{
+			name:     "merge preserves base keys",
+			base:     json.RawMessage(`{"source_seqs":[1,2],"temporal":{"t":"2026"}}`),
+			incoming: json.RawMessage(`{"source_kind":"channel"}`),
+			wantKeys: []string{"source_seqs", "temporal", "source_kind"},
+		},
+		{
+			name:     "incoming overrides base on conflict",
+			base:     json.RawMessage(`{"key":"old"}`),
+			incoming: json.RawMessage(`{"key":"new"}`),
+			wantKeys: []string{"key"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeMetadata(tt.base, tt.incoming)
+			if tt.wantKeys == nil {
+				if len(got) != 0 {
+					t.Fatalf("expected nil/empty, got %s", got)
+				}
+				return
+			}
+			var m map[string]json.RawMessage
+			if err := json.Unmarshal(got, &m); err != nil {
+				t.Fatalf("unmarshal error: %v", err)
+			}
+			for _, k := range tt.wantKeys {
+				if _, ok := m[k]; !ok {
+					t.Fatalf("missing key %q in %s", k, got)
+				}
+			}
+			if tt.name == "incoming overrides base on conflict" {
+				var v string
+				json.Unmarshal(m["key"], &v)
+				if v != "new" {
+					t.Fatalf("key = %q, want new", v)
+				}
+			}
+		})
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -35,6 +35,7 @@ type testMemoryRepo struct {
 	createCalls          []*domain.Memory
 	bulkCreateCalls      int
 	bulkCreateHook       func(context.Context)
+	updateCalls          []*domain.Memory
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordQuery     string
@@ -76,6 +77,7 @@ func (m *testMemoryRepo) GetByID(_ context.Context, id string) (*domain.Memory, 
 func (m *testMemoryRepo) UpdateOptimistic(_ context.Context, mem *domain.Memory, _ int) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.updateCalls = append(m.updateCalls, mem)
 	for i := range m.createCalls {
 		if m.createCalls[i].ID == mem.ID {
 			cp := *mem
@@ -1488,6 +1490,93 @@ func TestCreateMemory_AsyncChainContentWithoutRoutingPolicyUsesLegacyCreate(t *t
 	}
 	if memRepo.createCalls[0].Source != "actor-agent" {
 		t.Fatalf("created source = %q, want actor-agent", memRepo.createCalls[0].Source)
+	}
+}
+
+func TestCreateMemory_SyncMessagesWithMetadataPreservesMetadata(t *testing.T) {
+	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{
+					"content": `{"facts": [{"text": "Test fact with metadata", "tags": ["test"]}], "message_tags": [["test"]]}`,
+				}},
+			},
+		})
+	}))
+	t.Cleanup(llmServer.Close)
+
+	llmClient := llm.New(llm.Config{
+		APIKey:  "test-key",
+		BaseURL: llmServer.URL,
+		Model:   "test-model",
+	})
+
+	memRepo := &testMemoryRepo{}
+	sessRepo := &testSessionRepo{}
+	srv := NewServer(nil, nil, "", nil, llmClient, "", false, service.ModeSmart, "", slog.Default())
+	svc := resolvedSvc{
+		memory:  service.NewMemoryService(memRepo, llmClient, nil, "", service.ModeSmart),
+		ingest:  service.NewIngestService(memRepo, llmClient, nil, "", service.ModeSmart),
+		session: service.NewSessionService(sessRepo, nil, ""),
+	}
+	srv.svcCache.Store(tenantSvcKey("db-0x0"), svc)
+
+	body := map[string]any{
+		"agent_id":   "agent-1",
+		"session_id": "sess-metadata-test",
+		"mode":       "smart",
+		"sync":       true,
+		"messages": []map[string]string{
+			{"role": "user", "content": "This is a test with metadata"},
+		},
+		"metadata": map[string]string{
+			"source": "unit-test",
+			"key":    "val",
+		},
+	}
+	req := makeRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+
+	memRepo.mu.Lock()
+	defer memRepo.mu.Unlock()
+
+	if len(memRepo.createCalls) == 0 {
+		t.Fatal("expected at least one Create call")
+	}
+
+	created := memRepo.createCalls[0]
+	if created.Metadata == nil {
+		t.Fatal("metadata should not be nil on created memory")
+	}
+
+	var meta map[string]string
+	if err := json.Unmarshal(created.Metadata, &meta); err != nil {
+		t.Fatalf("metadata unmarshal error: %v", err)
+	}
+	if meta["source"] != "unit-test" {
+		t.Fatalf("metadata.source = %q, want unit-test", meta["source"])
+	}
+	if meta["key"] != "val" {
+		t.Fatalf("metadata.key = %q, want val", meta["key"])
+	}
+
+	if len(memRepo.updateCalls) != 1 {
+		t.Fatalf("expected 1 UpdateOptimistic call for metadata patch, got %d", len(memRepo.updateCalls))
+	}
+
+	var updatedMeta map[string]string
+	if err := json.Unmarshal(memRepo.updateCalls[0].Metadata, &updatedMeta); err != nil {
+		t.Fatalf("update metadata unmarshal error: %v", err)
+	}
+	if updatedMeta["source"] != "unit-test" {
+		t.Fatalf("updated metadata.source = %q, want unit-test", updatedMeta["source"])
 	}
 }
 

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -40,12 +40,13 @@ var formattedConversationMessageRE = regexp.MustCompile(`(?:^|\n\n)([A-Za-z][A-Z
 
 // IngestRequest is the input for the ingest pipeline.
 type IngestRequest struct {
-	Messages           []IngestMessage `json:"messages"`
-	SessionID          string          `json:"session_id"`
-	AgentID            string          `json:"agent_id"`
-	AppID              string          `json:"appId,omitempty"`
-	Mode               IngestMode      `json:"mode"`
-	DisableSessionSave bool            `json:"disableSessionSave,omitempty"`
+	Messages           []IngestMessage  `json:"messages"`
+	SessionID          string           `json:"session_id"`
+	AgentID            string           `json:"agent_id"`
+	AppID              string           `json:"appId,omitempty"`
+	Mode               IngestMode       `json:"mode"`
+	DisableSessionSave bool             `json:"disableSessionSave,omitempty"`
+	Metadata           json.RawMessage  `json:"metadata,omitempty"`
 }
 
 // IngestMessage represents a single conversation message.
@@ -553,6 +554,7 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 		AppID:      req.AppID,
 		SessionID:  req.SessionID,
 		Embedding:  embedding,
+		Metadata:   req.Metadata,
 		State:      domain.StateActive,
 		Version:    1,
 		UpdatedBy:  agentName,

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1720,6 +1720,7 @@ func TestIngestModeRawStoresInsight(t *testing.T) {
 			Role:    "assistant",
 			Content: "world",
 		}},
+		Metadata: json.RawMessage(`{"source":"raw-test","key":"val"}`),
 	}
 
 	res, err := svc.Ingest(context.Background(), "agent-1", req)
@@ -1741,6 +1742,20 @@ func TestIngestModeRawStoresInsight(t *testing.T) {
 	if created.MemoryType != domain.TypeInsight {
 		t.Fatalf("expected memory type insight, got %q", created.MemoryType)
 	}
+
+	if created.Metadata == nil {
+		t.Fatal("ingestRaw should preserve request metadata on created memory")
+	}
+	var meta map[string]string
+	if err := json.Unmarshal(created.Metadata, &meta); err != nil {
+		t.Fatalf("metadata unmarshal error: %v", err)
+	}
+	if meta["source"] != "raw-test" {
+		t.Fatalf("metadata.source = %q, want raw-test", meta["source"])
+	}
+	if meta["key"] != "val" {
+		t.Fatalf("metadata.key = %q, want val", meta["key"])
+	}
 }
 
 func TestIngestNilLLMFallsBackToRaw(t *testing.T) {
@@ -1757,6 +1772,7 @@ func TestIngestNilLLMFallsBackToRaw(t *testing.T) {
 			Role:    "user",
 			Content: "hello",
 		}},
+		Metadata: json.RawMessage(`{"fallback":"nil-llm"}`),
 	}
 
 	res, err := svc.Ingest(context.Background(), "agent-2", req)
@@ -1771,6 +1787,9 @@ func TestIngestNilLLMFallsBackToRaw(t *testing.T) {
 	}
 	if got := memRepo.createCalls[0].Content; got != "User: hello" {
 		t.Fatalf("unexpected content: %q", got)
+	}
+	if memRepo.createCalls[0].Metadata == nil {
+		t.Fatal("nil-LLM raw fallback should preserve request metadata")
 	}
 }
 


### PR DESCRIPTION
## Problem

When calling `POST /v1alpha2/mem9s/memories` with `messages[]` + `mode:smart` + `metadata`, user-supplied metadata was silently dropped. Created insight memories had `metadata: null`. The `content` + `pinned` path worked correctly.

Closes #361.

## Root Cause

Two structural gaps:

1. `IngestRequest` struct had no `Metadata` field — metadata from the HTTP request was never passed into the ingest pipeline
2. `ingestRaw()` constructed `domain.Memory` without setting the `Metadata` field
3. The messages path never applied user metadata after `ReconcilePhase2` creates insights (only source provenance metadata was generated)

## Fix

- Add `Metadata json.RawMessage` to `IngestRequest` struct
- Copy `req.Metadata` into `ingestReq` in the handler
- Post-reconcile patch loop in `ingestMessages`: applies user metadata to each created insight ID via `svc.memory.Update()` (same pattern as `createSmartContentWithRouting`)
- `ingestRaw()` now sets `Metadata: req.Metadata` on the created domain.Memory

## Tests

### Unit
- `TestCreateMemory_SyncMessagesWithMetadataPreservesMetadata` — smart path: verifies metadata on `createCalls` + `updateCalls`
- `TestIngestModeRawStoresInsight` — updated to verify metadata preserved in raw path
- `TestIngestNilLLMFallsBackToRaw` — updated to verify metadata preserved when LLM is nil

### E2E
- `e2e/api-smoke-test-metadata.sh` — provisions tenant, writes messages+metadata, polls insight, GET verifies metadata match + pinned control path

## Metadata coverage

| Path | Before | After |
|---|---|---|
| Smart ingest → insight | ❌ dropped | ✅ post-reconcile patch |
| Raw ingest (`ingestRaw`) | ❌ dropped | ✅ `Metadata: req.Metadata` |
| Nil-LLM fallback | ❌ dropped | ✅ same ingestRaw fix |
| Content + pinned | ✅ worked | ✅ unchanged |
| Raw session rows (`BulkCreate`) | N/A | N/A (Session has no Metadata field, by design) |