### PR TITLE
[codex] add How it work docs link

### DIFF
--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -184,6 +184,21 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
                 ))}
               </span>
             </a>
+            <a
+              href="https://gtm.mem9.ai/main"
+              class="docs-menu-item"
+              target="_blank"
+              rel="noopener"
+              role="menuitem"
+            >
+              <span class="localized-label">
+                {navLabels('howItWork').map((label) => (
+                  <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                    {label.value}
+                  </span>
+                ))}
+              </span>
+            </a>
           </div>
         </div>
         <a
@@ -365,6 +380,21 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
               >
                 <span class="localized-label">
                   {navLabels('apiReferences').map((label) => (
+                    <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
+                      {label.value}
+                    </span>
+                  ))}
+                </span>
+              </a>
+              <a
+                href="https://gtm.mem9.ai/main"
+                class="mobile-menu-item"
+                target="_blank"
+                rel="noopener"
+                role="menuitem"
+              >
+                <span class="localized-label">
+                  {navLabels('howItWork').map((label) => (
                     <span class="localized-label-option" data-locale-option={label.locale} lang={label.lang}>
                       {label.value}
                     </span>

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -57,6 +57,7 @@ export interface SiteNavCopy {
   consoleDocs: string;
   api: string;
   apiReferences: string;
+  howItWork: string;
   releaseNotes: string;
   contact: string;
 }
@@ -6097,6 +6098,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'mem9 Console Docs',
       api: 'API',
       apiReferences: 'API References',
+      howItWork: 'How it work',
       releaseNotes: 'Release Notes',
       contact: 'Contact Us',
     },
@@ -6456,6 +6458,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'mem9 Console 文档',
       api: 'API',
       apiReferences: 'API 参考',
+      howItWork: 'How it work',
       releaseNotes: '发布说明',
       contact: '联系我们',
     },
@@ -6801,6 +6804,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'mem9 Console 文檔',
       api: 'API',
       apiReferences: 'API 參考',
+      howItWork: 'How it work',
       releaseNotes: '發布說明',
       contact: '聯絡我們',
     },
@@ -7151,6 +7155,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'mem9 Console ドキュメント',
       api: 'API',
       apiReferences: 'API リファレンス',
+      howItWork: 'How it work',
       releaseNotes: 'リリースノート',
       contact: 'お問い合わせ',
     },
@@ -7506,6 +7511,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'mem9 Console 문서',
       api: 'API',
       apiReferences: 'API 레퍼런스',
+      howItWork: 'How it work',
       releaseNotes: '릴리스 노트',
       contact: '문의하기',
     },
@@ -7858,6 +7864,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'Dokumentasi mem9 Console',
       api: 'API',
       apiReferences: 'Referensi API',
+      howItWork: 'How it work',
       releaseNotes: 'Catatan Rilis',
       contact: 'Hubungi Kami',
     },
@@ -8213,6 +8220,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       consoleDocs: 'เอกสาร mem9 Console',
       api: 'API',
       apiReferences: 'เอกสารอ้างอิง API',
+      howItWork: 'How it work',
       releaseNotes: 'บันทึกการเผยแพร่',
       contact: 'ติดต่อเรา',
     },


### PR DESCRIPTION
## Summary
- add a new Docs dropdown item labeled "How it work" after API References
- open the new item in a separate tab at https://gtm.mem9.ai/main
- include the same item in the mobile menu and route copy through the site i18n content layer

## Validation
- cd site && npx tsc --noEmit
- cd site && npm run build
