### PR TITLE
feat: normalize runtime quota 402 envelope

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2392,7 +2392,7 @@
         "description": "No content."
       },
       "RuntimeQuotaDenied": {
-        "description": "Runtime usage quota denied. Plugins should use details.mem9Code to enter the quota UX path and details.upgradeUrl as the direct user action link when present.",
+        "description": "Runtime usage quota denied. Plugins should use details.mem9Code to enter the quota UX path and details.recommendedAction.url as the direct user action link when present.",
         "content": {
           "application/json": {
             "schema": {
@@ -2407,9 +2407,36 @@
                     "retryable": false,
                     "meter": "memory_recall_requests",
                     "limitType": "includedQuota",
-                    "upgradeAction": "claimApiKey",
-                    "bindingState": "unclaimed",
-                    "upgradeUrl": "https://mem9.ai/console/claim?key=mk_example",
+                    "recommendedAction": {
+                      "bindingState": "unclaimed",
+                      "type": "claimApiKey",
+                      "url": "https://mem9.ai/console/claim?key=mk_example"
+                    },
+                    "quotaGateResult": {
+                      "outcome": "blocked",
+                      "reason": "includedQuotaExhausted"
+                    },
+                    "mem9Code": "runtime_quota_denied"
+                  }
+                }
+              },
+              "claimedQuotaExhausted": {
+                "value": {
+                  "code": "quota_exhausted",
+                  "message": "Included quota is exhausted.",
+                  "details": {
+                    "retryable": false,
+                    "meter": "memory_recall_requests",
+                    "limitType": "includedQuota",
+                    "recommendedAction": {
+                      "bindingState": "claimed",
+                      "type": "upgradePlan",
+                      "url": "https://mem9.ai/console/billing/plan"
+                    },
+                    "quotaGateResult": {
+                      "outcome": "blocked",
+                      "reason": "includedQuotaExhausted"
+                    },
                     "mem9Code": "runtime_quota_denied"
                   }
                 }
@@ -2422,9 +2449,15 @@
                     "retryable": false,
                     "meter": "memory_write_requests",
                     "limitType": "spendingLimit",
-                    "upgradeAction": "increaseSpendingLimit",
-                    "bindingState": "claimed",
-                    "upgradeUrl": "https://mem9.ai/console/billing/plan",
+                    "recommendedAction": {
+                      "bindingState": "claimed",
+                      "type": "increaseSpendingLimit",
+                      "url": "https://mem9.ai/console/billing/plan"
+                    },
+                    "quotaGateResult": {
+                      "outcome": "blocked",
+                      "reason": "onDemandBudgetExhausted"
+                    },
                     "mem9Code": "runtime_quota_denied"
                   }
                 }
@@ -3266,25 +3299,11 @@
               "spendingLimit"
             ]
           },
