### PR TITLE
[codex] add pricing docs to console guide

### DIFF
--- a/site/src/components/DocsArticlePage.astro
+++ b/site/src/components/DocsArticlePage.astro
@@ -1,5 +1,5 @@
 ---
-import { resolveDocsLocale, type DocsLink, type DocsLocale, type DocsPageCopy, type DocsSection } from '../content/docs';
+import { resolveDocsLocale, type DocsLink, type DocsLocale, type DocsPageCopy, type DocsSection, type DocsTable } from '../content/docs';
 import { DEFAULT_LOCALE } from '../content/site';
 
 interface Props {
@@ -23,6 +23,14 @@ function plainText(value: string | undefined): string {
   return (value ?? '').replace(/<[^>]*>/g, ' ');
 }
 
+function docsTableSearchText(table: DocsTable): string {
+  return [
+    table.caption,
+    ...table.columns,
+    ...table.rows.flat(),
+  ].join(' ');
+}
+
 function docsSectionSearchText(section: DocsSection): string {
   return [
     section.label,
@@ -30,11 +38,13 @@ function docsSectionSearchText(section: DocsSection): string {
     section.intro,
     ...(section.paragraphs ?? []).map(plainText),
     ...(section.bullets ?? []),
+    ...(section.tables ?? []).map(docsTableSearchText),
     ...(section.links ?? []).map((link) => link.label),
     ...(section.subsections ?? []).flatMap((subsection) => [
       subsection.title,
       ...(subsection.paragraphs ?? []).map(plainText),
       ...(subsection.bullets ?? []),
+      ...(subsection.tables ?? []).map(docsTableSearchText),
       ...(subsection.links ?? []).map((link) => link.label),
     ]),
   ].join(' ');
@@ -136,6 +146,30 @@ function docsSectionSearchText(section: DocsSection): string {
                     </ul>
                   )}
 
+                  {section.tables?.map((table) => (
+                    <div class="docs-table-wrap" role="region" aria-label={table.caption ?? section.title} tabindex="0">
+                      <table class="docs-table">
+                        {table.caption && <caption>{table.caption}</caption>}
+                        <thead>
+                          <tr>
+                            {table.columns.map((column) => (
+                              <th scope="col">{column}</th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {table.rows.map((row) => (
+                            <tr>
+                              {row.map((cell, cellIndex) => (
+                                cellIndex === 0 ? <th scope="row">{cell}</th> : <td>{cell}</td>
+                              ))}
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ))}
+
                   {section.subsections?.map((subsection) => (
                     <section class="docs-subsection surface-card">
                       <h3 class="docs-subsection-title">{subsection.title}</h3>
@@ -149,6 +183,29 @@ function docsSectionSearchText(section: DocsSection): string {
                           ))}
                         </ul>
                       )}
+                      {subsection.tables?.map((table) => (
+                        <div class="docs-table-wrap" role="region" aria-label={table.caption ?? subsection.title} tabindex="0">
+                          <table class="docs-table">
+                            {table.caption && <caption>{table.caption}</caption>}
+                            <thead>
+                              <tr>
+                                {table.columns.map((column) => (
+                                  <th scope="col">{column}</th>
+                                ))}
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {table.rows.map((row) => (
+                                <tr>
+                                  {row.map((cell, cellIndex) => (
+                                    cellIndex === 0 ? <th scope="row">{cell}</th> : <td>{cell}</td>
+                                  ))}
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                      ))}
                       {subsection.links && subsection.links.length > 0 && (
                         <div class="docs-link-row">
                           {subsection.links.map((link) => (
@@ -475,6 +532,60 @@ function docsSectionSearchText(section: DocsSection): string {
   .docs-bullets.is-compact {
     margin-top: 0.75rem;
     gap: 0.45rem;
+  }
+
+  .docs-table-wrap {
+    margin-top: 1rem;
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: 0.85rem;
+    background: linear-gradient(180deg, var(--surface-elevated-start), var(--surface-elevated-end));
+    box-shadow: var(--surface-inset);
+  }
+
+  .docs-table-wrap:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+
+  .docs-table {
+    width: 100%;
+    min-width: 42rem;
+    border-collapse: collapse;
+    color: var(--text-dim);
+    font-size: 0.92rem;
+    line-height: 1.55;
+  }
+
+  .docs-table caption {
+    padding: 0.85rem 0.95rem;
+    text-align: left;
+    color: var(--text);
+    font-weight: 650;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .docs-table th,
+  .docs-table td {
+    padding: 0.75rem 0.95rem;
+    text-align: left;
+    vertical-align: top;
+    border-top: 1px solid var(--border);
+  }
+
+  .docs-table caption + thead th {
+    border-top: 0;
+  }
+
+  .docs-table thead th {
+    background: var(--button-active-bg);
+    color: var(--text);
+    font-weight: 650;
+  }
+
+  .docs-table tbody th {
+    color: var(--text);
+    font-weight: 620;
   }
 
   .docs-subsection {

--- a/site/src/components/Pricing.astro
+++ b/site/src/components/Pricing.astro
@@ -28,6 +28,11 @@ function getPlanHref(tier: SiteBillingTier): string {
       <p class="section-desc" data-i18n="billing.description">
         {billing.description}
       </p>
+      {billing.docsLinkLabel && (
+        <a href="/console-docs#pricing" class="pricing-docs-link">
+          {billing.docsLinkLabel}
+        </a>
+      )}
     </div>
 
     <div class="pricing-table-wrap surface-card">
@@ -239,6 +244,31 @@ function getPlanHref(tier: SiteBillingTier): string {
   .section-head .section-desc {
     margin-left: 0;
     margin-right: 0;
+  }
+
+  .pricing-docs-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    margin-top: 1rem;
+    color: var(--text);
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--text) 45%, transparent);
+    text-underline-offset: 0.18em;
+  }
+
+  .pricing-docs-link::after {
+    content: "->";
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    color: var(--accent);
+  }
+
+  .pricing-docs-link:hover {
+    color: var(--accent);
+    opacity: 1;
+    text-decoration-color: currentColor;
   }
 
   .pricing-table-wrap {

--- a/site/src/components/Pricing.astro
+++ b/site/src/components/Pricing.astro
@@ -29,7 +29,7 @@ function getPlanHref(tier: SiteBillingTier): string {
         {billing.description}
       </p>
       {billing.docsLinkLabel && (
-        <a href="/console-docs#pricing" class="pricing-docs-link">
+        <a href="/console-docs#pricing" class="pricing-docs-link" data-i18n="billing.docsLinkLabel">
           {billing.docsLinkLabel}
         </a>
       )}

--- a/site/src/content/console-docs.ts
+++ b/site/src/content/console-docs.ts
@@ -1,4 +1,94 @@
-import type { DocsLocale, DocsPageCopy } from './docs';
+import type { DocsLocale, DocsPageCopy, DocsSection } from './docs';
+
+const pricingDocsSection: DocsSection = {
+  id: 'pricing',
+  label: '10',
+  title: 'Pricing',
+  intro:
+    'mem9 pricing is based on monthly Add Request and Retrieval Request quotas. Free has fixed included usage, while paid plans can extend with on-demand usage when billing controls are configured.',
+  paragraphs: [
+    'Public pricing intentionally exposes two usage meters: Add Requests and Retrieval Requests. Core Console workflows stay consistent across plans; the main tier differences are included quota, support level, on-demand behavior, and enterprise contract options.',
+  ],
+  tables: [
+    {
+      caption: 'Plans and included usage',
+      columns: ['Plan', 'Monthly price', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
+      rows: [
+        ['Free', '$0', '13,000 / month', '1,300 / month', 'Unlimited', 'Community', 'Not available; fixed monthly quota'],
+        ['Starter', '$9 / month', '65,000 / month', '6,500 / month', 'Unlimited', 'Email', 'Available with payment method and spend cap'],
+        ['Pro', '$120 / month', '650,000 / month', '65,000 / month', 'Unlimited', 'Priority', 'Available with payment method and spend cap'],
+        ['Enterprise', 'Custom', 'Unlimited or custom contract terms', 'Unlimited or custom contract terms', 'Unlimited', 'Dedicated support and custom SLA', 'Custom commercial terms'],
+      ],
+    },
+    {
+      caption: 'Capability and billing differences by tier',
+      columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
+      rows: [
+        ['Core Console workflows', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Core workflows plus custom enterprise support'],
+        ['Monthly quotas', 'Fixed included usage only', 'Higher included quota for small teams and early products', 'Higher included quota for production or heavier agent usage', 'Unlimited or negotiated quota'],
+        ['On-demand usage', 'No on-demand billing; upgrade or wait for the next billing cycle after limits are reached', '$0.20 / 1,000 Add Requests and $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests and $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
+        ['Spend cap', 'Not applicable', 'Required before auto top-up can run', 'Required before auto top-up can run', 'Contracted limits or account terms'],
+        ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
+        ['Enterprise options', 'Not included', 'Not included', 'Not included', 'Security review, dedicated support, custom SLA, BYOK, dedicated retention, or large-scale storage terms can be handled by contract'],
+      ],
+    },
+  ],
+  subsections: [
+    {
+      title: 'Request definitions',
+      paragraphs: [
+        'An Add Request is one memory write or memory distillation operation. It can process messages, text, events, or structured facts into durable memory.',
+        'A Retrieval Request is one memory query or recall operation scoped by user, agent, app, Space, metadata filter, or query text.',
+      ],
+      bullets: [
+        'An Add Request can include fact extraction, memory creation, memory update, deduplication, reconciliation, embedding, and storage write.',
+        'A Retrieval Request can include semantic search, keyword search, hybrid search, metadata filtering, ranking, and result assembly.',
+        'For Space Chains, one recall counts as one Retrieval Request even if the chain scans multiple Spaces.',
+        'Very large payloads, long conversation imports, very large top_k, unusually broad multi-Space recall, or abnormal high-frequency usage may be handled by fair-use policy or Enterprise pricing.',
+      ],
+    },
+    {
+      title: 'On-demand usage, auto top-up, and spend caps',
+      paragraphs: [
+        'Free does not support on-demand overage billing. When a Free account reaches its included quota, it must upgrade or wait for the next billing cycle.',
+        'Starter and Pro users can enable auto top-up after adding a valid payment method. Users should configure a monthly spend cap before relying on on-demand usage. Once the hard cap is reached, overage API calls are paused until the next billing cycle or until the cap is increased.',
+      ],
+      tables: [
+        {
+          caption: 'On-demand rates for paid self-serve plans',
+          columns: ['Usage meter', 'Rate', 'Applies to'],
+          rows: [
+            ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
+            ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Coupon codes',
+      paragraphs: [
+        'To use a coupon code, click Upgrade Plan from Console Billing or Subscribe from the pricing page, choose a plan, and review the Payment summary. Enter the code in the Coupon code field before completing payment.',
+        'A coupon code can be used only once per account. Startups can email a short summary of their company, product, stage, expected mem9 usage, and requested support to <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> to apply for a coupon code.',
+      ],
+    },
+    {
+      title: 'Billing rules FAQ',
+      tables: [
+        {
+          caption: 'Common billing rules',
+          columns: ['Question', 'Answer'],
+          rows: [
+            ['Do monthly quotas roll over?', 'No. Included monthly quotas reset every billing cycle and do not roll over.'],
+            ['Do failed requests count?', 'Client-side validation errors and platform errors are not billed. Successfully processed requests may be billed even if no new memory is created.'],
+            ['Do duplicate or no-op Add Requests count?', 'Yes, if extraction, deduplication, or reconciliation has already been executed.'],
+            ['Is storage billed separately?', 'Storage is included under normal usage. Large-scale storage or dedicated retention requirements may be handled through Enterprise pricing.'],
+            ['Can customers bring their own LLM key?', 'BYOK can be supported for Enterprise customers. In that case, LLM cost may be excluded from mem9 usage pricing or handled as pass-through cost.'],
+          ],
+        },
+      ],
+    },
+  ],
+};
 
 export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
   en: {
@@ -30,7 +120,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'pricing', 'safe-operations'] },
     ],
     sections: [
       {
@@ -251,9 +341,10 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      pricingDocsSection,
       {
         id: 'safe-operations',
-        label: '10',
+        label: '11',
         title: 'Safe Operations',
         intro: 'Console exposes powerful controls, so treat changes deliberately.',
         bullets: [
@@ -295,7 +386,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: '开始', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: '记忆工作流', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: '高级工作流', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
+      { title: '高级工作流', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'pricing', 'safe-operations'] },
     ],
     sections: [
       {
@@ -516,9 +607,10 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
+      pricingDocsSection,
       {
         id: 'safe-operations',
-        label: '10',
+        label: '11',
         title: '安全操作建议',
         intro: 'Console 暴露了关键控制能力，操作时要有明确意图。',
         bullets: [
@@ -560,7 +652,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'pricing', 'safe-operations'] },
     ],
     sections: [
       {
@@ -662,9 +754,10 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
           { title: 'Settings', bullets: ['account と organization の管理、theme、language、logout に使います。'] },
         ],
       },
+      pricingDocsSection,
       {
         id: 'safe-operations',
-        label: '10',
+        label: '11',
         title: 'Safe Operations',
         bullets: [
           'API key は信頼できる client に設定する時だけ reveal します。',
@@ -704,7 +797,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'pricing', 'safe-operations'] },
     ],
     sections: [
       { id: 'quick-start', label: '01', title: 'Quick Start', bullets: ['Log in 메뉴에서 mem9 Console 에 로그인합니다.', '변경 전에 organization 과 project 를 확인합니다.', '공식 OpenClaw onboarding prompt 는 Install mem9 에서 복사합니다.', '기존 mem9 API key 는 Claim API key 로 Space 에 연결합니다.', 'Space 또는 Memories 에서 agent 가 저장한 memory 를 확인합니다.'] },
@@ -716,7 +809,8 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['새 chain 을 만들거나 기존 chain key 를 import 합니다.', 'detail 에서 key, nodes, memory tools 를 관리합니다.'] }, { title: 'Nodes and routing', bullets: ['active key 가 있는 Space 를 추가합니다.', 'node order 가 recall order 입니다.', 'routing policy prompt 로 검색 조건을 제한할 수 있습니다.'] }, { title: 'Chain keys', bullets: ['chain key 를 만들거나 bind 합니다.', '필요 없는 key 는 disable 합니다.', 'recall tools 로 single Space 와 비교합니다.'] }] },
       { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['Activity sidebar 에서 Webhooks 를 엽니다.', 'All, Space, Space Chain filter 로 project list 를 좁힙니다.', 'table 에서 endpoint, scope, URL host, enabled, events, last delivery 를 확인합니다.'] }, { title: 'Create and edit', bullets: ['Space 또는 Space Chain, resource, URL, events, enabled state 를 설정합니다.', 'production endpoint 는 HTTPS 를 사용합니다.', 'signing secret 은 create / rotate-secret 뒤 한 번만 표시됩니다.'] }, { title: 'Actions and deliveries', bullets: ['row menu 에서 edit, test, deliveries, rotate secret, enable / disable, delete 를 실행합니다.', 'deliveries drawer 에서 status, attempts, HTTP status, last error, retry time 을 확인합니다.'] }] },
       { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['recall / write request usage 를 확인합니다.', 'date range, daily trend, usage events 를 봅니다.'] }, { title: 'Billing', bullets: ['current plan, period, included access, on-demand settings 를 확인합니다.'] }, { title: 'Settings', bullets: ['account 와 organization 관리, theme, language, logout 에 사용합니다.'] }] },
-      { id: 'safe-operations', label: '10', title: 'Safe Operations', bullets: ['API key 는 trusted client 설정 시에만 reveal 합니다.', 'delete 전에 preview 와 confirmation 을 확인합니다.', '섞이면 안 되는 data 는 별도 Space 로 나눕니다.', '결과가 이상하면 org, project, Space, key, appId filter 를 확인합니다.'] },
+      pricingDocsSection,
+      { id: 'safe-operations', label: '11', title: 'Safe Operations', bullets: ['API key 는 trusted client 설정 시에만 reveal 합니다.', 'delete 전에 preview 와 confirmation 을 확인합니다.', '섞이면 안 되는 data 는 별도 Space 로 나눕니다.', '결과가 이상하면 org, project, Space, key, appId filter 를 확인합니다.'] },
     ],
   },
   id: {
@@ -748,7 +842,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'pricing', 'safe-operations'] },
     ],
     sections: [
       { id: 'quick-start', label: '01', title: 'Quick Start', bullets: ['Buka mem9 Console dari menu Log in lalu masuk.', 'Pastikan organization dan project sebelum mengubah resource.', 'Gunakan Install mem9 untuk prompt onboarding OpenClaw resmi.', 'Gunakan Claim API key untuk menautkan key lama ke Space.', 'Buka Space atau Memories untuk melihat memory yang disimpan agent.'] },
@@ -760,7 +854,8 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['Buat chain baru atau import chain key yang ada.', 'Detail page mengelola key, nodes, dan memory tools.'] }, { title: 'Nodes and routing', bullets: ['Tambahkan Space yang punya active key.', 'Node order menentukan recall order.', 'Routing policy prompt membatasi kapan node dicari.'] }, { title: 'Chain keys', bullets: ['Create atau bind chain key.', 'Disable key yang tidak dipakai.', 'Bandingkan chain dengan single Space memakai recall tools.'] }] },
       { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['Buka Webhooks dari Activity sidebar.', 'Gunakan filter All, Space, atau Space Chain.', 'Tabel menampilkan endpoint, scope, URL host, enabled, events, dan last delivery.'] }, { title: 'Create and edit', bullets: ['Pilih Space atau Space Chain, resource, URL, events, dan enabled state.', 'Endpoint production harus HTTPS.', 'signing secret hanya muncul sekali setelah create atau rotate-secret.'] }, { title: 'Actions and deliveries', bullets: ['Row menu mendukung edit, test, deliveries, rotate secret, enable / disable, dan delete.', 'Drawer deliveries menampilkan status, attempts, HTTP status, last error, dan retry time.'] }] },
       { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['Pantau recall / write request usage.', 'Lihat date range, daily trend, dan usage events.'] }, { title: 'Billing', bullets: ['Lihat current plan, period, included access, dan on-demand settings.'] }, { title: 'Settings', bullets: ['Untuk account, organization, theme, language, dan logout.'] }] },
-      { id: 'safe-operations', label: '10', title: 'Safe Operations', bullets: ['Reveal API key hanya untuk trusted client.', 'Baca preview dan confirmation sebelum delete.', 'Pisahkan data sensitif ke Space berbeda.', 'Jika hasil aneh, cek org, project, Space, key, dan appId filter.'] },
+      pricingDocsSection,
+      { id: 'safe-operations', label: '11', title: 'Safe Operations', bullets: ['Reveal API key hanya untuk trusted client.', 'Baca preview dan confirmation sebelum delete.', 'Pisahkan data sensitif ke Space berbeda.', 'Jika hasil aneh, cek org, project, Space, key, dan appId filter.'] },
     ],
   },
   th: {
@@ -792,7 +887,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
     tocGroups: [
       { title: 'Start Here', sectionIDs: ['quick-start', 'account-model', 'install-and-claim'] },
       { title: 'Memory Workflows', sectionIDs: ['spaces', 'space-detail', 'memories'] },
-      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'safe-operations'] },
+      { title: 'Advanced Workflows', sectionIDs: ['space-chains', 'webhooks', 'usage-billing-settings', 'pricing', 'safe-operations'] },
     ],
     sections: [
       { id: 'quick-start', label: '01', title: 'Quick Start', bullets: ['เปิด mem9 Console จากเมนู Log in แล้วเข้าสู่ระบบ', 'ตรวจ organization และ project ก่อนแก้ resource', 'ใช้ Install mem9 เพื่อคัดลอก OpenClaw onboarding prompt', 'ใช้ Claim API key เพื่อผูก key เดิมเข้ากับ Space', 'เปิด Space หรือ Memories เพื่อดู memory ที่ agent บันทึก'] },
@@ -804,7 +899,8 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['สร้าง chain ใหม่หรือ import chain key เดิม', 'หน้า detail ใช้จัดการ key, nodes และ memory tools'] }, { title: 'Nodes and routing', bullets: ['เพิ่ม Space ที่มี active key', 'node order คือ recall order', 'routing policy prompt จำกัดว่า node ควรถูกค้นหาเมื่อใด'] }, { title: 'Chain keys', bullets: ['Create หรือ bind chain key', 'Disable key ที่ไม่ใช้แล้ว', 'ใช้ recall tools เปรียบเทียบ chain กับ Space เดี่ยว'] }] },
       { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['เปิด Webhooks จาก Activity sidebar', 'ใช้ filter All, Space หรือ Space Chain', 'ตารางแสดง endpoint, scope, URL host, enabled, events และ last delivery'] }, { title: 'Create and edit', bullets: ['เลือก Space หรือ Space Chain, resource, URL, events และ enabled state', 'production endpoint ต้องใช้ HTTPS', 'signing secret แสดงเพียงครั้งเดียวหลัง create หรือ rotate-secret'] }, { title: 'Actions and deliveries', bullets: ['row menu ใช้ edit, test, deliveries, rotate secret, enable / disable และ delete', 'deliveries drawer แสดง status, attempts, HTTP status, last error และ retry time'] }] },
       { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['ดู recall / write request usage', 'ดู date range, daily trend และ usage events'] }, { title: 'Billing', bullets: ['ดู current plan, period, included access และ on-demand settings'] }, { title: 'Settings', bullets: ['สำหรับ account, organization, theme, language และ logout'] }] },
