### PR TITLE
feat(session-edit): raw-session edit overlay (display-only, Session Search)

### DIFF
--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -273,3 +273,30 @@ type Session struct {
 	CreatedAt   time.Time   `json:"created_at"`
 	UpdatedAt   time.Time   `json:"updated_at"`
 }
+
+// SessionEdit is a display overlay for a single raw session row. It is a
+// current-overlay record (at most one per session row; ID == sessions.id),
+// not an audit history: re-editing the same row upserts this one row and
+// bumps Version. The sessions table is never modified, so the overlay only
+// changes how Session Search renders an already-matched row.
+type SessionEdit struct {
+	ID              string   `json:"id"` // == sessions.id
+	AppID           string   `json:"appId,omitempty"`
+	SessionID       string   `json:"session_id,omitempty"`
+	Seq             int      `json:"seq"`
+	AgentID         string   `json:"agent_id,omitempty"`
+	OriginalContent string   `json:"original_content"`
+	EditedContent   string   `json:"edited_content"`
+	EditedTags      []string `json:"edited_tags,omitempty"`
+	// EditedTagsSet distinguishes "tags omitted (leave display tags as-is)"
+	// from "tags explicitly set (including [] to clear)". It mirrors whether
+	// the edited_tags column is non-NULL; only when true does the overlay
+	// replace a row's rendered tags.
+	EditedTagsSet bool        `json:"-"`
+	EditedBy      string      `json:"edited_by,omitempty"`
+	Reason        string      `json:"reason,omitempty"`
+	Version       int         `json:"version"`
+	State         MemoryState `json:"state"`
+	CreatedAt     time.Time   `json:"created_at"`
+	UpdatedAt     time.Time   `json:"updated_at"`
+}

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -286,6 +286,11 @@ func (s *Server) Router(
 
 		// Session messages (raw captured turns).
 		r.Get("/session-messages", s.handleListSessionMessages)
+		// Raw-session edit overlay (display-only; only affects Session Search
+		// rendering, never the sessions/memories tables or recall).
+		r.Put("/session-messages/{id}", s.editSessionMessage)
+		r.Get("/session-messages/{id}/edit", s.getSessionMessageEdit)
+		r.Delete("/session-messages/{id}/edit", s.deleteSessionMessageEdit)
 	})
 
 	return r

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -902,6 +902,13 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	if memories == nil {
 		memories = []domain.Memory{}
 	}
