### PR TITLE
feat: support runtime quota and rate-limit handling in plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "mem9",
       "source": "./claude-plugin",
       "description": "Persistent cloud memory for Claude Code with automatic recall, transcript ingest, and on-demand setup, recall, and store skills.",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "homepage": "https://mem9.ai",
       "repository": "https://github.com/mem9-ai/mem9",
       "license": "Apache-2.0"

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Persistent cloud memory for Claude Code. Requires Node.js 18+, auto-initializes auth on startup, recalls memories on each user turn, and uploads structured conversation turns to mem9.",
   "author": {
     "name": "mem9-ai"

--- a/claude-plugin/hooks/common.sh
+++ b/claude-plugin/hooks/common.sh
@@ -196,24 +196,58 @@ mem9_provision_auth() {
   "${MEM9_CURL_BIN}" -sf --max-time 8 -X POST "${MEM9_API_URL%/}/v1alpha1/mem9s"
 }
 
+mem9_api_request() {
+  local method="$1"
+  local path="$2"
+  local body="${3:-}"
+  local response
+  local http_code
+  local response_body
+  local curl_args=(
+    -sS
+    --max-time 8
+    -X "${method}"
+    -H "Content-Type: application/json"
+    -H "X-API-Key: ${MEM9_API_KEY}"
+    -H "X-Mnemo-Agent-Id: ${MEM9_WRITER_ID}"
+  )
+
+  if [[ -n "${body}" ]]; then
+    curl_args+=(-d "${body}")
+  fi
+
+  if ! response="$("${MEM9_CURL_BIN}" "${curl_args[@]}" -w $'\n%{http_code}' "$(mem9_memory_base)${path}")"; then
+    return 1
+  fi
+
+  http_code="${response##*$'\n'}"
+  response_body="${response%$'\n'"${http_code}"}"
+  printf '%s' "${response_body}"
+
+  case "${http_code}" in
+    2*)
+      return 0
+      ;;
+    *)
+      return 22
+      ;;
+  esac
+}
+
 mem9_api_get() {
   local path="$1"
-  "${MEM9_CURL_BIN}" -sf --max-time 8 \
-    -H "Content-Type: application/json" \
-    -H "X-API-Key: ${MEM9_API_KEY}" \
-    -H "X-Mnemo-Agent-Id: ${MEM9_WRITER_ID}" \
-    "$(mem9_memory_base)${path}"
+  mem9_api_request "GET" "${path}"
 }
 
 mem9_api_post() {
   local path="$1"
   local body="$2"
-  "${MEM9_CURL_BIN}" -sf --max-time 8 \
-    -H "Content-Type: application/json" \
-    -H "X-API-Key: ${MEM9_API_KEY}" \
-    -H "X-Mnemo-Agent-Id: ${MEM9_WRITER_ID}" \
-    -d "${body}" \
-    "$(mem9_memory_base)${path}"
+  mem9_api_request "POST" "${path}" "${body}"
+}
+
+mem9_quota_notice_from_body() {
+  local operation="$1"
+  node "${MEM9_SCRIPT_DIR}/lib/quota-error.mjs" notice "${operation}" 2>/dev/null || true
 }
 
 mem9_ingest_transcript() {
@@ -227,6 +261,8 @@ mem9_ingest_transcript() {
   local transcript_path
   local payload
   local body
+  local response
+  local quota_notice
   local stats
   local messages_count
   local user_count
@@ -275,7 +311,7 @@ mem9_ingest_transcript() {
     "assistant_count" "${assistant_count}" \
     "content_bytes" "${total_bytes}"
 
-  if mem9_api_post "/memories" "${body}" >/dev/null 2>&1; then
+  if response="$(mem9_api_post "/memories" "${body}" 2>/dev/null)"; then
     mem9_debug "${hook_name}" "ingest_sent" \
       "mode" "${mode}" \
       "session_id" "${session_id}" \
@@ -284,6 +320,15 @@ mem9_ingest_transcript() {
       "assistant_count" "${assistant_count}" \
       "content_bytes" "${total_bytes}"
     return 0
+  fi
+
+  quota_notice="$(printf '%s' "${response:-}" | mem9_quota_notice_from_body "ingest paused")"
+  if [[ -n "${quota_notice}" ]]; then
+    mem9_debug "${hook_name}" "ingest_quota_denied" \
+      "mode" "${mode}" \
+      "session_id" "${session_id}" \
+      "messages_count" "${messages_count}"
+    return 1
   fi
 
   mem9_debug "${hook_name}" "ingest_request_failed" \

--- a/claude-plugin/hooks/common.sh
+++ b/claude-plugin/hooks/common.sh
@@ -9,6 +9,7 @@ MEM9_AGENT_ID="${MEM9_AGENT_ID:-claude-code-main}"
 MEM9_WRITER_ID="${MEM9_WRITER_ID:-claude-code}"
 MEM9_CURL_BIN="${MEM9_CURL_BIN:-curl}"
 MEM9_AUTH_SOURCE="${MEM9_AUTH_SOURCE:-}"
+MEM9_HTTP_STATUS_MARKER="__MEM9_HTTP_STATUS__="
 
 mem9_require_node() {
   command -v node >/dev/null 2>&1 || return 1
@@ -222,13 +223,13 @@ mem9_api_request() {
 
   http_code="${response##*$'\n'}"
   response_body="${response%$'\n'"${http_code}"}"
-  printf '%s' "${response_body}"
-
   case "${http_code}" in
     2*)
+      printf '%s' "${response_body}"
       return 0
       ;;
     *)
+      printf '%s\n%s%s' "${response_body}" "${MEM9_HTTP_STATUS_MARKER}" "${http_code}"
       return 22
       ;;
   esac
@@ -247,7 +248,19 @@ mem9_api_post() {
 
 mem9_quota_notice_from_body() {
   local operation="$1"
-  node "${MEM9_SCRIPT_DIR}/lib/quota-error.mjs" notice "${operation}" 2>/dev/null || true
+  local input
+  local body
+  local status=""
+  local marker=$'\n'"${MEM9_HTTP_STATUS_MARKER}"
+
+  input="$(cat)"
+  body="${input}"
+  if [[ "${input}" == *"${marker}"* ]]; then
+    status="${input##*${marker}}"
+    body="${input%"${marker}${status}"}"
+  fi
+
+  printf '%s' "${body}" | node "${MEM9_SCRIPT_DIR}/lib/quota-error.mjs" notice "${operation}" "${status}" 2>/dev/null || true
 }
 
 mem9_ingest_transcript() {

--- a/claude-plugin/hooks/common.test.sh
+++ b/claude-plugin/hooks/common.test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+STUB_CURL="${TMP_DIR}/curl"
+cat > "${STUB_CURL}" <<'SH'
+#!/usr/bin/env bash
+cat <<'EOF'
+{"error":"Post-quota rate limit exceeded.","details":{"errorCategory":"runtime_quota_denied","runtimeQuota":{"meter":"memory_recall_requests"}}}
+429
+EOF
+SH
+chmod +x "${STUB_CURL}"
+
+export CLAUDE_PLUGIN_DATA="${TMP_DIR}/data"
+export MEM9_API_KEY="mem9_test"
+export MEM9_API_URL="https://api.mem9.ai"
+export MEM9_CURL_BIN="${STUB_CURL}"
+export MEM9_WRITER_ID="claude-code-test"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/common.sh"
+
+response=""
+if response="$(mem9_api_get "/memories?q=test&limit=10" 2>/dev/null)"; then
+  printf 'expected mem9_api_get to fail for HTTP 429\n' >&2
+  exit 1
+fi
+
+notice="$(printf '%s' "${response}" | mem9_quota_notice_from_body "recall paused")"
+
+case "${notice}" in
+  *"temporary request limit"* ) ;;
+  *)
+    printf 'expected rate-limit guidance, got: %s\n' "${notice}" >&2
+    exit 1
+    ;;
+esac
+
+case "${notice}" in
+  *"quota/rate-limit check blocked this request"* ) ;;
+  *)
+    printf 'expected generic quota/rate-limit action, got: %s\n' "${notice}" >&2
+    exit 1
+    ;;
+esac

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -90,6 +90,9 @@ if (command === "code") {
 }
 
 const actionText = quotaDenied.actionUrl
-  ? ` ${actionLabel(quotaDenied.actionType)}: ${quotaDenied.actionUrl}`
+  ? ` User action required: ${actionLabel(quotaDenied.actionType)}: ${quotaDenied.actionUrl}`
   : "";
-process.stdout.write(`[mem9] ${operation}: ${sentence(quotaDenied.message)}${actionText}`);
+const replyInstruction = quotaDenied.actionUrl
+  ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${quotaDenied.actionUrl}`
+  : " In your reply, briefly tell the user mem9 memory is paused.";
+process.stdout.write(`[mem9] ${operation}: ${sentence(quotaDenied.message)}${actionText}${replyInstruction}`);

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -56,7 +56,7 @@ function isPostQuotaRateLimited(quotaDenied) {
 
 function quotaReason(quotaDenied) {
   if (isPostQuotaRateLimited(quotaDenied)) {
-    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+    return "this API key has reached the temporary request limit for this memory feature";
   }
   if (quotaDenied.actionType === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
@@ -124,7 +124,7 @@ function actionInstruction(quotaDenied) {
     if (!quotaDenied.actionUrl) {
       return retry;
     }
-    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
   }
   if (!quotaDenied.actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -19,6 +19,14 @@ function normalizePositiveInteger(value) {
   return number;
 }
 
+function normalizeStatus(value) {
+  const number = typeof value === "number" ? value : Number(value);
+  if (!Number.isInteger(number) || number < 100 || number > 599) {
+    return null;
+  }
+  return number;
+}
+
 function quotaGateReason(runtimeQuota) {
   const quotaGateResult = isRecord(runtimeQuota.quotaGateResult)
     ? runtimeQuota.quotaGateResult
@@ -42,7 +50,8 @@ function retryAfterSeconds(runtimeQuota) {
 }
 
 function isPostQuotaRateLimited(quotaDenied) {
-  return quotaDenied.quotaGateReason === "postQuotaRateLimitExceeded";
+  return quotaDenied.status === 429 ||
+    quotaDenied.quotaGateReason === "postQuotaRateLimitExceeded";
 }
 
 function quotaReason(quotaDenied) {
@@ -125,7 +134,7 @@ function actionInstruction(quotaDenied) {
   }
 }
 
-function parseQuotaDenied(payload) {
+function parseQuotaDenied(payload, status) {
   if (!isRecord(payload)) {
     return null;
   }
@@ -142,6 +151,7 @@ function parseQuotaDenied(payload) {
   const providerActionCode = normalizeString(recommendedAction.providerActionCode);
   const actionUrl = normalizeString(recommendedAction.url);
   return {
+    status,
     code: "runtime_quota_denied",
     message: normalizeString(payload.error) || "Runtime usage quota denied.",
     meter: normalizeString(runtimeQuota.meter),
@@ -167,7 +177,8 @@ function readPayload() {
 
 const command = process.argv[2] || "notice";
 const operation = process.argv[3] || "mem9 request";
-const quotaDenied = parseQuotaDenied(readPayload());
+const status = normalizeStatus(process.argv[4]);
+const quotaDenied = parseQuotaDenied(readPayload(), status);
 
 if (!quotaDenied) {
   process.exit(1);

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// quota-error.mjs — Format mem9 runtime quota denial payloads for hooks.
+
+import { readFileSync } from "node:fs";
+
+const QUOTA_CODES = new Set([
+  "quota_exhausted",
+  "spending_limit_exceeded",
+  "runtime_quota_denied",
+]);
+
+function isRecord(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function actionLabel(type) {
+  switch (type) {
+    case "claimApiKey":
+      return "Claim this API key";
+    case "upgradePlan":
+      return "Upgrade your plan";
+    case "increaseSpendingLimit":
+      return "Increase your spending limit";
+    case "enableOnDemand":
+      return "Enable on-demand usage";
+    case "resolveAccountState":
+      return "Resolve account state";
+    default:
+      return "Open mem9 console";
+  }
+}
+
+function parseQuotaDenied(payload) {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const details = isRecord(payload.details) ? payload.details : {};
+  const code = normalizeString(payload.code);
+  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
+  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+    return null;
+  }
+
+  const recommendedAction = isRecord(details.recommendedAction)
+    ? details.recommendedAction
+    : {};
+  const actionType = normalizeString(recommendedAction.type ?? details.upgradeAction);
+  const actionUrl = normalizeString(recommendedAction.url ?? details.upgradeUrl);
+  return {
+    code: code || "runtime_quota_denied",
+    message: normalizeString(payload.message) || "runtime usage quota denied",
+    actionType,
+    actionUrl,
+  };
+}
+
+function readPayload() {
+  const raw = readFileSync(0, "utf8");
+  if (!raw.trim()) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+const command = process.argv[2] || "notice";
+const operation = process.argv[3] || "mem9 request";
+const quotaDenied = parseQuotaDenied(readPayload());
+
+if (!quotaDenied) {
+  process.exit(1);
+}
+
+if (command === "code") {
+  process.stdout.write(quotaDenied.code);
+  process.exit(0);
+}
+
+const actionText = quotaDenied.actionUrl
+  ? ` ${actionLabel(quotaDenied.actionType)}: ${quotaDenied.actionUrl}`
+  : "";
+process.stdout.write(`[mem9] ${operation}: ${quotaDenied.message}.${actionText}`);

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -3,8 +3,6 @@
 
 import { readFileSync } from "node:fs";
 
-const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
-
 function isRecord(value) {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
@@ -106,8 +104,7 @@ function quotaNoticeSubject(quotaDenied, operation) {
 function actionInstruction(quotaDenied) {
   if (!quotaDenied.actionUrl) {
     if (isPostQuotaRateLimited(quotaDenied)) {
-      const billingUrl = quotaDenied.actionUrl || DEFAULT_BILLING_ACTION_URL;
-      return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${billingUrl}. Include the link exactly as written.`;
+      return "Tell them that the quota/rate-limit check blocked this request and to retry later or open the mem9 console to review account and billing settings.";
     }
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -3,13 +3,6 @@
 
 import { readFileSync } from "node:fs";
 
-const QUOTA_CODES = new Set([
-  "quota_exhausted",
-  "post_quota_rate_limited",
-  "spending_limit_exceeded",
-  "runtime_access_blocked",
-  "runtime_quota_denied",
-]);
 const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 function isRecord(value) {
@@ -28,21 +21,21 @@ function normalizePositiveInteger(value) {
   return number;
 }
 
-function quotaGateReason(details) {
-  const quotaGateResult = isRecord(details.quotaGateResult)
-    ? details.quotaGateResult
+function quotaGateReason(runtimeQuota) {
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult)
+    ? runtimeQuota.quotaGateResult
     : {};
   return normalizeString(quotaGateResult.reason);
 }
 
-function retryAfterSeconds(details) {
-  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+function retryAfterSeconds(runtimeQuota) {
+  const direct = normalizePositiveInteger(runtimeQuota.retryAfterSeconds);
   if (direct != null) {
     return direct;
   }
 
-  const quotaGateResult = isRecord(details.quotaGateResult)
-    ? details.quotaGateResult
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult)
+    ? runtimeQuota.quotaGateResult
     : {};
   const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit)
     ? quotaGateResult.postQuotaRateLimit
@@ -51,27 +44,26 @@ function retryAfterSeconds(details) {
 }
 
 function isPostQuotaRateLimited(quotaDenied) {
-  return quotaDenied.code === "post_quota_rate_limited" ||
-    quotaDenied.quotaGateReason === "postQuotaRateLimitExceeded";
+  return quotaDenied.quotaGateReason === "postQuotaRateLimitExceeded";
 }
 
 function quotaReason(quotaDenied) {
   if (isPostQuotaRateLimited(quotaDenied)) {
     return "this API key has reached the temporary request limit for this memory feature";
   }
-  if (quotaDenied.actionType === "claimApiKey") {
+  if (quotaDenied.providerActionCode === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
   }
-  if (quotaDenied.actionType === "increaseSpendingLimit" || quotaDenied.code === "spending_limit_exceeded") {
+  if (quotaDenied.providerActionCode === "increaseSpendingLimit") {
     return "the configured spending limit would be exceeded";
   }
-  if (quotaDenied.actionType === "enableOnDemand") {
+  if (quotaDenied.providerActionCode === "enableOnDemand") {
     return "the included usage quota has been used up and on-demand usage is not enabled";
   }
-  if (quotaDenied.actionType === "upgradePlan" || quotaDenied.code === "quota_exhausted") {
+  if (quotaDenied.providerActionCode === "upgradePlan") {
     return "the included usage quota for this mem9 account has been used up";
   }
-  if (quotaDenied.code === "runtime_access_blocked") {
+  if (quotaDenied.providerActionCode === "resolveAccountState") {
     return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
@@ -120,7 +112,7 @@ function actionInstruction(quotaDenied) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 
-  switch (quotaDenied.actionType) {
+  switch (quotaDenied.providerActionCode) {
     case "claimApiKey":
       return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${quotaDenied.actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
     case "upgradePlan":
@@ -142,24 +134,23 @@ function parseQuotaDenied(payload) {
   }
 
   const details = isRecord(payload.details) ? payload.details : {};
-  const code = normalizeString(payload.code);
-  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
-  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+  if (normalizeString(details.errorCategory) !== "runtime_quota_denied") {
     return null;
   }
+  const runtimeQuota = isRecord(details.runtimeQuota) ? details.runtimeQuota : {};
 
-  const recommendedAction = isRecord(details.recommendedAction)
-    ? details.recommendedAction
+  const recommendedAction = isRecord(runtimeQuota.recommendedAction)
+    ? runtimeQuota.recommendedAction
     : {};
-  const actionType = normalizeString(recommendedAction.type ?? details.upgradeAction);
-  const actionUrl = normalizeString(recommendedAction.url ?? details.upgradeUrl);
+  const providerActionCode = normalizeString(recommendedAction.providerActionCode);
+  const actionUrl = normalizeString(recommendedAction.url);
   return {
-    code: code || "runtime_quota_denied",
-    message: normalizeString(payload.message) || "runtime usage quota denied",
-    meter: normalizeString(details.meter),
-    quotaGateReason: quotaGateReason(details),
-    retryAfterSeconds: retryAfterSeconds(details),
-    actionType,
+    code: "runtime_quota_denied",
+    message: normalizeString(payload.error) || "Runtime usage quota denied.",
+    meter: normalizeString(runtimeQuota.meter),
+    quotaGateReason: quotaGateReason(runtimeQuota),
+    retryAfterSeconds: retryAfterSeconds(runtimeQuota),
+    providerActionCode,
     actionUrl,
   };
 }

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -10,6 +10,7 @@ const QUOTA_CODES = new Set([
   "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
+const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 function isRecord(value) {
   return value != null && typeof value === "object" && !Array.isArray(value);
@@ -110,21 +111,10 @@ function quotaNoticeSubject(quotaDenied, operation) {
   };
 }
 
-function retryInstruction(quotaDenied) {
-  if (quotaDenied.retryAfterSeconds != null) {
-    const unit = quotaDenied.retryAfterSeconds === 1 ? "second" : "seconds";
-    return `Ask them to wait ${quotaDenied.retryAfterSeconds} ${unit} before trying again.`;
-  }
-  return "Ask them to wait briefly before trying again.";
-}
-
 function actionInstruction(quotaDenied) {
   if (isPostQuotaRateLimited(quotaDenied)) {
-    const retry = retryInstruction(quotaDenied);
-    if (!quotaDenied.actionUrl) {
-      return retry;
-    }
-    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+    const billingUrl = quotaDenied.actionUrl || DEFAULT_BILLING_ACTION_URL;
+    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${billingUrl}. Include the link exactly as written.`;
   }
   if (!quotaDenied.actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -34,6 +34,10 @@ function actionLabel(type) {
   }
 }
 
+function sentence(message) {
+  return /[.!?]$/.test(message) ? message : `${message}.`;
+}
+
 function parseQuotaDenied(payload) {
   if (!isRecord(payload)) {
     return null;
@@ -88,4 +92,4 @@ if (command === "code") {
 const actionText = quotaDenied.actionUrl
   ? ` ${actionLabel(quotaDenied.actionType)}: ${quotaDenied.actionUrl}`
   : "";
-process.stdout.write(`[mem9] ${operation}: ${quotaDenied.message}.${actionText}`);
+process.stdout.write(`[mem9] ${operation}: ${sentence(quotaDenied.message)}${actionText}`);

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -5,7 +5,9 @@ import { readFileSync } from "node:fs";
 
 const QUOTA_CODES = new Set([
   "quota_exhausted",
+  "post_quota_rate_limited",
   "spending_limit_exceeded",
+  "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
 
@@ -17,7 +19,45 @@ function normalizeString(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function normalizePositiveInteger(value) {
+  const number = typeof value === "number" ? value : Number.NaN;
+  if (!Number.isInteger(number) || number <= 0) {
+    return null;
+  }
+  return number;
+}
+
+function quotaGateReason(details) {
+  const quotaGateResult = isRecord(details.quotaGateResult)
+    ? details.quotaGateResult
+    : {};
+  return normalizeString(quotaGateResult.reason);
+}
+
+function retryAfterSeconds(details) {
+  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+  if (direct != null) {
+    return direct;
+  }
+
+  const quotaGateResult = isRecord(details.quotaGateResult)
+    ? details.quotaGateResult
+    : {};
+  const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit)
+    ? quotaGateResult.postQuotaRateLimit
+    : {};
+  return normalizePositiveInteger(postQuotaRateLimit.retryAfterSeconds);
+}
+
+function isPostQuotaRateLimited(quotaDenied) {
+  return quotaDenied.code === "post_quota_rate_limited" ||
+    quotaDenied.quotaGateReason === "postQuotaRateLimitExceeded";
+}
+
 function quotaReason(quotaDenied) {
+  if (isPostQuotaRateLimited(quotaDenied)) {
+    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+  }
   if (quotaDenied.actionType === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
   }
@@ -29,6 +69,9 @@ function quotaReason(quotaDenied) {
   }
   if (quotaDenied.actionType === "upgradePlan" || quotaDenied.code === "quota_exhausted") {
     return "the included usage quota for this mem9 account has been used up";
+  }
+  if (quotaDenied.code === "runtime_access_blocked") {
+    return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
 }
@@ -67,7 +110,22 @@ function quotaNoticeSubject(quotaDenied, operation) {
   };
 }
 
+function retryInstruction(quotaDenied) {
+  if (quotaDenied.retryAfterSeconds != null) {
+    const unit = quotaDenied.retryAfterSeconds === 1 ? "second" : "seconds";
+    return `Ask them to wait ${quotaDenied.retryAfterSeconds} ${unit} before trying again.`;
+  }
+  return "Ask them to wait briefly before trying again.";
+}
+
 function actionInstruction(quotaDenied) {
+  if (isPostQuotaRateLimited(quotaDenied)) {
+    const retry = retryInstruction(quotaDenied);
+    if (!quotaDenied.actionUrl) {
+      return retry;
+    }
+    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+  }
   if (!quotaDenied.actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
@@ -109,6 +167,8 @@ function parseQuotaDenied(payload) {
     code: code || "runtime_quota_denied",
     message: normalizeString(payload.message) || "runtime usage quota denied",
     meter: normalizeString(details.meter),
+    quotaGateReason: quotaGateReason(details),
+    retryAfterSeconds: retryAfterSeconds(details),
     actionType,
     actionUrl,
   };

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -112,11 +112,11 @@ function quotaNoticeSubject(quotaDenied, operation) {
 }
 
 function actionInstruction(quotaDenied) {
-  if (isPostQuotaRateLimited(quotaDenied)) {
-    const billingUrl = quotaDenied.actionUrl || DEFAULT_BILLING_ACTION_URL;
-    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${billingUrl}. Include the link exactly as written.`;
-  }
   if (!quotaDenied.actionUrl) {
+    if (isPostQuotaRateLimited(quotaDenied)) {
+      const billingUrl = quotaDenied.actionUrl || DEFAULT_BILLING_ACTION_URL;
+      return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${billingUrl}. Include the link exactly as written.`;
+    }
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 

--- a/claude-plugin/hooks/lib/quota-error.mjs
+++ b/claude-plugin/hooks/lib/quota-error.mjs
@@ -17,25 +17,75 @@ function normalizeString(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
-function actionLabel(type) {
-  switch (type) {
-    case "claimApiKey":
-      return "Claim this API key";
-    case "upgradePlan":
-      return "Upgrade your plan";
-    case "increaseSpendingLimit":
-      return "Increase your spending limit";
-    case "enableOnDemand":
-      return "Enable on-demand usage";
-    case "resolveAccountState":
-      return "Resolve account state";
-    default:
-      return "Open mem9 console";
+function quotaReason(quotaDenied) {
+  if (quotaDenied.actionType === "claimApiKey") {
+    return "the included usage quota for this API key has been used up";
   }
+  if (quotaDenied.actionType === "increaseSpendingLimit" || quotaDenied.code === "spending_limit_exceeded") {
+    return "the configured spending limit would be exceeded";
+  }
+  if (quotaDenied.actionType === "enableOnDemand") {
+    return "the included usage quota has been used up and on-demand usage is not enabled";
+  }
+  if (quotaDenied.actionType === "upgradePlan" || quotaDenied.code === "quota_exhausted") {
+    return "the included usage quota for this mem9 account has been used up";
+  }
+  return "the runtime quota check blocked this request";
 }
 
-function sentence(message) {
-  return /[.!?]$/.test(message) ? message : `${message}.`;
+function quotaNoticeSubject(quotaDenied, operation) {
+  if (quotaDenied.meter === "memory_write_requests") {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (quotaDenied.meter === "memory_recall_requests") {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  const operationText = normalizeString(operation).toLowerCase();
+  if (/\b(ingest|save|store|write)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (/\b(recall|search)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  return {
+    headline: "Mem9 memory is temporarily unavailable",
+    userState: "mem9 cannot complete the memory request right now",
+  };
+}
+
+function actionInstruction(quotaDenied) {
+  if (!quotaDenied.actionUrl) {
+    return "Ask them to open the mem9 console to resolve the account or billing state.";
+  }
+
+  switch (quotaDenied.actionType) {
+    case "claimApiKey":
+      return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${quotaDenied.actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
+    case "upgradePlan":
+      return `Ask them to open this link to upgrade their mem9 plan and get more included usage: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+    case "increaseSpendingLimit":
+      return `Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+    case "enableOnDemand":
+      return `Ask them to open this link to enable billing or on-demand usage for mem9: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+    case "resolveAccountState":
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+    default:
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${quotaDenied.actionUrl}. Include the link exactly as written.`;
+  }
 }
 
 function parseQuotaDenied(payload) {
@@ -58,6 +108,7 @@ function parseQuotaDenied(payload) {
   return {
     code: code || "runtime_quota_denied",
     message: normalizeString(payload.message) || "runtime usage quota denied",
+    meter: normalizeString(details.meter),
     actionType,
     actionUrl,
   };
@@ -89,10 +140,5 @@ if (command === "code") {
   process.exit(0);
 }
 
-const actionText = quotaDenied.actionUrl
-  ? ` User action required: ${actionLabel(quotaDenied.actionType)}: ${quotaDenied.actionUrl}`
-  : "";
-const replyInstruction = quotaDenied.actionUrl
-  ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${quotaDenied.actionUrl}`
-  : " In your reply, briefly tell the user mem9 memory is paused.";
-process.stdout.write(`[mem9] ${operation}: ${sentence(quotaDenied.message)}${actionText}${replyInstruction}`);
+const subject = quotaNoticeSubject(quotaDenied, operation);
+process.stdout.write(`${subject.headline} because ${quotaReason(quotaDenied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(quotaDenied)}`);

--- a/claude-plugin/hooks/user-prompt-submit.sh
+++ b/claude-plugin/hooks/user-prompt-submit.sh
@@ -36,7 +36,16 @@ mem9_debug "UserPromptSubmit" "recall_request" \
   "auth_source" "${MEM9_AUTH_SOURCE:-unknown}"
 
 encoded_prompt="$(printf '%s' "${prompt}" | node -e 'const fs=require("node:fs"); const raw=fs.readFileSync(0, "utf8").trim(); process.stdout.write(encodeURIComponent(raw));')"
+response=""
 if ! response="$(mem9_api_get "/memories?q=${encoded_prompt}&limit=10" 2>/dev/null)"; then
+  quota_notice="$(printf '%s' "${response:-}" | mem9_quota_notice_from_body "recall paused")"
+  if [[ -n "${quota_notice}" ]]; then
+    mem9_debug "UserPromptSubmit" "recall_quota_denied" \
+      "prompt_length" "${#prompt}"
+    mem9_emit_context "UserPromptSubmit" "${quota_notice}"
+    exit 0
+  fi
+
   mem9_debug "UserPromptSubmit" "recall_request_failed" \
     "prompt_length" "${#prompt}"
   exit 0

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Persistent memory for Codex. Run $mem9:setup once, then mem9 recalls before prompts and saves recent turns on stop.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/hooks/stop.mjs
+++ b/codex-plugin/hooks/stop.mjs
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { loadRuntimeStateFromDisk } from "../lib/config.mjs";
 import { appendDebugError, appendDebugLog } from "./shared/debug.mjs";
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../lib/http.mjs";
+import { parseRuntimeQuotaDenied } from "../lib/quota-error.mjs";
 import { parseTranscriptText, selectStopWindow } from "./shared/transcript.mjs";
 
 export const STOP_MAX_MESSAGES = 20;
@@ -87,11 +88,25 @@ export async function runStop(input) {
     messages,
   };
 
-  await input.post(
-    buildIngestUrl(input.runtime.baseUrl),
-    body,
-    { timeoutMs: input.runtime.defaultTimeoutMs },
-  );
+  try {
+    await input.post(
+      buildIngestUrl(input.runtime.baseUrl),
+      body,
+      { timeoutMs: input.runtime.defaultTimeoutMs },
+    );
+  } catch (error) {
+    const quotaDenied = parseRuntimeQuotaDenied(error);
+    if (!quotaDenied) {
+      throw error;
+    }
+
+    debug("ingest_quota_denied", {
+      code: quotaDenied.code,
+      actionType: quotaDenied.recommendedAction?.type,
+      hasActionUrl: Boolean(quotaDenied.recommendedAction?.url),
+    });
+    return undefined;
+  }
   debug("ingest_sent", {
     selectedMessageCount: messages.length,
     selectedBytes,

--- a/codex-plugin/hooks/user-prompt-submit.mjs
+++ b/codex-plugin/hooks/user-prompt-submit.mjs
@@ -7,6 +7,7 @@ import { loadRuntimeStateFromDisk } from "../lib/config.mjs";
 import { appendDebugError, appendDebugLog } from "./shared/debug.mjs";
 import { formatMemoriesBlock, hookAdditionalContext, stripInjectedMemories } from "./shared/format.mjs";
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../lib/http.mjs";
+import { formatRuntimeQuotaNotice, parseRuntimeQuotaDenied } from "../lib/quota-error.mjs";
 
 const RECALL_LIMIT = 10;
 
@@ -103,10 +104,28 @@ export async function runUserPromptSubmit(input) {
     queryChars: query.length,
     timeoutMs: input.runtime.searchTimeoutMs,
   });
-  const result = await input.search(
-    buildRecallUrl(input.runtime.baseUrl, query),
-    { timeoutMs: input.runtime.searchTimeoutMs },
-  );
+  let result;
+  try {
+    result = await input.search(
+      buildRecallUrl(input.runtime.baseUrl, query),
+      { timeoutMs: input.runtime.searchTimeoutMs },
+    );
+  } catch (error) {
+    const quotaDenied = parseRuntimeQuotaDenied(error);
+    if (!quotaDenied) {
+      throw error;
+    }
+
+    debug("recall_quota_denied", {
+      code: quotaDenied.code,
+      actionType: quotaDenied.recommendedAction?.type,
+      hasActionUrl: Boolean(quotaDenied.recommendedAction?.url),
+    });
+    return hookAdditionalContext(
+      "UserPromptSubmit",
+      formatRuntimeQuotaNotice(error, "recall paused"),
+    );
+  }
   const memories = extractMemories(result).slice(0, RECALL_LIMIT);
   debug("recall_response", {
     memoryCount: memories.length,

--- a/codex-plugin/lib/http.mjs
+++ b/codex-plugin/lib/http.mjs
@@ -11,6 +11,46 @@ import { DEFAULT_REQUEST_TIMEOUT_MS } from "./config.mjs";
  * }} Mem9FetchOptions
  */
 
+export class Mem9HttpError extends Error {
+  constructor(message, { status, body, data } = {}) {
+    super(message);
+    this.name = "Mem9HttpError";
+    this.status = status;
+    this.body = body ?? "";
+    this.data = data;
+  }
+}
+
+function parseJsonOrNull(text) {
+  if (!text) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function errorMessageFromBody(status, body, data) {
+  if (data && typeof data === "object") {
+    if (typeof data.message === "string" && data.message.trim()) {
+      return data.message.trim();
+    }
+    if (typeof data.error === "string" && data.error.trim()) {
+      return data.error.trim();
+    }
+  }
+
+  const text = String(body ?? "").trim();
+  if (text) {
+    return text;
+  }
+
+  return `HTTP ${status}`;
+}
+
 export async function mem9FetchJson(url, options = {}) {
   const response = await fetch(url, {
     method: options.method ?? "GET",
@@ -23,7 +63,15 @@ export async function mem9FetchJson(url, options = {}) {
 
   if (!response.ok) {
     const body = await response.text();
-    throw new Error(`mem9 request failed (${response.status}): ${body}`);
+    const data = parseJsonOrNull(body);
+    throw new Mem9HttpError(
+      `mem9 request failed (${response.status}): ${errorMessageFromBody(response.status, body, data)}`,
+      {
+        status: response.status,
+        body,
+        data,
+      },
+    );
   }
 
   if (response.status === 204) {

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -1,0 +1,128 @@
+// @ts-nocheck
+
+import { Mem9HttpError } from "./http.mjs";
+
+const QUOTA_CODES = new Set([
+  "quota_exhausted",
+  "spending_limit_exceeded",
+  "runtime_quota_denied",
+]);
+
+function isRecord(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function normalizeString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function payloadFromUnknown(value) {
+  if (value instanceof Mem9HttpError) {
+    return value.data;
+  }
+
+  if (isRecord(value) && isRecord(value.data)) {
+    return value.data;
+  }
+
+  return value;
+}
+
+function statusFromUnknown(value) {
+  if (value instanceof Mem9HttpError && typeof value.status === "number") {
+    return value.status;
+  }
+
+  if (isRecord(value) && typeof value.status === "number") {
+    return value.status;
+  }
+
+  return null;
+}
+
+function normalizeRecommendedAction(details) {
+  const current = isRecord(details.recommendedAction)
+    ? details.recommendedAction
+    : {};
+  const type = normalizeString(current.type ?? details.upgradeAction);
+  const bindingState = normalizeString(current.bindingState ?? details.bindingState);
+  const url = normalizeString(current.url ?? details.upgradeUrl);
+
+  if (!type && !bindingState && !url) {
+    return null;
+  }
+
+  return {
+    ...(bindingState ? { bindingState } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+function actionLabel(type) {
+  switch (type) {
+    case "claimApiKey":
+      return "Claim this API key";
+    case "upgradePlan":
+      return "Upgrade your plan";
+    case "increaseSpendingLimit":
+      return "Increase your spending limit";
+    case "enableOnDemand":
+      return "Enable on-demand usage";
+    case "resolveAccountState":
+      return "Resolve account state";
+    default:
+      return "Open mem9 console";
+  }
+}
+
+export function parseRuntimeQuotaDenied(value) {
+  const payload = payloadFromUnknown(value);
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const details = isRecord(payload.details) ? payload.details : {};
+  const code = normalizeString(payload.code);
+  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
+  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+    return null;
+  }
+
+  const message = normalizeString(payload.message) || "runtime usage quota denied";
+  return {
+    status: statusFromUnknown(value),
+    code: code || "runtime_quota_denied",
+    message,
+    details,
+    recommendedAction: normalizeRecommendedAction(details),
+  };
+}
+
+export function runtimeQuotaDeniedSummary(value) {
+  const denied = parseRuntimeQuotaDenied(value);
+  if (!denied) {
+    return null;
+  }
+
+  return {
+    status: "quota_denied",
+    code: denied.code,
+    message: denied.message,
+    ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
+  };
+}
+
+export function formatRuntimeQuotaNotice(value, operation = "mem9 request") {
+  const denied = parseRuntimeQuotaDenied(value);
+  if (!denied) {
+    return "";
+  }
+
+  const action = denied.recommendedAction;
+  const actionUrl = normalizeString(action?.url);
+  const actionText = actionUrl
+    ? ` ${actionLabel(normalizeString(action?.type))}: ${actionUrl}`
+    : "";
+  return `[mem9] ${operation}: ${denied.message}.${actionText}`;
+}

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -59,25 +59,79 @@ function normalizeRecommendedAction(details) {
   };
 }
 
-function actionLabel(type) {
-  switch (type) {
-    case "claimApiKey":
-      return "Claim this API key";
-    case "upgradePlan":
-      return "Upgrade your plan";
-    case "increaseSpendingLimit":
-      return "Increase your spending limit";
-    case "enableOnDemand":
-      return "Enable on-demand usage";
-    case "resolveAccountState":
-      return "Resolve account state";
-    default:
-      return "Open mem9 console";
+function quotaReason(denied) {
+  const actionType = normalizeString(denied.recommendedAction?.type);
+  if (actionType === "claimApiKey") {
+    return "the included usage quota for this API key has been used up";
   }
+  if (actionType === "increaseSpendingLimit" || denied.code === "spending_limit_exceeded") {
+    return "the configured spending limit would be exceeded";
+  }
+  if (actionType === "enableOnDemand") {
+    return "the included usage quota has been used up and on-demand usage is not enabled";
+  }
+  if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
+    return "the included usage quota for this mem9 account has been used up";
+  }
+  return "the runtime quota check blocked this request";
 }
 
-function sentence(message) {
-  return /[.!?]$/.test(message) ? message : `${message}.`;
+function quotaNoticeSubject(denied, operation) {
+  const meter = normalizeString(denied.meter);
+  if (meter === "memory_write_requests") {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (meter === "memory_recall_requests") {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  const operationText = normalizeString(operation).toLowerCase();
+  if (/\b(ingest|save|store|write)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (/\b(recall|search)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  return {
+    headline: "Mem9 memory is temporarily unavailable",
+    userState: "mem9 cannot complete the memory request right now",
+  };
+}
+
+function actionInstruction(action) {
+  const actionType = normalizeString(action?.type);
+  const actionUrl = normalizeString(action?.url);
+  if (!actionUrl) {
+    return "Ask them to open the mem9 console to resolve the account or billing state.";
+  }
+
+  switch (actionType) {
+    case "claimApiKey":
+      return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
+    case "upgradePlan":
+      return `Ask them to open this link to upgrade their mem9 plan and get more included usage: ${actionUrl}. Include the link exactly as written.`;
+    case "increaseSpendingLimit":
+      return `Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${actionUrl}. Include the link exactly as written.`;
+    case "enableOnDemand":
+      return `Ask them to open this link to enable billing or on-demand usage for mem9: ${actionUrl}. Include the link exactly as written.`;
+    case "resolveAccountState":
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${actionUrl}. Include the link exactly as written.`;
+    default:
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${actionUrl}. Include the link exactly as written.`;
+  }
 }
 
 export function parseRuntimeQuotaDenied(value) {
@@ -98,6 +152,7 @@ export function parseRuntimeQuotaDenied(value) {
     status: statusFromUnknown(value),
     code: code || "runtime_quota_denied",
     message,
+    meter: normalizeString(details.meter),
     details,
     recommendedAction: normalizeRecommendedAction(details),
   };
@@ -123,13 +178,6 @@ export function formatRuntimeQuotaNotice(value, operation = "mem9 request") {
     return "";
   }
 
-  const action = denied.recommendedAction;
-  const actionUrl = normalizeString(action?.url);
-  const actionText = actionUrl
-    ? ` User action required: ${actionLabel(normalizeString(action?.type))}: ${actionUrl}`
-    : "";
-  const replyInstruction = actionUrl
-    ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${actionUrl}`
-    : " In your reply, briefly tell the user mem9 memory is paused.";
-  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}${replyInstruction}`;
+  const subject = quotaNoticeSubject(denied, operation);
+  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied.recommendedAction)}`;
 }

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -2,13 +2,6 @@
 
 import { Mem9HttpError } from "./http.mjs";
 
-const QUOTA_CODES = new Set([
-  "quota_exhausted",
-  "post_quota_rate_limited",
-  "spending_limit_exceeded",
-  "runtime_access_blocked",
-  "runtime_quota_denied",
-]);
 const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 function isRecord(value) {
@@ -51,40 +44,44 @@ function statusFromUnknown(value) {
   return null;
 }
 
-function normalizeRecommendedAction(details) {
-  const current = isRecord(details.recommendedAction)
-    ? details.recommendedAction
+function normalizeRecommendedAction(runtimeQuota) {
+  const current = isRecord(runtimeQuota.recommendedAction)
+    ? runtimeQuota.recommendedAction
     : {};
-  const type = normalizeString(current.type ?? details.upgradeAction);
-  const bindingState = normalizeString(current.bindingState ?? details.bindingState);
-  const url = normalizeString(current.url ?? details.upgradeUrl);
+  const bindingState = normalizeString(current.bindingState);
+  const providerActionCode = normalizeString(current.providerActionCode);
+  const severity = normalizeString(current.severity);
+  const type = normalizeString(current.type);
+  const url = normalizeString(current.url);
 
-  if (!type && !bindingState && !url) {
+  if (!type && !bindingState && !providerActionCode && !severity && !url) {
     return null;
   }
 
   return {
     ...(bindingState ? { bindingState } : {}),
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
     ...(type ? { type } : {}),
     ...(url ? { url } : {}),
   };
 }
 
-function quotaGateReason(details) {
-  const quotaGateResult = isRecord(details.quotaGateResult)
-    ? details.quotaGateResult
+function quotaGateReason(runtimeQuota) {
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult)
+    ? runtimeQuota.quotaGateResult
     : {};
   return normalizeString(quotaGateResult.reason);
 }
 
-function retryAfterSeconds(details) {
-  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+function retryAfterSeconds(runtimeQuota) {
+  const direct = normalizePositiveInteger(runtimeQuota.retryAfterSeconds);
   if (direct != null) {
     return direct;
   }
 
-  const quotaGateResult = isRecord(details.quotaGateResult)
-    ? details.quotaGateResult
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult)
+    ? runtimeQuota.quotaGateResult
     : {};
   const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit)
     ? quotaGateResult.postQuotaRateLimit
@@ -94,7 +91,6 @@ function retryAfterSeconds(details) {
 
 function isPostQuotaRateLimited(denied) {
   return denied.status === 429 ||
-    denied.code === "post_quota_rate_limited" ||
     denied.quotaGateReason === "postQuotaRateLimitExceeded";
 }
 
@@ -102,20 +98,20 @@ function quotaReason(denied) {
   if (isPostQuotaRateLimited(denied)) {
     return "this API key has reached the temporary request limit for this memory feature";
   }
-  const actionType = normalizeString(denied.recommendedAction?.type);
-  if (actionType === "claimApiKey") {
+  const providerActionCode = normalizeString(denied.recommendedAction?.providerActionCode);
+  if (providerActionCode === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
   }
-  if (actionType === "increaseSpendingLimit" || denied.code === "spending_limit_exceeded") {
+  if (providerActionCode === "increaseSpendingLimit") {
     return "the configured spending limit would be exceeded";
   }
-  if (actionType === "enableOnDemand") {
+  if (providerActionCode === "enableOnDemand") {
     return "the included usage quota has been used up and on-demand usage is not enabled";
   }
-  if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
+  if (providerActionCode === "upgradePlan") {
     return "the included usage quota for this mem9 account has been used up";
   }
-  if (denied.code === "runtime_access_blocked") {
+  if (providerActionCode === "resolveAccountState") {
     return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
@@ -166,7 +162,7 @@ function actionUrlForDenied(denied) {
 
 function actionInstruction(denied) {
   const action = denied.recommendedAction;
-  const actionType = normalizeString(action?.type);
+  const providerActionCode = normalizeString(action?.providerActionCode);
   const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
   if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
@@ -176,7 +172,7 @@ function actionInstruction(denied) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 
-  switch (actionType) {
+  switch (providerActionCode) {
     case "claimApiKey":
       return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
     case "upgradePlan":
@@ -199,22 +195,21 @@ export function parseRuntimeQuotaDenied(value) {
   }
 
   const details = isRecord(payload.details) ? payload.details : {};
-  const code = normalizeString(payload.code);
-  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
-  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+  if (normalizeString(details.errorCategory) !== "runtime_quota_denied") {
     return null;
   }
+  const runtimeQuota = isRecord(details.runtimeQuota) ? details.runtimeQuota : {};
 
-  const message = normalizeString(payload.message) || "runtime usage quota denied";
+  const message = normalizeString(payload.error) || "Runtime usage quota denied.";
   return {
     status: statusFromUnknown(value),
-    code: code || "runtime_quota_denied",
+    code: "runtime_quota_denied",
     message,
-    meter: normalizeString(details.meter),
+    meter: normalizeString(runtimeQuota.meter),
     details,
-    quotaGateReason: quotaGateReason(details),
-    retryAfterSeconds: retryAfterSeconds(details),
-    recommendedAction: normalizeRecommendedAction(details),
+    quotaGateReason: quotaGateReason(runtimeQuota),
+    retryAfterSeconds: retryAfterSeconds(runtimeQuota),
+    recommendedAction: normalizeRecommendedAction(runtimeQuota),
   };
 }
 

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -126,7 +126,10 @@ export function formatRuntimeQuotaNotice(value, operation = "mem9 request") {
   const action = denied.recommendedAction;
   const actionUrl = normalizeString(action?.url);
   const actionText = actionUrl
-    ? ` ${actionLabel(normalizeString(action?.type))}: ${actionUrl}`
+    ? ` User action required: ${actionLabel(normalizeString(action?.type))}: ${actionUrl}`
     : "";
-  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}`;
+  const replyInstruction = actionUrl
+    ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${actionUrl}`
+    : " In your reply, briefly tell the user mem9 memory is paused.";
+  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}${replyInstruction}`;
 }

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -4,7 +4,9 @@ import { Mem9HttpError } from "./http.mjs";
 
 const QUOTA_CODES = new Set([
   "quota_exhausted",
+  "post_quota_rate_limited",
   "spending_limit_exceeded",
+  "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
 
@@ -14,6 +16,14 @@ function isRecord(value) {
 
 function normalizeString(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizePositiveInteger(value) {
+  const number = typeof value === "number" ? value : Number.NaN;
+  if (!Number.isInteger(number) || number <= 0) {
+    return null;
+  }
+  return number;
 }
 
 function payloadFromUnknown(value) {
@@ -59,7 +69,38 @@ function normalizeRecommendedAction(details) {
   };
 }
 
+function quotaGateReason(details) {
+  const quotaGateResult = isRecord(details.quotaGateResult)
+    ? details.quotaGateResult
+    : {};
+  return normalizeString(quotaGateResult.reason);
+}
+
+function retryAfterSeconds(details) {
+  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+  if (direct != null) {
+    return direct;
+  }
+
+  const quotaGateResult = isRecord(details.quotaGateResult)
+    ? details.quotaGateResult
+    : {};
+  const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit)
+    ? quotaGateResult.postQuotaRateLimit
+    : {};
+  return normalizePositiveInteger(postQuotaRateLimit.retryAfterSeconds);
+}
+
+function isPostQuotaRateLimited(denied) {
+  return denied.status === 429 ||
+    denied.code === "post_quota_rate_limited" ||
+    denied.quotaGateReason === "postQuotaRateLimitExceeded";
+}
+
 function quotaReason(denied) {
+  if (isPostQuotaRateLimited(denied)) {
+    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+  }
   const actionType = normalizeString(denied.recommendedAction?.type);
   if (actionType === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
@@ -72,6 +113,9 @@ function quotaReason(denied) {
   }
   if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
     return "the included usage quota for this mem9 account has been used up";
+  }
+  if (denied.code === "runtime_access_blocked") {
+    return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
 }
@@ -111,9 +155,25 @@ function quotaNoticeSubject(denied, operation) {
   };
 }
 
-function actionInstruction(action) {
+function retryInstruction(denied) {
+  if (denied.retryAfterSeconds != null) {
+    const unit = denied.retryAfterSeconds === 1 ? "second" : "seconds";
+    return `Ask them to wait ${denied.retryAfterSeconds} ${unit} before trying again.`;
+  }
+  return "Ask them to wait briefly before trying again.";
+}
+
+function actionInstruction(denied) {
+  const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
   const actionUrl = normalizeString(action?.url);
+  if (isPostQuotaRateLimited(denied)) {
+    const retry = retryInstruction(denied);
+    if (!actionUrl) {
+      return retry;
+    }
+    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+  }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
@@ -154,6 +214,8 @@ export function parseRuntimeQuotaDenied(value) {
     message,
     meter: normalizeString(details.meter),
     details,
+    quotaGateReason: quotaGateReason(details),
+    retryAfterSeconds: retryAfterSeconds(details),
     recommendedAction: normalizeRecommendedAction(details),
   };
 }
@@ -168,6 +230,7 @@ export function runtimeQuotaDeniedSummary(value) {
     status: "quota_denied",
     code: denied.code,
     message: denied.message,
+    ...(denied.retryAfterSeconds != null ? { retryAfterSeconds: denied.retryAfterSeconds } : {}),
     ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
   };
 }
@@ -179,5 +242,5 @@ export function formatRuntimeQuotaNotice(value, operation = "mem9 request") {
   }
 
   const subject = quotaNoticeSubject(denied, operation);
-  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied.recommendedAction)}`;
+  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied)}`;
 }

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -99,7 +99,7 @@ function isPostQuotaRateLimited(denied) {
 
 function quotaReason(denied) {
   if (isPostQuotaRateLimited(denied)) {
-    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+    return "this API key has reached the temporary request limit for this memory feature";
   }
   const actionType = normalizeString(denied.recommendedAction?.type);
   if (actionType === "claimApiKey") {
@@ -172,7 +172,7 @@ function actionInstruction(denied) {
     if (!actionUrl) {
       return retry;
     }
-    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -9,6 +9,7 @@ const QUOTA_CODES = new Set([
   "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
+const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 function isRecord(value) {
   return value != null && typeof value === "object" && !Array.isArray(value);
@@ -155,24 +156,20 @@ function quotaNoticeSubject(denied, operation) {
   };
 }
 
-function retryInstruction(denied) {
-  if (denied.retryAfterSeconds != null) {
-    const unit = denied.retryAfterSeconds === 1 ? "second" : "seconds";
-    return `Ask them to wait ${denied.retryAfterSeconds} ${unit} before trying again.`;
+function actionUrlForDenied(denied) {
+  const actionUrl = normalizeString(denied.recommendedAction?.url);
+  if (actionUrl) {
+    return actionUrl;
   }
-  return "Ask them to wait briefly before trying again.";
+  return isPostQuotaRateLimited(denied) ? DEFAULT_BILLING_ACTION_URL : "";
 }
 
 function actionInstruction(denied) {
   const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
-  const actionUrl = normalizeString(action?.url);
+  const actionUrl = actionUrlForDenied(denied);
   if (isPostQuotaRateLimited(denied)) {
-    const retry = retryInstruction(denied);
-    if (!actionUrl) {
-      return retry;
-    }
-    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
@@ -225,6 +222,7 @@ export function runtimeQuotaDeniedSummary(value) {
   if (!denied) {
     return null;
   }
+  const actionUrl = actionUrlForDenied(denied);
 
   return {
     status: "quota_denied",
@@ -232,6 +230,7 @@ export function runtimeQuotaDeniedSummary(value) {
     message: denied.message,
     ...(denied.retryAfterSeconds != null ? { retryAfterSeconds: denied.retryAfterSeconds } : {}),
     ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
+    ...(actionUrl ? { actionUrl } : {}),
   };
 }
 

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -2,8 +2,6 @@
 
 import { Mem9HttpError } from "./http.mjs";
 
-const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
-
 function isRecord(value) {
   return value != null && typeof value === "object" && !Array.isArray(value);
 }
@@ -48,18 +46,16 @@ function normalizeRecommendedAction(runtimeQuota) {
   const current = isRecord(runtimeQuota.recommendedAction)
     ? runtimeQuota.recommendedAction
     : {};
-  const bindingState = normalizeString(current.bindingState);
   const providerActionCode = normalizeString(current.providerActionCode);
   const severity = normalizeString(current.severity);
   const type = normalizeString(current.type);
   const url = normalizeString(current.url);
 
-  if (!type && !bindingState && !providerActionCode && !severity && !url) {
+  if (!type && !providerActionCode && !severity && !url) {
     return null;
   }
 
   return {
-    ...(bindingState ? { bindingState } : {}),
     ...(providerActionCode ? { providerActionCode } : {}),
     ...(severity ? { severity } : {}),
     ...(type ? { type } : {}),
@@ -153,22 +149,17 @@ function quotaNoticeSubject(denied, operation) {
 }
 
 function actionUrlForDenied(denied) {
-  const actionUrl = normalizeString(denied.recommendedAction?.url);
-  if (actionUrl) {
-    return actionUrl;
-  }
-  return isPostQuotaRateLimited(denied) ? DEFAULT_BILLING_ACTION_URL : "";
+  return normalizeString(denied.recommendedAction?.url);
 }
 
 function actionInstruction(denied) {
   const action = denied.recommendedAction;
   const providerActionCode = normalizeString(action?.providerActionCode);
-  const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
-  if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
-    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
-  }
   if (!actionUrl) {
+    if (isPostQuotaRateLimited(denied)) {
+      return "Tell them that the quota/rate-limit check blocked this request and to retry later or open the mem9 console to review account and billing settings.";
+    }
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -76,6 +76,10 @@ function actionLabel(type) {
   }
 }
 
+function sentence(message) {
+  return /[.!?]$/.test(message) ? message : `${message}.`;
+}
+
 export function parseRuntimeQuotaDenied(value) {
   const payload = payloadFromUnknown(value);
   if (!isRecord(payload)) {
@@ -124,5 +128,5 @@ export function formatRuntimeQuotaNotice(value, operation = "mem9 request") {
   const actionText = actionUrl
     ? ` ${actionLabel(normalizeString(action?.type))}: ${actionUrl}`
     : "";
-  return `[mem9] ${operation}: ${denied.message}.${actionText}`;
+  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}`;
 }

--- a/codex-plugin/lib/quota-error.mjs
+++ b/codex-plugin/lib/quota-error.mjs
@@ -167,8 +167,9 @@ function actionUrlForDenied(denied) {
 function actionInstruction(denied) {
   const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
+  const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
-  if (isPostQuotaRateLimited(denied)) {
+  if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
     return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {

--- a/codex-plugin/package.json
+++ b/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/codex-plugin",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Persistent memory for Codex with setup-driven hooks, prompt recall, and stop-time save.",
   "type": "module",
   "license": "Apache-2.0",

--- a/codex-plugin/skills/recall/scripts/recall.mjs
+++ b/codex-plugin/skills/recall/scripts/recall.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../../../lib/http.mjs";
+import { runtimeQuotaDeniedSummary } from "../../../lib/quota-error.mjs";
 import { loadReadyRuntimeState } from "../../../lib/skill-runtime.mjs";
 
 const DEFAULT_LIMIT = 10;
@@ -165,18 +166,38 @@ export async function runRecall(argv = process.argv.slice(2), options = {}) {
     env: options.env,
   });
   const fetchJson = options.fetchJson ?? mem9FetchJson;
-  const payload = await fetchJson(
-    buildRecallUrl(
-      state.runtime.baseUrl,
+  let payload;
+  try {
+    payload = await fetchJson(
+      buildRecallUrl(
+        state.runtime.baseUrl,
+        query,
+        args.limit,
+      ),
+      {
+        method: "GET",
+        headers: mem9Headers(state.runtime.apiKey, state.runtime.agentId),
+        timeoutMs: state.runtime.searchTimeoutMs,
+      },
+    );
+  } catch (error) {
+    const quotaSummary = runtimeQuotaDeniedSummary(error);
+    if (!quotaSummary) {
+      throw error;
+    }
+
+    const summary = {
+      ...quotaSummary,
+      profileId: state.runtime.profileId,
+      configSource: state.configSource,
       query,
-      args.limit,
-    ),
-    {
-      method: "GET",
-      headers: mem9Headers(state.runtime.apiKey, state.runtime.agentId),
-      timeoutMs: state.runtime.searchTimeoutMs,
-    },
-  );
+      memoryCount: 0,
+      memories: [],
+    };
+    const stdout = options.stdout ?? process.stdout;
+    stdout?.write?.(`${JSON.stringify(summary)}\n`);
+    return summary;
+  }
   const memories = extractMemories(payload)
     .slice(0, args.limit)
     .map(normalizeMemorySummary)

--- a/codex-plugin/skills/store/scripts/store.mjs
+++ b/codex-plugin/skills/store/scripts/store.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../../../lib/http.mjs";
+import { runtimeQuotaDeniedSummary } from "../../../lib/quota-error.mjs";
 import { loadReadyRuntimeState } from "../../../lib/skill-runtime.mjs";
 
 function normalizeString(value) {
@@ -111,18 +112,35 @@ export async function runStore(argv = process.argv.slice(2), options = {}) {
     env: options.env,
   });
   const fetchJson = options.fetchJson ?? mem9FetchJson;
-  await fetchJson(
-    buildMem9Url(state.runtime.baseUrl, "v1alpha2/mem9s/memories").toString(),
-    {
-      method: "POST",
-      headers: mem9Headers(state.runtime.apiKey, state.runtime.agentId),
-      body: JSON.stringify({
-        content,
-        sync: true,
-      }),
-      timeoutMs: state.runtime.defaultTimeoutMs,
-    },
-  );
+  try {
+    await fetchJson(
+      buildMem9Url(state.runtime.baseUrl, "v1alpha2/mem9s/memories").toString(),
+      {
+        method: "POST",
+        headers: mem9Headers(state.runtime.apiKey, state.runtime.agentId),
+        body: JSON.stringify({
+          content,
+          sync: true,
+        }),
+        timeoutMs: state.runtime.defaultTimeoutMs,
+      },
+    );
+  } catch (error) {
+    const quotaSummary = runtimeQuotaDeniedSummary(error);
+    if (!quotaSummary) {
+      throw error;
+    }
+
+    const summary = {
+      ...quotaSummary,
+      profileId: state.runtime.profileId,
+      configSource: state.configSource,
+      contentChars: content.length,
+    };
+    const stdout = options.stdout ?? process.stdout;
+    stdout?.write?.(`${JSON.stringify(summary)}\n`);
+    return summary;
+  }
 
   const summary = {
     status: "ok",

--- a/codex-plugin/tests/plugin-files.test.mjs
+++ b/codex-plugin/tests/plugin-files.test.mjs
@@ -12,11 +12,11 @@ test("plugin manifest exposes mem9 setup skill and basic metadata", () => {
   );
 
   assert.equal(manifest.name, "mem9");
-  assert.equal(manifest.version, "0.2.3");
+  assert.equal(manifest.version, "0.2.4");
   assert.equal(manifest.skills, "./skills/");
   assert.equal(typeof manifest.description, "string");
   assert.match(manifest.description, /\$mem9:setup/);
-  assert.equal(packageManifest.version, "0.2.3");
+  assert.equal(packageManifest.version, "0.2.4");
   assert.equal(packageManifest.version, manifest.version);
   assert.equal(packageManifest.engines.node, ">=22");
   assert.equal(packageManifest.files.includes("lib/"), true);

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -193,7 +193,6 @@ test("runRecall returns a structured runtime quota denial summary", async () => 
           status: 402,
           data: runtimeQuotaPayload("Included quota is exhausted.", {
             recommendedAction: {
-              bindingState: "unclaimed",
               providerActionCode: "claimApiKey",
               type: "openUrl",
               url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -214,7 +213,6 @@ test("runRecall returns a structured runtime quota denial summary", async () => 
   assert.equal(quotaResult.code, "runtime_quota_denied");
   assert.equal(quotaResult.memoryCount, 0);
   assert.deepEqual(quotaResult.recommendedAction, {
-    bindingState: "unclaimed",
     providerActionCode: "claimApiKey",
     type: "openUrl",
     url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -270,7 +268,7 @@ test("runRecall returns a structured post-quota rate limit summary", async () =>
   assert.equal(quotaResult.status, "quota_denied");
   assert.equal(quotaResult.code, "runtime_quota_denied");
   assert.equal(quotaResult.retryAfterSeconds, 23);
-  assert.equal(quotaResult.actionUrl, "https://console.mem9.ai/console/billing/plan");
+  assert.equal(quotaResult.actionUrl, undefined);
   assert.equal(quotaResult.memoryCount, 0);
   assert.deepEqual(JSON.parse(stdoutText), quotaResult);
   assert.equal(stdoutText.includes("key-search"), false);

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -12,6 +12,20 @@ import { Mem9HttpError } from "../lib/http.mjs";
 import { buildRuntimeIssueMessage } from "../lib/skill-runtime.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
+/**
+ * @param {string} error
+ * @param {Record<string, unknown>} [runtimeQuota]
+ */
+function runtimeQuotaPayload(error, runtimeQuota = {}) {
+  return {
+    error,
+    details: {
+      errorCategory: "runtime_quota_denied",
+      runtimeQuota,
+    },
+  };
+}
+
 test("buildRecallUrl encodes q and limit", () => {
   const url = buildRecallUrl("https://api.mem9.ai/", "remember rust tips", 7);
   assert.equal(
@@ -177,18 +191,14 @@ test("runRecall returns a structured runtime quota denial summary", async () => 
       fetchJson: async () => {
         throw new Mem9HttpError("quota denied", {
           status: 402,
-          data: {
-            code: "quota_exhausted",
-            message: "Included quota is exhausted.",
-            details: {
-              mem9Code: "runtime_quota_denied",
-              recommendedAction: {
-                bindingState: "unclaimed",
-                type: "claimApiKey",
-                url: "https://console.mem9.ai/console/claim?key=mem9_test",
-              },
+          data: runtimeQuotaPayload("Included quota is exhausted.", {
+            recommendedAction: {
+              bindingState: "unclaimed",
+              providerActionCode: "claimApiKey",
+              type: "openUrl",
+              url: "https://console.mem9.ai/console/claim?key=mem9_test",
             },
-          },
+          }),
         });
       },
       stdout: {
@@ -201,11 +211,12 @@ test("runRecall returns a structured runtime quota denial summary", async () => 
   const quotaResult = /** @type {any} */ (result);
 
   assert.equal(quotaResult.status, "quota_denied");
-  assert.equal(quotaResult.code, "quota_exhausted");
+  assert.equal(quotaResult.code, "runtime_quota_denied");
   assert.equal(quotaResult.memoryCount, 0);
   assert.deepEqual(quotaResult.recommendedAction, {
     bindingState: "unclaimed",
-    type: "claimApiKey",
+    providerActionCode: "claimApiKey",
+    type: "openUrl",
     url: "https://console.mem9.ai/console/claim?key=mem9_test",
   });
   assert.deepEqual(JSON.parse(stdoutText), quotaResult);
@@ -231,26 +242,20 @@ test("runRecall returns a structured post-quota rate limit summary", async () =>
       fetchJson: async () => {
         throw new Mem9HttpError("rate limited", {
           status: 429,
-          data: {
-            code: "post_quota_rate_limited",
-            message: "Post-quota rate limit exceeded.",
-            details: {
-              mem9Code: "runtime_quota_denied",
-              retryable: true,
-              meter: "memory_recall_requests",
-              quotaGateResult: {
-                outcome: "rateLimited",
-                mode: "postQuota",
-                reason: "postQuotaRateLimitExceeded",
-                postQuotaRateLimit: {
-                  requestsPerMinute: 4,
-                  windowDurationSeconds: 60,
-                  scope: "apiKeyMeter",
-                  retryAfterSeconds: 23,
-                },
+          data: runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+            meter: "memory_recall_requests",
+            quotaGateResult: {
+              outcome: "rateLimited",
+              mode: "postQuota",
+              reason: "postQuotaRateLimitExceeded",
+              postQuotaRateLimit: {
+                requestsPerMinute: 4,
+                windowDurationSeconds: 60,
+                scope: "apiKeyMeter",
+                retryAfterSeconds: 23,
               },
             },
-          },
+          }),
         });
       },
       stdout: {
@@ -263,7 +268,7 @@ test("runRecall returns a structured post-quota rate limit summary", async () =>
   const quotaResult = /** @type {any} */ (result);
 
   assert.equal(quotaResult.status, "quota_denied");
-  assert.equal(quotaResult.code, "post_quota_rate_limited");
+  assert.equal(quotaResult.code, "runtime_quota_denied");
   assert.equal(quotaResult.retryAfterSeconds, 23);
   assert.equal(quotaResult.actionUrl, "https://console.mem9.ai/console/billing/plan");
   assert.equal(quotaResult.memoryCount, 0);

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -265,6 +265,7 @@ test("runRecall returns a structured post-quota rate limit summary", async () =>
   assert.equal(quotaResult.status, "quota_denied");
   assert.equal(quotaResult.code, "post_quota_rate_limited");
   assert.equal(quotaResult.retryAfterSeconds, 23);
+  assert.equal(quotaResult.actionUrl, "https://console.mem9.ai/console/billing/plan");
   assert.equal(quotaResult.memoryCount, 0);
   assert.deepEqual(JSON.parse(stdoutText), quotaResult);
   assert.equal(stdoutText.includes("key-search"), false);

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -8,6 +8,7 @@ import {
   main,
   runRecall,
 } from "../skills/recall/scripts/recall.mjs";
+import { Mem9HttpError } from "../lib/http.mjs";
 import { buildRuntimeIssueMessage } from "../lib/skill-runtime.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
@@ -155,6 +156,60 @@ test("runRecall accepts the query from stdin text", async () => {
   );
 
   assert.equal(result.query, "release checklist");
+});
+
+test("runRecall returns a structured runtime quota denial summary", async () => {
+  let stdoutText = "";
+
+  const result = await runRecall(
+    ["--query", "team preferences"],
+    {
+      state: {
+        configSource: "project",
+        runtime: {
+          profileId: "work",
+          baseUrl: "https://api.mem9.ai",
+          apiKey: "key-search",
+          agentId: "codex",
+          searchTimeoutMs: 15000,
+        },
+      },
+      fetchJson: async () => {
+        throw new Mem9HttpError("quota denied", {
+          status: 402,
+          data: {
+            code: "quota_exhausted",
+            message: "Included quota is exhausted.",
+            details: {
+              mem9Code: "runtime_quota_denied",
+              recommendedAction: {
+                bindingState: "unclaimed",
+                type: "claimApiKey",
+                url: "https://console.mem9.ai/console/claim?key=mem9_test",
+              },
+            },
+          },
+        });
+      },
+      stdout: {
+        write(/** @type {string} */ chunk) {
+          stdoutText += chunk;
+        },
+      },
+    },
+  );
+  const quotaResult = /** @type {any} */ (result);
+
+  assert.equal(quotaResult.status, "quota_denied");
+  assert.equal(quotaResult.code, "quota_exhausted");
+  assert.equal(quotaResult.memoryCount, 0);
+  assert.deepEqual(quotaResult.recommendedAction, {
+    bindingState: "unclaimed",
+    type: "claimApiKey",
+    url: "https://console.mem9.ai/console/claim?key=mem9_test",
+  });
+  assert.deepEqual(JSON.parse(stdoutText), quotaResult);
+  assert.equal(stdoutText.includes("key-search"), false);
 });
 
 test("runtime helper explains how to repair a missing mem9 api key", () => {

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -212,6 +212,64 @@ test("runRecall returns a structured runtime quota denial summary", async () => 
   assert.equal(stdoutText.includes("key-search"), false);
 });
 
+test("runRecall returns a structured post-quota rate limit summary", async () => {
+  let stdoutText = "";
+
+  const result = await runRecall(
+    ["--query", "team preferences"],
+    {
+      state: {
+        configSource: "project",
+        runtime: {
+          profileId: "work",
+          baseUrl: "https://api.mem9.ai",
+          apiKey: "key-search",
+          agentId: "codex",
+          searchTimeoutMs: 15000,
+        },
+      },
+      fetchJson: async () => {
+        throw new Mem9HttpError("rate limited", {
+          status: 429,
+          data: {
+            code: "post_quota_rate_limited",
+            message: "Post-quota rate limit exceeded.",
+            details: {
+              mem9Code: "runtime_quota_denied",
+              retryable: true,
+              meter: "memory_recall_requests",
+              quotaGateResult: {
+                outcome: "rateLimited",
+                mode: "postQuota",
+                reason: "postQuotaRateLimitExceeded",
+                postQuotaRateLimit: {
+                  requestsPerMinute: 4,
+                  windowDurationSeconds: 60,
+                  scope: "apiKeyMeter",
+                  retryAfterSeconds: 23,
+                },
+              },
+            },
+          },
+        });
+      },
+      stdout: {
+        write(/** @type {string} */ chunk) {
+          stdoutText += chunk;
+        },
+      },
+    },
+  );
+  const quotaResult = /** @type {any} */ (result);
+
+  assert.equal(quotaResult.status, "quota_denied");
+  assert.equal(quotaResult.code, "post_quota_rate_limited");
+  assert.equal(quotaResult.retryAfterSeconds, 23);
+  assert.equal(quotaResult.memoryCount, 0);
+  assert.deepEqual(JSON.parse(stdoutText), quotaResult);
+  assert.equal(stdoutText.includes("key-search"), false);
+});
+
 test("runtime helper explains how to repair a missing mem9 api key", () => {
   const message = buildRuntimeIssueMessage({
     issueCode: "missing_api_key",

--- a/codex-plugin/tests/stop.test.mjs
+++ b/codex-plugin/tests/stop.test.mjs
@@ -507,7 +507,6 @@ test("stop records runtime quota denial without failing the hook", async () => {
         status: 402,
         data: runtimeQuotaPayload("Spending limit is exhausted.", {
           recommendedAction: {
-            bindingState: "claimed",
             providerActionCode: "increaseSpendingLimit",
             type: "openUrl",
             url: "https://console.mem9.ai/console/billing/plan",

--- a/codex-plugin/tests/stop.test.mjs
+++ b/codex-plugin/tests/stop.test.mjs
@@ -14,6 +14,7 @@ import {
   parseTranscriptText,
   selectStopWindow,
 } from "../hooks/shared/transcript.mjs";
+import { Mem9HttpError } from "../lib/http.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
 const STOP_ENTRY = path.resolve("./hooks/stop.mjs");
@@ -469,6 +470,56 @@ test("stop posts smart ingest with a recent message window", async () => {
     debugEvents.map((event) => event.stage),
     ["ingest_window_selected", "ingest_sent"],
   );
+});
+
+test("stop records runtime quota denial without failing the hook", async () => {
+  /** @type {Array<{stage: string, fields: Record<string, unknown> | undefined}>} */
+  const debugEvents = [];
+
+  const result = await runStop({
+    sessionId: "session-1",
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      defaultTimeoutMs: 8_000,
+    },
+    transcriptMessages: [
+      { role: "user", content: "u1" },
+      { role: "assistant", content: "a1" },
+    ],
+    async post() {
+      throw new Mem9HttpError("quota denied", {
+        status: 402,
+        data: {
+          code: "spending_limit_exceeded",
+          message: "Spending limit is exhausted.",
+          details: {
+            mem9Code: "runtime_quota_denied",
+            recommendedAction: {
+              type: "increaseSpendingLimit",
+              bindingState: "claimed",
+              url: "https://console.mem9.ai/console/billing/plan",
+            },
+          },
+        },
+      });
+    },
+    debug(stage, fields) {
+      debugEvents.push({ stage, fields });
+    },
+  });
+
+  assert.equal(result, undefined);
+  assert.deepEqual(
+    debugEvents.map((event) => event.stage),
+    ["ingest_window_selected", "ingest_quota_denied"],
+  );
+  assert.deepEqual(debugEvents.at(-1)?.fields, {
+    code: "spending_limit_exceeded",
+    actionType: "increaseSpendingLimit",
+    hasActionUrl: true,
+  });
 });
 
 for (const issueCode of NON_READY_ISSUE_CODES) {

--- a/codex-plugin/tests/stop.test.mjs
+++ b/codex-plugin/tests/stop.test.mjs
@@ -21,6 +21,20 @@ const STOP_ENTRY = path.resolve("./hooks/stop.mjs");
 /** @type {Array<"plugin_disabled" | "plugin_missing" | "legacy_paused">} */
 const NON_READY_ISSUE_CODES = ["plugin_disabled", "plugin_missing", "legacy_paused"];
 
+/**
+ * @param {string} error
+ * @param {Record<string, unknown>} [runtimeQuota]
+ */
+function runtimeQuotaPayload(error, runtimeQuota = {}) {
+  return {
+    error,
+    details: {
+      errorCategory: "runtime_quota_denied",
+      runtimeQuota,
+    },
+  };
+}
+
 test("buildIngestUrl keeps a configured base path", () => {
   assert.equal(
     buildIngestUrl("https://api.mem9.ai/base"),
@@ -491,18 +505,14 @@ test("stop records runtime quota denial without failing the hook", async () => {
     async post() {
       throw new Mem9HttpError("quota denied", {
         status: 402,
-        data: {
-          code: "spending_limit_exceeded",
-          message: "Spending limit is exhausted.",
-          details: {
-            mem9Code: "runtime_quota_denied",
-            recommendedAction: {
-              type: "increaseSpendingLimit",
-              bindingState: "claimed",
-              url: "https://console.mem9.ai/console/billing/plan",
-            },
+        data: runtimeQuotaPayload("Spending limit is exhausted.", {
+          recommendedAction: {
+            bindingState: "claimed",
+            providerActionCode: "increaseSpendingLimit",
+            type: "openUrl",
+            url: "https://console.mem9.ai/console/billing/plan",
           },
-        },
+        }),
       });
     },
     debug(stage, fields) {
@@ -516,8 +526,8 @@ test("stop records runtime quota denial without failing the hook", async () => {
     ["ingest_window_selected", "ingest_quota_denied"],
   );
   assert.deepEqual(debugEvents.at(-1)?.fields, {
-    code: "spending_limit_exceeded",
-    actionType: "increaseSpendingLimit",
+    code: "runtime_quota_denied",
+    actionType: "openUrl",
     hasActionUrl: true,
   });
 });

--- a/codex-plugin/tests/store.test.mjs
+++ b/codex-plugin/tests/store.test.mjs
@@ -154,7 +154,6 @@ test("runStore returns a structured runtime quota denial summary", async () => {
           status: 402,
           data: runtimeQuotaPayload("Spending limit is exhausted.", {
             recommendedAction: {
-              bindingState: "claimed",
               providerActionCode: "increaseSpendingLimit",
               type: "openUrl",
               url: "https://console.mem9.ai/console/billing/plan",
@@ -175,7 +174,6 @@ test("runStore returns a structured runtime quota denial summary", async () => {
   assert.equal(quotaResult.code, "runtime_quota_denied");
   assert.equal(quotaResult.contentChars, "The user prefers concise release notes.".length);
   assert.deepEqual(quotaResult.recommendedAction, {
-    bindingState: "claimed",
     providerActionCode: "increaseSpendingLimit",
     type: "openUrl",
     url: "https://console.mem9.ai/console/billing/plan",

--- a/codex-plugin/tests/store.test.mjs
+++ b/codex-plugin/tests/store.test.mjs
@@ -8,6 +8,20 @@ import { Mem9HttpError } from "../lib/http.mjs";
 import { main, runStore } from "../skills/store/scripts/store.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
+/**
+ * @param {string} error
+ * @param {Record<string, unknown>} [runtimeQuota]
+ */
+function runtimeQuotaPayload(error, runtimeQuota = {}) {
+  return {
+    error,
+    details: {
+      errorCategory: "runtime_quota_denied",
+      runtimeQuota,
+    },
+  };
+}
+
 test("main prints store help without calling mem9", async () => {
   let stdoutText = "";
 
@@ -138,18 +152,14 @@ test("runStore returns a structured runtime quota denial summary", async () => {
       fetchJson: async () => {
         throw new Mem9HttpError("quota denied", {
           status: 402,
-          data: {
-            code: "spending_limit_exceeded",
-            message: "Spending limit is exhausted.",
-            details: {
-              mem9Code: "runtime_quota_denied",
-              recommendedAction: {
-                bindingState: "claimed",
-                type: "increaseSpendingLimit",
-                url: "https://console.mem9.ai/console/billing/plan",
-              },
+          data: runtimeQuotaPayload("Spending limit is exhausted.", {
+            recommendedAction: {
+              bindingState: "claimed",
+              providerActionCode: "increaseSpendingLimit",
+              type: "openUrl",
+              url: "https://console.mem9.ai/console/billing/plan",
             },
-          },
+          }),
         });
       },
       stdout: {
@@ -162,11 +172,12 @@ test("runStore returns a structured runtime quota denial summary", async () => {
   const quotaResult = /** @type {any} */ (result);
 
   assert.equal(quotaResult.status, "quota_denied");
-  assert.equal(quotaResult.code, "spending_limit_exceeded");
+  assert.equal(quotaResult.code, "runtime_quota_denied");
   assert.equal(quotaResult.contentChars, "The user prefers concise release notes.".length);
   assert.deepEqual(quotaResult.recommendedAction, {
     bindingState: "claimed",
-    type: "increaseSpendingLimit",
+    providerActionCode: "increaseSpendingLimit",
+    type: "openUrl",
     url: "https://console.mem9.ai/console/billing/plan",
   });
   assert.deepEqual(JSON.parse(stdoutText), quotaResult);

--- a/codex-plugin/tests/store.test.mjs
+++ b/codex-plugin/tests/store.test.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { buildRuntimeIssueMessage } from "../lib/skill-runtime.mjs";
+import { Mem9HttpError } from "../lib/http.mjs";
 import { main, runStore } from "../skills/store/scripts/store.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
@@ -116,6 +117,61 @@ test("runStore accepts the content from stdin text", async () => {
   );
 
   assert.equal(result.contentChars, "Remember that release notes should stay short.".length);
+});
+
+test("runStore returns a structured runtime quota denial summary", async () => {
+  let stdoutText = "";
+
+  const result = await runStore(
+    ["--content", "The user prefers concise release notes."],
+    {
+      state: {
+        configSource: "global",
+        runtime: {
+          profileId: "default",
+          baseUrl: "https://api.mem9.ai",
+          apiKey: "key-save",
+          agentId: "codex",
+          defaultTimeoutMs: 8000,
+        },
+      },
+      fetchJson: async () => {
+        throw new Mem9HttpError("quota denied", {
+          status: 402,
+          data: {
+            code: "spending_limit_exceeded",
+            message: "Spending limit is exhausted.",
+            details: {
+              mem9Code: "runtime_quota_denied",
+              recommendedAction: {
+                bindingState: "claimed",
+                type: "increaseSpendingLimit",
+                url: "https://console.mem9.ai/console/billing/plan",
+              },
+            },
+          },
+        });
+      },
+      stdout: {
+        write(/** @type {string} */ chunk) {
+          stdoutText += chunk;
+        },
+      },
+    },
+  );
+  const quotaResult = /** @type {any} */ (result);
+
+  assert.equal(quotaResult.status, "quota_denied");
+  assert.equal(quotaResult.code, "spending_limit_exceeded");
+  assert.equal(quotaResult.contentChars, "The user prefers concise release notes.".length);
+  assert.deepEqual(quotaResult.recommendedAction, {
+    bindingState: "claimed",
+    type: "increaseSpendingLimit",
+    url: "https://console.mem9.ai/console/billing/plan",
+  });
+  assert.deepEqual(JSON.parse(stdoutText), quotaResult);
+  assert.equal(stdoutText.includes("key-save"), false);
+  assert.equal(stdoutText.includes("The user prefers concise release notes."), false);
 });
 
 test("runStore keeps a configured base path", async () => {

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -274,7 +274,6 @@ test("user prompt submit renders runtime quota denial action", async () => {
         data: runtimeQuotaPayload("Included quota is exhausted.", {
           meter: "memory_recall_requests",
           recommendedAction: {
-            bindingState: "unclaimed",
             providerActionCode: "claimApiKey",
             type: "openUrl",
             url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -315,7 +314,6 @@ test("runtime quota notice renders spending limit guidance", () => {
       data: runtimeQuotaPayload("On-demand spending limit would be exceeded.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "increaseSpendingLimit",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -380,7 +378,7 @@ test("runtime quota notice ignores generic api rate limits", () => {
   assert.equal(notice, "");
 });
 
-test("runtime quota notice renders post-quota rate limit billing guidance", () => {
+test("runtime quota notice renders post-quota rate limit guidance without action URL", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 429,
@@ -403,13 +401,11 @@ test("runtime quota notice renders post-quota rate limit billing guidance", () =
   );
 
   assert.match(notice, /temporary request limit/);
-  assert.match(notice, /upgrade their mem9 plan or set up billing/);
-  assert.match(notice, /console\/billing\/plan/);
+  assert.match(notice, /quota\/rate-limit check blocked this request/);
+  assert.match(notice, /retry later or open the mem9 console/);
+  assert.doesNotMatch(notice, /console\/billing\/plan/);
   assert.doesNotMatch(notice, /wait 23 seconds before trying again/);
-  assert.equal(
-    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
-    1,
-  );
+  assert.equal((notice.match(/https:\/\//g) ?? []).length, 0);
 });
 
 test("runtime quota notice renders post-quota billing action when provided", () => {
@@ -419,7 +415,6 @@ test("runtime quota notice renders post-quota billing action when provided", () 
       data: runtimeQuotaPayload("Post-quota rate limit exceeded.", {
         meter: "memory_write_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "upgradePlan",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -457,7 +452,6 @@ test("runtime quota notice renders post-quota claim action when provided", () =>
       data: runtimeQuotaPayload("Post-quota rate limit exceeded.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "unclaimed",
           providerActionCode: "claimApiKey",
           type: "openUrl",
           url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -496,7 +490,6 @@ test("runtime quota notice renders write meter guidance", () => {
       data: runtimeQuotaPayload("Included quota is exhausted.", {
         meter: "memory_write_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "upgradePlan",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -274,6 +274,7 @@ test("user prompt submit renders runtime quota denial action", async () => {
   assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(parsed.hookSpecificOutput.additionalContext, /Included quota is exhausted/);
   assert.match(parsed.hookSpecificOutput.additionalContext, /console\/claim\?key=mem9_test/);
+  assert.doesNotMatch(parsed.hookSpecificOutput.additionalContext, /\.\. Claim/);
   assert.equal(debugEvents.at(-1)?.stage, "recall_quota_denied");
   assert.deepEqual(debugEvents.at(-1)?.fields, {
     code: "quota_exhausted",

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -323,7 +323,7 @@ test("runtime quota notice renders spending limit guidance", () => {
   );
 });
 
-test("runtime quota notice renders post-quota rate limit retry guidance", () => {
+test("runtime quota notice renders post-quota rate limit billing guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 429,
@@ -352,8 +352,13 @@ test("runtime quota notice renders post-quota rate limit retry guidance", () => 
   );
 
   assert.match(notice, /temporary request limit/);
-  assert.match(notice, /wait 23 seconds before trying again/);
-  assert.doesNotMatch(notice, /open the mem9 console/);
+  assert.match(notice, /upgrade their mem9 plan or set up billing/);
+  assert.match(notice, /console\/billing\/plan/);
+  assert.doesNotMatch(notice, /wait 23 seconds before trying again/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
 });
 
 test("runtime quota notice renders post-quota billing action when provided", () => {
@@ -390,9 +395,9 @@ test("runtime quota notice renders post-quota billing action when provided", () 
   );
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
-  assert.match(notice, /wait 1 second before trying again/);
-  assert.match(notice, /higher mem9 usage limits/);
+  assert.match(notice, /upgrade their mem9 plan or set up billing/);
   assert.match(notice, /console\/billing\/plan/);
+  assert.doesNotMatch(notice, /wait 1 second before trying again/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
     1,

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -14,6 +14,7 @@ import {
   extractMemories,
   runUserPromptSubmit,
 } from "../hooks/user-prompt-submit.mjs";
+import { Mem9HttpError } from "../lib/http.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
 const USER_PROMPT_SUBMIT_ENTRY = path.resolve("./hooks/user-prompt-submit.mjs");
@@ -232,6 +233,53 @@ test("user prompt submit recalls memories with the search timeout bucket", async
     debugEvents.map((event) => event.stage),
     ["recall_request", "recall_response", "context_injected"],
   );
+});
+
+test("user prompt submit renders runtime quota denial action", async () => {
+  /** @type {Array<{stage: string, fields: Record<string, unknown> | undefined}>} */
+  const debugEvents = [];
+
+  const output = await runUserPromptSubmit({
+    prompt: "remember my preference",
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
+    },
+    async search() {
+      throw new Mem9HttpError("quota denied", {
+        status: 402,
+        data: {
+          code: "quota_exhausted",
+          message: "Included quota is exhausted.",
+          details: {
+            mem9Code: "runtime_quota_denied",
+            recommendedAction: {
+              type: "claimApiKey",
+              bindingState: "unclaimed",
+              url: "https://console.mem9.ai/console/claim?key=mem9_test",
+            },
+          },
+        },
+      });
+    },
+    debug(stage, fields) {
+      debugEvents.push({ stage, fields });
+    },
+  });
+
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Included quota is exhausted/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /console\/claim\?key=mem9_test/);
+  assert.equal(debugEvents.at(-1)?.stage, "recall_quota_denied");
+  assert.deepEqual(debugEvents.at(-1)?.fields, {
+    code: "quota_exhausted",
+    actionType: "claimApiKey",
+    hasActionUrl: true,
+  });
 });
 
 test("user prompt submit skips empty queries after stripping injected memories", async () => {

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -273,6 +273,7 @@ test("user prompt submit renders runtime quota denial action", async () => {
   const parsed = JSON.parse(output);
   assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
   assert.match(parsed.hookSpecificOutput.additionalContext, /Included quota is exhausted/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /include this URL exactly/);
   assert.match(parsed.hookSpecificOutput.additionalContext, /console\/claim\?key=mem9_test/);
   assert.doesNotMatch(parsed.hookSpecificOutput.additionalContext, /\.\. Claim/);
   assert.equal(debugEvents.at(-1)?.stage, "recall_quota_denied");

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -351,8 +351,7 @@ test("runtime quota notice renders post-quota rate limit retry guidance", () => 
     "recall paused",
   );
 
-  assert.match(notice, /post-quota mode/);
-  assert.match(notice, /temporary rate limit/);
+  assert.match(notice, /temporary request limit/);
   assert.match(notice, /wait 23 seconds before trying again/);
   assert.doesNotMatch(notice, /open the mem9 console/);
 });
@@ -392,7 +391,7 @@ test("runtime quota notice renders post-quota billing action when provided", () 
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
   assert.match(notice, /wait 1 second before trying again/);
-  assert.match(notice, /more continuous mem9 usage/);
+  assert.match(notice, /higher mem9 usage limits/);
   assert.match(notice, /console\/billing\/plan/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -323,6 +323,83 @@ test("runtime quota notice renders spending limit guidance", () => {
   );
 });
 
+test("runtime quota notice renders post-quota rate limit retry guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 429,
+      data: {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_recall_requests",
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
+          },
+        },
+      },
+    }),
+    "recall paused",
+  );
+
+  assert.match(notice, /post-quota mode/);
+  assert.match(notice, /temporary rate limit/);
+  assert.match(notice, /wait 23 seconds before trying again/);
+  assert.doesNotMatch(notice, /open the mem9 console/);
+});
+
+test("runtime quota notice renders post-quota billing action when provided", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 429,
+      data: {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_write_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "upgradePlan",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 2,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 1,
+            },
+          },
+        },
+      },
+    }),
+    "memory save paused",
+  );
+
+  assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
+  assert.match(notice, /wait 1 second before trying again/);
+  assert.match(notice, /more continuous mem9 usage/);
+  assert.match(notice, /console\/billing\/plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
 test("runtime quota notice renders write meter guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -15,6 +15,7 @@ import {
   runUserPromptSubmit,
 } from "../hooks/user-prompt-submit.mjs";
 import { Mem9HttpError } from "../lib/http.mjs";
+import { formatRuntimeQuotaNotice } from "../lib/quota-error.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
 const USER_PROMPT_SUBMIT_ENTRY = path.resolve("./hooks/user-prompt-submit.mjs");
@@ -256,6 +257,7 @@ test("user prompt submit renders runtime quota denial action", async () => {
           message: "Included quota is exhausted.",
           details: {
             mem9Code: "runtime_quota_denied",
+            meter: "memory_recall_requests",
             recommendedAction: {
               type: "claimApiKey",
               bindingState: "unclaimed",
@@ -272,9 +274,16 @@ test("user prompt submit renders runtime quota denial action", async () => {
 
   const parsed = JSON.parse(output);
   assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
-  assert.match(parsed.hookSpecificOutput.additionalContext, /Included quota is exhausted/);
-  assert.match(parsed.hookSpecificOutput.additionalContext, /include this URL exactly/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Mem9 recall is temporarily unavailable/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /included usage quota for this API key has been used up/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /sign in or create a mem9 account and claim this API key/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /upgrade their plan or set up billing/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Include the link exactly as written/);
   assert.match(parsed.hookSpecificOutput.additionalContext, /console\/claim\?key=mem9_test/);
+  assert.equal(
+    parsed.hookSpecificOutput.additionalContext.match(/https:\/\/console\.mem9\.ai\/console\/claim\?key=mem9_test/g)?.length,
+    1,
+  );
   assert.doesNotMatch(parsed.hookSpecificOutput.additionalContext, /\.\. Claim/);
   assert.equal(debugEvents.at(-1)?.stage, "recall_quota_denied");
   assert.deepEqual(debugEvents.at(-1)?.fields, {
@@ -282,6 +291,67 @@ test("user prompt submit renders runtime quota denial action", async () => {
     actionType: "claimApiKey",
     hasActionUrl: true,
   });
+});
+
+test("runtime quota notice renders spending limit guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 402,
+      data: {
+        code: "spending_limit_exceeded",
+        message: "On-demand spending limit would be exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            type: "increaseSpendingLimit",
+            bindingState: "claimed",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+        },
+      },
+    }),
+    "recall paused",
+  );
+
+  assert.match(notice, /configured spending limit would be exceeded/);
+  assert.match(notice, /increase the mem9 spending limit or adjust billing settings/);
+  assert.match(notice, /Include the link exactly as written/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
+test("runtime quota notice renders write meter guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 402,
+      data: {
+        code: "quota_exhausted",
+        message: "Included quota is exhausted.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          meter: "memory_write_requests",
+          recommendedAction: {
+            type: "upgradePlan",
+            bindingState: "claimed",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+        },
+      },
+    }),
+    "recall paused",
+  );
+
+  assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
+  assert.match(notice, /mem9 cannot save new memories right now/);
+  assert.match(notice, /upgrade their mem9 plan and get more included usage/);
+  assert.doesNotMatch(notice, /cannot recall memories/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
 });
 
 test("user prompt submit skips empty queries after stripping injected memories", async () => {

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -23,6 +23,25 @@ const USER_PROMPT_SUBMIT_ENTRY = path.resolve("./hooks/user-prompt-submit.mjs");
 const NON_READY_ISSUE_CODES = ["plugin_disabled", "plugin_missing", "legacy_paused"];
 
 /**
+ * @param {string} error
+ * @param {Record<string, unknown> | null} [runtimeQuota]
+ */
+function runtimeQuotaPayload(error, runtimeQuota = {}) {
+  /** @type {{errorCategory: string, runtimeQuota?: Record<string, unknown>}} */
+  const details = {
+    errorCategory: "runtime_quota_denied",
+  };
+  if (runtimeQuota !== null) {
+    details.runtimeQuota = runtimeQuota;
+  }
+
+  return {
+    error,
+    details,
+  };
+}
+
+/**
  * @param {string} filePath
  * @param {unknown} value
  */
@@ -252,19 +271,15 @@ test("user prompt submit renders runtime quota denial action", async () => {
     async search() {
       throw new Mem9HttpError("quota denied", {
         status: 402,
-        data: {
-          code: "quota_exhausted",
-          message: "Included quota is exhausted.",
-          details: {
-            mem9Code: "runtime_quota_denied",
-            meter: "memory_recall_requests",
-            recommendedAction: {
-              type: "claimApiKey",
-              bindingState: "unclaimed",
-              url: "https://console.mem9.ai/console/claim?key=mem9_test",
-            },
+        data: runtimeQuotaPayload("Included quota is exhausted.", {
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "unclaimed",
+            providerActionCode: "claimApiKey",
+            type: "openUrl",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
           },
-        },
+        }),
       });
     },
     debug(stage, fields) {
@@ -287,8 +302,8 @@ test("user prompt submit renders runtime quota denial action", async () => {
   assert.doesNotMatch(parsed.hookSpecificOutput.additionalContext, /\.\. Claim/);
   assert.equal(debugEvents.at(-1)?.stage, "recall_quota_denied");
   assert.deepEqual(debugEvents.at(-1)?.fields, {
-    code: "quota_exhausted",
-    actionType: "claimApiKey",
+    code: "runtime_quota_denied",
+    actionType: "openUrl",
     hasActionUrl: true,
   });
 });
@@ -297,19 +312,15 @@ test("runtime quota notice renders spending limit guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 402,
-      data: {
-        code: "spending_limit_exceeded",
-        message: "On-demand spending limit would be exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          meter: "memory_recall_requests",
-          recommendedAction: {
-            type: "increaseSpendingLimit",
-            bindingState: "claimed",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
+      data: runtimeQuotaPayload("On-demand spending limit would be exceeded.", {
+        meter: "memory_recall_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "increaseSpendingLimit",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     }),
     "recall paused",
   );
@@ -323,30 +334,70 @@ test("runtime quota notice renders spending limit guidance", () => {
   );
 });
 
+test("runtime quota notice handles missing runtime quota metadata", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 402,
+      data: runtimeQuotaPayload("Runtime access is blocked.", null),
+    }),
+    "recall paused",
+  );
+
+  assert.match(notice, /runtime quota check blocked this request/);
+  assert.match(notice, /open the mem9 console/);
+});
+
+test("runtime quota notice handles unknown provider action codes", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 402,
+      data: runtimeQuotaPayload("Custom quota action required.", {
+        recommendedAction: {
+          providerActionCode: "contactSupport",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/support",
+        },
+      }),
+    }),
+    "recall paused",
+  );
+
+  assert.match(notice, /open this mem9 link to resolve the account or billing state/);
+  assert.match(notice, /console\/support/);
+});
+
+test("runtime quota notice ignores generic api rate limits", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("rate limited", {
+      status: 429,
+      data: {
+        error: "rate limit exceeded",
+      },
+    }),
+    "recall paused",
+  );
+
+  assert.equal(notice, "");
+});
+
 test("runtime quota notice renders post-quota rate limit billing guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 429,
-      data: {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_recall_requests",
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 4,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 23,
-            },
+      data: runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
           },
         },
-      },
+      }),
     }),
     "recall paused",
   );
@@ -365,31 +416,26 @@ test("runtime quota notice renders post-quota billing action when provided", () 
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 429,
-      data: {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_write_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "upgradePlan",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 2,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 1,
-            },
+      data: runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
+        },
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 2,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 1,
           },
         },
-      },
+      }),
     }),
     "memory save paused",
   );
@@ -408,31 +454,26 @@ test("runtime quota notice renders post-quota claim action when provided", () =>
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 429,
-      data: {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_recall_requests",
-          recommendedAction: {
-            bindingState: "unclaimed",
-            type: "claimApiKey",
-            url: "https://console.mem9.ai/console/claim?key=mem9_test",
-          },
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 4,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 23,
-            },
+      data: runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_recall_requests",
+        recommendedAction: {
+          bindingState: "unclaimed",
+          providerActionCode: "claimApiKey",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        },
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
           },
         },
-      },
+      }),
     }),
     "recall paused",
   );
@@ -452,19 +493,15 @@ test("runtime quota notice renders write meter guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError("quota denied", {
       status: 402,
-      data: {
-        code: "quota_exhausted",
-        message: "Included quota is exhausted.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          meter: "memory_write_requests",
-          recommendedAction: {
-            type: "upgradePlan",
-            bindingState: "claimed",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
+      data: runtimeQuotaPayload("Included quota is exhausted.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     }),
     "recall paused",
   );

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -395,11 +395,55 @@ test("runtime quota notice renders post-quota billing action when provided", () 
   );
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
-  assert.match(notice, /upgrade their mem9 plan or set up billing/);
+  assert.match(notice, /upgrade their mem9 plan and get more included usage/);
   assert.match(notice, /console\/billing\/plan/);
   assert.doesNotMatch(notice, /wait 1 second before trying again/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
+test("runtime quota notice renders post-quota claim action when provided", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError("quota denied", {
+      status: 429,
+      data: {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "unclaimed",
+            type: "claimApiKey",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
+          },
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
+          },
+        },
+      },
+    }),
+    "recall paused",
+  );
+
+  assert.match(notice, /temporary request limit/);
+  assert.match(notice, /sign in or create a mem9 account and claim this API key/);
+  assert.match(notice, /After claiming the key, they can upgrade their plan or set up billing/);
+  assert.match(notice, /console\/claim\?key=mem9_test/);
+  assert.doesNotMatch(notice, /console\/billing\/plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/claim\?key=mem9_test/g)?.length,
     1,
   );
 });

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -12,6 +12,7 @@
  */
 
 import { isPendingProvisionError, type MemoryBackend } from "./backend.js";
+import { formatRuntimeQuotaNotice } from "./quota-error.js";
 import type { Memory, IngestMessage } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -262,6 +263,13 @@ export function registerHooks(
         if (isPendingProvisionError(err)) {
           return;
         }
+        const quotaNotice = formatRuntimeQuotaNotice(err, "recall paused");
+        if (quotaNotice) {
+          logger.info(quotaNotice);
+          return {
+            prependContext: quotaNotice,
+          };
+        }
         // Graceful degradation — never block the LLM call
         logger.error(`[mem9] before_prompt_build failed: ${String(err)}`);
       }
@@ -313,6 +321,11 @@ export function registerHooks(
       logger.info("[mem9] Session context saved before reset");
     } catch (err) {
       if (isPendingProvisionError(err)) {
+        return;
+      }
+      const quotaNotice = formatRuntimeQuotaNotice(err, "before_reset save paused");
+      if (quotaNotice) {
+        logger.info(quotaNotice);
         return;
       }
       // Best-effort — never block /reset
@@ -423,6 +436,11 @@ export function registerHooks(
       }
     } catch (err) {
       if (isPendingProvisionError(err)) {
+        return;
+      }
+      const quotaNotice = formatRuntimeQuotaNotice(err, "agent_end ingest paused");
+      if (quotaNotice) {
+        logger.info(quotaNotice);
         return;
       }
       // Best-effort — never fail the agent end phase

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -27,6 +27,7 @@ const MAX_CONTENT_LEN = 500; // truncate individual memory content in prompt
 // Ingest defaults — configurable via maxIngestBytes in plugin config
 const DEFAULT_MAX_INGEST_BYTES = 200_000; // ~200KB safe for most LLM context windows
 const MAX_INGEST_MESSAGES = 20; // absolute cap even if small messages
+const BACKGROUND_QUOTA_PAUSED_LOG = "[mem9] memory saving paused by runtime quota";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -325,7 +326,7 @@ export function registerHooks(
       }
       const quotaNotice = formatRuntimeQuotaNotice(err, "before_reset save paused");
       if (quotaNotice) {
-        logger.info(quotaNotice);
+        logger.info(BACKGROUND_QUOTA_PAUSED_LOG);
         return;
       }
       // Best-effort — never block /reset
@@ -440,7 +441,7 @@ export function registerHooks(
       }
       const quotaNotice = formatRuntimeQuotaNotice(err, "agent_end ingest paused");
       if (quotaNotice) {
-        logger.info(quotaNotice);
+        logger.info(BACKGROUND_QUOTA_PAUSED_LOG);
         return;
       }
       // Best-effort — never fail the agent end phase

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import mnemoPlugin from "./index.js";
+import { formatRuntimeQuotaNotice, Mem9HttpError } from "./quota-error.js";
 
 interface RegisteredTool {
   name: string;
@@ -293,6 +294,7 @@ test("before_prompt_build returns runtime quota denial action context", async ()
       message: "Included quota is exhausted.",
       details: {
         mem9Code: "runtime_quota_denied",
+        meter: "memory_recall_requests",
         recommendedAction: {
           bindingState: "unclaimed",
           type: "claimApiKey",
@@ -318,14 +320,86 @@ test("before_prompt_build returns runtime quota denial action context", async ()
     const beforePromptBuild = api.getHook("before_prompt_build");
     const hookResult = await beforePromptBuild({ prompt: "remember alpha" }) as { prependContext?: string } | undefined;
 
-    assert.match(hookResult?.prependContext ?? "", /Included quota is exhausted/);
-    assert.match(hookResult?.prependContext ?? "", /include this URL exactly/);
+    assert.match(hookResult?.prependContext ?? "", /Mem9 recall is temporarily unavailable/);
+    assert.match(hookResult?.prependContext ?? "", /included usage quota for this API key has been used up/);
+    assert.match(hookResult?.prependContext ?? "", /sign in or create a mem9 account and claim this API key/);
+    assert.match(hookResult?.prependContext ?? "", /upgrade their plan or set up billing/);
+    assert.match(hookResult?.prependContext ?? "", /Include the link exactly as written/);
     assert.match(hookResult?.prependContext ?? "", /console\/claim\?key=mem9_test/);
+    assert.equal(
+      hookResult?.prependContext?.match(/https:\/\/console\.mem9\.ai\/console\/claim\?key=mem9_test/g)?.length,
+      1,
+    );
     assert.doesNotMatch(hookResult?.prependContext ?? "", /\.\. Claim/);
-    assert.equal(infoLogs.some((line) => line.includes("recall paused")), true);
+    assert.equal(infoLogs.some((line) => line.includes("Mem9 recall is temporarily unavailable")), true);
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "On-demand spending limit would be exceeded.",
+      402,
+      "",
+      {
+        code: "spending_limit_exceeded",
+        message: "On-demand spending limit would be exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "increaseSpendingLimit",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /configured spending limit would be exceeded/);
+  assert.match(notice, /increase the mem9 spending limit or adjust billing settings/);
+  assert.match(notice, /Include the link exactly as written/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
+test("formatRuntimeQuotaNotice renders write meter guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Included quota is exhausted.",
+      402,
+      "",
+      {
+        code: "quota_exhausted",
+        message: "Included quota is exhausted.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          meter: "memory_write_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "upgradePlan",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
+  assert.match(notice, /mem9 cannot save new memories right now/);
+  assert.match(notice, /upgrade their mem9 plan and get more included usage/);
+  assert.doesNotMatch(notice, /cannot recall memories/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
 });
 
 test("before_prompt_build strips OpenClaw metadata wrappers before recall search", async () => {

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -178,6 +178,54 @@ test("memory capability stays idle until explicit provision runs", async () => {
   }
 });
 
+test("memory tools return structured runtime quota denial payloads", async () => {
+  const originalFetch = globalThis.fetch;
+  const apiUrl = uniqueApiUrl("tool-quota");
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      code: "spending_limit_exceeded",
+      message: "Spending limit is exhausted.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        recommendedAction: {
+          bindingState: "claimed",
+          type: "increaseSpendingLimit",
+          url: "https://console.mem9.ai/console/billing/plan",
+        },
+      },
+    }), {
+      status: 402,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const api = createStubApi({
+      apiUrl,
+      apiKey: "space-tool-quota",
+    });
+    mnemoPlugin.register(api);
+
+    const searchTool = api.getTools().find((item) => item.name === "memory_search");
+    assert.ok(searchTool);
+
+    const output = await searchTool.execute("call-1", { q: "hello" });
+    assert.equal(typeof output, "string");
+    const parsed = JSON.parse(output as string);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.code, "spending_limit_exceeded");
+    assert.equal(parsed.action_url, "https://console.mem9.ai/console/billing/plan");
+    assert.deepEqual(parsed.quota.recommendedAction, {
+      bindingState: "claimed",
+      type: "increaseSpendingLimit",
+      url: "https://console.mem9.ai/console/billing/plan",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("before_prompt_build forwards the prompt as q during recall search", async () => {
   const originalFetch = globalThis.fetch;
   const apiUrl = uniqueApiUrl("before-prompt-q");
@@ -229,6 +277,50 @@ test("before_prompt_build forwards the prompt as q during recall search", async 
     assert.equal(url.searchParams.get("q"), prompt);
     assert.equal(url.searchParams.get("limit"), "10");
     assert.equal(typeof hookResult?.prependContext, "string");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("before_prompt_build returns runtime quota denial action context", async () => {
+  const originalFetch = globalThis.fetch;
+  const apiUrl = uniqueApiUrl("before-prompt-quota");
+  const infoLogs: string[] = [];
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      code: "quota_exhausted",
+      message: "Included quota is exhausted.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        recommendedAction: {
+          bindingState: "unclaimed",
+          type: "claimApiKey",
+          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        },
+      },
+    }), {
+      status: 402,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const api = createStubApi(
+      {
+        apiUrl,
+        apiKey: "space-before-prompt-quota",
+      },
+      { infoLogs },
+    );
+    mnemoPlugin.register(api);
+
+    const beforePromptBuild = api.getHook("before_prompt_build");
+    const hookResult = await beforePromptBuild({ prompt: "remember alpha" }) as { prependContext?: string } | undefined;
+
+    assert.match(hookResult?.prependContext ?? "", /Included quota is exhausted/);
+    assert.match(hookResult?.prependContext ?? "", /console\/claim\?key=mem9_test/);
+    assert.equal(infoLogs.some((line) => line.includes("recall paused")), true);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -201,7 +201,6 @@ test("memory tools return structured runtime quota denial payloads", async () =>
     return new Response(JSON.stringify({
       ...runtimeQuotaPayload("Spending limit is exhausted.", {
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "increaseSpendingLimit",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -230,7 +229,6 @@ test("memory tools return structured runtime quota denial payloads", async () =>
     assert.equal(parsed.code, "runtime_quota_denied");
     assert.equal(parsed.action_url, "https://console.mem9.ai/console/billing/plan");
     assert.deepEqual(parsed.quota.recommendedAction, {
-      bindingState: "claimed",
       providerActionCode: "increaseSpendingLimit",
       type: "openUrl",
       url: "https://console.mem9.ai/console/billing/plan",
@@ -306,7 +304,6 @@ test("before_prompt_build returns runtime quota denial action context", async ()
       ...runtimeQuotaPayload("Included quota is exhausted.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "unclaimed",
           providerActionCode: "claimApiKey",
           type: "openUrl",
           url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -357,7 +354,6 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
       runtimeQuotaPayload("On-demand spending limit would be exceeded.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "increaseSpendingLimit",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -428,7 +424,7 @@ test("formatRuntimeQuotaNotice ignores generic api rate limits", () => {
   assert.equal(notice, "");
 });
 
-test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", () => {
+test("formatRuntimeQuotaNotice renders post-quota rate limit guidance without action URL", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(
       "Post-quota rate limit exceeded.",
@@ -453,13 +449,11 @@ test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", 
   );
 
   assert.match(notice, /temporary request limit/);
-  assert.match(notice, /upgrade their mem9 plan or set up billing/);
-  assert.match(notice, /console\/billing\/plan/);
+  assert.match(notice, /quota\/rate-limit check blocked this request/);
+  assert.match(notice, /retry later or open the mem9 console/);
+  assert.doesNotMatch(notice, /console\/billing\/plan/);
   assert.doesNotMatch(notice, /wait 23 seconds before trying again/);
-  assert.equal(
-    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
-    1,
-  );
+  assert.equal((notice.match(/https:\/\//g) ?? []).length, 0);
 });
 
 test("formatRuntimeQuotaNotice renders post-quota billing action when provided", () => {
@@ -471,7 +465,6 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
       runtimeQuotaPayload("Post-quota rate limit exceeded.", {
         meter: "memory_write_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "upgradePlan",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -511,7 +504,6 @@ test("formatRuntimeQuotaNotice renders post-quota claim action when provided", (
       runtimeQuotaPayload("Post-quota rate limit exceeded.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "unclaimed",
           providerActionCode: "claimApiKey",
           type: "openUrl",
           url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -552,7 +544,6 @@ test("formatRuntimeQuotaNotice renders write meter guidance", () => {
       runtimeQuotaPayload("Included quota is exhausted.", {
         meter: "memory_write_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "upgradePlan",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -445,11 +445,57 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
   );
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
-  assert.match(notice, /upgrade their mem9 plan or set up billing/);
+  assert.match(notice, /upgrade their mem9 plan and get more included usage/);
   assert.match(notice, /console\/billing\/plan/);
   assert.doesNotMatch(notice, /wait 1 second before trying again/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
+test("formatRuntimeQuotaNotice renders post-quota claim action when provided", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Post-quota rate limit exceeded.",
+      429,
+      "",
+      {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "unclaimed",
+            type: "claimApiKey",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
+          },
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /temporary request limit/);
+  assert.match(notice, /sign in or create a mem9 account and claim this API key/);
+  assert.match(notice, /After claiming the key, they can upgrade their plan or set up billing/);
+  assert.match(notice, /console\/claim\?key=mem9_test/);
+  assert.doesNotMatch(notice, /console\/billing\/plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/claim\?key=mem9_test/g)?.length,
     1,
   );
 });

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -319,6 +319,7 @@ test("before_prompt_build returns runtime quota denial action context", async ()
     const hookResult = await beforePromptBuild({ prompt: "remember alpha" }) as { prependContext?: string } | undefined;
 
     assert.match(hookResult?.prependContext ?? "", /Included quota is exhausted/);
+    assert.match(hookResult?.prependContext ?? "", /include this URL exactly/);
     assert.match(hookResult?.prependContext ?? "", /console\/claim\?key=mem9_test/);
     assert.doesNotMatch(hookResult?.prependContext ?? "", /\.\. Claim/);
     assert.equal(infoLogs.some((line) => line.includes("recall paused")), true);

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -369,6 +369,87 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   );
 });
 
+test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Post-quota rate limit exceeded.",
+      429,
+      "",
+      {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_recall_requests",
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /post-quota mode/);
+  assert.match(notice, /temporary rate limit/);
+  assert.match(notice, /wait 23 seconds before trying again/);
+  assert.doesNotMatch(notice, /open the mem9 console/);
+});
+
+test("formatRuntimeQuotaNotice renders post-quota billing action when provided", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Post-quota rate limit exceeded.",
+      429,
+      "",
+      {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_write_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "upgradePlan",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 2,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 1,
+            },
+          },
+        },
+      },
+    ),
+    "memory save paused",
+  );
+
+  assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
+  assert.match(notice, /wait 1 second before trying again/);
+  assert.match(notice, /more continuous mem9 usage/);
+  assert.match(notice, /console\/billing\/plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
 test("formatRuntimeQuotaNotice renders write meter guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -369,7 +369,7 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   );
 });
 
-test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", () => {
+test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(
       "Post-quota rate limit exceeded.",
@@ -400,8 +400,13 @@ test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", ()
   );
 
   assert.match(notice, /temporary request limit/);
-  assert.match(notice, /wait 23 seconds before trying again/);
-  assert.doesNotMatch(notice, /open the mem9 console/);
+  assert.match(notice, /upgrade their mem9 plan or set up billing/);
+  assert.match(notice, /console\/billing\/plan/);
+  assert.doesNotMatch(notice, /wait 23 seconds before trying again/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
 });
 
 test("formatRuntimeQuotaNotice renders post-quota billing action when provided", () => {
@@ -440,9 +445,9 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
   );
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
-  assert.match(notice, /wait 1 second before trying again/);
-  assert.match(notice, /higher mem9 usage limits/);
+  assert.match(notice, /upgrade their mem9 plan or set up billing/);
   assert.match(notice, /console\/billing\/plan/);
+  assert.doesNotMatch(notice, /wait 1 second before trying again/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
     1,

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -15,6 +15,20 @@ interface SearchCapability {
 
 type HookHandler = (...args: unknown[]) => unknown;
 
+function runtimeQuotaPayload(error: string, runtimeQuota: Record<string, unknown> | null = {}): Record<string, unknown> {
+  const details: Record<string, unknown> = {
+    errorCategory: "runtime_quota_denied",
+  };
+  if (runtimeQuota !== null) {
+    details.runtimeQuota = runtimeQuota;
+  }
+
+  return {
+    error,
+    details,
+  };
+}
+
 interface StubApi {
   pluginConfig?: unknown;
   logger: {
@@ -185,16 +199,14 @@ test("memory tools return structured runtime quota denial payloads", async () =>
 
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({
-      code: "spending_limit_exceeded",
-      message: "Spending limit is exhausted.",
-      details: {
-        mem9Code: "runtime_quota_denied",
+      ...runtimeQuotaPayload("Spending limit is exhausted.", {
         recommendedAction: {
           bindingState: "claimed",
-          type: "increaseSpendingLimit",
+          providerActionCode: "increaseSpendingLimit",
+          type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     }), {
       status: 402,
       headers: { "Content-Type": "application/json" },
@@ -215,11 +227,12 @@ test("memory tools return structured runtime quota denial payloads", async () =>
     assert.equal(typeof output, "string");
     const parsed = JSON.parse(output as string);
     assert.equal(parsed.ok, false);
-    assert.equal(parsed.code, "spending_limit_exceeded");
+    assert.equal(parsed.code, "runtime_quota_denied");
     assert.equal(parsed.action_url, "https://console.mem9.ai/console/billing/plan");
     assert.deepEqual(parsed.quota.recommendedAction, {
       bindingState: "claimed",
-      type: "increaseSpendingLimit",
+      providerActionCode: "increaseSpendingLimit",
+      type: "openUrl",
       url: "https://console.mem9.ai/console/billing/plan",
     });
   } finally {
@@ -290,17 +303,15 @@ test("before_prompt_build returns runtime quota denial action context", async ()
 
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({
-      code: "quota_exhausted",
-      message: "Included quota is exhausted.",
-      details: {
-        mem9Code: "runtime_quota_denied",
+      ...runtimeQuotaPayload("Included quota is exhausted.", {
         meter: "memory_recall_requests",
         recommendedAction: {
           bindingState: "unclaimed",
-          type: "claimApiKey",
+          providerActionCode: "claimApiKey",
+          type: "openUrl",
           url: "https://console.mem9.ai/console/claim?key=mem9_test",
         },
-      },
+      }),
     }), {
       status: 402,
       headers: { "Content-Type": "application/json" },
@@ -343,19 +354,15 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
       "On-demand spending limit would be exceeded.",
       402,
       "",
-      {
-        code: "spending_limit_exceeded",
-        message: "On-demand spending limit would be exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          meter: "memory_recall_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "increaseSpendingLimit",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
+      runtimeQuotaPayload("On-demand spending limit would be exceeded.", {
+        meter: "memory_recall_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "increaseSpendingLimit",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     ),
     "recall paused",
   );
@@ -369,32 +376,78 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   );
 });
 
+test("formatRuntimeQuotaNotice handles missing runtime quota metadata", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Runtime access is blocked.",
+      402,
+      "",
+      runtimeQuotaPayload("Runtime access is blocked.", null),
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /runtime quota check blocked this request/);
+  assert.match(notice, /open the mem9 console/);
+});
+
+test("formatRuntimeQuotaNotice handles unknown provider action codes", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Custom quota action required.",
+      402,
+      "",
+      runtimeQuotaPayload("Custom quota action required.", {
+        recommendedAction: {
+          providerActionCode: "contactSupport",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/support",
+        },
+      }),
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /open this mem9 link to resolve the account or billing state/);
+  assert.match(notice, /console\/support/);
+});
+
+test("formatRuntimeQuotaNotice ignores generic api rate limits", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "rate limit exceeded",
+      429,
+      "",
+      {
+        error: "rate limit exceeded",
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.equal(notice, "");
+});
+
 test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(
       "Post-quota rate limit exceeded.",
       429,
       "",
-      {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_recall_requests",
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 4,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 23,
-            },
+      runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
           },
         },
-      },
+      }),
     ),
     "recall paused",
   );
@@ -415,31 +468,26 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
       "Post-quota rate limit exceeded.",
       429,
       "",
-      {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_write_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "upgradePlan",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 2,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 1,
-            },
+      runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
+        },
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 2,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 1,
           },
         },
-      },
+      }),
     ),
     "memory save paused",
   );
@@ -460,31 +508,26 @@ test("formatRuntimeQuotaNotice renders post-quota claim action when provided", (
       "Post-quota rate limit exceeded.",
       429,
       "",
-      {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_recall_requests",
-          recommendedAction: {
-            bindingState: "unclaimed",
-            type: "claimApiKey",
-            url: "https://console.mem9.ai/console/claim?key=mem9_test",
-          },
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 4,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 23,
-            },
+      runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_recall_requests",
+        recommendedAction: {
+          bindingState: "unclaimed",
+          providerActionCode: "claimApiKey",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        },
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
           },
         },
-      },
+      }),
     ),
     "recall paused",
   );
@@ -506,19 +549,15 @@ test("formatRuntimeQuotaNotice renders write meter guidance", () => {
       "Included quota is exhausted.",
       402,
       "",
-      {
-        code: "quota_exhausted",
-        message: "Included quota is exhausted.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          meter: "memory_write_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "upgradePlan",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
+      runtimeQuotaPayload("Included quota is exhausted.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     ),
     "recall paused",
   );

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -399,8 +399,7 @@ test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", ()
     "recall paused",
   );
 
-  assert.match(notice, /post-quota mode/);
-  assert.match(notice, /temporary rate limit/);
+  assert.match(notice, /temporary request limit/);
   assert.match(notice, /wait 23 seconds before trying again/);
   assert.doesNotMatch(notice, /open the mem9 console/);
 });
@@ -442,7 +441,7 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
   assert.match(notice, /wait 1 second before trying again/);
-  assert.match(notice, /more continuous mem9 usage/);
+  assert.match(notice, /higher mem9 usage limits/);
   assert.match(notice, /console\/billing\/plan/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -829,6 +829,68 @@ test("agent_end logs conversation-access diagnostic once when messages are unava
   );
 });
 
+test("background save quota handling logs a terse status", async () => {
+  const originalFetch = globalThis.fetch;
+  const infoLogs: string[] = [];
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      ...runtimeQuotaPayload("Included quota is exhausted.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
+        },
+      }),
+    }), {
+      status: 402,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const api = createStubApi(
+      {
+        apiUrl: uniqueApiUrl("background-quota"),
+        apiKey: "space-background-quota",
+      },
+      { infoLogs },
+    );
+    mnemoPlugin.register(api);
+
+    await api.getHook("before_reset")({
+      messages: [
+        {
+          role: "user",
+          content: "remember this detailed preference before reset",
+        },
+      ],
+    });
+    await api.getHook("agent_end")({
+      success: true,
+      messages: [
+        {
+          role: "user",
+          content: "remember this detailed preference at agent end",
+        },
+        {
+          role: "assistant",
+          content: "saved for later",
+        },
+      ],
+    });
+
+    assert.equal(
+      infoLogs.filter((line) => line === "[mem9] memory saving paused by runtime quota").length,
+      2,
+    );
+    assert.equal(infoLogs.some((line) => line.includes("In your reply")), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("first before_prompt_build hook provisions once and unlocks memory access", async () => {
   const originalFetch = globalThis.fetch;
   const apiUrl = uniqueApiUrl("explicit-provision");

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -320,6 +320,7 @@ test("before_prompt_build returns runtime quota denial action context", async ()
 
     assert.match(hookResult?.prependContext ?? "", /Included quota is exhausted/);
     assert.match(hookResult?.prependContext ?? "", /console\/claim\?key=mem9_test/);
+    assert.doesNotMatch(hookResult?.prependContext ?? "", /\.\. Claim/);
     assert.equal(infoLogs.some((line) => line.includes("recall paused")), true);
   } finally {
     globalThis.fetch = originalFetch;

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -11,6 +11,7 @@ import {
   type BackendTimeouts,
 } from "./server-backend.js";
 import { registerHooks } from "./hooks.js";
+import { toolErrorPayload } from "./quota-error.js";
 import type {
   PluginConfig,
   Memory,
@@ -104,6 +105,10 @@ function jsonResult(data: unknown) {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function jsonToolError(err: unknown) {
+  return jsonResult(toolErrorPayload(err));
 }
 
 function sleep(ms: number): Promise<void> {
@@ -401,10 +406,7 @@ function buildTools(
           const result = await backend.store(input);
           return jsonResult({ ok: true, data: result });
         } catch (err) {
-          return jsonResult({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     },
@@ -441,10 +443,7 @@ function buildTools(
           const result = await backend.search(input);
           return jsonResult({ ok: true, ...result });
         } catch (err) {
-          return jsonResult({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     },
@@ -468,10 +467,7 @@ function buildTools(
             return jsonResult({ ok: false, error: "memory not found" });
           return jsonResult({ ok: true, data: result });
         } catch (err) {
-          return jsonResult({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     },
@@ -504,10 +500,7 @@ function buildTools(
             return jsonResult({ ok: false, error: "memory not found" });
           return jsonResult({ ok: true, data: result });
         } catch (err) {
-          return jsonResult({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     },
@@ -531,10 +524,7 @@ function buildTools(
             return jsonResult({ ok: false, error: "memory not found" });
           return jsonResult({ ok: true });
         } catch (err) {
-          return jsonResult({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     },

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -1,6 +1,8 @@
 const QUOTA_CODES = new Set([
   "quota_exhausted",
+  "post_quota_rate_limited",
   "spending_limit_exceeded",
+  "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
 
@@ -27,6 +29,8 @@ export interface RuntimeQuotaDenied {
   code: string;
   message: string;
   meter?: string;
+  quotaGateReason?: string;
+  retryAfterSeconds?: number;
   recommendedAction?: RuntimeRecommendedAction;
 }
 
@@ -36,6 +40,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizePositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 }
 
 export function parseJsonOrUndefined(text: string): unknown {
@@ -84,7 +92,32 @@ function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRe
   };
 }
 
+function quotaGateReason(details: Record<string, unknown>): string {
+  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+  return normalizeString(quotaGateResult.reason);
+}
+
+function retryAfterSeconds(details: Record<string, unknown>): number | null {
+  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+  if (direct !== null) {
+    return direct;
+  }
+
+  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+  const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit) ? quotaGateResult.postQuotaRateLimit : {};
+  return normalizePositiveInteger(postQuotaRateLimit.retryAfterSeconds);
+}
+
+function isPostQuotaRateLimited(denied: RuntimeQuotaDenied): boolean {
+  return denied.status === 429 ||
+    denied.code === "post_quota_rate_limited" ||
+    denied.quotaGateReason === "postQuotaRateLimitExceeded";
+}
+
 function quotaReason(denied: RuntimeQuotaDenied): string {
+  if (isPostQuotaRateLimited(denied)) {
+    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+  }
   const actionType = normalizeString(denied.recommendedAction?.type);
   if (actionType === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
@@ -97,6 +130,9 @@ function quotaReason(denied: RuntimeQuotaDenied): string {
   }
   if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
     return "the included usage quota for this mem9 account has been used up";
+  }
+  if (denied.code === "runtime_access_blocked") {
+    return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
 }
@@ -136,9 +172,25 @@ function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { he
   };
 }
 
-function actionInstruction(action?: RuntimeRecommendedAction): string {
+function retryInstruction(denied: RuntimeQuotaDenied): string {
+  if (denied.retryAfterSeconds !== undefined) {
+    const unit = denied.retryAfterSeconds === 1 ? "second" : "seconds";
+    return `Ask them to wait ${denied.retryAfterSeconds} ${unit} before trying again.`;
+  }
+  return "Ask them to wait briefly before trying again.";
+}
+
+function actionInstruction(denied: RuntimeQuotaDenied): string {
+  const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
   const actionUrl = normalizeString(action?.url);
+  if (isPostQuotaRateLimited(denied)) {
+    const retry = retryInstruction(denied);
+    if (!actionUrl) {
+      return retry;
+    }
+    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+  }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
@@ -173,11 +225,15 @@ export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | nu
   }
 
   const recommendedAction = normalizeRecommendedAction(details);
+  const retryAfter = retryAfterSeconds(details);
+  const reason = quotaGateReason(details);
   return {
     status: value instanceof Mem9HttpError ? value.status : null,
     code: code || "runtime_quota_denied",
     message: normalizeString(payload.message) || "runtime usage quota denied",
     ...(normalizeString(details.meter) ? { meter: normalizeString(details.meter) } : {}),
+    ...(reason ? { quotaGateReason: reason } : {}),
+    ...(retryAfter !== null ? { retryAfterSeconds: retryAfter } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
   };
 }
@@ -189,7 +245,7 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
   }
 
   const subject = quotaNoticeSubject(denied, operation);
-  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied.recommendedAction)}`;
+  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied)}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {
@@ -203,6 +259,7 @@ export function toolErrorPayload(error: unknown): Record<string, unknown> {
       quota: {
         code: denied.code,
         message: denied.message,
+        ...(denied.retryAfterSeconds !== undefined ? { retryAfterSeconds: denied.retryAfterSeconds } : {}),
         ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
       },
       ...(denied.recommendedAction?.url ? { action_url: denied.recommendedAction.url } : {}),

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -1,10 +1,3 @@
-const QUOTA_CODES = new Set([
-  "quota_exhausted",
-  "post_quota_rate_limited",
-  "spending_limit_exceeded",
-  "runtime_access_blocked",
-  "runtime_quota_denied",
-]);
 const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 export class Mem9HttpError extends Error {
@@ -21,6 +14,8 @@ export class Mem9HttpError extends Error {
 
 export interface RuntimeRecommendedAction {
   bindingState?: string;
+  providerActionCode?: string;
+  severity?: string;
   type?: string;
   url?: string;
 }
@@ -76,42 +71,45 @@ export function messageFromErrorBody(status: number, body: string, data: unknown
   return text || `HTTP ${status}`;
 }
 
-function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRecommendedAction | null {
-  const nested = isRecord(details.recommendedAction) ? details.recommendedAction : {};
-  const bindingState = normalizeString(nested.bindingState ?? details.bindingState);
-  const type = normalizeString(nested.type ?? details.upgradeAction);
-  const url = normalizeString(nested.url ?? details.upgradeUrl);
+function normalizeRecommendedAction(runtimeQuota: Record<string, unknown>): RuntimeRecommendedAction | null {
+  const nested = isRecord(runtimeQuota.recommendedAction) ? runtimeQuota.recommendedAction : {};
+  const bindingState = normalizeString(nested.bindingState);
+  const providerActionCode = normalizeString(nested.providerActionCode);
+  const severity = normalizeString(nested.severity);
+  const type = normalizeString(nested.type);
+  const url = normalizeString(nested.url);
 
-  if (!bindingState && !type && !url) {
+  if (!bindingState && !providerActionCode && !severity && !type && !url) {
     return null;
   }
 
   return {
     ...(bindingState ? { bindingState } : {}),
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
     ...(type ? { type } : {}),
     ...(url ? { url } : {}),
   };
 }
 
-function quotaGateReason(details: Record<string, unknown>): string {
-  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+function quotaGateReason(runtimeQuota: Record<string, unknown>): string {
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult) ? runtimeQuota.quotaGateResult : {};
   return normalizeString(quotaGateResult.reason);
 }
 
-function retryAfterSeconds(details: Record<string, unknown>): number | null {
-  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+function retryAfterSeconds(runtimeQuota: Record<string, unknown>): number | null {
+  const direct = normalizePositiveInteger(runtimeQuota.retryAfterSeconds);
   if (direct !== null) {
     return direct;
   }
 
-  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult) ? runtimeQuota.quotaGateResult : {};
   const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit) ? quotaGateResult.postQuotaRateLimit : {};
   return normalizePositiveInteger(postQuotaRateLimit.retryAfterSeconds);
 }
 
 function isPostQuotaRateLimited(denied: RuntimeQuotaDenied): boolean {
   return denied.status === 429 ||
-    denied.code === "post_quota_rate_limited" ||
     denied.quotaGateReason === "postQuotaRateLimitExceeded";
 }
 
@@ -119,20 +117,20 @@ function quotaReason(denied: RuntimeQuotaDenied): string {
   if (isPostQuotaRateLimited(denied)) {
     return "this API key has reached the temporary request limit for this memory feature";
   }
-  const actionType = normalizeString(denied.recommendedAction?.type);
-  if (actionType === "claimApiKey") {
+  const providerActionCode = normalizeString(denied.recommendedAction?.providerActionCode);
+  if (providerActionCode === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
   }
-  if (actionType === "increaseSpendingLimit" || denied.code === "spending_limit_exceeded") {
+  if (providerActionCode === "increaseSpendingLimit") {
     return "the configured spending limit would be exceeded";
   }
-  if (actionType === "enableOnDemand") {
+  if (providerActionCode === "enableOnDemand") {
     return "the included usage quota has been used up and on-demand usage is not enabled";
   }
-  if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
+  if (providerActionCode === "upgradePlan") {
     return "the included usage quota for this mem9 account has been used up";
   }
-  if (denied.code === "runtime_access_blocked") {
+  if (providerActionCode === "resolveAccountState") {
     return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
@@ -183,7 +181,7 @@ function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
 
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
-  const actionType = normalizeString(action?.type);
+  const providerActionCode = normalizeString(action?.providerActionCode);
   const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
   if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
@@ -193,7 +191,7 @@ function actionInstruction(denied: RuntimeQuotaDenied): string {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 
-  switch (actionType) {
+  switch (providerActionCode) {
     case "claimApiKey":
       return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
     case "upgradePlan":
@@ -216,20 +214,19 @@ export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | nu
   }
 
   const details = isRecord(payload.details) ? payload.details : {};
-  const code = normalizeString(payload.code);
-  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
-  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+  if (normalizeString(details.errorCategory) !== "runtime_quota_denied") {
     return null;
   }
+  const runtimeQuota = isRecord(details.runtimeQuota) ? details.runtimeQuota : {};
 
-  const recommendedAction = normalizeRecommendedAction(details);
-  const retryAfter = retryAfterSeconds(details);
-  const reason = quotaGateReason(details);
+  const recommendedAction = normalizeRecommendedAction(runtimeQuota);
+  const retryAfter = retryAfterSeconds(runtimeQuota);
+  const reason = quotaGateReason(runtimeQuota);
   return {
     status: value instanceof Mem9HttpError ? value.status : null,
-    code: code || "runtime_quota_denied",
-    message: normalizeString(payload.message) || "runtime usage quota denied",
-    ...(normalizeString(details.meter) ? { meter: normalizeString(details.meter) } : {}),
+    code: "runtime_quota_denied",
+    message: normalizeString(payload.error) || "Runtime usage quota denied.",
+    ...(normalizeString(runtimeQuota.meter) ? { meter: normalizeString(runtimeQuota.meter) } : {}),
     ...(reason ? { quotaGateReason: reason } : {}),
     ...(retryAfter !== null ? { retryAfterSeconds: retryAfter } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -5,6 +5,7 @@ const QUOTA_CODES = new Set([
   "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
+const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 export class Mem9HttpError extends Error {
   constructor(
@@ -172,24 +173,20 @@ function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { he
   };
 }
 
-function retryInstruction(denied: RuntimeQuotaDenied): string {
-  if (denied.retryAfterSeconds !== undefined) {
-    const unit = denied.retryAfterSeconds === 1 ? "second" : "seconds";
-    return `Ask them to wait ${denied.retryAfterSeconds} ${unit} before trying again.`;
+function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
+  const actionUrl = normalizeString(denied.recommendedAction?.url);
+  if (actionUrl) {
+    return actionUrl;
   }
-  return "Ask them to wait briefly before trying again.";
+  return isPostQuotaRateLimited(denied) ? DEFAULT_BILLING_ACTION_URL : "";
 }
 
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
-  const actionUrl = normalizeString(action?.url);
+  const actionUrl = actionUrlForDenied(denied);
   if (isPostQuotaRateLimited(denied)) {
-    const retry = retryInstruction(denied);
-    if (!actionUrl) {
-      return retry;
-    }
-    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
@@ -251,6 +248,7 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
 export function toolErrorPayload(error: unknown): Record<string, unknown> {
   const denied = parseRuntimeQuotaDenied(error);
   if (denied) {
+    const actionUrl = actionUrlForDenied(denied);
     return {
       ok: false,
       error: denied.message,
@@ -262,7 +260,7 @@ export function toolErrorPayload(error: unknown): Record<string, unknown> {
         ...(denied.retryAfterSeconds !== undefined ? { retryAfterSeconds: denied.retryAfterSeconds } : {}),
         ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
       },
-      ...(denied.recommendedAction?.url ? { action_url: denied.recommendedAction.url } : {}),
+      ...(actionUrl ? { action_url: actionUrl } : {}),
     };
   }
 

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -116,7 +116,7 @@ function isPostQuotaRateLimited(denied: RuntimeQuotaDenied): boolean {
 
 function quotaReason(denied: RuntimeQuotaDenied): string {
   if (isPostQuotaRateLimited(denied)) {
-    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+    return "this API key has reached the temporary request limit for this memory feature";
   }
   const actionType = normalizeString(denied.recommendedAction?.type);
   if (actionType === "claimApiKey") {
@@ -189,7 +189,7 @@ function actionInstruction(denied: RuntimeQuotaDenied): string {
     if (!actionUrl) {
       return retry;
     }
-    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -1,0 +1,159 @@
+const QUOTA_CODES = new Set([
+  "quota_exhausted",
+  "spending_limit_exceeded",
+  "runtime_quota_denied",
+]);
+
+export class Mem9HttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: string,
+    readonly data: unknown,
+  ) {
+    super(message);
+    this.name = "Mem9HttpError";
+  }
+}
+
+export interface RuntimeRecommendedAction {
+  bindingState?: string;
+  type?: string;
+  url?: string;
+}
+
+export interface RuntimeQuotaDenied {
+  status: number | null;
+  code: string;
+  message: string;
+  recommendedAction?: RuntimeRecommendedAction;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function parseJsonOrUndefined(text: string): unknown {
+  if (!text.trim()) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export function messageFromErrorBody(status: number, body: string, data: unknown): string {
+  if (isRecord(data)) {
+    const message = normalizeString(data.message);
+    if (message) {
+      return message;
+    }
+
+    const error = normalizeString(data.error);
+    if (error) {
+      return error;
+    }
+  }
+
+  const text = body.trim();
+  return text || `HTTP ${status}`;
+}
+
+function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRecommendedAction | null {
+  const nested = isRecord(details.recommendedAction) ? details.recommendedAction : {};
+  const bindingState = normalizeString(nested.bindingState ?? details.bindingState);
+  const type = normalizeString(nested.type ?? details.upgradeAction);
+  const url = normalizeString(nested.url ?? details.upgradeUrl);
+
+  if (!bindingState && !type && !url) {
+    return null;
+  }
+
+  return {
+    ...(bindingState ? { bindingState } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+function actionLabel(type: string): string {
+  switch (type) {
+    case "claimApiKey":
+      return "Claim this API key";
+    case "upgradePlan":
+      return "Upgrade your plan";
+    case "increaseSpendingLimit":
+      return "Increase your spending limit";
+    case "enableOnDemand":
+      return "Enable on-demand usage";
+    case "resolveAccountState":
+      return "Resolve account state";
+    default:
+      return "Open mem9 console";
+  }
+}
+
+export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | null {
+  const payload = value instanceof Mem9HttpError ? value.data : value;
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const details = isRecord(payload.details) ? payload.details : {};
+  const code = normalizeString(payload.code);
+  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
+  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+    return null;
+  }
+
+  const recommendedAction = normalizeRecommendedAction(details);
+  return {
+    status: value instanceof Mem9HttpError ? value.status : null,
+    code: code || "runtime_quota_denied",
+    message: normalizeString(payload.message) || "runtime usage quota denied",
+    ...(recommendedAction ? { recommendedAction } : {}),
+  };
+}
+
+export function formatRuntimeQuotaNotice(value: unknown, operation: string): string {
+  const denied = parseRuntimeQuotaDenied(value);
+  if (!denied) {
+    return "";
+  }
+
+  const actionUrl = normalizeString(denied.recommendedAction?.url);
+  const actionText = actionUrl
+    ? ` ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
+    : "";
+  return `[mem9] ${operation}: ${denied.message}.${actionText}`;
+}
+
+export function toolErrorPayload(error: unknown): Record<string, unknown> {
+  const denied = parseRuntimeQuotaDenied(error);
+  if (denied) {
+    return {
+      ok: false,
+      error: denied.message,
+      status_code: denied.status,
+      code: denied.code,
+      quota: {
+        code: denied.code,
+        message: denied.message,
+        ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
+      },
+      ...(denied.recommendedAction?.url ? { action_url: denied.recommendedAction.url } : {}),
+    };
+  }
+
+  return {
+    ok: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -26,6 +26,7 @@ export interface RuntimeQuotaDenied {
   status: number | null;
   code: string;
   message: string;
+  meter?: string;
   recommendedAction?: RuntimeRecommendedAction;
 }
 
@@ -83,25 +84,79 @@ function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRe
   };
 }
 
-function actionLabel(type: string): string {
-  switch (type) {
-    case "claimApiKey":
-      return "Claim this API key";
-    case "upgradePlan":
-      return "Upgrade your plan";
-    case "increaseSpendingLimit":
-      return "Increase your spending limit";
-    case "enableOnDemand":
-      return "Enable on-demand usage";
-    case "resolveAccountState":
-      return "Resolve account state";
-    default:
-      return "Open mem9 console";
+function quotaReason(denied: RuntimeQuotaDenied): string {
+  const actionType = normalizeString(denied.recommendedAction?.type);
+  if (actionType === "claimApiKey") {
+    return "the included usage quota for this API key has been used up";
   }
+  if (actionType === "increaseSpendingLimit" || denied.code === "spending_limit_exceeded") {
+    return "the configured spending limit would be exceeded";
+  }
+  if (actionType === "enableOnDemand") {
+    return "the included usage quota has been used up and on-demand usage is not enabled";
+  }
+  if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
+    return "the included usage quota for this mem9 account has been used up";
+  }
+  return "the runtime quota check blocked this request";
 }
 
-function sentence(message: string): string {
-  return /[.!?]$/.test(message) ? message : `${message}.`;
+function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { headline: string; userState: string } {
+  const meter = normalizeString(denied.meter);
+  if (meter === "memory_write_requests") {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (meter === "memory_recall_requests") {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  const operationText = normalizeString(operation).toLowerCase();
+  if (/\b(ingest|save|store|write)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (/\b(recall|search)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  return {
+    headline: "Mem9 memory is temporarily unavailable",
+    userState: "mem9 cannot complete the memory request right now",
+  };
+}
+
+function actionInstruction(action?: RuntimeRecommendedAction): string {
+  const actionType = normalizeString(action?.type);
+  const actionUrl = normalizeString(action?.url);
+  if (!actionUrl) {
+    return "Ask them to open the mem9 console to resolve the account or billing state.";
+  }
+
+  switch (actionType) {
+    case "claimApiKey":
+      return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
+    case "upgradePlan":
+      return `Ask them to open this link to upgrade their mem9 plan and get more included usage: ${actionUrl}. Include the link exactly as written.`;
+    case "increaseSpendingLimit":
+      return `Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${actionUrl}. Include the link exactly as written.`;
+    case "enableOnDemand":
+      return `Ask them to open this link to enable billing or on-demand usage for mem9: ${actionUrl}. Include the link exactly as written.`;
+    case "resolveAccountState":
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${actionUrl}. Include the link exactly as written.`;
+    default:
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${actionUrl}. Include the link exactly as written.`;
+  }
 }
 
 export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | null {
@@ -122,6 +177,7 @@ export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | nu
     status: value instanceof Mem9HttpError ? value.status : null,
     code: code || "runtime_quota_denied",
     message: normalizeString(payload.message) || "runtime usage quota denied",
+    ...(normalizeString(details.meter) ? { meter: normalizeString(details.meter) } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
   };
 }
@@ -132,14 +188,8 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
     return "";
   }
 
-  const actionUrl = normalizeString(denied.recommendedAction?.url);
-  const actionText = actionUrl
-    ? ` User action required: ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
-    : "";
-  const replyInstruction = actionUrl
-    ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${actionUrl}`
-    : " In your reply, briefly tell the user mem9 memory is paused.";
-  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}${replyInstruction}`;
+  const subject = quotaNoticeSubject(denied, operation);
+  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied.recommendedAction)}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -134,9 +134,12 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
 
   const actionUrl = normalizeString(denied.recommendedAction?.url);
   const actionText = actionUrl
-    ? ` ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
+    ? ` User action required: ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
     : "";
-  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}`;
+  const replyInstruction = actionUrl
+    ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${actionUrl}`
+    : " In your reply, briefly tell the user mem9 memory is paused.";
+  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}${replyInstruction}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -100,6 +100,10 @@ function actionLabel(type: string): string {
   }
 }
 
+function sentence(message: string): string {
+  return /[.!?]$/.test(message) ? message : `${message}.`;
+}
+
 export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | null {
   const payload = value instanceof Mem9HttpError ? value.data : value;
   if (!isRecord(payload)) {
@@ -132,7 +136,7 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
   const actionText = actionUrl
     ? ` ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
     : "";
-  return `[mem9] ${operation}: ${denied.message}.${actionText}`;
+  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -1,5 +1,3 @@
-const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
-
 export class Mem9HttpError extends Error {
   constructor(
     message: string,
@@ -13,7 +11,6 @@ export class Mem9HttpError extends Error {
 }
 
 export interface RuntimeRecommendedAction {
-  bindingState?: string;
   providerActionCode?: string;
   severity?: string;
   type?: string;
@@ -73,18 +70,16 @@ export function messageFromErrorBody(status: number, body: string, data: unknown
 
 function normalizeRecommendedAction(runtimeQuota: Record<string, unknown>): RuntimeRecommendedAction | null {
   const nested = isRecord(runtimeQuota.recommendedAction) ? runtimeQuota.recommendedAction : {};
-  const bindingState = normalizeString(nested.bindingState);
   const providerActionCode = normalizeString(nested.providerActionCode);
   const severity = normalizeString(nested.severity);
   const type = normalizeString(nested.type);
   const url = normalizeString(nested.url);
 
-  if (!bindingState && !providerActionCode && !severity && !type && !url) {
+  if (!providerActionCode && !severity && !type && !url) {
     return null;
   }
 
   return {
-    ...(bindingState ? { bindingState } : {}),
     ...(providerActionCode ? { providerActionCode } : {}),
     ...(severity ? { severity } : {}),
     ...(type ? { type } : {}),
@@ -172,22 +167,17 @@ function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { he
 }
 
 function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
-  const actionUrl = normalizeString(denied.recommendedAction?.url);
-  if (actionUrl) {
-    return actionUrl;
-  }
-  return isPostQuotaRateLimited(denied) ? DEFAULT_BILLING_ACTION_URL : "";
+  return normalizeString(denied.recommendedAction?.url);
 }
 
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
   const providerActionCode = normalizeString(action?.providerActionCode);
-  const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
-  if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
-    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
-  }
   if (!actionUrl) {
+    if (isPostQuotaRateLimited(denied)) {
+      return "Tell them that the quota/rate-limit check blocked this request and to retry later or open the mem9 console to review account and billing settings.";
+    }
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 

--- a/openclaw-plugin/quota-error.ts
+++ b/openclaw-plugin/quota-error.ts
@@ -184,8 +184,9 @@ function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
+  const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
-  if (isPostQuotaRateLimited(denied)) {
+  if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
     return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -87,14 +87,16 @@ test("runtime quota denial response bodies are preserved", async () => {
 
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({
-      code: "quota_exhausted",
-      message: "Included quota is exhausted.",
+      error: "Included quota is exhausted.",
       details: {
-        mem9Code: "runtime_quota_denied",
-        recommendedAction: {
-          bindingState: "unclaimed",
-          type: "claimApiKey",
-          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        errorCategory: "runtime_quota_denied",
+        runtimeQuota: {
+          recommendedAction: {
+            bindingState: "unclaimed",
+            providerActionCode: "claimApiKey",
+            type: "openUrl",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
+          },
         },
       },
     }), {
@@ -110,7 +112,7 @@ test("runtime quota denial response bodies are preserved", async () => {
       (error: unknown) => {
         assert.equal(error instanceof Mem9HttpError, true);
         const denied = parseRuntimeQuotaDenied(error);
-        assert.equal(denied?.code, "quota_exhausted");
+        assert.equal(denied?.code, "runtime_quota_denied");
         assert.equal(denied?.recommendedAction?.url, "https://console.mem9.ai/console/claim?key=mem9_test");
         return true;
       },
@@ -125,21 +127,21 @@ test("post-quota rate limit response bodies are preserved", async () => {
 
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({
-      code: "post_quota_rate_limited",
-      message: "Post-quota rate limit exceeded.",
+      error: "Post-quota rate limit exceeded.",
       details: {
-        mem9Code: "runtime_quota_denied",
-        retryable: true,
-        meter: "memory_recall_requests",
-        quotaGateResult: {
-          outcome: "rateLimited",
-          mode: "postQuota",
-          reason: "postQuotaRateLimitExceeded",
-          postQuotaRateLimit: {
-            requestsPerMinute: 4,
-            windowDurationSeconds: 60,
-            scope: "apiKeyMeter",
-            retryAfterSeconds: 23,
+        errorCategory: "runtime_quota_denied",
+        runtimeQuota: {
+          meter: "memory_recall_requests",
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
           },
         },
       },
@@ -156,7 +158,7 @@ test("post-quota rate limit response bodies are preserved", async () => {
       (error: unknown) => {
         assert.equal(error instanceof Mem9HttpError, true);
         const denied = parseRuntimeQuotaDenied(error);
-        assert.equal(denied?.code, "post_quota_rate_limited");
+        assert.equal(denied?.code, "runtime_quota_denied");
         assert.equal(denied?.retryAfterSeconds, 23);
         return true;
       },

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { ServerBackend } from "./server-backend.js";
+import { Mem9HttpError, parseRuntimeQuotaDenied } from "./quota-error.js";
 
 test("register forwards only utm_* params during create-new provision", async () => {
   const originalFetch = globalThis.fetch;
@@ -76,6 +77,44 @@ test("normal memory requests do not append provision query params", async () => 
     await backend.store({ content: "remember this" });
 
     assert.equal(requestedURL, "https://api.mem9.ai/v1alpha2/mem9s/memories");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("runtime quota denial response bodies are preserved", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      code: "quota_exhausted",
+      message: "Included quota is exhausted.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        recommendedAction: {
+          bindingState: "unclaimed",
+          type: "claimApiKey",
+          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        },
+      },
+    }), {
+      status: 402,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "space-key", "agent-1");
+    await assert.rejects(
+      () => backend.search({ q: "hello" }),
+      (error: unknown) => {
+        assert.equal(error instanceof Mem9HttpError, true);
+        const denied = parseRuntimeQuotaDenied(error);
+        assert.equal(denied?.code, "quota_exhausted");
+        assert.equal(denied?.recommendedAction?.url, "https://console.mem9.ai/console/claim?key=mem9_test");
+        return true;
+      },
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -119,3 +119,49 @@ test("runtime quota denial response bodies are preserved", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("post-quota rate limit response bodies are preserved", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      code: "post_quota_rate_limited",
+      message: "Post-quota rate limit exceeded.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        retryable: true,
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
+          },
+        },
+      },
+    }), {
+      status: 429,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "space-key", "agent-1");
+    await assert.rejects(
+      () => backend.search({ q: "hello" }),
+      (error: unknown) => {
+        assert.equal(error instanceof Mem9HttpError, true);
+        const denied = parseRuntimeQuotaDenied(error);
+        assert.equal(denied?.code, "post_quota_rate_limited");
+        assert.equal(denied?.retryAfterSeconds, 23);
+        return true;
+      },
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -82,6 +82,24 @@ test("normal memory requests do not append provision query params", async () => 
   }
 });
 
+test("normal memory requests reject malformed success JSON", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response("{", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "space-key", "agent-1");
+    await assert.rejects(() => backend.search({ q: "hello" }), SyntaxError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("runtime quota denial response bodies are preserved", async () => {
   const originalFetch = globalThis.fetch;
 
@@ -92,7 +110,6 @@ test("runtime quota denial response bodies are preserved", async () => {
         errorCategory: "runtime_quota_denied",
         runtimeQuota: {
           recommendedAction: {
-            bindingState: "unclaimed",
             providerActionCode: "claimApiKey",
             type: "openUrl",
             url: "https://console.mem9.ai/console/claim?key=mem9_test",

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -9,6 +9,11 @@ import type {
   IngestInput,
   IngestResult,
 } from "./types.js";
+import {
+  Mem9HttpError,
+  messageFromErrorBody,
+  parseJsonOrUndefined,
+} from "./quota-error.js";
 
 type ProvisionMem9sResponse = {
   id: string;
@@ -127,16 +132,22 @@ export class ServerBackend implements MemoryBackend {
   async get(id: string): Promise<Memory | null> {
     try {
       return await this.request<Memory>("GET", this.memoryPath(`/memories/${id}`));
-    } catch {
-      return null;
+    } catch (err) {
+      if (err instanceof Mem9HttpError && err.status === 404) {
+        return null;
+      }
+      throw err;
     }
   }
 
   async update(id: string, input: UpdateMemoryInput): Promise<Memory | null> {
     try {
       return await this.request<Memory>("PUT", this.memoryPath(`/memories/${id}`), input);
-    } catch {
-      return null;
+    } catch (err) {
+      if (err instanceof Mem9HttpError && err.status === 404) {
+        return null;
+      }
+      throw err;
     }
   }
 
@@ -144,8 +155,11 @@ export class ServerBackend implements MemoryBackend {
     try {
       await this.request("DELETE", this.memoryPath(`/memories/${id}`));
       return true;
-    } catch {
-      return false;
+    } catch (err) {
+      if (err instanceof Mem9HttpError && err.status === 404) {
+        return false;
+      }
+      throw err;
     }
   }
 
@@ -185,9 +199,15 @@ export class ServerBackend implements MemoryBackend {
       return undefined as T;
     }
 
-    const data = await resp.json();
+    const text = await resp.text();
+    const data = parseJsonOrUndefined(text);
     if (!resp.ok) {
-      throw new Error((data as { error?: string }).error || `HTTP ${resp.status}`);
+      throw new Mem9HttpError(
+        messageFromErrorBody(resp.status, text, data),
+        resp.status,
+        text,
+        data,
+      );
     }
     return data as T;
   }

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -200,8 +200,8 @@ export class ServerBackend implements MemoryBackend {
     }
 
     const text = await resp.text();
-    const data = parseJsonOrUndefined(text);
     if (!resp.ok) {
+      const data = parseJsonOrUndefined(text);
       throw new Mem9HttpError(
         messageFromErrorBody(resp.status, text, data),
         resp.status,
@@ -209,6 +209,6 @@ export class ServerBackend implements MemoryBackend {
         data,
       );
     }
-    return data as T;
+    return JSON.parse(text) as T;
   }
 }

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/opencode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -186,14 +186,16 @@ async function ingestSessionTranscript(
           sessionID,
           messageCount: selectedMessages.length,
         });
-        await submitMessagesForIngest({
+        const result = await submitMessagesForIngest({
           backend,
           messages: transcript,
           sessionID,
           agentID: state.agentID,
           debugLogger: options.debugLogger,
         });
-        state.lastIngestFingerprint = fingerprint;
+        if (result) {
+          state.lastIngestFingerprint = fingerprint;
+        }
       } finally {
         if (state.pendingIngestFingerprint === fingerprint) {
           state.pendingIngestFingerprint = null;

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -3,6 +3,7 @@ import type { IngestMessage, MemoryBackend } from "./backend.ts";
 import type { DebugLogger } from "./debug.ts";
 import { selectMessagesForIngest } from "./ingest/select.ts";
 import { submitMessagesForIngest } from "./ingest/submit.ts";
+import { formatRuntimeQuotaNotice, parseRuntimeQuotaDenied } from "./quota-error.ts";
 import { formatRecallBlock } from "./recall/format.ts";
 import { buildRecallQuery } from "./recall/query.ts";
 import type { SessionTranscriptLoader } from "./session-transcript.ts";
@@ -308,6 +309,18 @@ export function buildHooks(
           output.system.push(block);
         }
       } catch (error) {
+        const quotaDenied = parseRuntimeQuotaDenied(error);
+        if (quotaDenied) {
+          await options.debugLogger?.("recall.quota_denied", {
+            sessionID: input.sessionID,
+            code: quotaDenied.code,
+            actionType: quotaDenied.recommendedAction?.type,
+            hasActionUrl: Boolean(quotaDenied.recommendedAction?.url),
+          });
+          output.system.push(formatRuntimeQuotaNotice(error, "recall paused"));
+          return;
+        }
+
         await options.debugLogger?.("recall.error", {
           sessionID: input.sessionID,
           error: error instanceof Error ? error.message : String(error),

--- a/opencode-plugin/src/server/ingest/submit.ts
+++ b/opencode-plugin/src/server/ingest/submit.ts
@@ -1,5 +1,6 @@
 import type { IngestInput, IngestResult, MemoryBackend } from "../backend.ts";
 import type { DebugLogger } from "../debug.ts";
+import { parseRuntimeQuotaDenied } from "../quota-error.ts";
 import { selectMessagesForIngest } from "./select.ts";
 
 export interface SubmitIngestOptions {
@@ -45,6 +46,18 @@ export async function submitMessagesForIngest(
     });
     return result;
   } catch (error) {
+    const quotaDenied = parseRuntimeQuotaDenied(error);
+    if (quotaDenied) {
+      await options.debugLogger?.("ingest.quota_denied", {
+        sessionID: options.sessionID,
+        agentID: options.agentID,
+        code: quotaDenied.code,
+        actionType: quotaDenied.recommendedAction?.type,
+        hasActionUrl: Boolean(quotaDenied.recommendedAction?.url),
+      });
+      return null;
+    }
+
     await options.debugLogger?.("ingest.error", {
       sessionID: options.sessionID,
       agentID: options.agentID,

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -1,6 +1,8 @@
 const QUOTA_CODES = new Set([
   "quota_exhausted",
+  "post_quota_rate_limited",
   "spending_limit_exceeded",
+  "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
 
@@ -27,6 +29,8 @@ export interface RuntimeQuotaDenied {
   code: string;
   message: string;
   meter?: string;
+  quotaGateReason?: string;
+  retryAfterSeconds?: number;
   recommendedAction?: RuntimeRecommendedAction;
 }
 
@@ -36,6 +40,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function normalizeString(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizePositiveInteger(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
 }
 
 export function parseJsonOrUndefined(text: string): unknown {
@@ -84,7 +92,32 @@ function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRe
   };
 }
 
+function quotaGateReason(details: Record<string, unknown>): string {
+  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+  return normalizeString(quotaGateResult.reason);
+}
+
+function retryAfterSeconds(details: Record<string, unknown>): number | null {
+  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+  if (direct !== null) {
+    return direct;
+  }
+
+  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+  const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit) ? quotaGateResult.postQuotaRateLimit : {};
+  return normalizePositiveInteger(postQuotaRateLimit.retryAfterSeconds);
+}
+
+function isPostQuotaRateLimited(denied: RuntimeQuotaDenied): boolean {
+  return denied.status === 429 ||
+    denied.code === "post_quota_rate_limited" ||
+    denied.quotaGateReason === "postQuotaRateLimitExceeded";
+}
+
 function quotaReason(denied: RuntimeQuotaDenied): string {
+  if (isPostQuotaRateLimited(denied)) {
+    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+  }
   const actionType = normalizeString(denied.recommendedAction?.type);
   if (actionType === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
@@ -97,6 +130,9 @@ function quotaReason(denied: RuntimeQuotaDenied): string {
   }
   if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
     return "the included usage quota for this mem9 account has been used up";
+  }
+  if (denied.code === "runtime_access_blocked") {
+    return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
 }
@@ -136,9 +172,25 @@ function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { he
   };
 }
 
-function actionInstruction(action?: RuntimeRecommendedAction): string {
+function retryInstruction(denied: RuntimeQuotaDenied): string {
+  if (denied.retryAfterSeconds !== undefined) {
+    const unit = denied.retryAfterSeconds === 1 ? "second" : "seconds";
+    return `Ask them to wait ${denied.retryAfterSeconds} ${unit} before trying again.`;
+  }
+  return "Ask them to wait briefly before trying again.";
+}
+
+function actionInstruction(denied: RuntimeQuotaDenied): string {
+  const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
   const actionUrl = normalizeString(action?.url);
+  if (isPostQuotaRateLimited(denied)) {
+    const retry = retryInstruction(denied);
+    if (!actionUrl) {
+      return retry;
+    }
+    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+  }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
@@ -173,11 +225,15 @@ export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | nu
   }
 
   const recommendedAction = normalizeRecommendedAction(details);
+  const retryAfter = retryAfterSeconds(details);
+  const reason = quotaGateReason(details);
   return {
     status: value instanceof Mem9HttpError ? value.status : null,
     code: code || "runtime_quota_denied",
     message: normalizeString(payload.message) || "runtime usage quota denied",
     ...(normalizeString(details.meter) ? { meter: normalizeString(details.meter) } : {}),
+    ...(reason ? { quotaGateReason: reason } : {}),
+    ...(retryAfter !== null ? { retryAfterSeconds: retryAfter } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
   };
 }
@@ -189,7 +245,7 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
   }
 
   const subject = quotaNoticeSubject(denied, operation);
-  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied.recommendedAction)}`;
+  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied)}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {
@@ -203,6 +259,7 @@ export function toolErrorPayload(error: unknown): Record<string, unknown> {
       quota: {
         code: denied.code,
         message: denied.message,
+        ...(denied.retryAfterSeconds !== undefined ? { retryAfterSeconds: denied.retryAfterSeconds } : {}),
         ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
       },
       ...(denied.recommendedAction?.url ? { action_url: denied.recommendedAction.url } : {}),

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -1,10 +1,3 @@
-const QUOTA_CODES = new Set([
-  "quota_exhausted",
-  "post_quota_rate_limited",
-  "spending_limit_exceeded",
-  "runtime_access_blocked",
-  "runtime_quota_denied",
-]);
 const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 export class Mem9HttpError extends Error {
@@ -21,6 +14,8 @@ export class Mem9HttpError extends Error {
 
 export interface RuntimeRecommendedAction {
   bindingState?: string;
+  providerActionCode?: string;
+  severity?: string;
   type?: string;
   url?: string;
 }
@@ -76,42 +71,45 @@ export function messageFromErrorBody(status: number, body: string, data: unknown
   return text || `HTTP ${status}`;
 }
 
-function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRecommendedAction | null {
-  const nested = isRecord(details.recommendedAction) ? details.recommendedAction : {};
-  const bindingState = normalizeString(nested.bindingState ?? details.bindingState);
-  const type = normalizeString(nested.type ?? details.upgradeAction);
-  const url = normalizeString(nested.url ?? details.upgradeUrl);
+function normalizeRecommendedAction(runtimeQuota: Record<string, unknown>): RuntimeRecommendedAction | null {
+  const nested = isRecord(runtimeQuota.recommendedAction) ? runtimeQuota.recommendedAction : {};
+  const bindingState = normalizeString(nested.bindingState);
+  const providerActionCode = normalizeString(nested.providerActionCode);
+  const severity = normalizeString(nested.severity);
+  const type = normalizeString(nested.type);
+  const url = normalizeString(nested.url);
 
-  if (!bindingState && !type && !url) {
+  if (!bindingState && !providerActionCode && !severity && !type && !url) {
     return null;
   }
 
   return {
     ...(bindingState ? { bindingState } : {}),
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
     ...(type ? { type } : {}),
     ...(url ? { url } : {}),
   };
 }
 
-function quotaGateReason(details: Record<string, unknown>): string {
-  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+function quotaGateReason(runtimeQuota: Record<string, unknown>): string {
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult) ? runtimeQuota.quotaGateResult : {};
   return normalizeString(quotaGateResult.reason);
 }
 
-function retryAfterSeconds(details: Record<string, unknown>): number | null {
-  const direct = normalizePositiveInteger(details.retryAfterSeconds);
+function retryAfterSeconds(runtimeQuota: Record<string, unknown>): number | null {
+  const direct = normalizePositiveInteger(runtimeQuota.retryAfterSeconds);
   if (direct !== null) {
     return direct;
   }
 
-  const quotaGateResult = isRecord(details.quotaGateResult) ? details.quotaGateResult : {};
+  const quotaGateResult = isRecord(runtimeQuota.quotaGateResult) ? runtimeQuota.quotaGateResult : {};
   const postQuotaRateLimit = isRecord(quotaGateResult.postQuotaRateLimit) ? quotaGateResult.postQuotaRateLimit : {};
   return normalizePositiveInteger(postQuotaRateLimit.retryAfterSeconds);
 }
 
 function isPostQuotaRateLimited(denied: RuntimeQuotaDenied): boolean {
   return denied.status === 429 ||
-    denied.code === "post_quota_rate_limited" ||
     denied.quotaGateReason === "postQuotaRateLimitExceeded";
 }
 
@@ -119,20 +117,20 @@ function quotaReason(denied: RuntimeQuotaDenied): string {
   if (isPostQuotaRateLimited(denied)) {
     return "this API key has reached the temporary request limit for this memory feature";
   }
-  const actionType = normalizeString(denied.recommendedAction?.type);
-  if (actionType === "claimApiKey") {
+  const providerActionCode = normalizeString(denied.recommendedAction?.providerActionCode);
+  if (providerActionCode === "claimApiKey") {
     return "the included usage quota for this API key has been used up";
   }
-  if (actionType === "increaseSpendingLimit" || denied.code === "spending_limit_exceeded") {
+  if (providerActionCode === "increaseSpendingLimit") {
     return "the configured spending limit would be exceeded";
   }
-  if (actionType === "enableOnDemand") {
+  if (providerActionCode === "enableOnDemand") {
     return "the included usage quota has been used up and on-demand usage is not enabled";
   }
-  if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
+  if (providerActionCode === "upgradePlan") {
     return "the included usage quota for this mem9 account has been used up";
   }
-  if (denied.code === "runtime_access_blocked") {
+  if (providerActionCode === "resolveAccountState") {
     return "the current account or billing state blocks runtime memory access";
   }
   return "the runtime quota check blocked this request";
@@ -183,7 +181,7 @@ function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
 
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
-  const actionType = normalizeString(action?.type);
+  const providerActionCode = normalizeString(action?.providerActionCode);
   const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
   if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
@@ -193,7 +191,7 @@ function actionInstruction(denied: RuntimeQuotaDenied): string {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 
-  switch (actionType) {
+  switch (providerActionCode) {
     case "claimApiKey":
       return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
     case "upgradePlan":
@@ -216,20 +214,19 @@ export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | nu
   }
 
   const details = isRecord(payload.details) ? payload.details : {};
-  const code = normalizeString(payload.code);
-  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
-  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+  if (normalizeString(details.errorCategory) !== "runtime_quota_denied") {
     return null;
   }
+  const runtimeQuota = isRecord(details.runtimeQuota) ? details.runtimeQuota : {};
 
-  const recommendedAction = normalizeRecommendedAction(details);
-  const retryAfter = retryAfterSeconds(details);
-  const reason = quotaGateReason(details);
+  const recommendedAction = normalizeRecommendedAction(runtimeQuota);
+  const retryAfter = retryAfterSeconds(runtimeQuota);
+  const reason = quotaGateReason(runtimeQuota);
   return {
     status: value instanceof Mem9HttpError ? value.status : null,
-    code: code || "runtime_quota_denied",
-    message: normalizeString(payload.message) || "runtime usage quota denied",
-    ...(normalizeString(details.meter) ? { meter: normalizeString(details.meter) } : {}),
+    code: "runtime_quota_denied",
+    message: normalizeString(payload.error) || "Runtime usage quota denied.",
+    ...(normalizeString(runtimeQuota.meter) ? { meter: normalizeString(runtimeQuota.meter) } : {}),
     ...(reason ? { quotaGateReason: reason } : {}),
     ...(retryAfter !== null ? { retryAfterSeconds: retryAfter } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -5,6 +5,7 @@ const QUOTA_CODES = new Set([
   "runtime_access_blocked",
   "runtime_quota_denied",
 ]);
+const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
 
 export class Mem9HttpError extends Error {
   constructor(
@@ -172,24 +173,20 @@ function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { he
   };
 }
 
-function retryInstruction(denied: RuntimeQuotaDenied): string {
-  if (denied.retryAfterSeconds !== undefined) {
-    const unit = denied.retryAfterSeconds === 1 ? "second" : "seconds";
-    return `Ask them to wait ${denied.retryAfterSeconds} ${unit} before trying again.`;
+function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
+  const actionUrl = normalizeString(denied.recommendedAction?.url);
+  if (actionUrl) {
+    return actionUrl;
   }
-  return "Ask them to wait briefly before trying again.";
+  return isPostQuotaRateLimited(denied) ? DEFAULT_BILLING_ACTION_URL : "";
 }
 
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
-  const actionUrl = normalizeString(action?.url);
+  const actionUrl = actionUrlForDenied(denied);
   if (isPostQuotaRateLimited(denied)) {
-    const retry = retryInstruction(denied);
-    if (!actionUrl) {
-      return retry;
-    }
-    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";
@@ -251,6 +248,7 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
 export function toolErrorPayload(error: unknown): Record<string, unknown> {
   const denied = parseRuntimeQuotaDenied(error);
   if (denied) {
+    const actionUrl = actionUrlForDenied(denied);
     return {
       ok: false,
       error: denied.message,
@@ -262,7 +260,7 @@ export function toolErrorPayload(error: unknown): Record<string, unknown> {
         ...(denied.retryAfterSeconds !== undefined ? { retryAfterSeconds: denied.retryAfterSeconds } : {}),
         ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
       },
-      ...(denied.recommendedAction?.url ? { action_url: denied.recommendedAction.url } : {}),
+      ...(actionUrl ? { action_url: actionUrl } : {}),
     };
   }
 

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -116,7 +116,7 @@ function isPostQuotaRateLimited(denied: RuntimeQuotaDenied): boolean {
 
 function quotaReason(denied: RuntimeQuotaDenied): string {
   if (isPostQuotaRateLimited(denied)) {
-    return "this API key is in post-quota mode and its temporary rate limit for this memory meter has been reached";
+    return "this API key has reached the temporary request limit for this memory feature";
   }
   const actionType = normalizeString(denied.recommendedAction?.type);
   if (actionType === "claimApiKey") {
@@ -189,7 +189,7 @@ function actionInstruction(denied: RuntimeQuotaDenied): string {
     if (!actionUrl) {
       return retry;
     }
-    return `${retry} If they need more continuous mem9 usage, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
+    return `${retry} If they need higher mem9 usage limits, ask them to open this link to adjust billing or upgrade their plan: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {
     return "Ask them to open the mem9 console to resolve the account or billing state.";

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -1,0 +1,159 @@
+const QUOTA_CODES = new Set([
+  "quota_exhausted",
+  "spending_limit_exceeded",
+  "runtime_quota_denied",
+]);
+
+export class Mem9HttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: string,
+    readonly data: unknown,
+  ) {
+    super(message);
+    this.name = "Mem9HttpError";
+  }
+}
+
+export interface RuntimeRecommendedAction {
+  bindingState?: string;
+  type?: string;
+  url?: string;
+}
+
+export interface RuntimeQuotaDenied {
+  status: number | null;
+  code: string;
+  message: string;
+  recommendedAction?: RuntimeRecommendedAction;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function parseJsonOrUndefined(text: string): unknown {
+  if (!text.trim()) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export function messageFromErrorBody(status: number, body: string, data: unknown): string {
+  if (isRecord(data)) {
+    const message = normalizeString(data.message);
+    if (message) {
+      return message;
+    }
+
+    const error = normalizeString(data.error);
+    if (error) {
+      return error;
+    }
+  }
+
+  const text = body.trim();
+  return text || `HTTP ${status}`;
+}
+
+function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRecommendedAction | null {
+  const nested = isRecord(details.recommendedAction) ? details.recommendedAction : {};
+  const bindingState = normalizeString(nested.bindingState ?? details.bindingState);
+  const type = normalizeString(nested.type ?? details.upgradeAction);
+  const url = normalizeString(nested.url ?? details.upgradeUrl);
+
+  if (!bindingState && !type && !url) {
+    return null;
+  }
+
+  return {
+    ...(bindingState ? { bindingState } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+function actionLabel(type: string): string {
+  switch (type) {
+    case "claimApiKey":
+      return "Claim this API key";
+    case "upgradePlan":
+      return "Upgrade your plan";
+    case "increaseSpendingLimit":
+      return "Increase your spending limit";
+    case "enableOnDemand":
+      return "Enable on-demand usage";
+    case "resolveAccountState":
+      return "Resolve account state";
+    default:
+      return "Open mem9 console";
+  }
+}
+
+export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | null {
+  const payload = value instanceof Mem9HttpError ? value.data : value;
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const details = isRecord(payload.details) ? payload.details : {};
+  const code = normalizeString(payload.code);
+  const mem9Code = normalizeString(details.mem9Code ?? details.mem9_code ?? payload.mem9_code);
+  if (mem9Code !== "runtime_quota_denied" && !QUOTA_CODES.has(code)) {
+    return null;
+  }
+
+  const recommendedAction = normalizeRecommendedAction(details);
+  return {
+    status: value instanceof Mem9HttpError ? value.status : null,
+    code: code || "runtime_quota_denied",
+    message: normalizeString(payload.message) || "runtime usage quota denied",
+    ...(recommendedAction ? { recommendedAction } : {}),
+  };
+}
+
+export function formatRuntimeQuotaNotice(value: unknown, operation: string): string {
+  const denied = parseRuntimeQuotaDenied(value);
+  if (!denied) {
+    return "";
+  }
+
+  const actionUrl = normalizeString(denied.recommendedAction?.url);
+  const actionText = actionUrl
+    ? ` ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
+    : "";
+  return `[mem9] ${operation}: ${denied.message}.${actionText}`;
+}
+
+export function toolErrorPayload(error: unknown): Record<string, unknown> {
+  const denied = parseRuntimeQuotaDenied(error);
+  if (denied) {
+    return {
+      ok: false,
+      error: denied.message,
+      status_code: denied.status,
+      code: denied.code,
+      quota: {
+        code: denied.code,
+        message: denied.message,
+        ...(denied.recommendedAction ? { recommendedAction: denied.recommendedAction } : {}),
+      },
+      ...(denied.recommendedAction?.url ? { action_url: denied.recommendedAction.url } : {}),
+    };
+  }
+
+  return {
+    ok: false,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -26,6 +26,7 @@ export interface RuntimeQuotaDenied {
   status: number | null;
   code: string;
   message: string;
+  meter?: string;
   recommendedAction?: RuntimeRecommendedAction;
 }
 
@@ -83,25 +84,79 @@ function normalizeRecommendedAction(details: Record<string, unknown>): RuntimeRe
   };
 }
 
-function actionLabel(type: string): string {
-  switch (type) {
-    case "claimApiKey":
-      return "Claim this API key";
-    case "upgradePlan":
-      return "Upgrade your plan";
-    case "increaseSpendingLimit":
-      return "Increase your spending limit";
-    case "enableOnDemand":
-      return "Enable on-demand usage";
-    case "resolveAccountState":
-      return "Resolve account state";
-    default:
-      return "Open mem9 console";
+function quotaReason(denied: RuntimeQuotaDenied): string {
+  const actionType = normalizeString(denied.recommendedAction?.type);
+  if (actionType === "claimApiKey") {
+    return "the included usage quota for this API key has been used up";
   }
+  if (actionType === "increaseSpendingLimit" || denied.code === "spending_limit_exceeded") {
+    return "the configured spending limit would be exceeded";
+  }
+  if (actionType === "enableOnDemand") {
+    return "the included usage quota has been used up and on-demand usage is not enabled";
+  }
+  if (actionType === "upgradePlan" || denied.code === "quota_exhausted") {
+    return "the included usage quota for this mem9 account has been used up";
+  }
+  return "the runtime quota check blocked this request";
 }
 
-function sentence(message: string): string {
-  return /[.!?]$/.test(message) ? message : `${message}.`;
+function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { headline: string; userState: string } {
+  const meter = normalizeString(denied.meter);
+  if (meter === "memory_write_requests") {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (meter === "memory_recall_requests") {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  const operationText = normalizeString(operation).toLowerCase();
+  if (/\b(ingest|save|store|write)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 memory saving is temporarily unavailable",
+      userState: "mem9 cannot save new memories right now",
+    };
+  }
+  if (/\b(recall|search)\b/.test(operationText)) {
+    return {
+      headline: "Mem9 recall is temporarily unavailable",
+      userState: "mem9 cannot recall memories right now",
+    };
+  }
+
+  return {
+    headline: "Mem9 memory is temporarily unavailable",
+    userState: "mem9 cannot complete the memory request right now",
+  };
+}
+
+function actionInstruction(action?: RuntimeRecommendedAction): string {
+  const actionType = normalizeString(action?.type);
+  const actionUrl = normalizeString(action?.url);
+  if (!actionUrl) {
+    return "Ask them to open the mem9 console to resolve the account or billing state.";
+  }
+
+  switch (actionType) {
+    case "claimApiKey":
+      return `Ask them to open this link to sign in or create a mem9 account and claim this API key: ${actionUrl}. After claiming the key, they can upgrade their plan or set up billing to get more usage. Include the link exactly as written.`;
+    case "upgradePlan":
+      return `Ask them to open this link to upgrade their mem9 plan and get more included usage: ${actionUrl}. Include the link exactly as written.`;
+    case "increaseSpendingLimit":
+      return `Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${actionUrl}. Include the link exactly as written.`;
+    case "enableOnDemand":
+      return `Ask them to open this link to enable billing or on-demand usage for mem9: ${actionUrl}. Include the link exactly as written.`;
+    case "resolveAccountState":
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${actionUrl}. Include the link exactly as written.`;
+    default:
+      return `Ask them to open this mem9 link to resolve the account or billing state: ${actionUrl}. Include the link exactly as written.`;
+  }
 }
 
 export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | null {
@@ -122,6 +177,7 @@ export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | nu
     status: value instanceof Mem9HttpError ? value.status : null,
     code: code || "runtime_quota_denied",
     message: normalizeString(payload.message) || "runtime usage quota denied",
+    ...(normalizeString(details.meter) ? { meter: normalizeString(details.meter) } : {}),
     ...(recommendedAction ? { recommendedAction } : {}),
   };
 }
@@ -132,14 +188,8 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
     return "";
   }
 
-  const actionUrl = normalizeString(denied.recommendedAction?.url);
-  const actionText = actionUrl
-    ? ` User action required: ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
-    : "";
-  const replyInstruction = actionUrl
-    ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${actionUrl}`
-    : " In your reply, briefly tell the user mem9 memory is paused.";
-  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}${replyInstruction}`;
+  const subject = quotaNoticeSubject(denied, operation);
+  return `${subject.headline} because ${quotaReason(denied)}. In your reply, briefly tell the user that ${subject.userState}. ${actionInstruction(denied.recommendedAction)}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -134,9 +134,12 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
 
   const actionUrl = normalizeString(denied.recommendedAction?.url);
   const actionText = actionUrl
-    ? ` ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
+    ? ` User action required: ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
     : "";
-  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}`;
+  const replyInstruction = actionUrl
+    ? ` In your reply, briefly tell the user mem9 memory is paused and include this URL exactly: ${actionUrl}`
+    : " In your reply, briefly tell the user mem9 memory is paused.";
+  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}${replyInstruction}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -100,6 +100,10 @@ function actionLabel(type: string): string {
   }
 }
 
+function sentence(message: string): string {
+  return /[.!?]$/.test(message) ? message : `${message}.`;
+}
+
 export function parseRuntimeQuotaDenied(value: unknown): RuntimeQuotaDenied | null {
   const payload = value instanceof Mem9HttpError ? value.data : value;
   if (!isRecord(payload)) {
@@ -132,7 +136,7 @@ export function formatRuntimeQuotaNotice(value: unknown, operation: string): str
   const actionText = actionUrl
     ? ` ${actionLabel(normalizeString(denied.recommendedAction?.type))}: ${actionUrl}`
     : "";
-  return `[mem9] ${operation}: ${denied.message}.${actionText}`;
+  return `[mem9] ${operation}: ${sentence(denied.message)}${actionText}`;
 }
 
 export function toolErrorPayload(error: unknown): Record<string, unknown> {

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -1,5 +1,3 @@
-const DEFAULT_BILLING_ACTION_URL = "https://console.mem9.ai/console/billing/plan";
-
 export class Mem9HttpError extends Error {
   constructor(
     message: string,
@@ -13,7 +11,6 @@ export class Mem9HttpError extends Error {
 }
 
 export interface RuntimeRecommendedAction {
-  bindingState?: string;
   providerActionCode?: string;
   severity?: string;
   type?: string;
@@ -73,18 +70,16 @@ export function messageFromErrorBody(status: number, body: string, data: unknown
 
 function normalizeRecommendedAction(runtimeQuota: Record<string, unknown>): RuntimeRecommendedAction | null {
   const nested = isRecord(runtimeQuota.recommendedAction) ? runtimeQuota.recommendedAction : {};
-  const bindingState = normalizeString(nested.bindingState);
   const providerActionCode = normalizeString(nested.providerActionCode);
   const severity = normalizeString(nested.severity);
   const type = normalizeString(nested.type);
   const url = normalizeString(nested.url);
 
-  if (!bindingState && !providerActionCode && !severity && !type && !url) {
+  if (!providerActionCode && !severity && !type && !url) {
     return null;
   }
 
   return {
-    ...(bindingState ? { bindingState } : {}),
     ...(providerActionCode ? { providerActionCode } : {}),
     ...(severity ? { severity } : {}),
     ...(type ? { type } : {}),
@@ -172,22 +167,17 @@ function quotaNoticeSubject(denied: RuntimeQuotaDenied, operation: string): { he
 }
 
 function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
-  const actionUrl = normalizeString(denied.recommendedAction?.url);
-  if (actionUrl) {
-    return actionUrl;
-  }
-  return isPostQuotaRateLimited(denied) ? DEFAULT_BILLING_ACTION_URL : "";
+  return normalizeString(denied.recommendedAction?.url);
 }
 
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
   const providerActionCode = normalizeString(action?.providerActionCode);
-  const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
-  if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
-    return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
-  }
   if (!actionUrl) {
+    if (isPostQuotaRateLimited(denied)) {
+      return "Tell them that the quota/rate-limit check blocked this request and to retry later or open the mem9 console to review account and billing settings.";
+    }
     return "Ask them to open the mem9 console to resolve the account or billing state.";
   }
 

--- a/opencode-plugin/src/server/quota-error.ts
+++ b/opencode-plugin/src/server/quota-error.ts
@@ -184,8 +184,9 @@ function actionUrlForDenied(denied: RuntimeQuotaDenied): string {
 function actionInstruction(denied: RuntimeQuotaDenied): string {
   const action = denied.recommendedAction;
   const actionType = normalizeString(action?.type);
+  const explicitActionUrl = normalizeString(action?.url);
   const actionUrl = actionUrlForDenied(denied);
-  if (isPostQuotaRateLimited(denied)) {
+  if (!explicitActionUrl && isPostQuotaRateLimited(denied)) {
     return `Ask them to open this link to upgrade their mem9 plan or set up billing for higher usage limits: ${actionUrl}. Include the link exactly as written.`;
   }
   if (!actionUrl) {

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -83,8 +83,8 @@ export class ServerBackend implements MemoryBackend {
     if (resp.status === 204) return undefined as T;
 
     const text = await resp.text();
-    const data = parseJsonOrUndefined(text);
     if (!resp.ok) {
+      const data = parseJsonOrUndefined(text);
       throw new Mem9HttpError(
         messageFromErrorBody(resp.status, text, data),
         resp.status,
@@ -92,7 +92,7 @@ export class ServerBackend implements MemoryBackend {
         data,
       );
     }
-    return data as T;
+    return JSON.parse(text) as T;
   }
 
   async store(input: CreateMemoryInput): Promise<StoreResult> {

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -12,10 +12,11 @@ import type {
   SearchInput,
 } from "../shared/types.ts";
 import { DEFAULT_SCOPE_CONFIG } from "../shared/defaults.ts";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
+import {
+  Mem9HttpError,
+  messageFromErrorBody,
+  parseJsonOrUndefined,
+} from "./quota-error.ts";
 
 function normalizeTimeoutMs(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
@@ -82,11 +83,14 @@ export class ServerBackend implements MemoryBackend {
     if (resp.status === 204) return undefined as T;
 
     const text = await resp.text();
-    const data = text ? (JSON.parse(text) as unknown) : undefined;
+    const data = parseJsonOrUndefined(text);
     if (!resp.ok) {
-      const message =
-        isRecord(data) && typeof data.error === "string" ? data.error : `HTTP ${resp.status}`;
-      throw new Error(message);
+      throw new Mem9HttpError(
+        messageFromErrorBody(resp.status, text, data),
+        resp.status,
+        text,
+        data,
+      );
     }
     return data as T;
   }
@@ -133,7 +137,7 @@ export class ServerBackend implements MemoryBackend {
     try {
       return await this.request<Memory>("GET", this.memoryPath(`/memories/${id}`));
     } catch (err) {
-      if (err instanceof Error && (err.message.includes("not found") || err.message.includes("404"))) {
+      if (err instanceof Mem9HttpError && err.status === 404) {
         return null;
       }
       throw err;
@@ -144,7 +148,7 @@ export class ServerBackend implements MemoryBackend {
     try {
       return await this.request<Memory>("PUT", this.memoryPath(`/memories/${id}`), input);
     } catch (err) {
-      if (err instanceof Error && (err.message.includes("not found") || err.message.includes("404"))) {
+      if (err instanceof Mem9HttpError && err.status === 404) {
         return null;
       }
       throw err;
@@ -156,7 +160,7 @@ export class ServerBackend implements MemoryBackend {
       await this.request("DELETE", this.memoryPath(`/memories/${id}`));
       return true;
     } catch (err) {
-      if (err instanceof Error && (err.message.includes("not found") || err.message.includes("404"))) {
+      if (err instanceof Mem9HttpError && err.status === 404) {
         return false;
       }
       throw err;

--- a/opencode-plugin/src/server/tools.ts
+++ b/opencode-plugin/src/server/tools.ts
@@ -5,6 +5,11 @@ import type {
   UpdateMemoryInput,
   SearchInput,
 } from "../shared/types.ts";
+import { toolErrorPayload } from "./quota-error.ts";
+
+function jsonToolError(error: unknown): string {
+  return JSON.stringify(toolErrorPayload(error));
+}
 
 /**
  * Build the 5 memory tools for OpenCode.
@@ -45,10 +50,7 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           const result = await backend.store(input);
           return JSON.stringify({ ok: true, data: result });
         } catch (err) {
-          return JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     }),
@@ -97,10 +99,7 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           const result = await backend.search(input);
           return JSON.stringify({ ok: true, ...result });
         } catch (err) {
-          return JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     }),
@@ -118,10 +117,7 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           }
           return JSON.stringify({ ok: true, data: result });
         } catch (err) {
-          return JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     }),
@@ -157,10 +153,7 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           }
           return JSON.stringify({ ok: true, data: result });
         } catch (err) {
-          return JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     }),
@@ -178,10 +171,7 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
           }
           return JSON.stringify({ ok: true });
         } catch (err) {
-          return JSON.stringify({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
+          return jsonToolError(err);
         }
       },
     }),

--- a/opencode-plugin/tests/ingest.test.ts
+++ b/opencode-plugin/tests/ingest.test.ts
@@ -379,14 +379,16 @@ test("buildHooks retries session.idle ingest after quota denial", async () => {
             402,
             "",
             {
-              code: "quota_exhausted",
-              message: "Included quota is exhausted.",
+              error: "Included quota is exhausted.",
               details: {
-                mem9Code: "runtime_quota_denied",
-                recommendedAction: {
-                  bindingState: "unclaimed",
-                  type: "claimApiKey",
-                  url: "https://console.mem9.ai/console/claim?key=mem9_test",
+                errorCategory: "runtime_quota_denied",
+                runtimeQuota: {
+                  recommendedAction: {
+                    bindingState: "unclaimed",
+                    providerActionCode: "claimApiKey",
+                    type: "openUrl",
+                    url: "https://console.mem9.ai/console/claim?key=mem9_test",
+                  },
                 },
               },
             },

--- a/opencode-plugin/tests/ingest.test.ts
+++ b/opencode-plugin/tests/ingest.test.ts
@@ -10,6 +10,7 @@ import type {
 import { redactDebugPayload } from "../src/server/debug.js";
 import { buildHooks } from "../src/server/hooks.js";
 import { selectMessagesForIngest } from "../src/server/ingest/select.js";
+import { Mem9HttpError } from "../src/server/quota-error.js";
 import type {
   CreateMemoryInput,
   Memory,
@@ -361,6 +362,63 @@ test("buildHooks retries session.idle ingest after a previous failure", async ()
   await waitForBackgroundTasks();
 
   assert.equal(ingestCalls.length, 2);
+});
+
+test("buildHooks retries session.idle ingest after quota denial", async () => {
+  let attempt = 0;
+  const ingestCalls: IngestInput[] = [];
+  const logEvents: string[] = [];
+  const hooks = buildHooks(
+    createBackend({
+      async ingestImpl(input) {
+        attempt += 1;
+        ingestCalls.push(input);
+        if (attempt === 1) {
+          throw new Mem9HttpError(
+            "Included quota is exhausted.",
+            402,
+            "",
+            {
+              code: "quota_exhausted",
+              message: "Included quota is exhausted.",
+              details: {
+                mem9Code: "runtime_quota_denied",
+                recommendedAction: {
+                  bindingState: "unclaimed",
+                  type: "claimApiKey",
+                  url: "https://console.mem9.ai/console/claim?key=mem9_test",
+                },
+              },
+            },
+          );
+        }
+        return {
+          status: "ok",
+          memories_changed: 1,
+        };
+      },
+    }),
+    {
+      debugLogger: async (event) => {
+        logEvents.push(event);
+      },
+      loadSessionTranscript: async () => [
+        { role: "user", content: "Remember quota retry behavior." },
+        { role: "assistant", content: "I will retry after quota recovers." },
+      ],
+    },
+  );
+
+  const onEvent = hooks.event;
+  assert.ok(onEvent);
+
+  await onEvent(createSessionIdleEventInput("session-quota-retry"));
+  await waitForBackgroundTasks();
+  await onEvent(createSessionIdleEventInput("session-quota-retry"));
+  await waitForBackgroundTasks();
+
+  assert.equal(ingestCalls.length, 2);
+  assert.equal(logEvents.includes("ingest.quota_denied"), true);
 });
 
 test("buildHooks skips session.idle ingest when the transcript has no assistant message", async () => {

--- a/opencode-plugin/tests/ingest.test.ts
+++ b/opencode-plugin/tests/ingest.test.ts
@@ -384,7 +384,6 @@ test("buildHooks retries session.idle ingest after quota denial", async () => {
                 errorCategory: "runtime_quota_denied",
                 runtimeQuota: {
                   recommendedAction: {
-                    bindingState: "unclaimed",
                     providerActionCode: "claimApiKey",
                     type: "openUrl",
                     url: "https://console.mem9.ai/console/claim?key=mem9_test",

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -578,6 +578,7 @@ test("buildHooks renders runtime quota denial action in recall context", async (
 
   assert.equal(output.system.length, 2);
   assert.match(output.system[1] ?? "", /Included quota is exhausted/);
+  assert.match(output.system[1] ?? "", /include this URL exactly/);
   assert.match(output.system[1] ?? "", /console\/claim\?key=mem9_test/);
   assert.doesNotMatch(output.system[1] ?? "", /\.\. Claim/);
   assert.deepEqual(

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -5,7 +5,7 @@ import type { Hooks } from "@opencode-ai/plugin";
 import type { MemoryBackend } from "../src/server/backend.js";
 import type { IngestInput, IngestResult } from "../src/server/backend.js";
 import { buildHooks } from "../src/server/hooks.js";
-import { Mem9HttpError } from "../src/server/quota-error.js";
+import { formatRuntimeQuotaNotice, Mem9HttpError } from "../src/server/quota-error.js";
 import { formatRecallBlock } from "../src/server/recall/format.js";
 import {
   buildRecallQuery,
@@ -547,6 +547,7 @@ test("buildHooks renders runtime quota denial action in recall context", async (
           message: "Included quota is exhausted.",
           details: {
             mem9Code: "runtime_quota_denied",
+            meter: "memory_recall_requests",
             recommendedAction: {
               bindingState: "unclaimed",
               type: "claimApiKey",
@@ -577,12 +578,84 @@ test("buildHooks renders runtime quota denial action in recall context", async (
   await onSystemTransform(createSystemTransformInput("session-quota"), output);
 
   assert.equal(output.system.length, 2);
-  assert.match(output.system[1] ?? "", /Included quota is exhausted/);
-  assert.match(output.system[1] ?? "", /include this URL exactly/);
+  assert.match(output.system[1] ?? "", /Mem9 recall is temporarily unavailable/);
+  assert.match(output.system[1] ?? "", /included usage quota for this API key has been used up/);
+  assert.match(output.system[1] ?? "", /sign in or create a mem9 account and claim this API key/);
+  assert.match(output.system[1] ?? "", /upgrade their plan or set up billing/);
+  assert.match(output.system[1] ?? "", /Include the link exactly as written/);
   assert.match(output.system[1] ?? "", /console\/claim\?key=mem9_test/);
+  assert.equal(
+    output.system[1]?.match(/https:\/\/console\.mem9\.ai\/console\/claim\?key=mem9_test/g)?.length,
+    1,
+  );
   assert.doesNotMatch(output.system[1] ?? "", /\.\. Claim/);
   assert.deepEqual(
     debugEvents.map((entry) => entry.event),
     ["recall.capture", "recall.request", "recall.quota_denied"],
+  );
+});
+
+test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "On-demand spending limit would be exceeded.",
+      402,
+      "",
+      {
+        code: "spending_limit_exceeded",
+        message: "On-demand spending limit would be exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "increaseSpendingLimit",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /configured spending limit would be exceeded/);
+  assert.match(notice, /increase the mem9 spending limit or adjust billing settings/);
+  assert.match(notice, /Include the link exactly as written/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
+test("formatRuntimeQuotaNotice renders write meter guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Included quota is exhausted.",
+      402,
+      "",
+      {
+        code: "quota_exhausted",
+        message: "Included quota is exhausted.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          meter: "memory_write_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "upgradePlan",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
+  assert.match(notice, /mem9 cannot save new memories right now/);
+  assert.match(notice, /upgrade their mem9 plan and get more included usage/);
+  assert.doesNotMatch(notice, /cannot recall memories/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
   );
 });

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -703,11 +703,57 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
   );
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
-  assert.match(notice, /upgrade their mem9 plan or set up billing/);
+  assert.match(notice, /upgrade their mem9 plan and get more included usage/);
   assert.match(notice, /console\/billing\/plan/);
   assert.doesNotMatch(notice, /wait 1 second before trying again/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
+test("formatRuntimeQuotaNotice renders post-quota claim action when provided", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Post-quota rate limit exceeded.",
+      429,
+      "",
+      {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "unclaimed",
+            type: "claimApiKey",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
+          },
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /temporary request limit/);
+  assert.match(notice, /sign in or create a mem9 account and claim this API key/);
+  assert.match(notice, /After claiming the key, they can upgrade their plan or set up billing/);
+  assert.match(notice, /console\/claim\?key=mem9_test/);
+  assert.doesNotMatch(notice, /console\/billing\/plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/claim\?key=mem9_test/g)?.length,
     1,
   );
 });

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -627,6 +627,87 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   );
 });
 
+test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Post-quota rate limit exceeded.",
+      429,
+      "",
+      {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_recall_requests",
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
+          },
+        },
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /post-quota mode/);
+  assert.match(notice, /temporary rate limit/);
+  assert.match(notice, /wait 23 seconds before trying again/);
+  assert.doesNotMatch(notice, /open the mem9 console/);
+});
+
+test("formatRuntimeQuotaNotice renders post-quota billing action when provided", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Post-quota rate limit exceeded.",
+      429,
+      "",
+      {
+        code: "post_quota_rate_limited",
+        message: "Post-quota rate limit exceeded.",
+        details: {
+          mem9Code: "runtime_quota_denied",
+          retryable: true,
+          meter: "memory_write_requests",
+          recommendedAction: {
+            bindingState: "claimed",
+            type: "upgradePlan",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 2,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 1,
+            },
+          },
+        },
+      },
+    ),
+    "memory save paused",
+  );
+
+  assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
+  assert.match(notice, /wait 1 second before trying again/);
+  assert.match(notice, /more continuous mem9 usage/);
+  assert.match(notice, /console\/billing\/plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});
+
 test("formatRuntimeQuotaNotice renders write meter guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -579,6 +579,7 @@ test("buildHooks renders runtime quota denial action in recall context", async (
   assert.equal(output.system.length, 2);
   assert.match(output.system[1] ?? "", /Included quota is exhausted/);
   assert.match(output.system[1] ?? "", /console\/claim\?key=mem9_test/);
+  assert.doesNotMatch(output.system[1] ?? "", /\.\. Claim/);
   assert.deepEqual(
     debugEvents.map((entry) => entry.event),
     ["recall.capture", "recall.request", "recall.quota_denied"],

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -627,7 +627,7 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   );
 });
 
-test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", () => {
+test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(
       "Post-quota rate limit exceeded.",
@@ -658,8 +658,13 @@ test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", ()
   );
 
   assert.match(notice, /temporary request limit/);
-  assert.match(notice, /wait 23 seconds before trying again/);
-  assert.doesNotMatch(notice, /open the mem9 console/);
+  assert.match(notice, /upgrade their mem9 plan or set up billing/);
+  assert.match(notice, /console\/billing\/plan/);
+  assert.doesNotMatch(notice, /wait 23 seconds before trying again/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
 });
 
 test("formatRuntimeQuotaNotice renders post-quota billing action when provided", () => {
@@ -698,9 +703,9 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
   );
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
-  assert.match(notice, /wait 1 second before trying again/);
-  assert.match(notice, /higher mem9 usage limits/);
+  assert.match(notice, /upgrade their mem9 plan or set up billing/);
   assert.match(notice, /console\/billing\/plan/);
+  assert.doesNotMatch(notice, /wait 1 second before trying again/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
     1,

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -657,8 +657,7 @@ test("formatRuntimeQuotaNotice renders post-quota rate limit retry guidance", ()
     "recall paused",
   );
 
-  assert.match(notice, /post-quota mode/);
-  assert.match(notice, /temporary rate limit/);
+  assert.match(notice, /temporary request limit/);
   assert.match(notice, /wait 23 seconds before trying again/);
   assert.doesNotMatch(notice, /open the mem9 console/);
 });
@@ -700,7 +699,7 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
 
   assert.match(notice, /Mem9 memory saving is temporarily unavailable/);
   assert.match(notice, /wait 1 second before trying again/);
-  assert.match(notice, /more continuous mem9 usage/);
+  assert.match(notice, /higher mem9 usage limits/);
   assert.match(notice, /console\/billing\/plan/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -559,7 +559,6 @@ test("buildHooks renders runtime quota denial action in recall context", async (
         runtimeQuotaPayload("Included quota is exhausted.", {
           meter: "memory_recall_requests",
           recommendedAction: {
-            bindingState: "unclaimed",
             providerActionCode: "claimApiKey",
             type: "openUrl",
             url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -614,7 +613,6 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
       runtimeQuotaPayload("On-demand spending limit would be exceeded.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "increaseSpendingLimit",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -685,7 +683,7 @@ test("formatRuntimeQuotaNotice ignores generic api rate limits", () => {
   assert.equal(notice, "");
 });
 
-test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", () => {
+test("formatRuntimeQuotaNotice renders post-quota rate limit guidance without action URL", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(
       "Post-quota rate limit exceeded.",
@@ -710,13 +708,11 @@ test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", 
   );
 
   assert.match(notice, /temporary request limit/);
-  assert.match(notice, /upgrade their mem9 plan or set up billing/);
-  assert.match(notice, /console\/billing\/plan/);
+  assert.match(notice, /quota\/rate-limit check blocked this request/);
+  assert.match(notice, /retry later or open the mem9 console/);
+  assert.doesNotMatch(notice, /console\/billing\/plan/);
   assert.doesNotMatch(notice, /wait 23 seconds before trying again/);
-  assert.equal(
-    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
-    1,
-  );
+  assert.equal((notice.match(/https:\/\//g) ?? []).length, 0);
 });
 
 test("formatRuntimeQuotaNotice renders post-quota billing action when provided", () => {
@@ -728,7 +724,6 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
       runtimeQuotaPayload("Post-quota rate limit exceeded.", {
         meter: "memory_write_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "upgradePlan",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",
@@ -768,7 +763,6 @@ test("formatRuntimeQuotaNotice renders post-quota claim action when provided", (
       runtimeQuotaPayload("Post-quota rate limit exceeded.", {
         meter: "memory_recall_requests",
         recommendedAction: {
-          bindingState: "unclaimed",
           providerActionCode: "claimApiKey",
           type: "openUrl",
           url: "https://console.mem9.ai/console/claim?key=mem9_test",
@@ -809,7 +803,6 @@ test("formatRuntimeQuotaNotice renders write meter guidance", () => {
       runtimeQuotaPayload("Included quota is exhausted.", {
         meter: "memory_write_requests",
         recommendedAction: {
-          bindingState: "claimed",
           providerActionCode: "upgradePlan",
           type: "openUrl",
           url: "https://console.mem9.ai/console/billing/plan",

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -40,6 +40,20 @@ function createMemory(overrides: Partial<Memory> = {}): Memory {
   };
 }
 
+function runtimeQuotaPayload(error: string, runtimeQuota: Record<string, unknown> | null = {}): Record<string, unknown> {
+  const details: Record<string, unknown> = {
+    errorCategory: "runtime_quota_denied",
+  };
+  if (runtimeQuota !== null) {
+    details.runtimeQuota = runtimeQuota;
+  }
+
+  return {
+    error,
+    details,
+  };
+}
+
 function createBackend(
   searchImpl?: (input: SearchInput) => Promise<SearchResult>,
 ): MemoryBackend {
@@ -542,19 +556,15 @@ test("buildHooks renders runtime quota denial action in recall context", async (
         "Included quota is exhausted.",
         402,
         "",
-        {
-          code: "quota_exhausted",
-          message: "Included quota is exhausted.",
-          details: {
-            mem9Code: "runtime_quota_denied",
-            meter: "memory_recall_requests",
-            recommendedAction: {
-              bindingState: "unclaimed",
-              type: "claimApiKey",
-              url: "https://console.mem9.ai/console/claim?key=mem9_test",
-            },
+        runtimeQuotaPayload("Included quota is exhausted.", {
+          meter: "memory_recall_requests",
+          recommendedAction: {
+            bindingState: "unclaimed",
+            providerActionCode: "claimApiKey",
+            type: "openUrl",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
           },
-        },
+        }),
       );
     }),
     {
@@ -601,19 +611,15 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
       "On-demand spending limit would be exceeded.",
       402,
       "",
-      {
-        code: "spending_limit_exceeded",
-        message: "On-demand spending limit would be exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          meter: "memory_recall_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "increaseSpendingLimit",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
+      runtimeQuotaPayload("On-demand spending limit would be exceeded.", {
+        meter: "memory_recall_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "increaseSpendingLimit",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     ),
     "recall paused",
   );
@@ -627,32 +633,78 @@ test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   );
 });
 
+test("formatRuntimeQuotaNotice handles missing runtime quota metadata", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Runtime access is blocked.",
+      402,
+      "",
+      runtimeQuotaPayload("Runtime access is blocked.", null),
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /runtime quota check blocked this request/);
+  assert.match(notice, /open the mem9 console/);
+});
+
+test("formatRuntimeQuotaNotice handles unknown provider action codes", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "Custom quota action required.",
+      402,
+      "",
+      runtimeQuotaPayload("Custom quota action required.", {
+        recommendedAction: {
+          providerActionCode: "contactSupport",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/support",
+        },
+      }),
+    ),
+    "recall paused",
+  );
+
+  assert.match(notice, /open this mem9 link to resolve the account or billing state/);
+  assert.match(notice, /console\/support/);
+});
+
+test("formatRuntimeQuotaNotice ignores generic api rate limits", () => {
+  const notice = formatRuntimeQuotaNotice(
+    new Mem9HttpError(
+      "rate limit exceeded",
+      429,
+      "",
+      {
+        error: "rate limit exceeded",
+      },
+    ),
+    "recall paused",
+  );
+
+  assert.equal(notice, "");
+});
+
 test("formatRuntimeQuotaNotice renders post-quota rate limit billing guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(
       "Post-quota rate limit exceeded.",
       429,
       "",
-      {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_recall_requests",
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 4,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 23,
-            },
+      runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
           },
         },
-      },
+      }),
     ),
     "recall paused",
   );
@@ -673,31 +725,26 @@ test("formatRuntimeQuotaNotice renders post-quota billing action when provided",
       "Post-quota rate limit exceeded.",
       429,
       "",
-      {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_write_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "upgradePlan",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 2,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 1,
-            },
+      runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
+        },
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 2,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 1,
           },
         },
-      },
+      }),
     ),
     "memory save paused",
   );
@@ -718,31 +765,26 @@ test("formatRuntimeQuotaNotice renders post-quota claim action when provided", (
       "Post-quota rate limit exceeded.",
       429,
       "",
-      {
-        code: "post_quota_rate_limited",
-        message: "Post-quota rate limit exceeded.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          retryable: true,
-          meter: "memory_recall_requests",
-          recommendedAction: {
-            bindingState: "unclaimed",
-            type: "claimApiKey",
-            url: "https://console.mem9.ai/console/claim?key=mem9_test",
-          },
-          quotaGateResult: {
-            outcome: "rateLimited",
-            mode: "postQuota",
-            reason: "postQuotaRateLimitExceeded",
-            postQuotaRateLimit: {
-              requestsPerMinute: 4,
-              windowDurationSeconds: 60,
-              scope: "apiKeyMeter",
-              retryAfterSeconds: 23,
-            },
+      runtimeQuotaPayload("Post-quota rate limit exceeded.", {
+        meter: "memory_recall_requests",
+        recommendedAction: {
+          bindingState: "unclaimed",
+          providerActionCode: "claimApiKey",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        },
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
           },
         },
-      },
+      }),
     ),
     "recall paused",
   );
@@ -764,19 +806,15 @@ test("formatRuntimeQuotaNotice renders write meter guidance", () => {
       "Included quota is exhausted.",
       402,
       "",
-      {
-        code: "quota_exhausted",
-        message: "Included quota is exhausted.",
-        details: {
-          mem9Code: "runtime_quota_denied",
-          meter: "memory_write_requests",
-          recommendedAction: {
-            bindingState: "claimed",
-            type: "upgradePlan",
-            url: "https://console.mem9.ai/console/billing/plan",
-          },
+      runtimeQuotaPayload("Included quota is exhausted.", {
+        meter: "memory_write_requests",
+        recommendedAction: {
+          bindingState: "claimed",
+          providerActionCode: "upgradePlan",
+          type: "openUrl",
+          url: "https://console.mem9.ai/console/billing/plan",
         },
-      },
+      }),
     ),
     "recall paused",
   );

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -5,6 +5,7 @@ import type { Hooks } from "@opencode-ai/plugin";
 import type { MemoryBackend } from "../src/server/backend.js";
 import type { IngestInput, IngestResult } from "../src/server/backend.js";
 import { buildHooks } from "../src/server/hooks.js";
+import { Mem9HttpError } from "../src/server/quota-error.js";
 import { formatRecallBlock } from "../src/server/recall/format.js";
 import {
   buildRecallQuery,
@@ -531,4 +532,55 @@ test("buildHooks degrades gracefully when recall search fails", async () => {
     ["recall.capture", "recall.request", "recall.error"],
   );
   assert.equal(debugEvents[2]?.payload.error, "search backend unavailable");
+});
+
+test("buildHooks renders runtime quota denial action in recall context", async () => {
+  const debugEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const hooks = buildHooks(
+    createBackend(async () => {
+      throw new Mem9HttpError(
+        "Included quota is exhausted.",
+        402,
+        "",
+        {
+          code: "quota_exhausted",
+          message: "Included quota is exhausted.",
+          details: {
+            mem9Code: "runtime_quota_denied",
+            recommendedAction: {
+              bindingState: "unclaimed",
+              type: "claimApiKey",
+              url: "https://console.mem9.ai/console/claim?key=mem9_test",
+            },
+          },
+        },
+      );
+    }),
+    {
+      debugLogger: async (event, payload = {}) => {
+        debugEvents.push({ event, payload });
+      },
+    },
+  );
+
+  const onChatMessage = hooks["chat.message"];
+  const onSystemTransform = hooks["experimental.chat.system.transform"];
+  assert.ok(onChatMessage);
+  assert.ok(onSystemTransform);
+
+  await onChatMessage(
+    createChatMessageInput("session-quota"),
+    createChatMessageOutput([textPart("Find relevant project context.")]),
+  );
+
+  const output = createSystemTransformOutput(["Existing system"]);
+  await onSystemTransform(createSystemTransformInput("session-quota"), output);
+
+  assert.equal(output.system.length, 2);
+  assert.match(output.system[1] ?? "", /Included quota is exhausted/);
+  assert.match(output.system[1] ?? "", /console\/claim\?key=mem9_test/);
+  assert.deepEqual(
+    debugEvents.map((entry) => entry.event),
+    ["recall.capture", "recall.request", "recall.quota_denied"],
+  );
 });

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -89,14 +89,16 @@ test("ServerBackend preserves runtime quota denial response bodies", async () =>
 
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({
-      code: "quota_exhausted",
-      message: "Included quota is exhausted.",
+      error: "Included quota is exhausted.",
       details: {
-        mem9Code: "runtime_quota_denied",
-        recommendedAction: {
-          bindingState: "unclaimed",
-          type: "claimApiKey",
-          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        errorCategory: "runtime_quota_denied",
+        runtimeQuota: {
+          recommendedAction: {
+            bindingState: "unclaimed",
+            providerActionCode: "claimApiKey",
+            type: "openUrl",
+            url: "https://console.mem9.ai/console/claim?key=mem9_test",
+          },
         },
       },
     }), {
@@ -112,7 +114,7 @@ test("ServerBackend preserves runtime quota denial response bodies", async () =>
       (error: unknown) => {
         assert.equal(error instanceof Mem9HttpError, true);
         const denied = parseRuntimeQuotaDenied(error);
-        assert.equal(denied?.code, "quota_exhausted");
+        assert.equal(denied?.code, "runtime_quota_denied");
         assert.equal(denied?.recommendedAction?.url, "https://console.mem9.ai/console/claim?key=mem9_test");
         return true;
       },
@@ -127,21 +129,21 @@ test("ServerBackend preserves post-quota rate limit response bodies", async () =
 
   globalThis.fetch = async () => {
     return new Response(JSON.stringify({
-      code: "post_quota_rate_limited",
-      message: "Post-quota rate limit exceeded.",
+      error: "Post-quota rate limit exceeded.",
       details: {
-        mem9Code: "runtime_quota_denied",
-        retryable: true,
-        meter: "memory_recall_requests",
-        quotaGateResult: {
-          outcome: "rateLimited",
-          mode: "postQuota",
-          reason: "postQuotaRateLimitExceeded",
-          postQuotaRateLimit: {
-            requestsPerMinute: 4,
-            windowDurationSeconds: 60,
-            scope: "apiKeyMeter",
-            retryAfterSeconds: 23,
+        errorCategory: "runtime_quota_denied",
+        runtimeQuota: {
+          meter: "memory_recall_requests",
+          quotaGateResult: {
+            outcome: "rateLimited",
+            mode: "postQuota",
+            reason: "postQuotaRateLimitExceeded",
+            postQuotaRateLimit: {
+              requestsPerMinute: 4,
+              windowDurationSeconds: 60,
+              scope: "apiKeyMeter",
+              retryAfterSeconds: 23,
+            },
           },
         },
       },
@@ -158,7 +160,7 @@ test("ServerBackend preserves post-quota rate limit response bodies", async () =
       (error: unknown) => {
         assert.equal(error instanceof Mem9HttpError, true);
         const denied = parseRuntimeQuotaDenied(error);
-        assert.equal(denied?.code, "post_quota_rate_limited");
+        assert.equal(denied?.code, "runtime_quota_denied");
         assert.equal(denied?.retryAfterSeconds, 23);
         return true;
       },

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -121,3 +121,49 @@ test("ServerBackend preserves runtime quota denial response bodies", async () =>
     globalThis.fetch = originalFetch;
   }
 });
+
+test("ServerBackend preserves post-quota rate limit response bodies", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      code: "post_quota_rate_limited",
+      message: "Post-quota rate limit exceeded.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        retryable: true,
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "rateLimited",
+          mode: "postQuota",
+          reason: "postQuotaRateLimitExceeded",
+          postQuotaRateLimit: {
+            requestsPerMinute: 4,
+            windowDurationSeconds: 60,
+            scope: "apiKeyMeter",
+            retryAfterSeconds: 23,
+          },
+        },
+      },
+    }), {
+      status: 429,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    await assert.rejects(
+      () => backend.search({ q: "hello" }),
+      (error: unknown) => {
+        assert.equal(error instanceof Mem9HttpError, true);
+        const denied = parseRuntimeQuotaDenied(error);
+        assert.equal(denied?.code, "post_quota_rate_limited");
+        assert.equal(denied?.retryAfterSeconds, 23);
+        return true;
+      },
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { ServerBackend } from "../src/server/server-backend.js";
+import { Mem9HttpError, parseRuntimeQuotaDenied } from "../src/server/quota-error.js";
 
 async function withPatchedAbortSignalTimeout(
   run: (capturedTimeouts: number[]) => Promise<void>,
@@ -78,6 +79,44 @@ test("ServerBackend uses searchTimeoutMs for search and defaultTimeoutMs for wri
 
       assert.deepEqual(capturedTimeouts, [16000, 11000]);
     });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("ServerBackend preserves runtime quota denial response bodies", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response(JSON.stringify({
+      code: "quota_exhausted",
+      message: "Included quota is exhausted.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        recommendedAction: {
+          bindingState: "unclaimed",
+          type: "claimApiKey",
+          url: "https://console.mem9.ai/console/claim?key=mem9_test",
+        },
+      },
+    }), {
+      status: 402,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    await assert.rejects(
+      () => backend.search({ q: "hello" }),
+      (error: unknown) => {
+        assert.equal(error instanceof Mem9HttpError, true);
+        const denied = parseRuntimeQuotaDenied(error);
+        assert.equal(denied?.code, "quota_exhausted");
+        assert.equal(denied?.recommendedAction?.url, "https://console.mem9.ai/console/claim?key=mem9_test");
+        return true;
+      },
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -84,6 +84,24 @@ test("ServerBackend uses searchTimeoutMs for search and defaultTimeoutMs for wri
   }
 });
 
+test("ServerBackend rejects malformed success JSON", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response("{", {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    await assert.rejects(() => backend.search({ q: "hello" }), SyntaxError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("ServerBackend preserves runtime quota denial response bodies", async () => {
   const originalFetch = globalThis.fetch;
 
@@ -94,7 +112,6 @@ test("ServerBackend preserves runtime quota denial response bodies", async () =>
         errorCategory: "runtime_quota_denied",
         runtimeQuota: {
           recommendedAction: {
-            bindingState: "unclaimed",
             providerActionCode: "claimApiKey",
             type: "openUrl",
             url: "https://console.mem9.ai/console/claim?key=mem9_test",

--- a/opencode-plugin/tests/tools.test.ts
+++ b/opencode-plugin/tests/tools.test.ts
@@ -24,7 +24,6 @@ function quotaError(): Mem9HttpError {
         errorCategory: "runtime_quota_denied",
         runtimeQuota: {
           recommendedAction: {
-            bindingState: "claimed",
             providerActionCode: "increaseSpendingLimit",
             type: "openUrl",
             url: "https://console.mem9.ai/console/billing/plan",
@@ -75,7 +74,6 @@ test("memory tools return structured runtime quota denial payloads", async () =>
   assert.equal(parsed.status_code, 402);
   assert.equal(parsed.action_url, "https://console.mem9.ai/console/billing/plan");
   assert.deepEqual(parsed.quota.recommendedAction, {
-    bindingState: "claimed",
     providerActionCode: "increaseSpendingLimit",
     type: "openUrl",
     url: "https://console.mem9.ai/console/billing/plan",

--- a/opencode-plugin/tests/tools.test.ts
+++ b/opencode-plugin/tests/tools.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { IngestInput, IngestResult, MemoryBackend } from "../src/server/backend.js";
+import { Mem9HttpError } from "../src/server/quota-error.js";
+import { buildTools } from "../src/server/tools.js";
+import type {
+  CreateMemoryInput,
+  Memory,
+  SearchInput,
+  SearchResult,
+  StoreResult,
+  UpdateMemoryInput,
+} from "../src/shared/types.js";
+
+function quotaError(): Mem9HttpError {
+  return new Mem9HttpError(
+    "Spending limit is exhausted.",
+    402,
+    "",
+    {
+      code: "spending_limit_exceeded",
+      message: "Spending limit is exhausted.",
+      details: {
+        mem9Code: "runtime_quota_denied",
+        recommendedAction: {
+          bindingState: "claimed",
+          type: "increaseSpendingLimit",
+          url: "https://console.mem9.ai/console/billing/plan",
+        },
+      },
+    },
+  );
+}
+
+function createBackend(): MemoryBackend {
+  return {
+    async store(_input: CreateMemoryInput): Promise<StoreResult> {
+      throw quotaError();
+    },
+    async search(_input: SearchInput): Promise<SearchResult> {
+      throw quotaError();
+    },
+    async get(_id: string): Promise<Memory | null> {
+      throw quotaError();
+    },
+    async update(_id: string, _input: UpdateMemoryInput): Promise<Memory | null> {
+      throw quotaError();
+    },
+    async remove(_id: string): Promise<boolean> {
+      throw quotaError();
+    },
+    async listRecent(_limit: number): Promise<Memory[]> {
+      return [];
+    },
+    async ingest(_input: IngestInput): Promise<IngestResult> {
+      return { status: "ok" };
+    },
+  };
+}
+
+test("memory tools return structured runtime quota denial payloads", async () => {
+  const tools = buildTools(createBackend()) as unknown as Record<
+    string,
+    { execute(args: Record<string, unknown>, context?: unknown): Promise<unknown> }
+  >;
+  const output = await tools.memory_search.execute({ q: "theme" });
+  assert.equal(typeof output, "string");
+
+  const parsed = JSON.parse(output as string);
+  assert.equal(parsed.ok, false);
+  assert.equal(parsed.code, "spending_limit_exceeded");
+  assert.equal(parsed.status_code, 402);
+  assert.equal(parsed.action_url, "https://console.mem9.ai/console/billing/plan");
+  assert.deepEqual(parsed.quota.recommendedAction, {
+    bindingState: "claimed",
+    type: "increaseSpendingLimit",
+    url: "https://console.mem9.ai/console/billing/plan",
+  });
+});

--- a/opencode-plugin/tests/tools.test.ts
+++ b/opencode-plugin/tests/tools.test.ts
@@ -19,14 +19,16 @@ function quotaError(): Mem9HttpError {
     402,
     "",
     {
-      code: "spending_limit_exceeded",
-      message: "Spending limit is exhausted.",
+      error: "Spending limit is exhausted.",
       details: {
-        mem9Code: "runtime_quota_denied",
-        recommendedAction: {
-          bindingState: "claimed",
-          type: "increaseSpendingLimit",
-          url: "https://console.mem9.ai/console/billing/plan",
+        errorCategory: "runtime_quota_denied",
+        runtimeQuota: {
+          recommendedAction: {
+            bindingState: "claimed",
+            providerActionCode: "increaseSpendingLimit",
+            type: "openUrl",
+            url: "https://console.mem9.ai/console/billing/plan",
+          },
         },
       },
     },
@@ -69,12 +71,13 @@ test("memory tools return structured runtime quota denial payloads", async () =>
 
   const parsed = JSON.parse(output as string);
   assert.equal(parsed.ok, false);
-  assert.equal(parsed.code, "spending_limit_exceeded");
+  assert.equal(parsed.code, "runtime_quota_denied");
   assert.equal(parsed.status_code, 402);
   assert.equal(parsed.action_url, "https://console.mem9.ai/console/billing/plan");
   assert.deepEqual(parsed.quota.recommendedAction, {
     bindingState: "claimed",
-    type: "increaseSpendingLimit",
+    providerActionCode: "increaseSpendingLimit",
+    type: "openUrl",
     url: "https://console.mem9.ai/console/billing/plan",
   });
 });


### PR DESCRIPTION
## What Changed
- In-repo plugins consume the public runtime quota envelope: top-level `error` plus `details.errorCategory=runtime_quota_denied`.
- Quota metadata is read from `details.runtimeQuota`; `recommendedAction` output is limited to public fields: `type`, `providerActionCode`, `severity`, and `url`.
- Action links are rendered from API-provided `recommendedAction.url`; URL-less post-quota 429 responses use generic quota/rate-limit guidance.
- Claude Code carries HTTP 429 status into quota notices so temporary rate-limit guidance matches the other plugins.
- OpenClaw keeps prompt-time recall quota notices visible while background save/ingest quota logs stay low-noise.
- OpenClaw and OpenCode keep tolerant parsing for error bodies and strict JSON parsing for successful non-204 responses.
- Claude Code, Codex, and OpenCode package/plugin metadata have patch version bumps for this user-visible behavior change.

## Why
- mem9-ai/mem9#382 defines the public runtime quota error response problem space.
- mem9-ai/mem9#383 owns the server-side public API contract and OpenAPI schema.
- #374 owns the in-repo plugin behavior for that public contract: parsing, UX text, tests, and release/versioning.

## Review Path
1. Start with `codex-plugin/lib/quota-error.mjs`, `claude-plugin/hooks/lib/quota-error.mjs`, `opencode-plugin/src/server/quota-error.ts`, and `openclaw-plugin/quota-error.ts`.
2. Check `claude-plugin/hooks/common.sh` for HTTP status propagation into Claude quota notices.
3. Check `openclaw-plugin/hooks.ts` for prompt-time notice behavior versus background save/ingest logging.
4. Check `opencode-plugin/src/server/server-backend.ts` and `openclaw-plugin/server-backend.ts` for the error-body versus success-body parsing split.
5. Check the plugin metadata/package version changes and release checklist below.

## Validation
- `pnpm --dir codex-plugin test`
- `pnpm --dir codex-plugin typecheck`
- `bash -n claude-plugin/hooks/common.sh`
- `bash claude-plugin/hooks/common.test.sh`
- `node --check claude-plugin/hooks/lib/quota-error.mjs`
- `node scripts/test.mjs` in `opencode-plugin`
- `node node_modules/typescript/lib/tsc.js --noEmit` in `opencode-plugin`
- `npm --prefix openclaw-plugin test`
- `npm --prefix openclaw-plugin run typecheck`
- `git diff --check`

## Release Checklist
- Claude Code: `claude-plugin/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` are bumped to `0.3.2`.
- Codex: `codex-plugin/.codex-plugin/plugin.json` and `codex-plugin/package.json` are bumped to `0.2.4`.
- OpenCode: `opencode-plugin/package.json` is bumped to `0.1.4`; after merge publish the exact package version from `main`:

```bash
git checkout main
git pull --ff-only
cd opencode-plugin
pnpm run typecheck
pnpm run pack:check
pnpm run publish:release current --dry-run
pnpm run publish:release current
npm view @mem9/opencode@0.1.4 version
```

- OpenClaw: `openclaw-plugin/package.json` remains at `0.4.12` so the existing publish helper owns the patch bump; after merge publish from up-to-date `main`:

```bash
git checkout main
git pull --ff-only
cd openclaw-plugin
./publish.sh patch
npm view @mem9/mem9@0.4.13 version
```

## Notes
- This PR covers the in-repo plugins: Codex, Claude Code, OpenCode, and OpenClaw.
