### PR TITLE
Add memory recall latency and timeout metrics

### DIFF
--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -738,6 +738,59 @@ type listResponse struct {
 	Offset   int             `json:"offset"`
 }
 
+type memoryRecallMetric struct {
+	mode  string
+	start time.Time
+}
+
+func newMemoryRecallMetric(auth *domain.AuthInfo, filter domain.MemoryFilter) memoryRecallMetric {
+	return memoryRecallMetric{
+		mode:  memoryRecallMode(auth, filter),
+		start: time.Now(),
+	}
+}
+
+func (m memoryRecallMetric) observe(ctx context.Context, err error) {
+	status := memoryRecallStatus(ctx, err)
+	metrics.MemoryRecallDuration.WithLabelValues(m.mode, status).Observe(time.Since(m.start).Seconds())
+	if status == "timeout" {
+		metrics.MemoryRecallTimeoutsTotal.WithLabelValues(m.mode).Inc()
+	}
+}
+
+func memoryRecallMode(auth *domain.AuthInfo, filter domain.MemoryFilter) string {
+	if auth != nil && auth.IsChain() {
+		return "chain"
+	}
+	if filter.ScanAll {
+		return "scan_all"
+	}
+	switch filter.MemoryType {
+	case "":
+		return "default"
+	case string(domain.TypeSession), string(domain.TypePinned), string(domain.TypeInsight):
+		return "single_pool"
+	default:
+		return "other"
+	}
+}
+
+func memoryRecallStatus(ctx context.Context, err error) string {
+	if err == nil && ctx != nil {
+		err = ctx.Err()
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "canceled"
+	}
+	if err != nil {
+		return "error"
+	}
+	return "ok"
+}
+
 func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	auth := authInfo(r)
 	q := r.URL.Query()
@@ -789,6 +842,14 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	var recallLease *runtimeusage.OperationLease
 	recallFinalized := false
 	recallSearch := filter.Query != "" && !contentKeywordSearch
+	var recallMetric *memoryRecallMetric
+	if recallSearch {
+		metric := newMemoryRecallMetric(auth, filter)
+		recallMetric = &metric
+		defer func() {
+			recallMetric.observe(r.Context(), err)
+		}()
+	}
 
 	if s.runtimeUsageEnabled() && recallSearch {
 		recallLease, err = s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
@@ -848,19 +909,20 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if recallSearch {
 		if s.runtimeUsageEnabled() && recallLease != nil {
-			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			if finalizeErr := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
 				return s.runtimeUsage.AfterRecallSuccess(ctx, recallLease, runtimeusage.RecallResult{
 					MemoryIDs: memoryIDs(memories),
 					AgentName: auth.AgentName,
 				})
-			}); err != nil {
+			}); finalizeErr != nil {
 				s.logger.Error("runtime usage recall finalization failed",
 					"operation_id", recallLease.OperationID,
 					"tenant_id", auth.TenantID,
 					"cluster_id", auth.ClusterID,
-					"err", err)
+					"err", finalizeErr)
 				recallFinalized = true
-				s.handleRuntimeUsageError(w, err)
+				err = finalizeErr
+				s.handleRuntimeUsageError(w, finalizeErr)
 				return
 			}
 			recallFinalized = true

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -20,9 +20,11 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/llm"
 	"github.com/qiffang/mnemos/server/internal/metering"