-      { id: 'safe-operations', label: '10', title: 'Safe Operations', bullets: ['Reveal API key เฉพาะ trusted client', 'อ่าน preview และ confirmation ก่อน delete', 'แยกข้อมูลที่ไม่ควรรวมกันไว้คนละ Space', 'ถ้าผลลัพธ์ผิดปกติ ให้ตรวจ org, project, Space, key และ appId filter'] },
+      pricingDocsSection,
+      { id: 'safe-operations', label: '11', title: 'Safe Operations', bullets: ['Reveal API key เฉพาะ trusted client', 'อ่าน preview และ confirmation ก่อน delete', 'แยกข้อมูลที่ไม่ควรรวมกันไว้คนละ Space', 'ถ้าผลลัพธ์ผิดปกติ ให้ตรวจ org, project, Space, key และ appId filter'] },
     ],
   },
 };

--- a/site/src/content/console-docs.ts
+++ b/site/src/content/console-docs.ts
@@ -1,93 +1,540 @@
 import type { DocsLocale, DocsPageCopy, DocsSection } from './docs';
 
-const pricingDocsSection: DocsSection = {
-  id: 'pricing',
-  label: '10',
-  title: 'Pricing',
-  intro:
-    'mem9 pricing is based on monthly Add Request and Retrieval Request quotas. Free has fixed included usage, while paid plans can extend with on-demand usage when billing controls are configured.',
-  paragraphs: [
-    'Public pricing intentionally exposes two usage meters: Add Requests and Retrieval Requests. Core Console workflows stay consistent across plans; the main tier differences are included quota, support level, on-demand behavior, and enterprise contract options.',
-  ],
-  tables: [
-    {
-      caption: 'Plans and included usage',
-      columns: ['Plan', 'Monthly price', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
-      rows: [
-        ['Free', '$0', '13,000 / month', '1,300 / month', 'Unlimited', 'Community', 'Not available; fixed monthly quota'],
-        ['Starter', '$9 / month', '65,000 / month', '6,500 / month', 'Unlimited', 'Email', 'Available with payment method and spend cap'],
-        ['Pro', '$120 / month', '650,000 / month', '65,000 / month', 'Unlimited', 'Priority', 'Available with payment method and spend cap'],
-        ['Enterprise', 'Custom', 'Unlimited or custom contract terms', 'Unlimited or custom contract terms', 'Unlimited', 'Dedicated support and custom SLA', 'Custom commercial terms'],
-      ],
-    },
-    {
-      caption: 'Capability and billing differences by tier',
-      columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
-      rows: [
-        ['Core Console workflows', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Core workflows plus custom enterprise support'],
-        ['Monthly quotas', 'Fixed included usage only', 'Higher included quota for small teams and early products', 'Higher included quota for production or heavier agent usage', 'Unlimited or negotiated quota'],
-        ['On-demand usage', 'No on-demand billing; upgrade or wait for the next billing cycle after limits are reached', '$0.20 / 1,000 Add Requests and $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests and $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
-        ['Spend cap', 'Not applicable', 'Required before auto top-up can run', 'Required before auto top-up can run', 'Contracted limits or account terms'],
-        ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
-        ['Enterprise options', 'Not included', 'Not included', 'Not included', 'Security review, dedicated support, custom SLA, BYOK, dedicated retention, or large-scale storage terms can be handled by contract'],
-      ],
-    },
-  ],
-  subsections: [
-    {
-      title: 'Request definitions',
-      paragraphs: [
-        'An Add Request is one memory write or memory distillation operation. It can process messages, text, events, or structured facts into durable memory.',
-        'A Retrieval Request is one memory query or recall operation scoped by user, agent, app, Space, metadata filter, or query text.',
-      ],
-      bullets: [
-        'An Add Request can include fact extraction, memory creation, memory update, deduplication, reconciliation, embedding, and storage write.',
-        'A Retrieval Request can include semantic search, keyword search, hybrid search, metadata filtering, ranking, and result assembly.',
-        'For Space Chains, one recall counts as one Retrieval Request even if the chain scans multiple Spaces.',
-        'Very large payloads, long conversation imports, very large top_k, unusually broad multi-Space recall, or abnormal high-frequency usage may be handled by fair-use policy or Enterprise pricing.',
-      ],
-    },
-    {
-      title: 'On-demand usage, auto top-up, and spend caps',
-      paragraphs: [
-        'Free does not support on-demand overage billing. When a Free account reaches its included quota, it must upgrade or wait for the next billing cycle.',
-        'Starter and Pro users can enable auto top-up after adding a valid payment method. Users should configure a monthly spend cap before relying on on-demand usage. Once the hard cap is reached, overage API calls are paused until the next billing cycle or until the cap is increased.',
-      ],
-      tables: [
-        {
-          caption: 'On-demand rates for paid self-serve plans',
-          columns: ['Usage meter', 'Rate', 'Applies to'],
-          rows: [
-            ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
-            ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
-          ],
-        },
-      ],
-    },
-    {
-      title: 'Coupon codes',
-      paragraphs: [
-        'To use a coupon code, click Upgrade Plan from Console Billing or Subscribe from the pricing page, choose a plan, and review the Payment summary. Enter the code in the Coupon code field before completing payment.',
-        'A coupon code can be used only once per account. Startups can email a short summary of their company, product, stage, expected mem9 usage, and requested support to <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> to apply for a coupon code.',
-      ],
-    },
-    {
-      title: 'Billing rules FAQ',
-      tables: [
-        {
-          caption: 'Common billing rules',
-          columns: ['Question', 'Answer'],
-          rows: [
-            ['Do monthly quotas roll over?', 'No. Included monthly quotas reset every billing cycle and do not roll over.'],
-            ['Do failed requests count?', 'Client-side validation errors and platform errors are not billed. Successfully processed requests may be billed even if no new memory is created.'],
-            ['Do duplicate or no-op Add Requests count?', 'Yes, if extraction, deduplication, or reconciliation has already been executed.'],
-            ['Is storage billed separately?', 'Storage is included under normal usage. Large-scale storage or dedicated retention requirements may be handled through Enterprise pricing.'],
-            ['Can customers bring their own LLM key?', 'BYOK can be supported for Enterprise customers. In that case, LLM cost may be excluded from mem9 usage pricing or handled as pass-through cost.'],
-          ],
-        },
-      ],
-    },
-  ],
+const pricingDocsSections: Record<DocsLocale, DocsSection> = {
+  en: {
+    id: 'pricing',
+    label: '10',
+    title: 'Pricing',
+    intro:
+      'mem9 pricing is based on monthly Add Request and Retrieval Request quotas. Free has fixed included usage, while paid plans can extend with on-demand usage when billing controls are configured.',
+    paragraphs: [
+      'Public pricing intentionally exposes two usage meters: Add Requests and Retrieval Requests. Core Console workflows stay consistent across plans; the main tier differences are included quota, support level, on-demand behavior, and enterprise contract options.',
+    ],
+    tables: [
+      {
+        caption: 'Plans and included usage',
+        columns: ['Plan', 'Monthly price', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
+        rows: [
+          ['Free', '$0', '13,000 / month', '1,300 / month', 'Unlimited', 'Community', 'Not available; fixed monthly quota'],
+          ['Starter', '$9 / month', '65,000 / month', '6,500 / month', 'Unlimited', 'Email', 'Available with payment method and spend cap'],
+          ['Pro', '$120 / month', '650,000 / month', '65,000 / month', 'Unlimited', 'Priority', 'Available with payment method and spend cap'],
+          ['Enterprise', 'Custom', 'Unlimited or custom contract terms', 'Unlimited or custom contract terms', 'Unlimited', 'Dedicated support and custom SLA', 'Custom commercial terms'],
+        ],
+      },
+      {
+        caption: 'Capability and billing differences by tier',
+        columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
+        rows: [
+          ['Core Console workflows', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Spaces, memory review, Space Chains, usage, billing, and settings', 'Core workflows plus custom enterprise support'],
+          ['Monthly quotas', 'Fixed included usage only', 'Higher included quota for small teams and early products', 'Higher included quota for production or heavier agent usage', 'Unlimited or negotiated quota'],
+          ['On-demand usage', 'No on-demand billing; upgrade or wait for the next billing cycle after limits are reached', '$0.20 / 1,000 Add Requests and $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests and $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
+          ['Spend cap', 'Not applicable', 'Required before auto top-up can run', 'Required before auto top-up can run', 'Contracted limits or account terms'],
+          ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
+          ['Enterprise options', 'Not included', 'Not included', 'Not included', 'Security review, dedicated support, custom SLA, BYOK, dedicated retention, or large-scale storage terms can be handled by contract'],
+        ],
+      },
+    ],
+    subsections: [
+      {
+        title: 'Request definitions',
+        paragraphs: [
+          'An Add Request is one memory write or memory distillation operation. It can process messages, text, events, or structured facts into durable memory.',
+          'A Retrieval Request is one memory query or recall operation scoped by user, agent, app, Space, metadata filter, or query text.',
+        ],
+        bullets: [
+          'An Add Request can include fact extraction, memory creation, memory update, deduplication, reconciliation, embedding, and storage write.',
+          'A Retrieval Request can include semantic search, keyword search, hybrid search, metadata filtering, ranking, and result assembly.',
+          'For Space Chains, one recall counts as one Retrieval Request even if the chain scans multiple Spaces.',
+          'Very large payloads, long conversation imports, very large top_k, unusually broad multi-Space recall, or abnormal high-frequency usage may be handled by fair-use policy or Enterprise pricing.',
+        ],
+      },
+      {
+        title: 'On-demand usage, auto top-up, and spend caps',
+        paragraphs: [
+          'Free does not support on-demand overage billing. When a Free account reaches its included quota, it must upgrade or wait for the next billing cycle.',
+          'Starter and Pro users can enable auto top-up after adding a valid payment method. Users should configure a monthly spend cap before relying on on-demand usage. Once the hard cap is reached, overage API calls are paused until the next billing cycle or until the cap is increased.',
+        ],
+        tables: [
+          {
+            caption: 'On-demand rates for paid self-serve plans',
+            columns: ['Usage meter', 'Rate', 'Applies to'],
+            rows: [
+              ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
+              ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Coupon codes',
+        paragraphs: [
+          'To use a coupon code, click Upgrade Plan from Console Billing or Subscribe from the pricing page, choose a plan, and review the Payment summary. Enter the code in the Coupon code field before completing payment.',
+          'A coupon code can be used only once per account. Startups can email a short summary of their company, product, stage, expected mem9 usage, and requested support to <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> to apply for a coupon code.',
+        ],
+      },
+      {
+        title: 'Billing rules FAQ',
+        tables: [
+          {
+            caption: 'Common billing rules',
+            columns: ['Question', 'Answer'],
+            rows: [
+              ['Do monthly quotas roll over?', 'No. Included monthly quotas reset every billing cycle and do not roll over.'],
+              ['Do failed requests count?', 'Client-side validation errors and platform errors are not billed. Successfully processed requests may be billed even if no new memory is created.'],
+              ['Do duplicate or no-op Add Requests count?', 'Yes, if extraction, deduplication, or reconciliation has already been executed.'],
+              ['Is storage billed separately?', 'Storage is included under normal usage. Large-scale storage or dedicated retention requirements may be handled through Enterprise pricing.'],
+              ['Can customers bring their own LLM key?', 'BYOK can be supported for Enterprise customers. In that case, LLM cost may be excluded from mem9 usage pricing or handled as pass-through cost.'],
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  zh: {
+    id: 'pricing',
+    label: '10',
+    title: '定价',
+    intro:
+      'mem9 定价基于每月 Add Request 和 Retrieval Request 额度。Free 使用固定包含额度；付费套餐在配置计费控制后可通过 on-demand 用量扩展。',
+    paragraphs: [
+      '公开定价只展示 Add Requests 和 Retrieval Requests 两类用量指标，方便理解。各套餐的 Console 核心工作流保持一致，主要差异在包含额度、支持等级、on-demand 行为和企业合同选项。',
+    ],
+    tables: [
+      {
+        caption: '套餐和包含额度',
+        columns: ['套餐', '月费', 'Add requests', 'Retrieval requests', '终端用户', '支持', 'On-demand'],
+        rows: [
+          ['Free', '$0', '13,000 / 月', '1,300 / 月', '不限', '社区', '不支持；使用固定月度额度'],
+          ['Starter', '$9 / 月', '65,000 / 月', '6,500 / 月', '不限', '邮件', '添加付款方式并设置 spend cap 后可用'],
+          ['Pro', '$120 / 月', '650,000 / 月', '65,000 / 月', '不限', '优先', '添加付款方式并设置 spend cap 后可用'],
+          ['Enterprise', '自定义', '不限或按合同约定', '不限或按合同约定', '不限', '专属支持和自定义 SLA', '自定义商务条款'],
+        ],
+      },
+      {
+        caption: '各套餐的能力和计费差异',
+        columns: ['能力', 'Free', 'Starter', 'Pro', 'Enterprise'],
+        rows: [
+          ['Console 核心工作流', 'Spaces、memory review、Space Chains、usage、billing 和 settings', 'Spaces、memory review、Space Chains、usage、billing 和 settings', 'Spaces、memory review、Space Chains、usage、billing 和 settings', '核心工作流加企业级自定义支持'],
+          ['月度额度', '仅固定包含额度', '适合小团队和早期产品的更高包含额度', '适合生产或更高 agent 用量的包含额度', '不限或协商额度'],
+          ['On-demand 用量', '不支持超额计费；达到限额后需升级或等待下个 billing cycle', '$0.20 / 1,000 Add Requests 和 $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests 和 $2.00 / 1,000 Retrieval Requests', '自定义条款'],
+          ['Spend cap', '不适用', 'auto top-up 生效前必须设置', 'auto top-up 生效前必须设置', '按合同限制或账号条款约定'],
+          ['支持', '社区', '邮件', '优先', '专属支持和自定义 SLA'],
+          ['企业选项', '不包含', '不包含', '不包含', '安全审查、专属支持、自定义 SLA、BYOK、专用 retention 或大规模存储条款可通过合同处理'],
+        ],
+      },
+    ],
+    subsections: [
+      {
+        title: '请求定义',
+        paragraphs: [
+          'Add Request 指一次 memory 写入或记忆沉淀操作，可将 messages、text、events 或 structured facts 处理成可长期保存的 memory。',
+          'Retrieval Request 指一次 memory 查询或召回操作，可按 user、agent、app、Space、metadata filter 或 query text 限定范围。',
+        ],
+        bullets: [
+          'Add Request 可包含 fact extraction、memory creation、memory update、deduplication、reconciliation、embedding 和 storage write。',
+          'Retrieval Request 可包含 semantic search、keyword search、hybrid search、metadata filtering、ranking 和 result assembly。',
+          '对于 Space Chains，一次 recall 即使扫描多个 Space，也只计为一次 Retrieval Request。',
+          '超大 payload、长对话导入、很大的 top_k、异常宽泛的多 Space 召回或异常高频用量，可能按 fair-use policy 或 Enterprise pricing 处理。',
+        ],
+      },
+      {
+        title: 'On-demand 用量、auto top-up 和 spend cap',
+        paragraphs: [
+          'Free 不支持 on-demand 超额计费。Free 账号达到包含额度后，需要升级套餐或等待下一个 billing cycle。',
+          'Starter 和 Pro 用户添加有效付款方式后可以启用 auto top-up。依赖 on-demand 用量前应配置月度 spend cap。达到 hard cap 后，超额 API 调用会暂停，直到下一个 billing cycle 或 cap 被提高。',
+        ],
+        tables: [
+          {
+            caption: '付费自助套餐的 on-demand 价格',
+            columns: ['用量指标', '价格', '适用套餐'],
+            rows: [
+              ['Add Request', '$0.20 / 1,000 requests', 'Starter 和 Pro'],
+              ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter 和 Pro'],
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Coupon code',
+        paragraphs: [
+          '使用 coupon code 时，在 Console Billing 中点击 Upgrade Plan，或从 pricing page 点击 Subscribe，选择套餐后查看 Payment summary，并在完成付款前将代码输入 Coupon code 字段。',
+          '一个 coupon code 每个账号只能使用一次。初创企业可以把公司、产品、阶段、预计 mem9 用量和需要的支持简要发送到 <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> 申请 coupon code。',
+        ],
+      },
+      {
+        title: '计费规则 FAQ',
+        tables: [
+          {
+            caption: '常见计费规则',
+            columns: ['问题', '回答'],
+            rows: [
+              ['月度额度会滚存吗？', '不会。包含的月度额度会在每个 billing cycle 重置，不会滚存。'],
+              ['失败请求会计费吗？', '客户端参数校验错误和平台错误不计费。已成功处理的请求即使没有新增 memory，也可能计入用量。'],
+              ['重复或 no-op Add Request 会计费吗？', '会，如果 extraction、deduplication 或 reconciliation 已经执行。'],
+              ['Storage 会单独计费吗？', '普通用量下 storage 包含在套餐内。大规模存储或专用 retention 需求可通过 Enterprise pricing 处理。'],
+              ['客户可以使用自己的 LLM key 吗？', 'Enterprise 客户可支持 BYOK。此时 LLM 成本可从 mem9 usage pricing 中剥离，或作为 pass-through cost 处理。'],
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  ja: {
+    id: 'pricing',
+    label: '10',
+    title: '料金',
+    intro:
+      'mem9 の料金は、月ごとの Add Request と Retrieval Request の割り当てに基づきます。Free は固定枠で、 paid plan は billing control を設定すると on-demand usage を利用できます。',
+    paragraphs: [
+      '公開料金では Add Requests と Retrieval Requests の 2 つの usage meter だけを表示します。Console の基本ワークフローは各 plan で共通で、主な違いは含まれる quota、support、on-demand、Enterprise 契約オプションです。',
+    ],
+    tables: [
+      {
+        caption: 'Plans and included usage',
+        columns: ['Plan', '月額', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
+        rows: [
+          ['Free', '$0', '13,000 / 月', '1,300 / 月', '無制限', 'Community', '利用不可。月ごとの固定 quota'],
+          ['Starter', '$9 / 月', '65,000 / 月', '6,500 / 月', '無制限', 'Email', 'payment method と spend cap の設定後に利用可能'],
+          ['Pro', '$120 / 月', '650,000 / 月', '65,000 / 月', '無制限', 'Priority', 'payment method と spend cap の設定後に利用可能'],
+          ['Enterprise', 'Custom', '無制限または契約条件による', '無制限または契約条件による', '無制限', 'Dedicated support and custom SLA', 'Custom commercial terms'],
+        ],
+      },
+      {
+        caption: 'Tier ごとの機能と billing の違い',
+        columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
+        rows: [
+          ['Core Console workflows', 'Spaces、memory review、Space Chains、usage、billing、settings', 'Spaces、memory review、Space Chains、usage、billing、settings', 'Spaces、memory review、Space Chains、usage、billing、settings', '基本 workflow に加えて enterprise support'],
+          ['Monthly quotas', '固定の included usage のみ', '小規模チームや初期 product 向けの quota', 'production や重めの agent usage 向けの quota', '無制限または交渉 quota'],
+          ['On-demand usage', 'overage billing なし。上限到達後は upgrade または次の billing cycle を待つ', '$0.20 / 1,000 Add Requests と $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests と $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
+          ['Spend cap', '対象外', 'auto top-up 前に必須', 'auto top-up 前に必須', '契約上の limit または account terms'],
+          ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
+          ['Enterprise options', 'なし', 'なし', 'なし', 'Security review、dedicated support、custom SLA、BYOK、dedicated retention、大規模 storage は契約で対応可能'],
+        ],
+      },
+    ],
+    subsections: [
+      {
+        title: 'Request definitions',
+        paragraphs: [
+          'Add Request は memory write または memory distillation の 1 回分です。messages、text、events、structured facts を durable memory に処理します。',
+          'Retrieval Request は user、agent、app、Space、metadata filter、query text で scoped された memory query または recall の 1 回分です。',
+        ],
+        bullets: [
+          'Add Request には fact extraction、memory creation、memory update、deduplication、reconciliation、embedding、storage write が含まれます。',
+          'Retrieval Request には semantic search、keyword search、hybrid search、metadata filtering、ranking、result assembly が含まれます。',
+          'Space Chains では、複数の Space を scan しても 1 recall は 1 Retrieval Request です。',
+          '非常に大きい payload、長い conversation import、大きい top_k、広すぎる multi-Space recall、異常に高頻度な usage は fair-use policy または Enterprise pricing で扱われる場合があります。',
+        ],
+      },
+      {
+        title: 'On-demand usage, auto top-up, and spend caps',
+        paragraphs: [
+          'Free は on-demand overage billing をサポートしません。included quota に達した場合は upgrade するか次の billing cycle を待ちます。',
+          'Starter と Pro は有効な payment method を追加した後に auto top-up を有効化できます。on-demand usage に依存する前に monthly spend cap を設定してください。hard cap に達すると、次の billing cycle または cap 引き上げまで overage API calls は停止します。',
+        ],
+        tables: [
+          {
+            caption: 'Paid self-serve plans の on-demand rates',
+            columns: ['Usage meter', 'Rate', 'Applies to'],
+            rows: [
+              ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
+              ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Coupon codes',
+        paragraphs: [
+          'Coupon code を使うには、Console Billing の Upgrade Plan または pricing page の Subscribe をクリックし、plan を選んで Payment summary を確認します。支払い完了前に Coupon code field に code を入力してください。',
+          'Coupon code は 1 account につき 1 回だけ利用できます。Startup は会社、product、stage、想定 mem9 usage、必要な support の短い summary を <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> に送ることで coupon code を申請できます。',
+        ],
+      },
+      {
+        title: 'Billing rules FAQ',
+        tables: [
+          {
+            caption: 'Common billing rules',
+            columns: ['Question', 'Answer'],
+            rows: [
+              ['Monthly quotas は繰り越されますか？', 'いいえ。included monthly quotas は各 billing cycle で reset され、繰り越されません。'],
+              ['Failed requests は count されますか？', 'client-side validation errors と platform errors は billed されません。正常に処理された request は新しい memory が作成されなくても billed される場合があります。'],
+              ['Duplicate または no-op Add Requests は count されますか？', 'はい。extraction、deduplication、reconciliation が既に実行された場合は count されます。'],
+              ['Storage は別料金ですか？', '通常利用では storage は含まれます。大規模 storage や dedicated retention requirements は Enterprise pricing で扱えます。'],
+              ['Customer は own LLM key を持ち込めますか？', 'Enterprise customers では BYOK をサポートできます。その場合、LLM cost は mem9 usage pricing から除外するか pass-through cost として扱えます。'],
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  ko: {
+    id: 'pricing',
+    label: '10',
+    title: '요금',
+    intro:
+      'mem9 요금은 월별 Add Request 와 Retrieval Request quota 를 기준으로 합니다. Free 는 고정 included usage 를 사용하며, 유료 plan 은 billing control 설정 후 on-demand usage 로 확장할 수 있습니다.',
+    paragraphs: [
+      '공개 가격은 Add Requests 와 Retrieval Requests 두 usage meter 만 보여줍니다. Core Console workflow 는 plan 간 동일하며, 주요 차이는 included quota, support level, on-demand 동작, enterprise 계약 옵션입니다.',
+    ],
+    tables: [
+      {
+        caption: 'Plans and included usage',
+        columns: ['Plan', '월 가격', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
+        rows: [
+          ['Free', '$0', '13,000 / 월', '1,300 / 월', '무제한', 'Community', '사용 불가. 고정 월 quota'],
+          ['Starter', '$9 / 월', '65,000 / 월', '6,500 / 월', '무제한', 'Email', 'payment method 와 spend cap 설정 후 사용 가능'],
+          ['Pro', '$120 / 월', '650,000 / 월', '65,000 / 월', '무제한', 'Priority', 'payment method 와 spend cap 설정 후 사용 가능'],
+          ['Enterprise', 'Custom', '무제한 또는 계약 조건', '무제한 또는 계약 조건', '무제한', 'Dedicated support and custom SLA', 'Custom commercial terms'],
+        ],
+      },
+      {
+        caption: 'Tier 별 기능 및 billing 차이',
+        columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
+        rows: [
+          ['Core Console workflows', 'Spaces, memory review, Space Chains, usage, billing, settings', 'Spaces, memory review, Space Chains, usage, billing, settings', 'Spaces, memory review, Space Chains, usage, billing, settings', 'Core workflow 와 custom enterprise support'],
+          ['Monthly quotas', '고정 included usage 만 제공', '소규모 팀과 초기 product 용 quota', 'production 또는 더 많은 agent usage 용 quota', '무제한 또는 협의 quota'],
+          ['On-demand usage', 'overage billing 없음. limit 도달 후 upgrade 하거나 다음 billing cycle 을 기다림', '$0.20 / 1,000 Add Requests 및 $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests 및 $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
+          ['Spend cap', '해당 없음', 'auto top-up 전에 필수', 'auto top-up 전에 필수', '계약 limit 또는 account terms'],
+          ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
+          ['Enterprise options', '미포함', '미포함', '미포함', 'Security review, dedicated support, custom SLA, BYOK, dedicated retention, 대규모 storage 조건은 계약으로 처리 가능'],
+        ],
+      },
+    ],
+    subsections: [
+      {
+        title: 'Request definitions',
+        paragraphs: [
+          'Add Request 는 memory write 또는 memory distillation 작업 1회입니다. messages, text, events, structured facts 를 durable memory 로 처리합니다.',
+          'Retrieval Request 는 user, agent, app, Space, metadata filter, query text 로 scope 된 memory query 또는 recall 1회입니다.',
+        ],
+        bullets: [
+          'Add Request 에는 fact extraction, memory creation, memory update, deduplication, reconciliation, embedding, storage write 가 포함될 수 있습니다.',
+          'Retrieval Request 에는 semantic search, keyword search, hybrid search, metadata filtering, ranking, result assembly 가 포함될 수 있습니다.',
+          'Space Chains 에서는 여러 Space 를 scan 하더라도 recall 1회는 Retrieval Request 1회로 계산됩니다.',
+          '매우 큰 payload, 긴 conversation import, 큰 top_k, 과도하게 넓은 multi-Space recall, 비정상적인 고빈도 usage 는 fair-use policy 또는 Enterprise pricing 으로 처리될 수 있습니다.',
+        ],
+      },
+      {
+        title: 'On-demand usage, auto top-up, and spend caps',
+        paragraphs: [
+          'Free 는 on-demand overage billing 을 지원하지 않습니다. included quota 에 도달하면 upgrade 하거나 다음 billing cycle 을 기다려야 합니다.',
+          'Starter 와 Pro 사용자는 유효한 payment method 를 추가한 뒤 auto top-up 을 켤 수 있습니다. on-demand usage 에 의존하기 전에 monthly spend cap 을 설정해야 합니다. hard cap 에 도달하면 다음 billing cycle 또는 cap 증가 전까지 overage API calls 가 일시 중지됩니다.',
+        ],
+        tables: [
+          {
+            caption: 'Paid self-serve plans 의 on-demand rates',
+            columns: ['Usage meter', 'Rate', 'Applies to'],
+            rows: [
+              ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
+              ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Coupon codes',
+        paragraphs: [
+          'Coupon code 를 사용하려면 Console Billing 의 Upgrade Plan 또는 pricing page 의 Subscribe 를 클릭하고, plan 을 선택한 뒤 Payment summary 를 확인합니다. 결제 완료 전에 Coupon code field 에 code 를 입력하세요.',
+          'Coupon code 는 account 당 한 번만 사용할 수 있습니다. Startup 은 회사, product, stage, 예상 mem9 usage, 필요한 support 요약을 <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> 으로 보내 coupon code 를 신청할 수 있습니다.',
+        ],
+      },
+      {
+        title: 'Billing rules FAQ',
+        tables: [
+          {
+            caption: 'Common billing rules',
+            columns: ['Question', 'Answer'],
+            rows: [
+              ['Monthly quotas 는 이월되나요?', '아니요. included monthly quotas 는 billing cycle 마다 reset 되며 이월되지 않습니다.'],
+              ['Failed requests 도 count 되나요?', 'client-side validation errors 와 platform errors 는 billed 되지 않습니다. 정상 처리된 request 는 새 memory 가 만들어지지 않아도 billed 될 수 있습니다.'],
+              ['Duplicate 또는 no-op Add Requests 는 count 되나요?', '예. extraction, deduplication, reconciliation 이 이미 실행된 경우 count 됩니다.'],
+              ['Storage 는 별도 과금인가요?', '일반 usage 에서는 storage 가 포함됩니다. 대규모 storage 또는 dedicated retention requirements 는 Enterprise pricing 으로 처리할 수 있습니다.'],
+              ['Customer 가 own LLM key 를 가져올 수 있나요?', 'Enterprise customers 는 BYOK 를 지원할 수 있습니다. 이 경우 LLM cost 는 mem9 usage pricing 에서 제외하거나 pass-through cost 로 처리할 수 있습니다.'],
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  id: {
+    id: 'pricing',
+    label: '10',
+    title: 'Harga',
+    intro:
+      'Harga mem9 didasarkan pada kuota bulanan Add Request dan Retrieval Request. Free memakai included usage tetap, sedangkan plan berbayar dapat diperluas dengan on-demand usage setelah billing control dikonfigurasi.',
+    paragraphs: [
+      'Harga publik hanya menampilkan dua usage meter: Add Requests dan Retrieval Requests. Core Console workflows tetap sama di semua plan; perbedaannya ada pada included quota, level support, perilaku on-demand, dan opsi kontrak Enterprise.',
+    ],
+    tables: [
+      {
+        caption: 'Plans and included usage',
+        columns: ['Plan', 'Harga bulanan', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
+        rows: [
+          ['Free', '$0', '13,000 / bulan', '1,300 / bulan', 'Unlimited', 'Community', 'Tidak tersedia; fixed monthly quota'],
+          ['Starter', '$9 / bulan', '65,000 / bulan', '6,500 / bulan', 'Unlimited', 'Email', 'Tersedia dengan payment method dan spend cap'],
+          ['Pro', '$120 / bulan', '650,000 / bulan', '65,000 / bulan', 'Unlimited', 'Priority', 'Tersedia dengan payment method dan spend cap'],
+          ['Enterprise', 'Custom', 'Unlimited atau sesuai kontrak', 'Unlimited atau sesuai kontrak', 'Unlimited', 'Dedicated support and custom SLA', 'Custom commercial terms'],
+        ],
+      },
+      {
+        caption: 'Perbedaan capability dan billing per tier',
+        columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
+        rows: [
+          ['Core Console workflows', 'Spaces, memory review, Space Chains, usage, billing, dan settings', 'Spaces, memory review, Space Chains, usage, billing, dan settings', 'Spaces, memory review, Space Chains, usage, billing, dan settings', 'Core workflows plus custom enterprise support'],
+          ['Monthly quotas', 'Hanya fixed included usage', 'Quota lebih besar untuk tim kecil dan produk awal', 'Quota lebih besar untuk production atau agent usage yang lebih berat', 'Unlimited atau negotiated quota'],
+          ['On-demand usage', 'Tidak ada overage billing; upgrade atau tunggu billing cycle berikutnya setelah limit tercapai', '$0.20 / 1,000 Add Requests dan $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests dan $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
+          ['Spend cap', 'Tidak berlaku', 'Wajib sebelum auto top-up berjalan', 'Wajib sebelum auto top-up berjalan', 'Contracted limits atau account terms'],
+          ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
+          ['Enterprise options', 'Tidak termasuk', 'Tidak termasuk', 'Tidak termasuk', 'Security review, dedicated support, custom SLA, BYOK, dedicated retention, atau large-scale storage terms dapat ditangani melalui kontrak'],
+        ],
+      },
+    ],
+    subsections: [
+      {
+        title: 'Request definitions',
+        paragraphs: [
+          'Add Request adalah satu operasi memory write atau memory distillation. Operasi ini memproses messages, text, events, atau structured facts menjadi durable memory.',
+          'Retrieval Request adalah satu operasi memory query atau recall yang di-scope oleh user, agent, app, Space, metadata filter, atau query text.',
+        ],
+        bullets: [
+          'Add Request dapat mencakup fact extraction, memory creation, memory update, deduplication, reconciliation, embedding, dan storage write.',
+          'Retrieval Request dapat mencakup semantic search, keyword search, hybrid search, metadata filtering, ranking, dan result assembly.',
+          'Untuk Space Chains, satu recall dihitung sebagai satu Retrieval Request meskipun chain memindai beberapa Spaces.',
+          'Payload sangat besar, long conversation imports, top_k sangat besar, multi-Space recall yang terlalu luas, atau usage abnormal berfrekuensi tinggi dapat ditangani melalui fair-use policy atau Enterprise pricing.',
+        ],
+      },
+      {
+        title: 'On-demand usage, auto top-up, and spend caps',
+        paragraphs: [
+          'Free tidak mendukung on-demand overage billing. Saat akun Free mencapai included quota, pengguna harus upgrade atau menunggu billing cycle berikutnya.',
+          'Pengguna Starter dan Pro dapat mengaktifkan auto top-up setelah menambahkan payment method valid. Konfigurasikan monthly spend cap sebelum bergantung pada on-demand usage. Setelah hard cap tercapai, overage API calls akan dijeda sampai billing cycle berikutnya atau cap dinaikkan.',
+        ],
+        tables: [
+          {
+            caption: 'On-demand rates untuk paid self-serve plans',
+            columns: ['Usage meter', 'Rate', 'Applies to'],
+            rows: [
+              ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
+              ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Coupon codes',
+        paragraphs: [
+          'Untuk memakai coupon code, klik Upgrade Plan dari Console Billing atau Subscribe dari pricing page, pilih plan, lalu tinjau Payment summary. Masukkan code di field Coupon code sebelum menyelesaikan pembayaran.',
+          'Coupon code hanya dapat digunakan satu kali per account. Startup dapat mengirim ringkasan singkat tentang company, product, stage, expected mem9 usage, dan requested support ke <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> untuk mengajukan coupon code.',
+        ],
+      },
+      {
+        title: 'Billing rules FAQ',
+        tables: [
+          {
+            caption: 'Common billing rules',
+            columns: ['Question', 'Answer'],
+            rows: [
+              ['Apakah monthly quotas roll over?', 'Tidak. Included monthly quotas reset setiap billing cycle dan tidak roll over.'],
+              ['Apakah failed requests dihitung?', 'Client-side validation errors dan platform errors tidak billed. Request yang berhasil diproses dapat billed meskipun tidak ada memory baru yang dibuat.'],
+              ['Apakah duplicate atau no-op Add Requests dihitung?', 'Ya, jika extraction, deduplication, atau reconciliation sudah dijalankan.'],
+              ['Apakah storage billed terpisah?', 'Storage termasuk dalam normal usage. Large-scale storage atau dedicated retention requirements dapat ditangani melalui Enterprise pricing.'],
+              ['Bisakah customer membawa own LLM key?', 'BYOK dapat didukung untuk Enterprise customers. Dalam kasus itu, LLM cost dapat dikeluarkan dari mem9 usage pricing atau diperlakukan sebagai pass-through cost.'],
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  th: {
+    id: 'pricing',
+    label: '10',
+    title: 'ราคา',
+    intro:
+      'ราคาของ mem9 อิงตามโควต้ารายเดือนของ Add Request และ Retrieval Request แพ็กเกจ Free มี included usage แบบคงที่ ส่วนแพ็กเกจแบบชำระเงินสามารถขยายด้วย on-demand usage ได้หลังตั้งค่า billing control',
+    paragraphs: [
+      'ราคาสาธารณะตั้งใจแสดง usage meter เพียงสองแบบคือ Add Requests และ Retrieval Requests โดย core Console workflows เหมือนกันในแต่ละ plan ความต่างหลักคือ included quota, support level, on-demand behavior และ Enterprise contract options',
+    ],
+    tables: [
+      {
+        caption: 'Plans and included usage',
+        columns: ['Plan', 'ราคารายเดือน', 'Add requests', 'Retrieval requests', 'End users', 'Support', 'On-demand'],
+        rows: [
+          ['Free', '$0', '13,000 / เดือน', '1,300 / เดือน', 'ไม่จำกัด', 'Community', 'ไม่รองรับ เป็น fixed monthly quota'],
+          ['Starter', '$9 / เดือน', '65,000 / เดือน', '6,500 / เดือน', 'ไม่จำกัด', 'Email', 'ใช้ได้เมื่อมี payment method และ spend cap'],
+          ['Pro', '$120 / เดือน', '650,000 / เดือน', '65,000 / เดือน', 'ไม่จำกัด', 'Priority', 'ใช้ได้เมื่อมี payment method และ spend cap'],
+          ['Enterprise', 'Custom', 'ไม่จำกัดหรือตามสัญญา', 'ไม่จำกัดหรือตามสัญญา', 'ไม่จำกัด', 'Dedicated support and custom SLA', 'Custom commercial terms'],
+        ],
+      },
+      {
+        caption: 'ความต่างของ capability และ billing ตาม tier',
+        columns: ['Capability', 'Free', 'Starter', 'Pro', 'Enterprise'],
+        rows: [
+          ['Core Console workflows', 'Spaces, memory review, Space Chains, usage, billing และ settings', 'Spaces, memory review, Space Chains, usage, billing และ settings', 'Spaces, memory review, Space Chains, usage, billing และ settings', 'Core workflows พร้อม custom enterprise support'],
+          ['Monthly quotas', 'มีเฉพาะ fixed included usage', 'quota ที่สูงขึ้นสำหรับทีมขนาดเล็กและ product ระยะแรก', 'quota ที่สูงขึ้นสำหรับ production หรือ agent usage ที่หนักขึ้น', 'ไม่จำกัดหรือตามที่ตกลง'],
+          ['On-demand usage', 'ไม่มี overage billing เมื่อถึง limit ต้อง upgrade หรือรอ billing cycle ถัดไป', '$0.20 / 1,000 Add Requests และ $2.00 / 1,000 Retrieval Requests', '$0.20 / 1,000 Add Requests และ $2.00 / 1,000 Retrieval Requests', 'Custom terms'],
+          ['Spend cap', 'ไม่เกี่ยวข้อง', 'ต้องตั้งค่าก่อน auto top-up ทำงาน', 'ต้องตั้งค่าก่อน auto top-up ทำงาน', 'ตาม contracted limits หรือ account terms'],
+          ['Support', 'Community', 'Email', 'Priority', 'Dedicated support and custom SLA'],
+          ['Enterprise options', 'ไม่รวม', 'ไม่รวม', 'ไม่รวม', 'Security review, dedicated support, custom SLA, BYOK, dedicated retention หรือ large-scale storage terms จัดการผ่านสัญญาได้'],
+        ],
+      },
+    ],
+    subsections: [
+      {
+        title: 'Request definitions',
+        paragraphs: [
+          'Add Request คือการทำ memory write หรือ memory distillation หนึ่งครั้ง เพื่อประมวลผล messages, text, events หรือ structured facts ให้เป็น durable memory',
+          'Retrieval Request คือ memory query หรือ recall หนึ่งครั้งที่ scope ด้วย user, agent, app, Space, metadata filter หรือ query text',
+        ],
+        bullets: [
+          'Add Request อาจรวม fact extraction, memory creation, memory update, deduplication, reconciliation, embedding และ storage write',
+          'Retrieval Request อาจรวม semantic search, keyword search, hybrid search, metadata filtering, ranking และ result assembly',
+          'สำหรับ Space Chains การ recall หนึ่งครั้งนับเป็นหนึ่ง Retrieval Request แม้ chain จะ scan หลาย Spaces',
+          'payload ขนาดใหญ่มาก, long conversation imports, top_k สูงมาก, multi-Space recall ที่กว้างผิดปกติ หรือ usage ความถี่สูงผิดปกติ อาจจัดการด้วย fair-use policy หรือ Enterprise pricing',
+        ],
+      },
+      {
+        title: 'On-demand usage, auto top-up, and spend caps',
+        paragraphs: [
+          'Free ไม่รองรับ on-demand overage billing เมื่อบัญชี Free ใช้ถึง included quota ต้อง upgrade หรือรอ billing cycle ถัดไป',
+          'ผู้ใช้ Starter และ Pro เปิด auto top-up ได้หลังเพิ่ม payment method ที่ถูกต้อง ควรตั้ง monthly spend cap ก่อนพึ่งพา on-demand usage เมื่อถึง hard cap แล้ว overage API calls จะถูก pause จนถึง billing cycle ถัดไปหรือจนกว่าจะเพิ่ม cap',
+        ],
+        tables: [
+          {
+            caption: 'On-demand rates สำหรับ paid self-serve plans',
+            columns: ['Usage meter', 'Rate', 'Applies to'],
+            rows: [
+              ['Add Request', '$0.20 / 1,000 requests', 'Starter and Pro'],
+              ['Retrieval Request', '$2.00 / 1,000 requests', 'Starter and Pro'],
+            ],
+          },
+        ],
+      },
+      {
+        title: 'Coupon codes',
+        paragraphs: [
+          'หากต้องการใช้ coupon code ให้คลิก Upgrade Plan จาก Console Billing หรือ Subscribe จาก pricing page เลือก plan แล้วตรวจ Payment summary จากนั้นกรอก code ในช่อง Coupon code ก่อนชำระเงินให้เสร็จ',
+          'Coupon code ใช้ได้เพียงหนึ่งครั้งต่อ account เท่านั้น Startup สามารถส่ง summary สั้นๆ เกี่ยวกับ company, product, stage, expected mem9 usage และ requested support ไปที่ <a href="mailto:mem9@pingcap.com">mem9@pingcap.com</a> เพื่อขอ coupon code',
+        ],
+      },
+      {
+        title: 'Billing rules FAQ',
+        tables: [
+          {
+            caption: 'Common billing rules',
+            columns: ['Question', 'Answer'],
+            rows: [
+              ['Monthly quotas roll over หรือไม่?', 'ไม่ Included monthly quotas จะ reset ทุก billing cycle และไม่ roll over'],
+              ['Failed requests ถูกนับหรือไม่?', 'Client-side validation errors และ platform errors ไม่ถูก billed ส่วน request ที่ประมวลผลสำเร็จอาจถูก billed แม้ไม่ได้สร้าง memory ใหม่'],
+              ['Duplicate หรือ no-op Add Requests ถูกนับหรือไม่?', 'นับ หาก extraction, deduplication หรือ reconciliation ถูกเรียกใช้แล้ว'],
+              ['Storage billed แยกหรือไม่?', 'Storage รวมอยู่ใน normal usage ส่วน large-scale storage หรือ dedicated retention requirements จัดการผ่าน Enterprise pricing ได้'],
+              ['Customer นำ own LLM key มาใช้ได้หรือไม่?', 'Enterprise customers รองรับ BYOK ได้ ในกรณีนั้น LLM cost อาจแยกออกจาก mem9 usage pricing หรือจัดเป็น pass-through cost'],
+            ],
+          },
+        ],
+      },
+    ],
+  },
 };
 
 export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
@@ -341,7 +788,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
-      pricingDocsSection,
+      pricingDocsSections.en,
       {
         id: 'safe-operations',
         label: '11',
@@ -607,7 +1054,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
           },
         ],
       },
-      pricingDocsSection,
+      pricingDocsSections.zh,
       {
         id: 'safe-operations',
         label: '11',
@@ -754,7 +1201,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
           { title: 'Settings', bullets: ['account と organization の管理、theme、language、logout に使います。'] },
         ],
       },
-      pricingDocsSection,
+      pricingDocsSections.ja,
       {
         id: 'safe-operations',
         label: '11',
@@ -809,7 +1256,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['새 chain 을 만들거나 기존 chain key 를 import 합니다.', 'detail 에서 key, nodes, memory tools 를 관리합니다.'] }, { title: 'Nodes and routing', bullets: ['active key 가 있는 Space 를 추가합니다.', 'node order 가 recall order 입니다.', 'routing policy prompt 로 검색 조건을 제한할 수 있습니다.'] }, { title: 'Chain keys', bullets: ['chain key 를 만들거나 bind 합니다.', '필요 없는 key 는 disable 합니다.', 'recall tools 로 single Space 와 비교합니다.'] }] },
       { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['Activity sidebar 에서 Webhooks 를 엽니다.', 'All, Space, Space Chain filter 로 project list 를 좁힙니다.', 'table 에서 endpoint, scope, URL host, enabled, events, last delivery 를 확인합니다.'] }, { title: 'Create and edit', bullets: ['Space 또는 Space Chain, resource, URL, events, enabled state 를 설정합니다.', 'production endpoint 는 HTTPS 를 사용합니다.', 'signing secret 은 create / rotate-secret 뒤 한 번만 표시됩니다.'] }, { title: 'Actions and deliveries', bullets: ['row menu 에서 edit, test, deliveries, rotate secret, enable / disable, delete 를 실행합니다.', 'deliveries drawer 에서 status, attempts, HTTP status, last error, retry time 을 확인합니다.'] }] },
       { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['recall / write request usage 를 확인합니다.', 'date range, daily trend, usage events 를 봅니다.'] }, { title: 'Billing', bullets: ['current plan, period, included access, on-demand settings 를 확인합니다.'] }, { title: 'Settings', bullets: ['account 와 organization 관리, theme, language, logout 에 사용합니다.'] }] },
-      pricingDocsSection,
+      pricingDocsSections.ko,
       { id: 'safe-operations', label: '11', title: 'Safe Operations', bullets: ['API key 는 trusted client 설정 시에만 reveal 합니다.', 'delete 전에 preview 와 confirmation 을 확인합니다.', '섞이면 안 되는 data 는 별도 Space 로 나눕니다.', '결과가 이상하면 org, project, Space, key, appId filter 를 확인합니다.'] },
     ],
   },
@@ -854,7 +1301,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['Buat chain baru atau import chain key yang ada.', 'Detail page mengelola key, nodes, dan memory tools.'] }, { title: 'Nodes and routing', bullets: ['Tambahkan Space yang punya active key.', 'Node order menentukan recall order.', 'Routing policy prompt membatasi kapan node dicari.'] }, { title: 'Chain keys', bullets: ['Create atau bind chain key.', 'Disable key yang tidak dipakai.', 'Bandingkan chain dengan single Space memakai recall tools.'] }] },
       { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['Buka Webhooks dari Activity sidebar.', 'Gunakan filter All, Space, atau Space Chain.', 'Tabel menampilkan endpoint, scope, URL host, enabled, events, dan last delivery.'] }, { title: 'Create and edit', bullets: ['Pilih Space atau Space Chain, resource, URL, events, dan enabled state.', 'Endpoint production harus HTTPS.', 'signing secret hanya muncul sekali setelah create atau rotate-secret.'] }, { title: 'Actions and deliveries', bullets: ['Row menu mendukung edit, test, deliveries, rotate secret, enable / disable, dan delete.', 'Drawer deliveries menampilkan status, attempts, HTTP status, last error, dan retry time.'] }] },
       { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['Pantau recall / write request usage.', 'Lihat date range, daily trend, dan usage events.'] }, { title: 'Billing', bullets: ['Lihat current plan, period, included access, dan on-demand settings.'] }, { title: 'Settings', bullets: ['Untuk account, organization, theme, language, dan logout.'] }] },
-      pricingDocsSection,
+      pricingDocsSections.id,
       { id: 'safe-operations', label: '11', title: 'Safe Operations', bullets: ['Reveal API key hanya untuk trusted client.', 'Baca preview dan confirmation sebelum delete.', 'Pisahkan data sensitif ke Space berbeda.', 'Jika hasil aneh, cek org, project, Space, key, dan appId filter.'] },
     ],
   },
@@ -899,7 +1346,7 @@ export const consoleDocsCopy: Record<DocsLocale, DocsPageCopy> = {
       { id: 'space-chains', label: '07', title: 'Space Chains', subsections: [{ title: 'Create or import', bullets: ['สร้าง chain ใหม่หรือ import chain key เดิม', 'หน้า detail ใช้จัดการ key, nodes และ memory tools'] }, { title: 'Nodes and routing', bullets: ['เพิ่ม Space ที่มี active key', 'node order คือ recall order', 'routing policy prompt จำกัดว่า node ควรถูกค้นหาเมื่อใด'] }, { title: 'Chain keys', bullets: ['Create หรือ bind chain key', 'Disable key ที่ไม่ใช้แล้ว', 'ใช้ recall tools เปรียบเทียบ chain กับ Space เดี่ยว'] }] },
       { id: 'webhooks', label: '08', title: 'Webhooks', subsections: [{ title: 'Project view', bullets: ['เปิด Webhooks จาก Activity sidebar', 'ใช้ filter All, Space หรือ Space Chain', 'ตารางแสดง endpoint, scope, URL host, enabled, events และ last delivery'] }, { title: 'Create and edit', bullets: ['เลือก Space หรือ Space Chain, resource, URL, events และ enabled state', 'production endpoint ต้องใช้ HTTPS', 'signing secret แสดงเพียงครั้งเดียวหลัง create หรือ rotate-secret'] }, { title: 'Actions and deliveries', bullets: ['row menu ใช้ edit, test, deliveries, rotate secret, enable / disable และ delete', 'deliveries drawer แสดง status, attempts, HTTP status, last error และ retry time'] }] },
       { id: 'usage-billing-settings', label: '09', title: 'Usage, Billing, Settings', subsections: [{ title: 'Usage', bullets: ['ดู recall / write request usage', 'ดู date range, daily trend และ usage events'] }, { title: 'Billing', bullets: ['ดู current plan, period, included access และ on-demand settings'] }, { title: 'Settings', bullets: ['สำหรับ account, organization, theme, language และ logout'] }] },
-      pricingDocsSection,
+      pricingDocsSections.th,
       { id: 'safe-operations', label: '11', title: 'Safe Operations', bullets: ['Reveal API key เฉพาะ trusted client', 'อ่าน preview และ confirmation ก่อน delete', 'แยกข้อมูลที่ไม่ควรรวมกันไว้คนละ Space', 'ถ้าผลลัพธ์ผิดปกติ ให้ตรวจ org, project, Space, key และ appId filter'] },
     ],
   },

--- a/site/src/content/docs.ts
+++ b/site/src/content/docs.ts
@@ -8,10 +8,17 @@ export interface DocsLink {
   external?: boolean;
 }
 
+export interface DocsTable {
+  caption?: string;
+  columns: string[];
+  rows: string[][];
+}
+
 export interface DocsSubsection {
   title: string;
   paragraphs?: string[];
   bullets?: string[];
+  tables?: DocsTable[];
   links?: DocsLink[];
 }
 
@@ -22,6 +29,7 @@ export interface DocsSection {
   intro?: string;
   paragraphs?: string[];
   bullets?: string[];
+  tables?: DocsTable[];
   subsections?: DocsSubsection[];
   links?: DocsLink[];
 }

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -6677,6 +6677,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: '定价',
       title: '简单透明的定价',
       description: '免费起步，按需扩展。',
+      docsLinkLabel: '在 Console 文档中阅读定价详情',
       featureLabels: [
         '终端用户',
         '添加请求',
@@ -7028,6 +7029,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: '定價',
       title: '簡單透明的定價',
       description: '免費起步，按需擴展。',
+      docsLinkLabel: '在 Console 文檔中閱讀定價詳情',
       featureLabels: [
         '終端使用者',
         '新增請求',
@@ -7382,6 +7384,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: '料金',
       title: 'シンプルで透明な料金体系',
       description: '無料で始めて、必要に応じてスケール。',
+      docsLinkLabel: 'Console ドキュメントで料金の詳細を読む',
       featureLabels: [
         'エンドユーザー',
         '追加リクエスト',
@@ -7735,6 +7738,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: '요금',
       title: '간단하고 투명한 요금제',
       description: '무료로 시작하고, 필요할 때 확장하세요.',
+      docsLinkLabel: 'Console 문서에서 요금 상세 보기',
       featureLabels: [
         '최종 사용자',
         '추가 요청',
@@ -8091,6 +8095,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: 'Harga',
       title: 'Harga yang sederhana dan transparan',
       description: 'Mulai gratis. Skalakan saat dibutuhkan.',
+      docsLinkLabel: 'Baca detail harga di dokumentasi Console',
       featureLabels: [
         'Pengguna akhir',
         'Permintaan add',
@@ -8447,6 +8452,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: 'ราคา',
       title: 'ราคาที่เรียบง่ายและโปร่งใส',
       description: 'เริ่มต้นฟรี ขยายเมื่อคุณต้องการ',
+      docsLinkLabel: 'อ่านรายละเอียดราคาในเอกสาร Console',
       featureLabels: [
         'ผู้ใช้ปลายทาง',
         'Add requests',

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -214,6 +214,7 @@ export interface SiteBillingPageCopy {
   kicker: string;
   title: string;
   description: string;
+  docsLinkLabel?: string;
   featureLabels: string[];
   tiers: SiteBillingTier[];
   contactMessage: string;
@@ -6328,6 +6329,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       kicker: 'Pricing',
       title: 'Simple, transparent pricing',
       description: 'Start free. Scale when you need to.',
+      docsLinkLabel: 'Read pricing details in Console Docs',
       featureLabels: [
         'End users',
         'Add requests',

--- a/site/src/scripts/site-ui.ts
+++ b/site/src/scripts/site-ui.ts
@@ -517,6 +517,38 @@ function resolveDocsLocale(locale: SiteLocale): DocsLocale {
   }
 }
 
+function findActiveDocsHashTarget(root: HTMLElement): HTMLElement | null {
+  const hash = window.location.hash.slice(1);
+  if (!hash) {
+    return null;
+  }
+
+  const activeCopy = root.querySelector<HTMLElement>('[data-docs-copy]:not([hidden])');
+  return Array.from(activeCopy?.querySelectorAll<HTMLElement>('[data-docs-anchor]') ?? [])
+    .find((anchor) => anchor.dataset.docsAnchor === hash) ?? null;
+}
+
+function scheduleDocsHashScroll(root: HTMLElement): void {
+  if (!window.location.hash) {
+    return;
+  }
+
+  window.requestAnimationFrame(() => {
+    findActiveDocsHashTarget(root)?.scrollIntoView({ block: 'start', behavior: 'auto' });
+    window.requestAnimationFrame(() => {
+      findActiveDocsHashTarget(root)?.scrollIntoView({ block: 'start', behavior: 'auto' });
+    });
+  });
+
+  window.setTimeout(() => {
+    findActiveDocsHashTarget(root)?.scrollIntoView({ block: 'start', behavior: 'auto' });
+  }, 120);
+
+  window.setTimeout(() => {
+    findActiveDocsHashTarget(root)?.scrollIntoView({ block: 'start', behavior: 'auto' });
+  }, 450);
+}
+
 function updateDocsPage(locale: SiteLocale): void {
   const docsLocale = resolveDocsLocale(locale);
   const root = document.querySelector<HTMLElement>('[data-docs-root]');
@@ -556,6 +588,8 @@ function updateDocsPage(locale: SiteLocale): void {
       backToTopButton.setAttribute('aria-label', activeCopy.dataset.docsBackToTopLabel);
     }
   }
+
+  scheduleDocsHashScroll(root);
 }
 
 function updateApiPage(locale: SiteLocale): void {
@@ -2082,6 +2116,11 @@ export function initSiteUI(): void {
     initDocsProgressBar();
     initDocsBackToTop();
     initDocsMobileToc();
+
+    const docsRoot = document.querySelector<HTMLElement>('[data-docs-root]');
+    if (docsRoot) {
+      scheduleDocsHashScroll(docsRoot);
+    }
   }
 
   if (isApiPage()) {


### PR DESCRIPTION
## Summary

- Add a Pricing section to mem9 Console Docs covering plan tiers, request definitions, on-demand usage, spend caps, coupon code usage, startup coupon requests, and billing FAQ.
- Localize the new Pricing docs section across supported Console Docs locales: English, Simplified Chinese, Japanese, Korean, Indonesian, and Thai.
- Localize the Pricing page link to `/console-docs#pricing` across all site locales, including Traditional Chinese.
- Extend the shared docs renderer with table support so tier and billing differences render as structured tables.
- Make docs hash navigation stable after locale/runtime initialization.

## Impact

Users can move from the public pricing page into detailed Console Docs and understand included quotas, on-demand rates, Enterprise options, and coupon behavior in their selected site language.

## Validation

- `cd site && npx tsc --noEmit`
- `cd site && npm run build`
- Browser check from the previous commit: clicked the Pricing page docs link and verified it lands on `/console-docs#pricing`, renders the Pricing heading, four tables, coupon copy, on-demand rates, and no browser console errors.