+	// Raw-session edit overlay (display-only): rewrite session-type results
+	// whose row has an active edit. Local/tenant path only — chain
+	// aggregation is out of scope for v0. Non-session memories are left
+	// untouched, so memory/fact recall is unaffected.
+	if !auth.IsChain() {
+		memories = s.resolveServices(auth).session.ApplySessionOverlay(r.Context(), memories)
+	}
 	if !contentKeywordSearch && rawQuery != "" && classifyRecallQueryShape(rawQuery) == recallQueryShapeTime {
 		for i := range memories {
 			memories[i].Content = service.TemporalRecallProjection(memories[i].Content, memories[i].Metadata)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -206,6 +206,7 @@ type testSessionRepo struct {
 	softDeleteErr        error
 	bulkSoftDeleteCalls  [][]string
 	bulkSoftDeleteResult int64
+	overlays             map[string]*domain.SessionEdit
 }
 
 func (s *testSessionRepo) BulkCreate(_ context.Context, sessions []*domain.Session) error {
@@ -302,6 +303,63 @@ func (s *testSessionRepo) ListBySessionIDs(_ context.Context, sessionIDs []strin
 	s.lastSessionIDs = append([]string(nil), sessionIDs...)
 	s.lastSessionLimit = limit
 	return append([]*domain.Session(nil), s.sessionListResults...), nil
+}
+
+func (s *testSessionRepo) UpsertSessionEdit(_ context.Context, edit *domain.SessionEdit) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.overlays == nil {
+		s.overlays = map[string]*domain.SessionEdit{}
+	}
+	cp := *edit
+	if existing, ok := s.overlays[edit.ID]; ok {
+		cp.Version = existing.Version + 1
+		cp.OriginalContent = existing.OriginalContent // preserve first snapshot
+		if !cp.EditedTagsSet {                        // COALESCE: keep prior tag override
+			cp.EditedTags = existing.EditedTags
+			cp.EditedTagsSet = existing.EditedTagsSet
+		}
+	} else {
+		cp.Version = 1
+	}
+	if cp.State == "" {
+		cp.State = domain.StateActive
+	}
+	s.overlays[edit.ID] = &cp
+	return nil
+}
+
+func (s *testSessionRepo) GetSessionEdit(_ context.Context, id string) (*domain.SessionEdit, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ov, ok := s.overlays[id]; ok && ov.State == domain.StateActive {
+		cp := *ov
+		return &cp, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (s *testSessionRepo) GetSessionEditsByIDs(_ context.Context, ids []string) (map[string]*domain.SessionEdit, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := map[string]*domain.SessionEdit{}
+	for _, id := range ids {
+		if ov, ok := s.overlays[id]; ok && ov.State == domain.StateActive {
+			cp := *ov
+			out[id] = &cp
+		}
+	}
+	return out, nil
+}
+
+func (s *testSessionRepo) DeleteSessionEdit(_ context.Context, id string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.overlays[id]; ok {
+		delete(s.overlays, id)
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func intPtr(v int) *int {

--- a/server/internal/handler/session_edit.go
+++ b/server/internal/handler/session_edit.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+// Raw-session edit overlay endpoints. These write/read only the
+// `session_edits` overlay table; the `sessions` table (content, embedding,
+// FTS) and the memories table are never touched. The overlay only changes
+// how Session Search renders an already-matched row — it does not change
+// searchability, and memory/fact recall is unaffected
+// (Session Search applies the overlay via svc.session.ApplySessionOverlay).
+
+type editSessionMessageRequest struct {
+	Content string `json:"content"`
+	// Tags is a pointer so an omitted field (nil = leave display tags
+	// unchanged) is distinguishable from an explicit [] (clear tags).
+	Tags   *[]string `json:"tags,omitempty"`
+	Reason string    `json:"reason,omitempty"`
+}
+
+type editSessionMessageResponse struct {
+	EditID  string              `json:"edit_id"`
+	Version int                 `json:"version"`
+	Edit    *domain.SessionEdit `json:"edit"`
+	Session *domain.Memory      `json:"session"`
+}
+
+// editSessionMessage handles PUT /session-messages/{id}: upsert the edit
+// overlay for a raw session row (id == sessions.id) and return the stored
+// overlay plus the effective (edited) session view.
+func (s *Server) editSessionMessage(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	if auth.IsChain() {
+		s.handleError(r.Context(), w, &domain.ValidationError{
+			Field: "session_edit", Message: "raw session edit is not supported on chain keys",
+		})
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	if strings.TrimSpace(id) == "" {
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "id", Message: "required"})
+		return
+	}
+
+	var req editSessionMessageRequest
+	if err := decode(r, &req); err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	if strings.TrimSpace(req.Content) == "" {
+		s.handleError(r.Context(), w, &domain.ValidationError{Field: "content", Message: "required"})
+		return
+	}
+
+	svc := s.resolveServices(auth)
+	edit, effective, err := svc.session.EditSessionOverlay(r.Context(), id, req.Content, req.Tags, auth.AgentName, req.Reason)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, editSessionMessageResponse{
+		EditID:  edit.ID,
+		Version: edit.Version,
+		Edit:    edit,
+		Session: effective,
+	})
+}
+
+// getSessionMessageEdit handles GET /session-messages/{id}/edit: return the
+// active overlay, or 404 if the row has not been edited.
+func (s *Server) getSessionMessageEdit(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	if auth.IsChain() {
+		s.handleError(r.Context(), w, &domain.ValidationError{
+			Field: "session_edit", Message: "raw session edit is not supported on chain keys",
+		})
+		return
+	}
+	id := chi.URLParam(r, "id")
+	svc := s.resolveServices(auth)
+	edit, err := svc.session.GetSessionOverlay(r.Context(), id)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, edit)
+}
+
+// deleteSessionMessageEdit handles DELETE /session-messages/{id}/edit:
+// remove the overlay so Session Search renders the original content again.
+func (s *Server) deleteSessionMessageEdit(w http.ResponseWriter, r *http.Request) {
+	auth := authInfo(r)
+	if auth.IsChain() {
+		s.handleError(r.Context(), w, &domain.ValidationError{
+			Field: "session_edit", Message: "raw session edit is not supported on chain keys",
+		})
+		return
+	}
+	id := chi.URLParam(r, "id")
+	svc := s.resolveServices(auth)
+	removed, err := svc.session.DeleteSessionOverlay(r.Context(), id)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
+	respond(w, http.StatusOK, map[string]any{"id": id, "reverted": removed > 0})
+}

--- a/server/internal/handler/session_edit_test.go
+++ b/server/internal/handler/session_edit_test.go
@@ -1,0 +1,217 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/middleware"
+)
+
+// Raw-session edit overlay: the edit endpoints write only the overlay and
+// never the sessions/memories tables; Session Search renders the edited
+// content for matched session rows while memory/fact recall is untouched.
+
+func sessionRow(id, content string) *domain.Memory {
+	meta, _ := json.Marshal(map[string]any{"role": "user", "seq": 3, "content_type": "text"})
+	return &domain.Memory{
+		ID: id, Content: content, MemoryType: domain.TypeSession,
+		SessionID: "sess-1", State: domain.StateActive, Metadata: meta,
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+}
+
+func TestEditSessionMessage_UpsertVersionAndEffectiveView(t *testing.T) {
+	sessionRepo := &testSessionRepo{getResult: sessionRow("turn-1", "original text")}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+
+	// First edit -> version 1, edited content echoed back.
+	req := withURLParam(makeRequest(t, http.MethodPut, "/session-messages/turn-1",
+		editSessionMessageRequest{Content: "corrected text"}), "id", "turn-1")
+	rr := httptest.NewRecorder()
+	srv.editSessionMessage(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp editSessionMessageResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Version != 1 {
+		t.Fatalf("first edit version = %d, want 1", resp.Version)
+	}
+	if resp.Session == nil || resp.Session.Content != "corrected text" {
+		t.Fatalf("effective content = %+v, want 'corrected text'", resp.Session)
+	}
+	if resp.Edit.OriginalContent != "original text" {
+		t.Fatalf("original snapshot = %q, want 'original text'", resp.Edit.OriginalContent)
+	}
+
+	// Second edit on the same row -> version 2, original snapshot preserved.
+	req = withURLParam(makeRequest(t, http.MethodPut, "/session-messages/turn-1",
+		editSessionMessageRequest{Content: "corrected again"}), "id", "turn-1")
+	rr = httptest.NewRecorder()
+	srv.editSessionMessage(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-edit status = %d: %s", rr.Code, rr.Body.String())
+	}
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.Version != 2 {
+		t.Fatalf("re-edit version = %d, want 2", resp.Version)
+	}
+	if resp.Edit.OriginalContent != "original text" {
+		t.Fatalf("original snapshot must survive re-edit, got %q", resp.Edit.OriginalContent)
+	}
+	// Still exactly one overlay row for the turn.
+	if len(sessionRepo.overlays) != 1 {
+		t.Fatalf("want one overlay row, got %d", len(sessionRepo.overlays))
+	}
+}
+
+func TestEditSessionMessage_RequiresContent(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{getResult: sessionRow("turn-1", "x")})
+	req := withURLParam(makeRequest(t, http.MethodPut, "/session-messages/turn-1",
+		editSessionMessageRequest{Content: "   "}), "id", "turn-1")
+	rr := httptest.NewRecorder()
+	srv.editSessionMessage(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestEditSessionMessage_NotFound(t *testing.T) {
+	// No getResult -> GetByID returns ErrNotFound.
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	req := withURLParam(makeRequest(t, http.MethodPut, "/session-messages/missing",
+		editSessionMessageRequest{Content: "x"}), "id", "missing")
+	rr := httptest.NewRecorder()
+	srv.editSessionMessage(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestSessionSearch_AppliesOverlay(t *testing.T) {
+	row := sessionRow("turn-1", "original text")
+	sessionRepo := &testSessionRepo{
+		getResult:   row,
+		listResults: []domain.Memory{*row},
+		listTotal:   1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+
+	// Edit the turn.
+	er := withURLParam(makeRequest(t, http.MethodPut, "/session-messages/turn-1",
+		editSessionMessageRequest{Content: "edited for display"}), "id", "turn-1")
+	srv.editSessionMessage(httptest.NewRecorder(), er)
+
+	// Session list/search should render the edited content + edited marker.
+	req := makeRequest(t, http.MethodGet, "/memories?memory_type=session", nil)
+	rr := httptest.NewRecorder()
+	srv.listMemories(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Memories) != 1 || resp.Memories[0].Content != "edited for display" {
+		t.Fatalf("overlay not applied to search: %+v", resp.Memories)
+	}
+	var meta map[string]any
+	_ = json.Unmarshal(resp.Memories[0].Metadata, &meta)
+	if meta["edited"] != true {
+		t.Fatalf("expected edited marker in metadata, got %v", meta)
+	}
+}
+
+func TestDeleteSessionMessageEdit_Reverts(t *testing.T) {
+	row := sessionRow("turn-1", "original text")
+	sessionRepo := &testSessionRepo{
+		getResult:   row,
+		listResults: []domain.Memory{*row},
+		listTotal:   1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+
+	srv.editSessionMessage(httptest.NewRecorder(), withURLParam(makeRequest(t, http.MethodPut,
+		"/session-messages/turn-1", editSessionMessageRequest{Content: "edited"}), "id", "turn-1"))
+
+	// Delete the overlay.
+	dr := withURLParam(makeRequest(t, http.MethodDelete, "/session-messages/turn-1/edit", nil), "id", "turn-1")
+	drr := httptest.NewRecorder()
+	srv.deleteSessionMessageEdit(drr, dr)
+	if drr.Code != http.StatusOK {
+		t.Fatalf("delete status = %d: %s", drr.Code, drr.Body.String())
+	}
+
+	// Search now renders the original again.
+	req := makeRequest(t, http.MethodGet, "/memories?memory_type=session", nil)
+	rr := httptest.NewRecorder()
+	srv.listMemories(rr, req)
+	var resp listResponse
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if len(resp.Memories) != 1 || resp.Memories[0].Content != "original text" {
+		t.Fatalf("revert failed, content = %+v", resp.Memories)
+	}
+}
+
+func TestEditSessionMessage_ChainRejected(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	req := makeRequest(t, http.MethodPut, "/session-messages/turn-1",
+		editSessionMessageRequest{Content: "x"})
+	// Promote to a chain auth context (IsChain() == Chain != nil).
+	auth := &domain.AuthInfo{AgentName: "chain-agent", Chain: &domain.ChainAuth{}}
+	req = req.WithContext(middleware.WithAuthContext(req.Context(), auth))
+	req = withURLParam(req, "id", "turn-1")
+	rr := httptest.NewRecorder()
+	srv.editSessionMessage(rr, req)
+	if rr.Code == http.StatusOK {
+		t.Fatalf("chain key must not be allowed to edit raw sessions: %d", rr.Code)
+	}
+}
+
+func TestSessionSearch_ContentOnlyEditKeepsOriginalTags(t *testing.T) {
+	row := sessionRow("turn-1", "original text")
+	row.Tags = []string{"old"}
+	sessionRepo := &testSessionRepo{getResult: row, listResults: []domain.Memory{*row}, listTotal: 1}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+
+	// Content-only edit (tags field omitted) must not touch display tags.
+	srv.editSessionMessage(httptest.NewRecorder(), withURLParam(makeRequest(t, http.MethodPut,
+		"/session-messages/turn-1", editSessionMessageRequest{Content: "edited"}), "id", "turn-1"))
+
+	rr := httptest.NewRecorder()
+	srv.listMemories(rr, makeRequest(t, http.MethodGet, "/memories?memory_type=session", nil))
+	var resp listResponse
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if len(resp.Memories) != 1 || resp.Memories[0].Content != "edited" {
+		t.Fatalf("content not applied: %+v", resp.Memories)
+	}
+	if len(resp.Memories[0].Tags) != 1 || resp.Memories[0].Tags[0] != "old" {
+		t.Fatalf("content-only edit must keep original tags, got %v", resp.Memories[0].Tags)
+	}
+}
+
+func TestSessionSearch_ExplicitTagsOverride(t *testing.T) {
+	row := sessionRow("turn-1", "original text")
+	row.Tags = []string{"old"}
+	sessionRepo := &testSessionRepo{getResult: row, listResults: []domain.Memory{*row}, listTotal: 1}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+
+	newTags := []string{"new"}
+	srv.editSessionMessage(httptest.NewRecorder(), withURLParam(makeRequest(t, http.MethodPut,
+		"/session-messages/turn-1", editSessionMessageRequest{Content: "edited", Tags: &newTags}), "id", "turn-1"))
+
+	rr := httptest.NewRecorder()
+	srv.listMemories(rr, makeRequest(t, http.MethodGet, "/memories?memory_type=session", nil))
+	var resp listResponse
+	_ = json.NewDecoder(rr.Body).Decode(&resp)
+	if len(resp.Memories[0].Tags) != 1 || resp.Memories[0].Tags[0] != "new" {
+		t.Fatalf("explicit tags must override, got %v", resp.Memories[0].Tags)
+	}
+}

--- a/server/internal/repository/factory.go
+++ b/server/internal/repository/factory.go
@@ -139,3 +139,15 @@ func (stubSessionRepo) FTSAvailable() bool { return false }
 func (stubSessionRepo) ListBySessionIDs(_ context.Context, _ []string, _ *string, _ int) ([]*domain.Session, error) {
 	return nil, fmt.Errorf("session messages: %w", domain.ErrNotSupported)
 }
+func (stubSessionRepo) UpsertSessionEdit(_ context.Context, _ *domain.SessionEdit) error {
+	return fmt.Errorf("session edit: %w", domain.ErrNotSupported)
+}
+func (stubSessionRepo) GetSessionEdit(_ context.Context, _ string) (*domain.SessionEdit, error) {
+	return nil, fmt.Errorf("session edit: %w", domain.ErrNotSupported)
+}
+func (stubSessionRepo) GetSessionEditsByIDs(_ context.Context, _ []string) (map[string]*domain.SessionEdit, error) {
+	return nil, fmt.Errorf("session edit: %w", domain.ErrNotSupported)
+}
+func (stubSessionRepo) DeleteSessionEdit(_ context.Context, _ string) (int64, error) {
+	return 0, fmt.Errorf("session edit: %w", domain.ErrNotSupported)
+}

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -118,4 +118,17 @@ type SessionRepo interface {
 	// session_id ASC, created_at ASC, seq ASC, id ASC. At most limitPerSession rows are
 	// returned per session_id. Returns ErrNotSupported on non-TiDB backends.
 	ListBySessionIDs(ctx context.Context, sessionIDs []string, appID *string, limitPerSession int) ([]*domain.Session, error)
+
+	// Raw-session edit overlay (display-only; never mutates `sessions`).
+	// UpsertSessionEdit creates or updates the single overlay row for
+	// edit.ID (== sessions.id); on update it bumps version and preserves
+	// the first OriginalContent snapshot. GetSessionEdit returns the
+	// active overlay or ErrNotFound. GetSessionEditsByIDs batch-loads
+	// active overlays keyed by id for Session Search rendering.
+	// DeleteSessionEdit removes the overlay (reverts to original).
+	// Returns ErrNotSupported on non-TiDB backends.
+	UpsertSessionEdit(ctx context.Context, edit *domain.SessionEdit) error
+	GetSessionEdit(ctx context.Context, id string) (*domain.SessionEdit, error)
+	GetSessionEditsByIDs(ctx context.Context, ids []string) (map[string]*domain.SessionEdit, error)
+	DeleteSessionEdit(ctx context.Context, id string) (int64, error)
 }

--- a/server/internal/repository/tidb/session_edits.go
+++ b/server/internal/repository/tidb/session_edits.go
@@ -1,0 +1,182 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	internaltenant "github.com/qiffang/mnemos/server/internal/tenant"
+)
+
+// session_edits is a display overlay over the immutable `sessions` table:
+// at most one row per session row (PK id == sessions.id), upserted in place
+// on re-edit. The sessions table is never touched, so these helpers only
+// read/write the overlay; retrieval (vector/FTS/keyword) is unaffected.
+
+// UpsertSessionEdit creates the overlay row on first edit (version 1,
+// original_content snapshotted) or updates it in place on re-edit (version
+// + 1, original_content preserved from the first edit, state reset active).
+func (r *SessionRepo) UpsertSessionEdit(ctx context.Context, edit *domain.SessionEdit) error {
+	if edit == nil || edit.ID == "" {
+		return fmt.Errorf("session edit: id required")
+	}
+	state := edit.State
+	if state == "" {
+		state = domain.StateActive
+	}
+	// edited_tags is NULL when the edit didn't set tags ("leave as-is"),
+	// and a JSON array (possibly []) when it did. COALESCE on update keeps
+	// any previously-set tag override when a later content-only edit omits
+	// tags, so a content-only re-edit never clears tags.
+	var editedTags any
+	if edit.EditedTagsSet {
+		editedTags = marshalTags(edit.EditedTags)
+	}
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO session_edits
+			(id, app_id, session_id, seq, agent_id, original_content, edited_content, edited_tags, edited_by, reason, version, state, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, NOW(), NOW())
+		 ON DUPLICATE KEY UPDATE
+			edited_content = VALUES(edited_content),
+			edited_tags    = COALESCE(VALUES(edited_tags), edited_tags),
+			edited_by      = VALUES(edited_by),
+			reason         = VALUES(reason),
+			version        = version + 1,
+			state          = VALUES(state),
+			updated_at     = NOW()`,
+		edit.ID, edit.AppID, nullStr(edit.SessionID), edit.Seq, nullStr(edit.AgentID),
+		edit.OriginalContent, edit.EditedContent, editedTags,
+		nullStr(edit.EditedBy), nullStr(edit.Reason), string(state),
+	)
+	if err != nil {
+		return fmt.Errorf("session edit upsert: %w", err)
+	}
+	return nil
+}
+
+// GetSessionEdit returns the active overlay for id, or domain.ErrNotFound.
+func (r *SessionRepo) GetSessionEdit(ctx context.Context, id string) (*domain.SessionEdit, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, app_id, session_id, seq, agent_id, original_content, edited_content, edited_tags, edited_by, reason, version, state, created_at, updated_at
+		 FROM session_edits WHERE id = ? AND state = 'active'`,
+		id,
+	)
+	edit, err := scanSessionEdit(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, domain.ErrNotFound
+		}
+		if internaltenant.IsTableNotFoundError(err) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, fmt.Errorf("session edit get: %w", err)
+	}
+	return edit, nil
+}
+
+// GetSessionEditsByIDs batch-loads active overlays keyed by id. Missing ids
+// are simply absent from the map. A missing table yields an empty map so
+// Session Search degrades to original content rather than erroring.
+func (r *SessionRepo) GetSessionEditsByIDs(ctx context.Context, ids []string) (map[string]*domain.SessionEdit, error) {
+	out := make(map[string]*domain.SessionEdit, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, app_id, session_id, seq, agent_id, original_content, edited_content, edited_tags, edited_by, reason, version, state, created_at, updated_at
+		 FROM session_edits WHERE state = 'active' AND id IN (`+strings.Join(placeholders, ",")+`)`,
+		args...,
+	)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return out, nil
+		}
+		return nil, fmt.Errorf("session edits batch get: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		edit, err := scanSessionEdit(rows)
+		if err != nil {
+			return nil, fmt.Errorf("session edits batch scan: %w", err)
+		}
+		out[edit.ID] = edit
+	}
+	return out, rows.Err()
+}
+
+// DeleteSessionEdit hard-deletes the overlay row (revert to original).
+// Returns the number of rows removed (0 if there was no overlay).
+func (r *SessionRepo) DeleteSessionEdit(ctx context.Context, id string) (int64, error) {
+	res, err := r.db.ExecContext(ctx, `DELETE FROM session_edits WHERE id = ?`, id)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("session edit delete: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("session edit delete rows affected: %w", err)
+	}
+	return n, nil
+}
+
+type sessionEditScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSessionEdit(s sessionEditScanner) (*domain.SessionEdit, error) {
+	var (
+		e         domain.SessionEdit
+		sessionID sql.NullString
+		agentID   sql.NullString
+		editedBy  sql.NullString
+		reason    sql.NullString
+		state     sql.NullString
+		tagsJSON  []byte
+		createdAt time.Time
+		updatedAt time.Time
+		seqNull   sql.NullInt64
+	)
+	if err := s.Scan(
+		&e.ID, &e.AppID, &sessionID, &seqNull, &agentID,
+		&e.OriginalContent, &e.EditedContent, &tagsJSON, &editedBy, &reason,
+		&e.Version, &state, &createdAt, &updatedAt,
+	); err != nil {
+		return nil, err
+	}
+	e.SessionID = sessionID.String
+	e.AgentID = agentID.String
+	e.EditedBy = editedBy.String
+	e.Reason = reason.String
+	e.Seq = int(seqNull.Int64)
+	// NULL edited_tags = no tag override; a non-NULL value (incl. "[]") is
+	// an explicit override.
+	if tagsJSON != nil {
+		e.EditedTags = unmarshalTags(tagsJSON)
+		e.EditedTagsSet = true
+	}
+	e.State = domain.MemoryState(state.String)
+	if e.State == "" {
+		e.State = domain.StateActive
+	}
+	e.CreatedAt = createdAt
+	e.UpdatedAt = updatedAt
+	return &e, nil
+}
+
+func nullStr(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/server/internal/service/session_edit.go
+++ b/server/internal/service/session_edit.go
@@ -1,0 +1,161 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+// Raw-session edit overlay (display-only). EditSessionOverlay /
+// GetSessionOverlay / DeleteSessionOverlay manage the single overlay row
+// per session turn; ApplySessionOverlay rewrites Session Search results so
+// an edited turn renders its edited content. None of this mutates the
+// `sessions` table, its embedding, or its FTS index — so retrieval and
+// memory/fact recall are unaffected; only rendering of already-matched
+// session rows changes.
+
+// EditSessionOverlay upserts the overlay for a raw session row (id ==
+// sessions.id). It snapshots the current (immutable) session content as the
+// overlay's original_content, then returns the stored overlay plus the
+// effective (edited) session view for the response. Returns
+// domain.ErrNotFound if the session row does not exist / is not active.
+func (s *SessionService) EditSessionOverlay(
+	ctx context.Context,
+	id, content string,
+	tags *[]string,
+	editedBy, reason string,
+) (*domain.SessionEdit, *domain.Memory, error) {
+	base, err := s.sessions.GetByID(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	edit := &domain.SessionEdit{
+		ID:              id,
+		AppID:           base.AppID,
+		SessionID:       base.SessionID,
+		Seq:             sessionSeqFromMemoryMeta(base),
+		AgentID:         base.AgentID,
+		OriginalContent: base.Content,
+		EditedContent:   content,
+		EditedBy:        editedBy,
+		Reason:          reason,
+		State:           domain.StateActive,
+	}
+	// nil tags = "leave display tags unchanged"; a non-nil slice (incl. an
+	// empty one) is an explicit override.
+	if tags != nil {
+		edit.EditedTags = *tags
+		edit.EditedTagsSet = true
+	}
+	if err := s.sessions.UpsertSessionEdit(ctx, edit); err != nil {
+		return nil, nil, err
+	}
+
+	stored, err := s.sessions.GetSessionEdit(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	effective := applyOverlayToMemory(*base, stored)
+	return stored, &effective, nil
+}
+
+// GetSessionOverlay returns the active overlay for a session row, or
+// domain.ErrNotFound when the row has not been edited.
+func (s *SessionService) GetSessionOverlay(ctx context.Context, id string) (*domain.SessionEdit, error) {
+	return s.sessions.GetSessionEdit(ctx, id)
+}
+
+// DeleteSessionOverlay removes the overlay (revert to original). It also
+// confirms the underlying session row exists so callers can return 404 for
+// an unknown id rather than a silent no-op. Returns the rows removed.
+func (s *SessionService) DeleteSessionOverlay(ctx context.Context, id string) (int64, error) {
+	if _, err := s.sessions.GetByID(ctx, id); err != nil {
+		return 0, err
+	}
+	return s.sessions.DeleteSessionEdit(ctx, id)
+}
+
+// ApplySessionOverlay rewrites session-type results in place: for every
+// memory whose id has an active overlay, the content/tags are replaced with
+// the edited versions and edited/edit_version/edited_at markers are merged
+// into metadata. Non-session memories and rows without an overlay are
+// returned untouched. A repository failure is non-fatal — results degrade
+// to original content rather than failing the whole search.
+func (s *SessionService) ApplySessionOverlay(ctx context.Context, memories []domain.Memory) []domain.Memory {
+	if len(memories) == 0 {
+		return memories
+	}
+	ids := make([]string, 0, len(memories))
+	for _, m := range memories {
+		if m.MemoryType == domain.TypeSession && m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return memories
+	}
+	overlays, err := s.sessions.GetSessionEditsByIDs(ctx, ids)
+	if err != nil || len(overlays) == 0 {
+		return memories
+	}
+	for i := range memories {
+		ov, ok := overlays[memories[i].ID]
+		if !ok {
+			continue
+		}
+		memories[i] = applyOverlayToMemory(memories[i], ov)
+	}
+	return memories
+}
+
+// applyOverlayToMemory returns a copy of base with the overlay's edited
+// content/tags applied and edit markers merged into metadata.
+func applyOverlayToMemory(base domain.Memory, ov *domain.SessionEdit) domain.Memory {
+	if ov == nil {
+		return base
+	}
+	base.Content = ov.EditedContent
+	// Only override rendered tags when the edit explicitly set them; a
+	// content-only edit must leave the original session tags intact.
+	if ov.EditedTagsSet {
+		base.Tags = ov.EditedTags
+	}
+	base.Metadata = mergeEditMarkers(base.Metadata, ov)
+	return base
+}
+
+// mergeEditMarkers adds edited / edit_version / edited_at onto existing
+// session metadata without dropping role/seq/content_type.
+func mergeEditMarkers(existing json.RawMessage, ov *domain.SessionEdit) json.RawMessage {
+	payload := map[string]any{}
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &payload); err != nil {
+			payload = map[string]any{}
+		}
+	}
+	payload["edited"] = true
+	payload["edit_version"] = ov.Version
+	payload["edited_at"] = ov.UpdatedAt
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return existing
+	}
+	return raw
+}
+
+// sessionSeqFromMemoryMeta extracts the seq a session row was stored with
+// (session GetByID encodes it in metadata as {"seq": N}).
+func sessionSeqFromMemoryMeta(m *domain.Memory) int {
+	if m == nil || len(m.Metadata) == 0 {
+		return 0
+	}
+	var meta struct {
+		Seq int `json:"seq"`
+	}
+	if err := json.Unmarshal(m.Metadata, &meta); err != nil {
+		return 0
+	}
+	return meta.Seq
+}

--- a/server/internal/service/session_edit_test.go
+++ b/server/internal/service/session_edit_test.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+// Overlay application is display-only: it rewrites session-type rows that
+// have an active edit and leaves everything else (including memory/fact
+// rows) byte-identical.
+
+func TestApplySessionOverlay_RewritesOnlyEditedSessions(t *testing.T) {
+	repo := &stubSessionRepo{overlays: map[string]*domain.SessionEdit{
+		"s1": {ID: "s1", EditedContent: "edited one", Version: 2, State: domain.StateActive},
+	}}
+	svc := newTestSessionService(repo)
+
+	meta, _ := json.Marshal(map[string]any{"role": "user", "seq": 1})
+	in := []domain.Memory{
+		{ID: "s1", Content: "orig one", MemoryType: domain.TypeSession, Metadata: meta},
+		{ID: "s2", Content: "orig two", MemoryType: domain.TypeSession, Metadata: meta},
+		{ID: "f1", Content: "a fact", MemoryType: domain.TypeInsight},
+	}
+	out := svc.ApplySessionOverlay(context.Background(), in)
+
+	if out[0].Content != "edited one" {
+		t.Fatalf("edited session not rewritten: %q", out[0].Content)
+	}
+	var m map[string]any
+	_ = json.Unmarshal(out[0].Metadata, &m)
+	if m["edited"] != true || m["role"] != "user" {
+		t.Fatalf("edit markers must merge without dropping role: %v", m)
+	}
+	if out[1].Content != "orig two" {
+		t.Fatalf("un-edited session must be untouched: %q", out[1].Content)
+	}
+	if out[2].Content != "a fact" {
+		t.Fatalf("fact/memory rows must never be overlaid: %q", out[2].Content)
+	}
+}
+
+func TestEditSessionOverlay_SnapshotsOriginalAndBumpsVersion(t *testing.T) {
+	base := &domain.Memory{ID: "s1", Content: "original", MemoryType: domain.TypeSession, AppID: "app"}
+	repo := &stubSessionRepo{getResult: base}
+	svc := newTestSessionService(repo)
+
+	edit, effective, err := svc.EditSessionOverlay(context.Background(), "s1", "v1 edit", nil, "alice", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edit.Version != 1 || edit.OriginalContent != "original" || effective.Content != "v1 edit" {
+		t.Fatalf("first edit: %+v / effective %q", edit, effective.Content)
+	}
+	edit, _, err = svc.EditSessionOverlay(context.Background(), "s1", "v2 edit", nil, "alice", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if edit.Version != 2 || edit.OriginalContent != "original" {
+		t.Fatalf("re-edit must bump version, keep original: %+v", edit)
+	}
+}
+
+func TestDeleteSessionOverlay_NotFoundWhenSessionMissing(t *testing.T) {
+	repo := &stubSessionRepo{getErr: domain.ErrNotFound} // underlying session row absent
+	svc := newTestSessionService(repo)
+	if _, err := svc.DeleteSessionOverlay(context.Background(), "missing"); err == nil {
+		t.Fatal("expected error when underlying session row is missing")
+	}
+}

--- a/server/internal/service/session_test.go
+++ b/server/internal/service/session_test.go
@@ -46,6 +46,7 @@ type stubSessionRepo struct {
 	listFilter     domain.MemoryFilter
 	softDeleteID   string
 	bulkDeleteIDs  []string
+	overlays       map[string]*domain.SessionEdit
 }
 
 type sessionListCall struct {
@@ -132,6 +133,55 @@ func (s *stubSessionRepo) ListBySessionIDs(_ context.Context, ids []string, appI
 	}
 	s.listCalls = append(s.listCalls, call)
 	return append([]*domain.Session(nil), s.sessionRows...), nil
+}
+
+func (s *stubSessionRepo) UpsertSessionEdit(_ context.Context, edit *domain.SessionEdit) error {
+	if s.overlays == nil {
+		s.overlays = map[string]*domain.SessionEdit{}
+	}
+	cp := *edit
+	if existing, ok := s.overlays[edit.ID]; ok {
+		cp.Version = existing.Version + 1
+		cp.OriginalContent = existing.OriginalContent
+		if !cp.EditedTagsSet {
+			cp.EditedTags = existing.EditedTags
+			cp.EditedTagsSet = existing.EditedTagsSet
+		}
+	} else {
+		cp.Version = 1
+	}
+	if cp.State == "" {
+		cp.State = domain.StateActive
+	}
+	s.overlays[edit.ID] = &cp
+	return nil
+}
+
+func (s *stubSessionRepo) GetSessionEdit(_ context.Context, id string) (*domain.SessionEdit, error) {
+	if ov, ok := s.overlays[id]; ok && ov.State == domain.StateActive {
+		cp := *ov
+		return &cp, nil
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (s *stubSessionRepo) GetSessionEditsByIDs(_ context.Context, ids []string) (map[string]*domain.SessionEdit, error) {
+	out := map[string]*domain.SessionEdit{}
+	for _, id := range ids {
+		if ov, ok := s.overlays[id]; ok && ov.State == domain.StateActive {
+			cp := *ov
+			out[id] = &cp
+		}
+	}
+	return out, nil
+}
+
+func (s *stubSessionRepo) DeleteSessionEdit(_ context.Context, id string) (int64, error) {
+	if _, ok := s.overlays[id]; ok {
+		delete(s.overlays, id)
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func newTestSessionService(repo *stubSessionRepo) *SessionService {
@@ -599,4 +649,16 @@ func (c *capturingSessionRepo) FTSAvailable() bool { return c.stub.FTSAvailable(
 
 func (c *capturingSessionRepo) ListBySessionIDs(ctx context.Context, ids []string, appID *string, limit int) ([]*domain.Session, error) {
 	return c.stub.ListBySessionIDs(ctx, ids, appID, limit)
+}
+func (c *capturingSessionRepo) UpsertSessionEdit(ctx context.Context, edit *domain.SessionEdit) error {
+	return c.stub.UpsertSessionEdit(ctx, edit)
+}
+func (c *capturingSessionRepo) GetSessionEdit(ctx context.Context, id string) (*domain.SessionEdit, error) {
+	return c.stub.GetSessionEdit(ctx, id)
+}
+func (c *capturingSessionRepo) GetSessionEditsByIDs(ctx context.Context, ids []string) (map[string]*domain.SessionEdit, error) {
+	return c.stub.GetSessionEditsByIDs(ctx, ids)
+}
+func (c *capturingSessionRepo) DeleteSessionEdit(ctx context.Context, id string) (int64, error) {
+	return c.stub.DeleteSessionEdit(ctx, id)
 }

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -139,6 +139,9 @@ func (c *schemaInitConnector) recordDDL(query string) {
 		c.existingTables["memories"] = true
 		c.existingCols["memories.app_id"] = true
 		c.indexColumns["idx_app"] = []string{"app_id"}
+	case strings.Contains(lowerQuery, "create table if not exists session_edits"):
+		c.existingTables["session_edits"] = true
+		c.existingCols["session_edits.edited_content"] = true
 	case strings.Contains(lowerQuery, "create table if not exists sessions"):
 		c.existingTables["sessions"] = true
 		c.existingCols["sessions.app_id"] = true
@@ -414,12 +417,14 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 	p := NewTiDBCloudProvisioner("http://localhost", "pool", "", 1024, 1536, false)
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
-			"memories": true,
-			"sessions": true,
+			"memories":      true,
+			"sessions":      true,
+			"session_edits": true,
 		},
 		existingCols: map[string]bool{
-			"memories.app_id": true,
-			"sessions.app_id": true,
+			"memories.app_id":              true,
+			"sessions.app_id":              true,
+			"session_edits.edited_content": true,
 		},
 		indexColumns: map[string][]string{
 			"idx_app":        {"app_id"},
@@ -466,8 +471,9 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesRejectsStaleAppSchema(t *
 	p := NewTiDBCloudProvisioner("http://localhost", "pool", "", 1024, 1536, false)
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
-			"memories": true,
-			"sessions": true,
+			"memories":      true,
+			"sessions":      true,
+			"session_edits": true,
 		},
 		existingCols: map[string]bool{
 			"memories.app_id": true,
@@ -502,12 +508,14 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesRejectsStaleAppSchema(t *
 func TestEnsureTiDBTenantRuntimeSchema_CreatesSearchIndexesOnly(t *testing.T) {
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
-			"memories": true,
-			"sessions": true,
+			"memories":      true,
+			"sessions":      true,
+			"session_edits": true,
 		},
 		existingCols: map[string]bool{
-			"memories.app_id": true,
-			"sessions.app_id": true,
+			"memories.app_id":              true,
+			"sessions.app_id":              true,
+			"session_edits.edited_content": true,
 		},
 		indexColumns: map[string][]string{
 			"idx_app":        {"app_id"},
@@ -550,12 +558,14 @@ func TestEnsureTiDBTenantRuntimeSchema_CreatesSearchIndexesOnly(t *testing.T) {
 func TestValidateTiDBTenantRuntimeSchema_SuccessDoesNotMutate(t *testing.T) {
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
-			"memories": true,
-			"sessions": true,
+			"memories":      true,
+			"sessions":      true,
+			"session_edits": true,
 		},
 		existingCols: map[string]bool{
-			"memories.app_id": true,
-			"sessions.app_id": true,
+			"memories.app_id":              true,
+			"sessions.app_id":              true,
+			"session_edits.edited_content": true,
 		},
 		indexColumns: map[string][]string{
 			"idx_app":         {"app_id"},
@@ -581,8 +591,9 @@ func TestValidateTiDBTenantRuntimeSchema_SuccessDoesNotMutate(t *testing.T) {
 func TestValidateTiDBTenantRuntimeSchema_RejectsOldSessionsDedupIndex(t *testing.T) {
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
-			"memories": true,
-			"sessions": true,
+			"memories":      true,
+			"sessions":      true,
+			"session_edits": true,
 		},
 		existingCols: map[string]bool{
 			"memories.app_id": true,
@@ -614,8 +625,9 @@ func TestValidateTiDBTenantRuntimeSchema_RejectsOldSessionsDedupIndex(t *testing
 func TestValidateTiDBTenantRuntimeSchema_RejectsNonUniqueSessionsDedupIndex(t *testing.T) {
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
-			"memories": true,
-			"sessions": true,
+			"memories":      true,
+			"sessions":      true,
+			"session_edits": true,
 		},
 		existingCols: map[string]bool{
 			"memories.app_id": true,

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -158,6 +158,33 @@ const TenantSessionsSchemaBase = `CREATE TABLE IF NOT EXISTS sessions (
     UNIQUE INDEX idx_sess_dedup   (app_id, session_id, content_hash)
 )`
 
+// TenantSessionEditsSchema is the raw-session edit overlay table. It is a
+// display overlay, NOT an audit-history table: at most one row per session
+// row (PK id == sessions.id), upserted in place on re-edit. The sessions
+// table itself (content / embedding / FTS) is never modified, so the edit
+// only affects how Session Search renders an already-matched row — it does
+// not change what is searchable, and memory/fact recall is untouched.
+// No embedding column: the overlay never participates in retrieval.
+const TenantSessionEditsSchema = `CREATE TABLE IF NOT EXISTS session_edits (
+    id               VARCHAR(36)     PRIMARY KEY,
+    app_id           VARCHAR(100)    NOT NULL DEFAULT '',
+    session_id       VARCHAR(100)    NULL,
+    seq              INT             NULL,
+    agent_id         VARCHAR(100)    NULL,
+    original_content MEDIUMTEXT      NOT NULL,
+    edited_content   MEDIUMTEXT      NOT NULL,
+    edited_tags      JSON,
+    edited_by        VARCHAR(100)    NULL,
+    reason           VARCHAR(500)    NULL,
+    version          INT             NOT NULL DEFAULT 1,
+    state            VARCHAR(20)     NOT NULL DEFAULT 'active',
+    created_at       TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_sedit_session (session_id),
+    INDEX idx_sedit_app     (app_id),
+    INDEX idx_sedit_state   (state)
+)`
+
 // BuildSessionsSchema builds the TiDB sessions schema with optional auto-embedding.
 func BuildSessionsSchema(autoModel string, autoDims int, clientDims int) string {
 	var embeddingCol string
@@ -229,6 +256,12 @@ func ensureTiDBTenantTablesAndSearchIndexes(ctx context.Context, db *sql.DB, aut
 			return fmt.Errorf("sessions fulltext index: %w", err)
 		}
 	}
+
+	// Raw-session edit overlay. No vector/FTS index — it never participates
+	// in retrieval, only in Session Search response rendering.
+	if err := ensureTable(ctx, db, "session_edits", TenantSessionEditsSchema); err != nil {
+		return fmt.Errorf("session_edits table: %w", err)
+	}
 	return nil
 }
 
@@ -279,6 +312,16 @@ func ValidateTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel 
 		if err := requireIndex(ctx, db, "sessions", "idx_sess_fts"); err != nil {
 			return fmt.Errorf("validate schema: sessions fulltext index: %w", err)
 		}
+	}
+
+	// Raw-session edit overlay table. Required because the edit endpoints
+	// depend on it, so a validate-only/offline check must not green-light a
+	// tenant schema that cannot serve them.
+	if err := requireTable(ctx, db, "session_edits"); err != nil {
+		return fmt.Errorf("validate schema: session_edits table: %w", err)
+	}
+	if err := requireColumn(ctx, db, "session_edits", "edited_content"); err != nil {
+		return fmt.Errorf("validate schema: session_edits edited_content column: %w", err)
 	}
 	return nil
 }

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -163,6 +163,32 @@ CREATE TABLE IF NOT EXISTS memories (
 -- ALTER TABLE memories DROP COLUMN tombstone;
 -- DROP INDEX idx_tombstone ON memories;
 
+-- Raw-session edit overlay (tenant data plane). Display-only: an edit only
+-- changes how Session Search renders an already-matched row; the sessions
+-- table, its embedding, and its FTS index are never modified, so retrieval
+-- and memory/fact recall are unaffected. Current-overlay, not history: one
+-- row per session turn (id == sessions.id), upserted in place on re-edit.
+CREATE TABLE IF NOT EXISTS session_edits (
+  id               VARCHAR(36)     PRIMARY KEY COMMENT 'Equals sessions.id',
+  app_id           VARCHAR(100)    NOT NULL DEFAULT '',
+  session_id       VARCHAR(100)    NULL,
+  seq              INT             NULL,
+  agent_id         VARCHAR(100)    NULL,
+  original_content MEDIUMTEXT      NOT NULL COMMENT 'Pre-edit snapshot (before)',
+  edited_content   MEDIUMTEXT      NOT NULL COMMENT 'Post-edit content (after)',
+  edited_tags      JSON            NULL     COMMENT 'NULL = no tag override; non-NULL (incl. []) overrides',
+  edited_by        VARCHAR(100)    NULL,
+  reason           VARCHAR(500)    NULL,
+  version          INT             NOT NULL DEFAULT 1,
+  state            VARCHAR(20)     NOT NULL DEFAULT 'active'
+                   COMMENT 'active|reverted',
+  created_at       TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+  updated_at       TIMESTAMP       DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_sedit_session       (session_id),
+  INDEX idx_sedit_app           (app_id),
+  INDEX idx_sedit_state         (state)
+);
+
 -- Marketing attribution captured at provision time (control plane).
 CREATE TABLE IF NOT EXISTS tenant_utm (
   tenant_id  VARCHAR(36)   NOT NULL PRIMARY KEY,


### PR DESCRIPTION
Edit raw session turns for display, without touching the `sessions` or
`memories` tables. Memory/fact recall is unaffected.

### Endpoints (v1alpha2)
- `PUT /session-messages/{id}` — upsert edit (`{content, tags?}`)
- `GET /session-messages/{id}/edit` — read overlay (404 if none)
- `DELETE /session-messages/{id}/edit` — remove overlay (revert)

### Behavior
- New `session_edits` overlay table, auto-created via schema ensure; one row per turn (`id == sessions.id`), upserted on re-edit (`version+1`, original snapshot kept). No embedding/FTS.
- Writes touch only `session_edits` — never `sessions`/`memories`, embeddings, or FTS.
- Session Search replaces `content`/`tags` for edited rows + adds `edited`/`edit_version` markers; `GET /session-messages` and non-session results unchanged.
- Editable: content + optional tags (pointer: omitted = keep tags, `[]` = clear). role/seq/session_id immutable. Chain keys rejected.

### Tradeoff
- Matching still runs on the original text; the overlay only rewrites display. Edit-added words aren't searchable; edit-removed words still match but render edited.

### Tests
- Upsert/version/snapshot, validation, 404, search overlay, content-only keeps tags, explicit tag override, revert, chain rejection, facts never overlaid. Full suite + vet pass.