+	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
@@ -43,6 +45,7 @@ type testMemoryRepo struct {
 	lastKeywordLimit     int
 	listResults          []domain.Memory
 	listTotal            int
+	listErr              error
 	lastListFilter       domain.MemoryFilter
 	listCalls            int
 	softDeleteCalls      []string
@@ -119,6 +122,9 @@ func (m *testMemoryRepo) List(_ context.Context, filter domain.MemoryFilter) ([]
 	defer m.mu.Unlock()
 	m.listCalls++
 	m.lastListFilter = filter
+	if m.listErr != nil {
+		return nil, 0, m.listErr
+	}
 	return append([]domain.Memory(nil), m.listResults...), m.listTotal, nil
 }
 func (m *testMemoryRepo) Count(context.Context) (int, error) { return 0, nil }
@@ -1017,6 +1023,101 @@ func TestListMemories_ScanAllListsAllLocalMemoryTypes(t *testing.T) {
 		sessionRepo.lastListFilter.Limit != 200 {
 		t.Fatalf("session list filter = %+v", sessionRepo.lastListFilter)
 	}
+}
+
+func TestListMemories_RecordsMemoryRecallDuration(t *testing.T) {
+	resetMemoryRecallMetrics()
+
+	memRepo := &testMemoryRepo{
+		listResults: []domain.Memory{
+			{
+				ID:         "insight-1",
+				Content:    "HEARTBEAT insight",
+				MemoryType: domain.TypeInsight,
+				State:      domain.StateActive,
+				CreatedAt:  time.Now(),
+				UpdatedAt:  time.Now(),
+			},
+		},
+		listTotal: 1,
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?q=HEARTBEAT&memory_type=insight&scanAll=true", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if got := memoryRecallHistogramCount(t, "scan_all", "ok"); got != 1 {
+		t.Fatalf("memory recall histogram count = %d, want 1", got)
+	}
+}
+
+func TestListMemories_RecordsMemoryRecallTimeout(t *testing.T) {
+	resetMemoryRecallMetrics()
+
+	memRepo := &testMemoryRepo{listErr: context.DeadlineExceeded}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?q=HEARTBEAT&memory_type=insight&scanAll=true", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if got := memoryRecallHistogramCount(t, "scan_all", "timeout"); got != 1 {
+		t.Fatalf("memory recall timeout histogram count = %d, want 1", got)
+	}
+	if got := memoryRecallTimeoutCounter(t, "scan_all"); got != 1 {
+		t.Fatalf("memory recall timeout counter = %v, want 1", got)
+	}
+}
+
+func resetMemoryRecallMetrics() {
+	metrics.MemoryRecallDuration.Reset()
+	metrics.MemoryRecallTimeoutsTotal.Reset()
+}
+
+func memoryRecallHistogramCount(t *testing.T, mode, status string) uint64 {
+	t.Helper()
+
+	observer, err := metrics.MemoryRecallDuration.GetMetricWithLabelValues(mode, status)
+	if err != nil {
+		t.Fatalf("get memory recall duration metric: %v", err)
+	}
+	metric, ok := observer.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("memory recall duration metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write memory recall duration metric: %v", err)
+	}
+	if pb.Histogram == nil {
+		return 0
+	}
+	return pb.Histogram.GetSampleCount()
+}
+
+func memoryRecallTimeoutCounter(t *testing.T, mode string) float64 {
+	t.Helper()
+
+	counter, err := metrics.MemoryRecallTimeoutsTotal.GetMetricWithLabelValues(mode)
+	if err != nil {
+		t.Fatalf("get memory recall timeout metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("memory recall timeout metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write memory recall timeout metric: %v", err)
+	}
+	if pb.Counter == nil {
+		return 0
+	}
+	return pb.Counter.GetValue()
 }
 
 func TestListMemories_ContentKeywordSearchBypassesRecall(t *testing.T) {

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -132,6 +132,30 @@ var (
 		},
 		[]string{"step", "model", "status"},
 	)
+
+	// MemoryRecallDuration observes end-to-end memory recall latency.
+	// mode labels: default, single_pool, scan_all, chain, other
+	// status labels: ok, error, timeout, canceled
+	MemoryRecallDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mnemo",
+			Name:      "memory_recall_duration_seconds",
+			Help:      "End-to-end memory recall request duration in seconds.",
+			Buckets:   []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120},
+		},
+		[]string{"mode", "status"},
+	)
+
+	// MemoryRecallTimeoutsTotal counts memory recall requests that ended in a timeout.
+	MemoryRecallTimeoutsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "memory_recall_timeouts_total",
+			Help:      "Total number of memory recall requests that ended in a timeout.",
+		},
+		[]string{"mode"},
+	)
+
 	// ActiveMemoryTotal is the current server-level total number of active memories.
 	ActiveMemoryTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mnemo",


### PR DESCRIPTION
## Summary

1. Add `mnemo_memory_recall_duration_seconds{mode,status}` to observe end-to-end memory recall latency.
2. Add `mnemo_memory_recall_timeouts_total{mode}` to count recall requests ending with `context.DeadlineExceeded`.
3. Instrument the memory recall path and classify requests by recall mode and terminal status.
4. Add handler tests for successful and timed-out recall metric recording.

## Tests

1. `gofmt -w server/internal/metrics/metrics.go server/internal/handler/memory.go server/internal/handler/memory_test.go`
2. `go test -count=1 ./internal/handler ./internal/metrics`

## Notes

1. Write-side alerts are intentionally out of scope because memory writes are async.
2. Runbooks alert rule changes live in the sibling `runbooks` repository and need a separate PR.