### PR TITLE
feat(session-search): add created_at time-range filter to raw-session search

### DIFF
--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -160,6 +160,12 @@ type MemoryFilter struct {
 	Offset     int
 	ScanAll    bool
 	MinScore   float64 // minimum cosine similarity for vector results; 0 = use default (0.3); -1 = disabled (return all)
+	// CreatedAfter / CreatedBefore bound results to a created_at window
+	// (closed interval). nil = unbounded on that side. Currently consumed
+	// only by the raw-session search/list path (buildSessionFilterConds);
+	// other pools ignore them so normal memory search is unchanged.
+	CreatedAfter  *time.Time
+	CreatedBefore *time.Time
 }
 
 // TenantStatus represents the lifecycle status of a tenant.

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -767,20 +767,49 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		tags = strings.Split(t, ",")
 	}
 
+	createdAfter, err := parseTimeParam(q.Get("created_after"), "created_after")
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	createdBefore, err := parseTimeParam(q.Get("created_before"), "created_before")
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	if createdAfter != nil && createdBefore != nil && createdAfter.After(*createdBefore) {
+		s.handleError(r.Context(), w, &domain.ValidationError{
+			Field: "created_after", Message: "must not be after created_before",
+		})
+		return
+	}
+	// The created_at window is consumed only by the session pool. Reject
+	// it on other pools rather than silently applying mixed semantics
+	// (session filtered, pinned/insight not) — same "explicit 400, never
+	// silent" stance as the RFC3339 parse above.
+	if (createdAfter != nil || createdBefore != nil) && q.Get("memory_type") != string(domain.TypeSession) {
+		s.handleError(r.Context(), w, &domain.ValidationError{
+			Field: "created_after", Message: "time-range filter requires memory_type=session",
+		})
+		return
+	}
+
 	filter := domain.MemoryFilter{
-		Query:      query,
-		Tags:       tags,
-		Source:     q.Get("source"),
-		State:      q.Get("state"),
-		MemoryType: q.Get("memory_type"),
-		AgentID:    q.Get("agent_id"),
-		SessionID:  q.Get("session_id"),
-		AppID:      appIDFilter,
-		SortBy:     q.Get("sort_by"),
-		SortDir:    q.Get("sort_dir"),
-		Limit:      limit,
-		Offset:     offset,
-		ScanAll:    parseBoolQuery(q.Get("scanAll")),
+		Query:         query,
+		Tags:          tags,
+		Source:        q.Get("source"),
+		State:         q.Get("state"),
+		MemoryType:    q.Get("memory_type"),
+		AgentID:       q.Get("agent_id"),
+		SessionID:     q.Get("session_id"),
+		AppID:         appIDFilter,
+		SortBy:        q.Get("sort_by"),
+		SortDir:       q.Get("sort_dir"),
+		Limit:         limit,
+		Offset:        offset,
+		ScanAll:       parseBoolQuery(q.Get("scanAll")),
+		CreatedAfter:  createdAfter,
+		CreatedBefore: createdBefore,
 	}
 	onlySession := filter.MemoryType == string(domain.TypeSession)
 
@@ -928,6 +957,21 @@ func parseAppIDFilter(q url.Values) (*string, error) {
 		return nil, &domain.ValidationError{Field: "appId", Message: "too long (max 100)"}
 	}
 	return &raw, nil
+}
+
+// parseTimeParam parses an optional RFC3339 timestamp query parameter.
+// Empty/absent → nil (no bound). A malformed value is a client error,
+// not a silently-ignored param.
+func parseTimeParam(raw, field string) (*time.Time, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return nil, &domain.ValidationError{Field: field, Message: "must be an RFC3339 timestamp"}
+	}
+	return &t, nil
 }
 
 func (s *Server) listLocalMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -4399,3 +4399,56 @@ func TestListMemories_SinglePoolRecall_NormalizesChineseRelativeQuery(t *testing
 		t.Fatalf("session filter query = %q, want %q", sessRepo.lastKeywordFilter.Query, expected)
 	}
 }