-          "upgradeAction": {
-            "type": "string",
-            "enum": [
-              "claimApiKey",
-              "upgradePlan",
-              "enableOnDemand",
-              "increaseSpendingLimit"
-            ]
+          "recommendedAction": {
+            "$ref": "#/components/schemas/RuntimeRecommendedAction"
           },
-          "bindingState": {
-            "type": "string",
-            "enum": [
-              "claimed",
-              "unclaimed"
-            ]
-          },
-          "upgradeUrl": {
-            "type": "string",
-            "description": "Console URL that the plugin can show directly to the user."
+          "quotaGateResult": {
+            "$ref": "#/components/schemas/RuntimeQuotaGateResult"
           },
           "mem9Code": {
             "type": "string",
@@ -3294,6 +3313,72 @@
           }
         },
         "additionalProperties": true
+      },
+      "RuntimeRecommendedAction": {
+        "type": "object",
+        "required": [
+          "bindingState",
+          "type",
+          "url"
+        ],
+        "properties": {
+          "bindingState": {
+            "type": "string",
+            "enum": [
+              "claimed",
+              "unclaimed"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "claimApiKey",
+              "upgradePlan",
+              "enableOnDemand",
+              "increaseSpendingLimit"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "description": "Console URL that the plugin can show directly to the user."
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeQuotaGateResult": {
+        "type": "object",
+        "required": [
+          "outcome",
+          "reason"
+        ],
+        "properties": {
+          "outcome": {
+            "type": "string",
+            "enum": [
+              "allowed",
+              "blocked",
+              "rateLimited"
+            ]
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "includedQuota",
+              "onDemand",
+              "postQuota"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "includedQuotaExhausted",
+              "onDemandDisabled",
+              "onDemandUnavailable",
+              "onDemandBudgetExhausted"
+            ]
+          }
+        },
+        "additionalProperties": false
       }
     }
   }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -640,6 +640,9 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "402": {
+            "$ref": "#/components/responses/RuntimeQuotaDenied"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -724,6 +727,9 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/RuntimeQuotaDenied"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -822,6 +828,9 @@
           "401": {
             "$ref": "#/components/responses/Unauthorized"
           },
+          "402": {
+            "$ref": "#/components/responses/RuntimeQuotaDenied"
+          },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
@@ -870,6 +879,9 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/RuntimeQuotaDenied"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -935,6 +947,9 @@
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/RuntimeQuotaDenied"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -2375,6 +2390,48 @@
       },
       "NoContent": {
         "description": "No content."
+      },
+      "RuntimeQuotaDenied": {
+        "description": "Runtime usage quota denied. Plugins should use details.mem9Code to enter the quota UX path and details.upgradeUrl as the direct user action link when present.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeQuotaDeniedError"
+            },
+            "examples": {
+              "unclaimedQuotaExhausted": {
+                "value": {
+                  "code": "quota_exhausted",
+                  "message": "Included quota is exhausted.",
+                  "details": {
+                    "retryable": false,
+                    "meter": "memory_recall_requests",
+                    "limitType": "includedQuota",
+                    "upgradeAction": "claimApiKey",
+                    "bindingState": "unclaimed",
+                    "upgradeUrl": "https://mem9.ai/console/claim?key=mk_example",
+                    "mem9Code": "runtime_quota_denied"
+                  }
+                }
+              },
+              "spendingLimitExceeded": {
+                "value": {
+                  "code": "spending_limit_exceeded",
+                  "message": "On-demand spending limit would be exceeded.",
+                  "details": {
+                    "retryable": false,
+                    "meter": "memory_write_requests",
+                    "limitType": "spendingLimit",
+                    "upgradeAction": "increaseSpendingLimit",
+                    "bindingState": "claimed",
+                    "upgradeUrl": "https://mem9.ai/console/billing/plan",
+                    "mem9Code": "runtime_quota_denied"
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     },
     "schemas": {
@@ -3159,6 +3216,84 @@
             }
           }
         }
+      },
+      "RuntimeQuotaDeniedError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "details"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Specific quota denial reason when available, or runtime_quota_denied for fallback errors.",
+            "examples": [
+              "quota_exhausted",
+              "spending_limit_exceeded",
+              "runtime_quota_denied"
+            ]
+          },
+          "message": {
+            "type": "string"
+          },
+          "details": {
+            "$ref": "#/components/schemas/RuntimeQuotaDeniedDetails"
+          }
+        }
+      },
+      "RuntimeQuotaDeniedDetails": {
+        "type": "object",
+        "required": [
+          "retryable",
+          "mem9Code"
+        ],
+        "properties": {
+          "retryable": {
+            "type": "boolean"
+          },
+          "meter": {
+            "type": "string",
+            "enum": [
+              "memory_recall_requests",
+              "memory_write_requests"
+            ]
+          },
+          "limitType": {
+            "type": "string",
+            "enum": [
+              "includedQuota",
+              "spendingLimit"
+            ]
+          },
+          "upgradeAction": {
+            "type": "string",
+            "enum": [
+              "claimApiKey",
+              "upgradePlan",
+              "enableOnDemand",
+              "increaseSpendingLimit"
+            ]
+          },
+          "bindingState": {
+            "type": "string",
+            "enum": [
+              "claimed",
+              "unclaimed"
+            ]
+          },
+          "upgradeUrl": {
+            "type": "string",
+            "description": "Console URL that the plugin can show directly to the user."
+          },
+          "mem9Code": {
+            "type": "string",
+            "enum": [
+              "runtime_quota_denied"
+            ]
+          }
+        },
+        "additionalProperties": true
       }
     }
   }

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -57,14 +57,10 @@ func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
 func (s *Server) handleRuntimeUsageError(w http.ResponseWriter, err error) {
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
-		body := denied.ResponseBody()
-		if body = ensureMem9QuotaDeniedCode(body); len(body) > 0 {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusPaymentRequired)
-			_, _ = w.Write(body)
-			return
-		}
-		respondError(w, http.StatusPaymentRequired, "runtime usage quota denied")
+		body := normalizeRuntimeQuotaDeniedBody(denied.ResponseBody())
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write(body)
 		return
 	}
 	status := runtimeusage.HTTPStatus(err)
@@ -82,21 +78,52 @@ func isRuntimeUsageError(err error) bool {
 	return errors.As(err, &denied) || errors.As(err, &unavailable) || errors.As(err, &conflict)
 }
 
-func ensureMem9QuotaDeniedCode(body []byte) []byte {
+type runtimeQuotaDeniedEnvelope struct {
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details"`
+}
+
+func normalizeRuntimeQuotaDeniedBody(body []byte) []byte {
 	body = bytes.TrimSpace(body)
-	if len(body) == 0 {
-		return nil
+	envelope := runtimeQuotaDeniedEnvelope{
+		Code:    "runtime_quota_denied",
+		Message: "runtime usage quota denied",
+		Details: map[string]any{
+			"retryable": false,
+			"mem9Code":  "runtime_quota_denied",
+		},
 	}
 	var parsed map[string]any
-	if err := json.Unmarshal(body, &parsed); err != nil {
-		return body
+	if len(body) > 0 && json.Unmarshal(body, &parsed) == nil {
+		if code, ok := parsed["code"].(string); ok && code != "" {
+			envelope.Code = code
+		}
+		if message, ok := parsed["message"].(string); ok && message != "" {
+			envelope.Message = message
+		}
+		if details, ok := parsed["details"].(map[string]any); ok {
+			envelope.Details = make(map[string]any, len(details)+2)
+			for key, value := range details {
+				envelope.Details[key] = value
+			}
+		}
+		if retryable, ok := parsed["retryable"].(bool); ok {
+			envelope.Details["retryable"] = retryable
+		}
+		if mem9Code, ok := parsed["mem9_code"].(string); ok && mem9Code != "" {
+			envelope.Details["mem9Code"] = mem9Code
+		}
 	}
-	if _, ok := parsed["mem9_code"]; !ok {
-		parsed["mem9_code"] = "runtime_quota_denied"
+	if _, ok := envelope.Details["retryable"]; !ok {
+		envelope.Details["retryable"] = false
 	}
-	out, err := json.Marshal(parsed)
+	if _, ok := envelope.Details["mem9Code"]; !ok {
+		envelope.Details["mem9Code"] = "runtime_quota_denied"
+	}
+	out, err := json.Marshal(envelope)
 	if err != nil {
-		return body
+		return []byte(`{"code":"runtime_quota_denied","message":"runtime usage quota denied","details":{"retryable":false,"mem9Code":"runtime_quota_denied"}}`)
 	}
 	return out
 }

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -13,10 +13,15 @@ func TestNormalizeRuntimeQuotaDeniedBodyPreservesConsoleDetails(t *testing.T) {
 			"retryable":false,
 			"meter":"memory_recall_requests",
 			"limitType":"includedQuota",
-			"upgradeAction":"upgradePlan",
-			"bindingState":"claimed",
-			"upgradeUrl":"https://console.example.com/billing/plan",
-			"mem9Code":"runtime_quota_denied"
+			"recommendedAction":{
+				"bindingState":"claimed",
+				"type":"upgradePlan",
+				"url":"https://console.example.com/console/billing/plan"
+			},
+			"quotaGateResult":{
+				"outcome":"blocked",
+				"reason":"includedQuotaExhausted"
+			}
 		}
 	}`))
 
@@ -28,8 +33,21 @@ func TestNormalizeRuntimeQuotaDeniedBodyPreservesConsoleDetails(t *testing.T) {
 		t.Fatalf("mem9_code should live under details: %#v", got)
 	}
 	details := got["details"].(map[string]any)
-	if details["meter"] != "memory_recall_requests" || details["upgradeAction"] != "upgradePlan" || details["bindingState"] != "claimed" || details["upgradeUrl"] != "https://console.example.com/billing/plan" || details["mem9Code"] != "runtime_quota_denied" {
+	recommendedAction := details["recommendedAction"].(map[string]any)
+	quotaGateResult := details["quotaGateResult"].(map[string]any)
+	if details["meter"] != "memory_recall_requests" ||
+		recommendedAction["type"] != "upgradePlan" ||
+		recommendedAction["bindingState"] != "claimed" ||
+		recommendedAction["url"] != "https://console.example.com/console/billing/plan" ||
+		quotaGateResult["outcome"] != "blocked" ||
+		quotaGateResult["reason"] != "includedQuotaExhausted" ||
+		details["mem9Code"] != "runtime_quota_denied" {
 		t.Fatalf("unexpected details: %#v", details)
+	}
+	for _, key := range []string{"upgradeAction", "bindingState", "upgradeUrl"} {
+		if _, ok := details[key]; ok {
+			t.Fatalf("legacy flat action field %q should be absent: %#v", key, details)
+		}
 	}
 }
 

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -1,0 +1,74 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestNormalizeRuntimeQuotaDeniedBodyPreservesConsoleDetails(t *testing.T) {
+	body := normalizeRuntimeQuotaDeniedBody([]byte(`{
+		"code":"quota_exhausted",
+		"message":"Included quota is exhausted.",
+		"details":{
+			"retryable":false,
+			"meter":"memory_recall_requests",
+			"limitType":"includedQuota",
+			"upgradeAction":"upgradePlan",
+			"bindingState":"claimed",
+			"upgradeUrl":"https://console.example.com/billing/plan",
+			"mem9Code":"runtime_quota_denied"
+		}
+	}`))
+
+	got := decodeRuntimeQuotaDeniedBody(t, body)
+	if got["code"] != "quota_exhausted" || got["message"] != "Included quota is exhausted." {
+		t.Fatalf("unexpected envelope: %#v", got)
+	}
+	if _, ok := got["mem9_code"]; ok {
+		t.Fatalf("mem9_code should live under details: %#v", got)
+	}
+	details := got["details"].(map[string]any)
+	if details["meter"] != "memory_recall_requests" || details["upgradeAction"] != "upgradePlan" || details["bindingState"] != "claimed" || details["upgradeUrl"] != "https://console.example.com/billing/plan" || details["mem9Code"] != "runtime_quota_denied" {
+		t.Fatalf("unexpected details: %#v", details)
+	}
+}
+
+func TestNormalizeRuntimeQuotaDeniedBodyMovesLegacyMem9Code(t *testing.T) {
+	body := normalizeRuntimeQuotaDeniedBody([]byte(`{
+		"code":"quota_exhausted",
+		"message":"Included quota is exhausted.",
+		"retryable":false,
+		"mem9_code":"runtime_quota_denied"
+	}`))
+
+	got := decodeRuntimeQuotaDeniedBody(t, body)
+	if _, ok := got["mem9_code"]; ok {
+		t.Fatalf("mem9_code should live under details: %#v", got)
+	}
+	details := got["details"].(map[string]any)
+	if details["retryable"] != false || details["mem9Code"] != "runtime_quota_denied" {
+		t.Fatalf("unexpected details: %#v", details)
+	}
+}
+
+func TestNormalizeRuntimeQuotaDeniedBodyUsesFallback(t *testing.T) {
+	body := normalizeRuntimeQuotaDeniedBody(nil)
+
+	got := decodeRuntimeQuotaDeniedBody(t, body)
+	if got["code"] != "runtime_quota_denied" || got["message"] != "runtime usage quota denied" {
+		t.Fatalf("unexpected fallback envelope: %#v", got)
+	}
+	details := got["details"].(map[string]any)
+	if details["retryable"] != false || details["mem9Code"] != "runtime_quota_denied" {
+		t.Fatalf("unexpected fallback details: %#v", details)
+	}
+}
+
+func decodeRuntimeQuotaDeniedBody(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	return got
+}


### PR DESCRIPTION
## What changed
- Normalized runtime quota 402 responses into a stable `code` / `message` / `details` envelope.
- Preserved console-server `recommendedAction` and `quotaGateResult` fields inside `details` for plugin consumption.
- Added plugin-facing `details.mem9Code=runtime_quota_denied` when console-server omits it.
- Kept legacy top-level `mem9_code` normalization into `details.mem9Code`.
- Updated `docs/api/openapi.json` examples and schemas for the nested quota action/result contract.

## Context
- Background: This is the mem9 server side of the first Issue https://github.com/mem9-ai/mem9-console-server/issues/110 implementation slice.
- Why this approach: Console-server owns the internal quota action/result contract, while mem9 server owns plugin-facing error taxonomy.
- How it works: The handler forwards console-server quota details, fills fallback retryability and `mem9Code`, and returns the plugin-facing 402 envelope on memory operations.

## Validation
- `go test ./internal/handler`
- `node -e "JSON.parse(require('fs').readFileSync('docs/api/openapi.json','utf8')); console.log('openapi json ok')"`

## Notes
- Depends on https://github.com/mem9-ai/mem9-console-server/pull/120 for the nested quota detail fields.
- The API key status endpoint and per-plugin handling stay in follow-up PRs.
