### PR TITLE
[codex] support TiDB Cloud PrivateLink endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,8 @@ The `MEM9_SOURCE_TURN_*` variables control how many source turn conversations ar
 | `MNEMO_TIDBCLOUD_POOL_ID` | No | `2` | TiDB Cloud Pool ID used for cluster takeover |
 | `MNEMO_TIDBCLOUD_API_KEY` | No | — | TiDB Cloud Pool API key. Used only when `MNEMO_TIDB_ZERO_ENABLED=false`, `MNEMO_DB_BACKEND=tidb`, and pool takeover is desired |
 | `MNEMO_TIDBCLOUD_API_SECRET` | No | — | TiDB Cloud Pool API secret for digest auth. Same conditions as `MNEMO_TIDBCLOUD_API_KEY` |
+| `MNEMO_TIDBCLOUD_PREFER_PRIVATELINK` | No | `false` | Prefer the TiDB Cloud private endpoint during Pool provisioning when its AWS PrivateLink service name is configured below |
+| `MNEMO_TIDBCLOUD_PRIVATELINK_SERVICE_NAMES` | No | — | Comma-separated AWS PrivateLink service names that this mem9-server can reach. Provisioning falls back to the public endpoint when the returned service name is absent |
 | `MNEMO_TENANT_POOL_MAX_IDLE` | No | `5` | Max idle tenant database connections kept in the in-process tenant pool |
 | `MNEMO_TENANT_POOL_MAX_OPEN` | No | `10` | Max open connections per tenant database handle |
 | `MNEMO_TENANT_POOL_CONNECT_TIMEOUT` | No | `3s` | Timeout for tenant pool cold-connect ping/open attempts |

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -229,8 +229,22 @@ func main() {
 	// Check for TiDB Cloud credentials (only if Zero is not enabled)
 	if provisioner == nil && cfg.DBBackend == "tidb" {
 		if os.Getenv("MNEMO_TIDBCLOUD_API_KEY") != "" && os.Getenv("MNEMO_TIDBCLOUD_API_SECRET") != "" {
-			provisioner = tenant.NewTiDBCloudProvisioner(cfg.TiDBCloudAPIURL, cfg.TiDBCloudPoolID, cfg.EmbedAutoModel, cfg.EmbedAutoDims, cfg.EmbedDims, cfg.FTSEnabled)
-			logger.Info("using TiDB Cloud Pool provisioner")
+			provisioner = tenant.NewTiDBCloudProvisionerWithPrivateLink(
+				cfg.TiDBCloudAPIURL,
+				cfg.TiDBCloudPoolID,
+				cfg.EmbedAutoModel,
+				cfg.EmbedAutoDims,
+				cfg.EmbedDims,
+				cfg.FTSEnabled,
+				tenant.TiDBCloudPrivateLinkConfig{
+					Prefer:       cfg.TiDBCloudPreferPrivateLink,
+					ServiceNames: cfg.TiDBCloudPrivateLinkServiceNames,
+				},
+			)
+			logger.Info("using TiDB Cloud Pool provisioner",
+				"prefer_privatelink", cfg.TiDBCloudPreferPrivateLink,
+				"privatelink_service_names", len(cfg.TiDBCloudPrivateLinkServiceNames),
+			)
 		}
 	}
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -52,8 +52,10 @@ type Config struct {
 	ChainRecallStopScore     float64
 
 	// TiDB Cloud Pool configuration
-	TiDBCloudAPIURL string
-	TiDBCloudPoolID string
+	TiDBCloudAPIURL                  string
+	TiDBCloudPoolID                  string
+	TiDBCloudPreferPrivateLink       bool
+	TiDBCloudPrivateLinkServiceNames map[string]struct{}
 
 	// FTSEnabled controls whether full-text search is attempted.
 	// Set MNEMO_FTS_ENABLED=true only when the TiDB cluster supports
@@ -161,59 +163,61 @@ func Load() (*Config, error) {
 
 	env := strings.ToLower(strings.TrimSpace(envOr("MNEMO_ENV", envOr("APP_ENV", "development"))))
 	cfg := &Config{
-		Port:                        envOr("MNEMO_PORT", "8080"),
-		DSN:                         dsn,
-		Env:                         env,
-		DBBackend:                   envOr("MNEMO_DB_BACKEND", "tidb"),
-		RateLimit:                   envFloat("MNEMO_RATE_LIMIT", 100),
-		RateBurst:                   envInt("MNEMO_RATE_BURST", 200),
-		EmbedAutoModel:              os.Getenv("MNEMO_EMBED_AUTO_MODEL"),
-		EmbedAutoDims:               envInt("MNEMO_EMBED_AUTO_DIMS", 1024),
-		EmbedAPIKey:                 os.Getenv("MNEMO_EMBED_API_KEY"),
-		EmbedBaseURL:                os.Getenv("MNEMO_EMBED_BASE_URL"),
-		EmbedModel:                  os.Getenv("MNEMO_EMBED_MODEL"),
-		EmbedDims:                   envInt("MNEMO_EMBED_DIMS", 1536),
-		LLMAPIKey:                   os.Getenv("MNEMO_LLM_API_KEY"),
-		LLMBaseURL:                  os.Getenv("MNEMO_LLM_BASE_URL"),
-		LLMModel:                    envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
-		LLMTemperature:              envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
-		IngestMode:                  envOr("MNEMO_INGEST_MODE", "smart"),
-		DisableSessionSave:          envBool("MNEMO_DISABLE_SESSION_SAVE", false),
-		TiDBZeroEnabled:             envBool("MNEMO_TIDB_ZERO_ENABLED", true),
-		TiDBZeroAPIURL:              envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
-		TiDBCloudAPIURL:             envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),
-		TiDBCloudPoolID:             envOr("MNEMO_TIDBCLOUD_POOL_ID", "2"),
-		TenantPoolMaxIdle:           envInt("MNEMO_TENANT_POOL_MAX_IDLE", 5),
-		TenantPoolMaxOpen:           envInt("MNEMO_TENANT_POOL_MAX_OPEN", 10),
-		TenantPoolConnectTimeout:    envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
-		TenantPoolIdleTimeout:       envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
-		TenantPoolTotalLimit:        envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
-		ChainRecallStopScore:        envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.8),
-		UploadDir:                   envOr("MNEMO_UPLOAD_DIR", "./uploads"),
-		FTSEnabled:                  envBool("MNEMO_FTS_ENABLED", false),
-		WorkerConcurrency:           envInt("MNEMO_WORKER_CONCURRENCY", 5),
-		MeteringEnabled:             meteringEnabled,
-		MeteringURL:                 meteringURL,
-		MeteringFlushInterval:       envDuration("MNEMO_METERING_FLUSH_INTERVAL", 10*time.Second),
-		RuntimeUsageEnabled:         runtimeUsageEnabled,
-		RuntimeUsageBaseURL:         runtimeUsageBaseURL,
-		RuntimeUsageInternalSecret:  strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")),
-		RuntimeUsageTimeout:         envDuration("MNEMO_RUNTIME_USAGE_TIMEOUT", 3*time.Second),
-		RuntimeUsageMeteringTimeout: envDuration("MNEMO_RUNTIME_USAGE_METERING_TIMEOUT", 5*time.Second),
-		RuntimeUsageReservationTTL:  envDuration("MNEMO_RUNTIME_USAGE_RESERVATION_TTL", 30*time.Minute),
-		RuntimeUsageOperationTTL:    envDuration("MNEMO_RUNTIME_USAGE_OPERATION_TTL", 30*time.Minute),
-		RuntimeUsageFailOpen:        runtimeUsageFailOpen,
-		RuntimeUsageOutboxEnabled:   runtimeUsageOutboxEnabled,
-		EncryptType:                 envOr("MNEMO_ENCRYPT_TYPE", "plain"),
-		EncryptKey:                  os.Getenv("MNEMO_ENCRYPT_KEY"),
-		DebugLLM:                    envBool("MNEMO_DEBUG_LLM", false),
-		ClusterBlacklist:            parseClusterBlacklist(os.Getenv("MNEMO_CLUSTER_BLACKLIST")),
-		AutoSpendLimitEnabled:       envBool("MNEMO_AUTO_SPEND_LIMIT_ENABLED", false),
-		AutoSpendLimitIncrement:     envInt("MNEMO_AUTO_SPEND_LIMIT_INCREMENT", 500),
-		AutoSpendLimitMax:           envInt("MNEMO_AUTO_SPEND_LIMIT_MAX", 10000),
-		AutoSpendLimitCooldown:      envDuration("MNEMO_AUTO_SPEND_LIMIT_COOLDOWN", 1*time.Hour),
-		UTMEnabled:                  envBool("MNEMO_UTM_ENABLED", false),
-		CORSAllowedOrigins:          parseCSV(envOr("MNEMO_CORS_ALLOWED_ORIGINS", defaultCORSAllowedOrigins(env))),
+		Port:                             envOr("MNEMO_PORT", "8080"),
+		DSN:                              dsn,
+		Env:                              env,
+		DBBackend:                        envOr("MNEMO_DB_BACKEND", "tidb"),
+		RateLimit:                        envFloat("MNEMO_RATE_LIMIT", 100),
+		RateBurst:                        envInt("MNEMO_RATE_BURST", 200),
+		EmbedAutoModel:                   os.Getenv("MNEMO_EMBED_AUTO_MODEL"),
+		EmbedAutoDims:                    envInt("MNEMO_EMBED_AUTO_DIMS", 1024),
+		EmbedAPIKey:                      os.Getenv("MNEMO_EMBED_API_KEY"),
+		EmbedBaseURL:                     os.Getenv("MNEMO_EMBED_BASE_URL"),
+		EmbedModel:                       os.Getenv("MNEMO_EMBED_MODEL"),
+		EmbedDims:                        envInt("MNEMO_EMBED_DIMS", 1536),
+		LLMAPIKey:                        os.Getenv("MNEMO_LLM_API_KEY"),
+		LLMBaseURL:                       os.Getenv("MNEMO_LLM_BASE_URL"),
+		LLMModel:                         envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
+		LLMTemperature:                   envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
+		IngestMode:                       envOr("MNEMO_INGEST_MODE", "smart"),
+		DisableSessionSave:               envBool("MNEMO_DISABLE_SESSION_SAVE", false),
+		TiDBZeroEnabled:                  envBool("MNEMO_TIDB_ZERO_ENABLED", true),
+		TiDBZeroAPIURL:                   envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),
+		TiDBCloudAPIURL:                  envOr("MNEMO_TIDBCLOUD_API_URL", "https://serverless.tidbapi.com"),
+		TiDBCloudPoolID:                  envOr("MNEMO_TIDBCLOUD_POOL_ID", "2"),
+		TiDBCloudPreferPrivateLink:       envBool("MNEMO_TIDBCLOUD_PREFER_PRIVATELINK", false),
+		TiDBCloudPrivateLinkServiceNames: parseCSVSet(os.Getenv("MNEMO_TIDBCLOUD_PRIVATELINK_SERVICE_NAMES")),
+		TenantPoolMaxIdle:                envInt("MNEMO_TENANT_POOL_MAX_IDLE", 5),
+		TenantPoolMaxOpen:                envInt("MNEMO_TENANT_POOL_MAX_OPEN", 10),
+		TenantPoolConnectTimeout:         envDuration("MNEMO_TENANT_POOL_CONNECT_TIMEOUT", 3*time.Second),
+		TenantPoolIdleTimeout:            envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
+		TenantPoolTotalLimit:             envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
+		ChainRecallStopScore:             envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.8),
+		UploadDir:                        envOr("MNEMO_UPLOAD_DIR", "./uploads"),
+		FTSEnabled:                       envBool("MNEMO_FTS_ENABLED", false),
+		WorkerConcurrency:                envInt("MNEMO_WORKER_CONCURRENCY", 5),
+		MeteringEnabled:                  meteringEnabled,
+		MeteringURL:                      meteringURL,
+		MeteringFlushInterval:            envDuration("MNEMO_METERING_FLUSH_INTERVAL", 10*time.Second),
+		RuntimeUsageEnabled:              runtimeUsageEnabled,
+		RuntimeUsageBaseURL:              runtimeUsageBaseURL,
+		RuntimeUsageInternalSecret:       strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")),
+		RuntimeUsageTimeout:              envDuration("MNEMO_RUNTIME_USAGE_TIMEOUT", 3*time.Second),
+		RuntimeUsageMeteringTimeout:      envDuration("MNEMO_RUNTIME_USAGE_METERING_TIMEOUT", 5*time.Second),
+		RuntimeUsageReservationTTL:       envDuration("MNEMO_RUNTIME_USAGE_RESERVATION_TTL", 30*time.Minute),
+		RuntimeUsageOperationTTL:         envDuration("MNEMO_RUNTIME_USAGE_OPERATION_TTL", 30*time.Minute),
+		RuntimeUsageFailOpen:             runtimeUsageFailOpen,
+		RuntimeUsageOutboxEnabled:        runtimeUsageOutboxEnabled,
+		EncryptType:                      envOr("MNEMO_ENCRYPT_TYPE", "plain"),
+		EncryptKey:                       os.Getenv("MNEMO_ENCRYPT_KEY"),
+		DebugLLM:                         envBool("MNEMO_DEBUG_LLM", false),
+		ClusterBlacklist:                 parseClusterBlacklist(os.Getenv("MNEMO_CLUSTER_BLACKLIST")),
+		AutoSpendLimitEnabled:            envBool("MNEMO_AUTO_SPEND_LIMIT_ENABLED", false),
+		AutoSpendLimitIncrement:          envInt("MNEMO_AUTO_SPEND_LIMIT_INCREMENT", 500),
+		AutoSpendLimitMax:                envInt("MNEMO_AUTO_SPEND_LIMIT_MAX", 10000),
+		AutoSpendLimitCooldown:           envDuration("MNEMO_AUTO_SPEND_LIMIT_COOLDOWN", 1*time.Hour),
+		UTMEnabled:                       envBool("MNEMO_UTM_ENABLED", false),
+		CORSAllowedOrigins:               parseCSV(envOr("MNEMO_CORS_ALLOWED_ORIGINS", defaultCORSAllowedOrigins(env))),
 	}
 	// Validate ingest mode.
 	switch cfg.IngestMode {
@@ -321,6 +325,10 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 }
 
 func parseClusterBlacklist(raw string) map[string]struct{} {
+	return parseCSVSet(raw)
+}
+
+func parseCSVSet(raw string) map[string]struct{} {
 	out := make(map[string]struct{})
 	for id := range strings.SplitSeq(raw, ",") {
 		if id := strings.TrimSpace(id); id != "" {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -48,6 +48,28 @@ func TestLoad_DisableSessionSave(t *testing.T) {
 	}
 }
 
+func TestLoad_TiDBCloudPrivateLinkConfig(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_TIDBCLOUD_PREFER_PRIVATELINK", "true")
+	t.Setenv("MNEMO_TIDBCLOUD_PRIVATELINK_SERVICE_NAMES", "vpce-svc-a, vpce-svc-b,,vpce-svc-a")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.TiDBCloudPreferPrivateLink {
+		t.Fatal("TiDBCloudPreferPrivateLink = false, want true")
+	}
+	if len(cfg.TiDBCloudPrivateLinkServiceNames) != 2 {
+		t.Fatalf("service names len = %d, want 2", len(cfg.TiDBCloudPrivateLinkServiceNames))
+	}
+	for _, name := range []string{"vpce-svc-a", "vpce-svc-b"} {
+		if _, ok := cfg.TiDBCloudPrivateLinkServiceNames[name]; !ok {
+			t.Fatalf("service names missing %q", name)
+		}
+	}
+}
+
 func TestLoad_MeteringSupportedFields(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_METERING_ENABLED", "true")

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -299,6 +299,106 @@ func TestTiDBCloudProvisioner_Provision_Success(t *testing.T) {
 	}
 }
 
+func TestTiDBCloudProvisioner_Provision_UsesPrivateLinkWhenPreferredAndServiceAllowed(t *testing.T) {
+	cleanup := setupTiDBCloudEnv(t)
+	defer cleanup()
+
+	server := newTiDBCloudTakeoverServer(t, tidbCloudTakeoverResponse(
+		"public.cluster.tidbcloud.com",
+		4000,
+		"private.cluster.tidbcloud.com",
+		4000,
+		"com.amazonaws.vpce.us-west-2.vpce-svc-allowed",
+	))
+	defer server.Close()
+
+	p := NewTiDBCloudProvisionerWithPrivateLink(server.URL, "test-pool", "", 0, 0, false, TiDBCloudPrivateLinkConfig{
+		Prefer: true,
+		ServiceNames: map[string]struct{}{
+			"com.amazonaws.vpce.us-west-2.vpce-svc-allowed": {},
+		},
+	})
+
+	info, err := p.Provision(context.Background())
+	if err != nil {
+		t.Fatalf("Provision failed: %v", err)
+	}
+	if info.Host != "private.cluster.tidbcloud.com" {
+		t.Fatalf("Host = %q, want private.cluster.tidbcloud.com", info.Host)
+	}
+	if info.Port != 4000 {
+		t.Fatalf("Port = %d, want 4000", info.Port)
+	}
+}
+
+func TestTiDBCloudProvisioner_Provision_FallsBackToPublicWhenPrivateLinkServiceNotAllowed(t *testing.T) {
+	cleanup := setupTiDBCloudEnv(t)
+	defer cleanup()
+
+	server := newTiDBCloudTakeoverServer(t, tidbCloudTakeoverResponse(
+		"public.cluster.tidbcloud.com",
+		4000,
+		"private.cluster.tidbcloud.com",
+		4000,
+		"com.amazonaws.vpce.us-west-2.vpce-svc-unconfigured",
+	))
+	defer server.Close()
+
+	p := NewTiDBCloudProvisionerWithPrivateLink(server.URL, "test-pool", "", 0, 0, false, TiDBCloudPrivateLinkConfig{
+		Prefer: true,
+		ServiceNames: map[string]struct{}{
+			"com.amazonaws.vpce.us-west-2.vpce-svc-allowed": {},
+		},
+	})
+
+	info, err := p.Provision(context.Background())
+	if err != nil {
+		t.Fatalf("Provision failed: %v", err)
+	}
+	if info.Host != "public.cluster.tidbcloud.com" {
+		t.Fatalf("Host = %q, want public.cluster.tidbcloud.com", info.Host)
+	}
+	if info.Port != 4000 {
+		t.Fatalf("Port = %d, want 4000", info.Port)
+	}
+}
+
+func newTiDBCloudTakeoverServer(t *testing.T, response map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="abc123", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+}
+
+func tidbCloudTakeoverResponse(publicHost string, publicPort int, privateHost string, privatePort int, serviceName string) map[string]interface{} {
+	return map[string]interface{}{
+		"clusterId": "cluster-123",
+		"endpoints": map[string]interface{}{
+			"public": map[string]interface{}{
+				"host": publicHost,
+				"port": publicPort,
+			},
+			"private": map[string]interface{}{
+				"host": privateHost,
+				"port": privatePort,
+				"aws": map[string]interface{}{
+					"serviceName": serviceName,
+				},
+			},
+		},
+		"userPrefix": "test",
+	}
+}
+
 // TestTiDBCloudProvisioner_Provision_APIError tests error handling when API returns error
 func TestTiDBCloudProvisioner_Provision_APIError(t *testing.T) {
 	cleanup := setupTiDBCloudEnv(t)

--- a/server/internal/tenant/starter.go
+++ b/server/internal/tenant/starter.go
@@ -22,30 +22,74 @@ import (
 // Note: MNEMO_TIDBCLOUD_API_KEY and MNEMO_TIDBCLOUD_API_SECRET are read via os.Getenv()
 // (not Config) as these are sensitive credentials that should not be persisted.
 type TiDBCloudProvisioner struct {
-	apiURL     string
-	apiKey     string
-	apiSecret  string
-	poolID     string
-	autoModel  string
-	autoDims   int
-	clientDims int
-	ftsEnabled bool
-	client     *http.Client
+	apiURL                  string
+	apiKey                  string
+	apiSecret               string
+	poolID                  string
+	autoModel               string
+	autoDims                int
+	clientDims              int
+	ftsEnabled              bool
+	preferPrivateLink       bool
+	privateLinkServiceNames map[string]struct{}
+	client                  *http.Client
+}
+
+type TiDBCloudPrivateLinkConfig struct {
+	Prefer       bool
+	ServiceNames map[string]struct{}
+}
+
+type tidbCloudEndpoint struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+type tidbCloudPrivateEndpoint struct {
+	Host string `json:"host"`
+	Port int    `json:"port"`
+	AWS  struct {
+		ServiceName string `json:"serviceName"`
+	} `json:"aws"`
+}
+
+type tidbCloudProvisionResponse struct {
+	ClusterID string `json:"clusterId"`
+	Endpoints struct {
+		Public  tidbCloudEndpoint        `json:"public"`
+		Private tidbCloudPrivateEndpoint `json:"private"`
+	} `json:"endpoints"`
+	UserPrefix string `json:"userPrefix"`
 }
 
 // NewTiDBCloudProvisioner creates a provisioner for TiDB Cloud Pool API.
 func NewTiDBCloudProvisioner(apiURL, poolID, autoModel string, autoDims int, clientDims int, ftsEnabled bool) *TiDBCloudProvisioner {
+	return NewTiDBCloudProvisionerWithPrivateLink(apiURL, poolID, autoModel, autoDims, clientDims, ftsEnabled, TiDBCloudPrivateLinkConfig{})
+}
+
+// NewTiDBCloudProvisionerWithPrivateLink creates a provisioner with optional AWS PrivateLink endpoint preference.
+func NewTiDBCloudProvisionerWithPrivateLink(apiURL, poolID, autoModel string, autoDims int, clientDims int, ftsEnabled bool, privateLink TiDBCloudPrivateLinkConfig) *TiDBCloudProvisioner {
 	return &TiDBCloudProvisioner{
-		apiURL:     apiURL,
-		apiKey:     os.Getenv("MNEMO_TIDBCLOUD_API_KEY"),
-		apiSecret:  os.Getenv("MNEMO_TIDBCLOUD_API_SECRET"),
-		poolID:     poolID,
-		autoModel:  autoModel,
-		autoDims:   autoDims,
-		clientDims: clientDims,
-		ftsEnabled: ftsEnabled,
-		client:     &http.Client{Timeout: 60 * time.Second},
+		apiURL:                  apiURL,
+		apiKey:                  os.Getenv("MNEMO_TIDBCLOUD_API_KEY"),
+		apiSecret:               os.Getenv("MNEMO_TIDBCLOUD_API_SECRET"),
+		poolID:                  poolID,
+		autoModel:               autoModel,
+		autoDims:                autoDims,
+		clientDims:              clientDims,
+		ftsEnabled:              ftsEnabled,
+		preferPrivateLink:       privateLink.Prefer,
+		privateLinkServiceNames: copyStringSet(privateLink.ServiceNames),
+		client:                  &http.Client{Timeout: 60 * time.Second},
 	}
+}
+
+func copyStringSet(in map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for key := range in {
+		out[key] = struct{}{}
+	}
+	return out
 }
 
 // Provision acquires a cluster from the TiDB Cloud Pool.
@@ -76,30 +120,45 @@ func (p *TiDBCloudProvisioner) Provision(ctx context.Context) (*ClusterInfo, err
 		return nil, fmt.Errorf("tidb cloud provision: status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	var result struct {
-		ClusterID string `json:"clusterId"`
-		Endpoints struct {
-			Public struct {
-				Host string `json:"host"`
-				Port int    `json:"port"`
-			} `json:"public"`
-		} `json:"endpoints"`
-		UserPrefix string `json:"userPrefix"`
-	}
+	var result tidbCloudProvisionResponse
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("tidb cloud provision: decode response: %w", err)
 	}
 
+	endpointInfo := p.selectConnectionEndpoint(result)
 	return &ClusterInfo{
 		ID:        uuid.New().String(),
 		ClusterID: result.ClusterID,
-		Host:      result.Endpoints.Public.Host,
-		Port:      result.Endpoints.Public.Port,
+		Host:      endpointInfo.Host,
+		Port:      endpointInfo.Port,
 		Username:  result.UserPrefix + ".root",
 		Password:  password,
 		DBName:    "test",
 	}, nil
+}
+
+func (p *TiDBCloudProvisioner) selectConnectionEndpoint(result tidbCloudProvisionResponse) tidbCloudEndpoint {
+	privateEndpoint := result.Endpoints.Private
+	if p.isPrivateLinkServiceAllowed(privateEndpoint.AWS.ServiceName) && privateEndpoint.Host != "" && privateEndpoint.Port != 0 {
+		return tidbCloudEndpoint{
+			Host: privateEndpoint.Host,
+			Port: privateEndpoint.Port,
+		}
+	}
+	return result.Endpoints.Public
+}
+
+func (p *TiDBCloudProvisioner) isPrivateLinkServiceAllowed(serviceName string) bool {
+	if !p.preferPrivateLink {
+		return false
+	}
+	serviceName = strings.TrimSpace(serviceName)
+	if serviceName == "" {
+		return false
+	}
+	_, ok := p.privateLinkServiceNames[serviceName]
+	return ok
 }
 
 const StarterProvisionerType = "tidb_cloud_starter"


### PR DESCRIPTION
## Summary

This adds optional TiDB Cloud Pool PrivateLink endpoint selection during tenant provisioning.

When `MNEMO_TIDBCLOUD_PREFER_PRIVATELINK=true`, mem9-server checks the TiDB Cloud takeover response's `endpoints.private.aws.serviceName` against `MNEMO_TIDBCLOUD_PRIVATELINK_SERVICE_NAMES`. If the service name is configured and the private endpoint has a host and port, the tenant row stores the private endpoint. Otherwise provisioning falls back to the public endpoint.

## Impact

Existing deployments keep the current public endpoint behavior by default. New deployments can opt in after their AWS VPC endpoint service connectivity is manually configured outside mem9-server.

## Validation

- `gofmt`
- `go test -race -count=1 ./internal/config/`
- `go test -race -count=1 ./internal/tenant/`
- `go test -race -count=1 ./cmd/mnemo-server`
- `make vet`
- `make test`