+
+func TestListMemories_TimeRangePropagatesToSessionFilter(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{{
+			ID: "sess-row-1", Content: "raw turn", MemoryType: domain.TypeSession,
+			State: domain.StateActive, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}},
+		listTotal: 1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := makeRequest(t, http.MethodGet,
+		"/memories?memory_type=session&created_after=2026-06-01T00:00:00Z&created_before=2026-06-30T23:59:59Z", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	f := sessionRepo.lastListFilter
+	if f.CreatedAfter == nil || !f.CreatedAfter.Equal(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("CreatedAfter = %v, want 2026-06-01T00:00:00Z", f.CreatedAfter)
+	}
+	if f.CreatedBefore == nil || !f.CreatedBefore.Equal(time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC)) {
+		t.Fatalf("CreatedBefore = %v, want 2026-06-30T23:59:59Z", f.CreatedBefore)
+	}
+}
+
+func TestListMemories_TimeRangeRequiresSessionType(t *testing.T) {
+	// The window is session-only; passing it without memory_type=session
+	// must 400 rather than silently apply mixed-pool semantics.
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?created_after=2026-06-01T00:00:00Z", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestListMemories_RejectsMalformedTimeParam(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?memory_type=session&created_after=2026-06-01", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 on non-RFC3339: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/server/internal/handler/parse_time_param_test.go
+++ b/server/internal/handler/parse_time_param_test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+// parseTimeParam is the wire-side half of the raw-session created_at
+// window filter: optional RFC3339 timestamps, absent → no bound, a
+// malformed value is a client error rather than a silently-ignored
+// param.
+
+func TestParseTimeParam_EmptyIsUnbounded(t *testing.T) {
+	for _, raw := range []string{"", "   "} {
+		got, err := parseTimeParam(raw, "created_after")
+		if err != nil {
+			t.Fatalf("parseTimeParam(%q) err = %v, want nil", raw, err)
+		}
+		if got != nil {
+			t.Fatalf("parseTimeParam(%q) = %v, want nil (unbounded)", raw, got)
+		}
+	}
+}
+
+func TestParseTimeParam_ValidRFC3339(t *testing.T) {
+	got, err := parseTimeParam("2026-06-17T14:00:00Z", "created_after")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	want := time.Date(2026, 6, 17, 14, 0, 0, 0, time.UTC)
+	if got == nil || !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestParseTimeParam_InvalidIsValidationError(t *testing.T) {
+	// Non-RFC3339 forms must be rejected, not silently dropped.
+	for _, raw := range []string{"2026-06-17", "yesterday", "1718632800"} {
+		got, err := parseTimeParam(raw, "created_before")
+		if got != nil {
+			t.Fatalf("parseTimeParam(%q) = %v, want nil on error", raw, got)
+		}
+		var ve *domain.ValidationError
+		if !errors.As(err, &ve) {
+			t.Fatalf("parseTimeParam(%q) err = %v, want *domain.ValidationError", raw, err)
+		}
+		if ve.Field != "created_before" {
+			t.Fatalf("error field = %q, want created_before", ve.Field)
+		}
+	}
+}

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -228,6 +228,18 @@ func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, 
 		conds = append(conds, "JSON_CONTAINS(tags, ?)")
 		args = append(args, string(tagJSON))
 	}
+	// Closed-interval created_at window (either side optional). Applied
+	// uniformly to every session search/list path because they all build
+	// their WHERE from this helper, so vector / FTS / keyword / list stay
+	// consistent under the same time filter.
+	if f.CreatedAfter != nil {
+		conds = append(conds, "created_at >= ?")
+		args = append(args, *f.CreatedAfter)
+	}
+	if f.CreatedBefore != nil {
+		conds = append(conds, "created_at <= ?")
+		args = append(args, *f.CreatedBefore)
+	}
 	if len(conds) == 0 {
 		conds = append(conds, "1=1")
 	}

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,5 +202,54 @@ func TestFillSessionMemory_PopulatesFields(t *testing.T) {
 	}
 	if result.UpdatedAt != now {
 		t.Errorf("UpdatedAt = %v, want %v", result.UpdatedAt, now)
+	}
+}
+
+func TestBuildSessionFilterConds_CreatedAtWindow(t *testing.T) {
+	repo := &SessionRepo{}
+	after := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 6, 30, 23, 59, 59, 0, time.UTC)
+
+	// No window → no created_at condition (existing behavior unchanged).
+	conds, args := repo.buildSessionFilterConds(domain.MemoryFilter{State: "all"})
+	for _, c := range conds {
+		if c == "created_at >= ?" || c == "created_at <= ?" {
+			t.Fatalf("unset window must not emit created_at cond, got %v", conds)
+		}
+	}
+	if len(args) != 0 {
+		t.Fatalf("unset window must add no args, got %v", args)
+	}
+
+	// Closed interval → both bounds, in order, with the timestamp args.
+	conds, args = repo.buildSessionFilterConds(domain.MemoryFilter{
+		State: "all", CreatedAfter: &after, CreatedBefore: &before,
+	})
+	joined := strings.Join(conds, " AND ")
+	if !strings.Contains(joined, "created_at >= ?") || !strings.Contains(joined, "created_at <= ?") {
+		t.Fatalf("closed interval must emit both bounds, got %q", joined)
+	}
+	if len(args) != 2 || args[0] != after || args[1] != before {
+		t.Fatalf("args = %v, want [after before]", args)
+	}
+
+	// Single-sided (after only).
+	conds, args = repo.buildSessionFilterConds(domain.MemoryFilter{State: "all", CreatedAfter: &after})
+	joined = strings.Join(conds, " AND ")
+	if !strings.Contains(joined, "created_at >= ?") || strings.Contains(joined, "created_at <= ?") {
+		t.Fatalf("after-only must emit only lower bound, got %q", joined)
+	}
+	if len(args) != 1 || args[0] != after {
+		t.Fatalf("after-only args = %v, want [after]", args)
+	}
+
+	// Single-sided (before only).
+	conds, args = repo.buildSessionFilterConds(domain.MemoryFilter{State: "all", CreatedBefore: &before})
+	joined = strings.Join(conds, " AND ")
+	if strings.Contains(joined, "created_at >= ?") || !strings.Contains(joined, "created_at <= ?") {
+		t.Fatalf("before-only must emit only upper bound, got %q", joined)
+	}
+	if len(args) != 1 || args[0] != before {
+		t.Fatalf("before-only args = %v, want [before]", args)
 	}
 }


### PR DESCRIPTION
## What

Adds an optional `created_at` time-window filter to the raw-session
search/list path, so callers can combine the existing keyword
(vector + FTS hybrid) search with a time range.

New query parameters on `GET /v1alpha2/mem9s/memories` (and the legacy
`GET /v1alpha1/mem9s/{tenantID}/memories`):

- `created_after`  — RFC3339 timestamp, inclusive lower bound
- `created_before` — RFC3339 timestamp, inclusive upper bound

Both are optional; omitting one leaves that side unbounded. Example:

