### PR TITLE
[codex] reduce recall DB traffic

### DIFF
--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -16,6 +16,194 @@ import (
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
+func TestMemoryVectorSearchSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	rows := &scriptedRows{
+		columns: append(memorySearchColumns(), "distance"),
+		values: [][]driver.Value{
+			append(memorySearchRow("m-vector-1", "vector match", "agent-1", "session-1", "active", []byte(`[]`), now), float64(0.2)),
+		},
+	}
+	db := newScriptedTestDB(t, []*queryExpectation{{
+		mustContain: []string{
+			"SELECT " + searchColumns + ", VEC_COSINE_DISTANCE(embedding, ?) AS distance",
+			"FROM memories",
+			"WHERE state = 'active' AND agent_id = ? AND embedding IS NOT NULL",
+			"ORDER BY VEC_COSINE_DISTANCE(embedding, ?)",
+			"LIMIT ?",
+		},
+		mustNotContain: []string{allColumns},
+		wantArgs:       []any{"[0.25,0.5]", "agent-1", "[0.25,0.5]", 3},
+		rows:           rows,
+	}})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.VectorSearch(context.Background(), []float32{0.25, 0.5}, domain.MemoryFilter{AgentID: "agent-1"}, 3)
+	if err != nil {
+		t.Fatalf("VectorSearch: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "m-vector-1" {
+		t.Fatalf("unexpected VectorSearch results: %+v", results)
+	}
+	if len(results[0].Embedding) != 0 {
+		t.Fatalf("VectorSearch hydrated embedding length = %d, want 0", len(results[0].Embedding))
+	}
+	if results[0].Score == nil || *results[0].Score < 0.799 || *results[0].Score > 0.801 {
+		t.Fatalf("VectorSearch score = %v, want about 0.8", results[0].Score)
+	}
+}
+
+func TestMemoryAutoVectorSearchSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	rows := &scriptedRows{
+		columns: append(memorySearchColumns(), "distance"),
+		values: [][]driver.Value{
+			append(memorySearchRow("m-auto-1", "auto vector match", "agent-1", "session-1", "active", []byte(`[]`), now), float64(0.15)),
+		},
+	}
+	db := newScriptedTestDB(t, []*queryExpectation{{
+		mustContain: []string{
+			"SELECT " + searchColumns + ", VEC_EMBED_COSINE_DISTANCE(embedding, ?) AS distance",
+			"FROM memories",
+			"WHERE state = 'active' AND agent_id = ? AND embedding IS NOT NULL",
+			"ORDER BY VEC_EMBED_COSINE_DISTANCE(embedding, ?)",
+			"LIMIT ?",
+		},
+		mustNotContain: []string{allColumns},
+		wantArgs:       []any{"recall query", "agent-1", "recall query", 2},
+		rows:           rows,
+	}})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "test-auto-model", true, "cluster-1")
+	results, err := repo.AutoVectorSearch(context.Background(), "recall query", domain.MemoryFilter{AgentID: "agent-1"}, 2)
+	if err != nil {
+		t.Fatalf("AutoVectorSearch: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "m-auto-1" {
+		t.Fatalf("unexpected AutoVectorSearch results: %+v", results)
+	}
+	if len(results[0].Embedding) != 0 {
+		t.Fatalf("AutoVectorSearch hydrated embedding length = %d, want 0", len(results[0].Embedding))
+	}
+	if results[0].Score == nil || *results[0].Score < 0.849 || *results[0].Score > 0.851 {
+		t.Fatalf("AutoVectorSearch score = %v, want about 0.85", results[0].Score)
+	}
+}
+
+func TestMemoryListSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain:    []string{"SELECT COUNT(*) FROM memories WHERE state = 'active'"},
+			mustNotContain: []string{"embedding"},
+			rows: &scriptedRows{
+				columns: []string{"COUNT(*)"},
+				values:  [][]driver.Value{{int64(1)}},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + searchColumns + " FROM memories",
+				"WHERE state = 'active'",
+				"ORDER BY updated_at DESC, id DESC",
+				"LIMIT ? OFFSET ?",
+			},
+			mustNotContain: []string{allColumns},
+			wantArgs:       []any{2, 0},
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					memorySearchRow("m-list-1", "list match", "agent-1", "session-1", "active", []byte(`[]`), now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, total, err := repo.List(context.Background(), domain.MemoryFilter{Limit: 2})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 1 || len(results) != 1 || results[0].ID != "m-list-1" {
+		t.Fatalf("unexpected List results: total=%d results=%+v", total, results)
+	}
+	if len(results[0].Embedding) != 0 {
+		t.Fatalf("List hydrated embedding length = %d, want 0", len(results[0].Embedding))
+	}
+}
+
+func TestMemoryListBootstrapSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{{
+		mustContain: []string{
+			"SELECT " + searchColumns + " FROM memories",
+			"WHERE state = 'active'",
+			"ORDER BY updated_at DESC",
+			"LIMIT ?",
+		},
+		mustNotContain: []string{allColumns},
+		wantArgs:       []any{3},
+		rows: &scriptedRows{
+			columns: memorySearchColumns(),
+			values: [][]driver.Value{
+				memorySearchRow("m-bootstrap-1", "bootstrap match", "agent-1", "session-1", "active", []byte(`[]`), now),
+			},
+		},
+	}})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.ListBootstrap(context.Background(), 3)
+	if err != nil {
+		t.Fatalf("ListBootstrap: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "m-bootstrap-1" {
+		t.Fatalf("unexpected ListBootstrap results: %+v", results)
+	}
+	if len(results[0].Embedding) != 0 {
+		t.Fatalf("ListBootstrap hydrated embedding length = %d, want 0", len(results[0].Embedding))
+	}
+}
+
+func TestMemoryGetEmbeddingsByIDSelectsOnlyEmbedding(t *testing.T) {
+	db := newScriptedTestDB(t, []*queryExpectation{{
+		mustContain: []string{
+			"SELECT id, embedding FROM memories",
+			"WHERE id IN (?,?)",
+			"state = 'active'",
+			"embedding IS NOT NULL",
+		},
+		mustNotContain: []string{"content", "metadata", "memory_type"},
+		wantArgs:       []any{"m-1", "m-2"},
+		rows: &scriptedRows{
+			columns: []string{"id", "embedding"},
+			values: [][]driver.Value{
+				{"m-1", []byte("[0.1,0.2]")},
+				{"m-2", []byte("[0.3,0.4]")},
+			},
+		},
+	}})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	embeddings, err := repo.GetEmbeddingsByID(context.Background(), []string{"m-1", "m-2"})
+	if err != nil {
+		t.Fatalf("GetEmbeddingsByID: %v", err)
+	}
+	if len(embeddings) != 2 {
+		t.Fatalf("len(embeddings) = %d, want 2", len(embeddings))
+	}
+	if got := embeddings["m-1"]; len(got) != 2 || got[0] != 0.1 || got[1] != 0.2 {
+		t.Fatalf("embedding m-1 = %v, want [0.1 0.2]", got)
+	}
+	if got := embeddings["m-2"]; len(got) != 2 || got[0] != 0.3 || got[1] != 0.4 {
+		t.Fatalf("embedding m-2 = %v, want [0.3 0.4]", got)
+	}
+}
+
 func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	initialCandidateLimit := 2
@@ -43,16 +231,16 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT " + allColumns + " FROM memories",
+				"SELECT " + searchColumns + " FROM memories",
 				"WHERE id IN (",
 				"AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
 			wantArgs:       firstPageArgs,
 			rows: &scriptedRows{
-				columns: memoryColumns(),
+				columns: memorySearchColumns(),
 				values: [][]driver.Value{
-					memoryRow("m-page-0-0001", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
+					memorySearchRow("m-page-0-0001", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
 				},
 			},
 		},
@@ -77,17 +265,17 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT " + allColumns + " FROM memories",
+				"SELECT " + searchColumns + " FROM memories",
 				"WHERE id IN (",
 				"AND state = ? AND agent_id = ? AND JSON_CONTAINS(tags, ?)",
 			},
 			mustNotContain: []string{"fts_match_word("},
 			wantArgs:       secondPageArgs,
 			rows: &scriptedRows{
-				columns: memoryColumns(),
+				columns: memorySearchColumns(),
 				values: [][]driver.Value{
-					memoryRow("m-page-0-0001", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
-					memoryRow("m-page-1-0000", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
+					memorySearchRow("m-page-0-0001", "match one", "agent-1", "session-1", "active", []byte(`["tag-a"]`), now),
+					memorySearchRow("m-page-1-0000", "match two", "agent-1", "session-2", "active", []byte(`["tag-a"]`), now),
 				},
 			},
 		},
@@ -250,17 +438,17 @@ func TestMemoryFTSSearch_StopsAfterRequestedLimitPageWhenFull(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"SELECT " + allColumns + " FROM memories",
+				"SELECT " + searchColumns + " FROM memories",
 				"WHERE id IN (",
 				"AND state = ? AND agent_id = ?",
 			},
 			mustNotContain: []string{"fts_match_word("},
 			wantArgs:       candidateArgs,
 			rows: &scriptedRows{
-				columns: memoryColumns(),
+				columns: memorySearchColumns(),
 				values: [][]driver.Value{
-					memoryRow("m-full-0000", "match one", "agent-1", "session-1", "active", []byte(`[]`), now),
-					memoryRow("m-full-0001", "match two", "agent-1", "session-2", "active", []byte(`[]`), now),
+					memorySearchRow("m-full-0000", "match one", "agent-1", "session-1", "active", []byte(`[]`), now),
+					memorySearchRow("m-full-0001", "match two", "agent-1", "session-2", "active", []byte(`[]`), now),
 				},
 			},
 		},
@@ -357,14 +545,14 @@ func TestMemoryFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 		},
 	}, &queryExpectation{
 		mustContain: []string{
-			"SELECT " + allColumns + " FROM memories",
+			"SELECT " + searchColumns + " FROM memories",
 			"WHERE id IN (",
 			"AND state = ?",
 		},
 		mustNotContain: []string{"fts_match_word("},
 		wantArgs:       append(initialCandidateArgs, "active"),
 		rows: &scriptedRows{
-			columns: memoryColumns(),
+			columns: memorySearchColumns(),
 		},
 	})
 	for page := 0; page < maxFTSFallbackPages; page++ {
@@ -390,14 +578,14 @@ func TestMemoryFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 			},
 		}, &queryExpectation{
 			mustContain: []string{
-				"SELECT " + allColumns + " FROM memories",
+				"SELECT " + searchColumns + " FROM memories",
 				"WHERE id IN (",
 				"AND state = ?",
 			},
 			mustNotContain: []string{"fts_match_word("},
 			wantArgs:       postFilterArgs,
 			rows: &scriptedRows{
-				columns: memoryColumns(),
+				columns: memorySearchColumns(),
 			},
 		})
 	}
@@ -689,21 +877,20 @@ func ftsCandidateArgs(prefix string, count int) []any {
 	return args
 }
 
-func memoryColumns() []string {
+func memorySearchColumns() []string {
 	return []string{
-		"id", "content", "source", "tags", "metadata", "embedding", "memory_type", "agent_id",
+		"id", "content", "source", "tags", "metadata", "memory_type", "agent_id",
 		"session_id", "app_id", "state", "version", "updated_by", "created_at", "updated_at", "superseded_by",
 	}
 }
 
-func memoryRow(id, content, agentID, sessionID, state string, tags []byte, ts time.Time) []driver.Value {
+func memorySearchRow(id, content, agentID, sessionID, state string, tags []byte, ts time.Time) []driver.Value {
 	return []driver.Value{
 		id,
 		content,
 		"chat",
 		tags,
 		[]byte(`{"k":"v"}`),
-		nil,
 		string(domain.TypeInsight),
 		agentID,
 		sessionID,

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -36,6 +36,7 @@ func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 
 const (
 	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
+	searchColumns            = `id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
 	maxFTSCandidatePageLimit = 10000
 	maxFTSFallbackPages      = 30
 	// TiDB Cloud FTS is only safe with fts_match_word as the only WHERE predicate,
@@ -80,6 +81,47 @@ func (r *MemoryRepo) GetByID(ctx context.Context, id string) (*domain.Memory, er
 		`SELECT `+allColumns+` FROM memories WHERE id = ? AND state = 'active'`, id,
 	)
 	return scanMemory(row)
+}
+
+func (r *MemoryRepo) GetEmbeddingsByID(ctx context.Context, ids []string) (map[string][]float32, error) {
+	if len(ids) == 0 {
+		return map[string][]float32{}, nil
+	}
+
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	query := `SELECT id, embedding FROM memories
+		WHERE id IN (` + strings.Join(placeholders, ",") + `)
+			AND state = 'active'
+			AND embedding IS NOT NULL`
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("get memory embeddings: %w", err)
+	}
+	defer rows.Close()
+
+	embeddings := make(map[string][]float32, len(ids))
+	for rows.Next() {
+		var id string
+		var embeddingStr []byte
+		if err := rows.Scan(&id, &embeddingStr); err != nil {
+			return nil, fmt.Errorf("scan memory embedding: %w", err)
+		}
+		embedding := parseVecString(embeddingStr)
+		if len(embedding) > 0 {
+			embeddings[id] = embedding
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return embeddings, nil
 }
 
 func (r *MemoryRepo) UpdateOptimistic(ctx context.Context, m *domain.Memory, expectedVersion int) error {
@@ -275,7 +317,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 		offset = 0
 	}
 
-	dataQuery := "SELECT " + allColumns + " FROM memories WHERE " +
+	dataQuery := "SELECT " + searchColumns + " FROM memories WHERE " +
 		where + " ORDER BY " + memoryListOrderBy(f) + " LIMIT ? OFFSET ?"
 	// Copy args to avoid mutating the original slice (append may reuse underlying array).
 	dataArgs := make([]any, len(args), len(args)+2)
@@ -291,7 +333,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 
 	var memories []domain.Memory
 	for rows.Next() {
-		m, err := scanMemoryRows(rows)
+		m, err := scanSearchMemoryRows(rows)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -338,7 +380,7 @@ func (r *MemoryRepo) ListBootstrap(ctx context.Context, limit int) ([]domain.Mem
 		limit = 20
 	}
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT `+allColumns+` FROM memories WHERE state = 'active' ORDER BY updated_at DESC LIMIT ?`,
+		`SELECT `+searchColumns+` FROM memories WHERE state = 'active' ORDER BY updated_at DESC LIMIT ?`,
 		limit,
 	)
 	if err != nil {
@@ -349,7 +391,7 @@ func (r *MemoryRepo) ListBootstrap(ctx context.Context, limit int) ([]domain.Mem
 
 	var memories []domain.Memory
 	for rows.Next() {
-		m, err := scanMemoryRows(rows)
+		m, err := scanSearchMemoryRows(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -424,7 +466,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 
 	where := strings.Join(conds, " AND ")
 
-	query := `SELECT ` + allColumns + `, VEC_COSINE_DISTANCE(embedding, ?) AS distance
+	query := `SELECT ` + searchColumns + `, VEC_COSINE_DISTANCE(embedding, ?) AS distance
 		 FROM memories
 		 WHERE ` + where + `
 		 ORDER BY VEC_COSINE_DISTANCE(embedding, ?)
@@ -446,7 +488,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 
 	var memories []domain.Memory
 	for rows.Next() {
-		m, err := scanMemoryRowsWithDistance(rows)
+		m, err := scanSearchMemoryRowsWithDistance(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -465,7 +507,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 
 	where := strings.Join(conds, " AND ")
 
-	query := `SELECT ` + allColumns + `, VEC_EMBED_COSINE_DISTANCE(embedding, ?) AS distance
+	query := `SELECT ` + searchColumns + `, VEC_EMBED_COSINE_DISTANCE(embedding, ?) AS distance
 		 FROM memories
 		 WHERE ` + where + `
 		 ORDER BY VEC_EMBED_COSINE_DISTANCE(embedding, ?)
@@ -486,7 +528,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 
 	var memories []domain.Memory
 	for rows.Next() {
-		m, err := scanMemoryRowsWithDistance(rows)
+		m, err := scanSearchMemoryRowsWithDistance(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -508,7 +550,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 	}
 
 	where := strings.Join(conds, " AND ")
-	sqlQuery := `SELECT ` + allColumns + ` FROM memories WHERE ` + where + ` ORDER BY updated_at DESC LIMIT ?`
+	sqlQuery := `SELECT ` + searchColumns + ` FROM memories WHERE ` + where + ` ORDER BY updated_at DESC LIMIT ?`
 	args = append(args, limit)
 
 	start := time.Now()
@@ -521,7 +563,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 
 	var memories []domain.Memory
 	for rows.Next() {
-		m, err := scanMemoryRows(rows)
+		m, err := scanSearchMemoryRows(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -675,7 +717,7 @@ func (r *MemoryRepo) fetchFilteredFTSMemories(ctx context.Context, candidates []
 	}
 	args = append(args, filterArgs...)
 
-	sqlQuery := `SELECT ` + allColumns + ` FROM memories
+	sqlQuery := `SELECT ` + searchColumns + ` FROM memories
 		WHERE id IN (` + strings.Join(placeholders, ",") + `) AND ` + where
 
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
@@ -686,7 +728,7 @@ func (r *MemoryRepo) fetchFilteredFTSMemories(ctx context.Context, candidates []
 
 	memoriesByID := make(map[string]domain.Memory, len(candidates))
 	for rows.Next() {
-		m, err := scanMemoryRows(rows)
+		m, err := scanSearchMemoryRows(rows)
 		if err != nil {
 			return nil, err
 		}
@@ -878,6 +920,63 @@ func scanMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
 	score := 1 - distance
 	m.Score = &score
 	return &m, nil
+}
+
+func scanSearchMemoryRows(rows *sql.Rows) (*domain.Memory, error) {
+	var m domain.Memory
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
+	var tagsJSON, metadataJSON []byte
+
+	err := rows.Scan(&m.ID, &m.Content, &source,
+		&tagsJSON, &metadataJSON, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
+		&m.CreatedAt, &m.UpdatedAt, &supersededBy)
+	if err != nil {
+		return nil, fmt.Errorf("scan memory search row: %w", err)
+	}
+	populateMemoryFields(&m, source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy, tagsJSON, metadataJSON)
+	return &m, nil
+}
+
+func scanSearchMemoryRowsWithDistance(rows *sql.Rows) (*domain.Memory, error) {
+	var m domain.Memory
+	var source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString
+	var tagsJSON, metadataJSON []byte
+	var distance float64
+
+	err := rows.Scan(&m.ID, &m.Content, &source,
+		&tagsJSON, &metadataJSON, &memoryType, &agentID, &sessionID, &appID, &state, &m.Version, &updatedBy,
+		&m.CreatedAt, &m.UpdatedAt, &supersededBy,
+		&distance)
+	if err != nil {
+		return nil, fmt.Errorf("scan memory search row with distance: %w", err)
+	}
+	populateMemoryFields(&m, source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy, tagsJSON, metadataJSON)
+	score := 1 - distance
+	m.Score = &score
+	return &m, nil
+}
+
+func populateMemoryFields(
+	m *domain.Memory,
+	source, memoryType, agentID, sessionID, appID, state, updatedBy, supersededBy sql.NullString,
+	tagsJSON, metadataJSON []byte,
+) {
+	m.Source = source.String
+	m.MemoryType = domain.MemoryType(memoryType.String)
+	if m.MemoryType == "" {
+		m.MemoryType = domain.TypePinned
+	}
+	m.AgentID = agentID.String
+	m.SessionID = sessionID.String
+	m.AppID = appID.String
+	m.State = domain.MemoryState(state.String)
+	if m.State == "" {
+		m.State = domain.StateActive
+	}
+	m.UpdatedBy = updatedBy.String
+	m.SupersededBy = supersededBy.String
+	m.Tags = unmarshalTags(tagsJSON)
+	m.Metadata = unmarshalRawJSON(metadataJSON)
 }
 
 func marshalTags(tags []string) []byte {

--- a/server/internal/repository/tidb/memory_integration_test.go
+++ b/server/internal/repository/tidb/memory_integration_test.go
@@ -320,8 +320,8 @@ func TestList(t *testing.T) {
 		if err != nil {
 			t.Fatalf("List: %v", err)
 		}
-		if total != 2 {
-			t.Fatalf("total mismatch: got %d want 2", total)
+		if total != 3 {
+			t.Fatalf("total mismatch: got %d want 3", total)
 		}
 		for _, m := range result {
 			if m.MemoryType != domain.TypeInsight {
@@ -501,7 +501,10 @@ func TestKeywordSearch(t *testing.T) {
 		"Python is used for data analysis scripts",
 	}
 	for _, c := range contents {
-		m := newTestMemory(func(m *domain.Memory) { m.Content = c })
+		m := newTestMemory(func(m *domain.Memory) {
+			m.Content = c
+			m.MemoryType = domain.TypeInsight
+		})
 		if err := repo.Create(ctx, m); err != nil {
 			t.Fatalf("Create: %v", err)
 		}
@@ -558,8 +561,11 @@ func TestListBootstrap(t *testing.T) {
 		if err := repo.Create(ctx, m); err != nil {
 			t.Fatalf("Create: %v", err)
 		}
+		updatedAt := time.Date(2026, 1, 1, 0, 0, i, 0, time.UTC)
+		if _, err := testDB.ExecContext(ctx, "UPDATE memories SET updated_at = ? WHERE id = ?", updatedAt, m.ID); err != nil {
+			t.Fatalf("set deterministic updated_at: %v", err)
+		}
 		ids = append(ids, m.ID)
-		time.Sleep(50 * time.Millisecond)
 	}
 
 	// Bootstrap with limit=3 — should get the 3 most recent.

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -38,9 +38,13 @@ type memoryRepoMock struct {
 	lastAutoVectorFilter domain.MemoryFilter
 	lastKeywordFilter    domain.MemoryFilter
 	lastFTSFilter        domain.MemoryFilter
+	vectorSearchHook     func(context.Context, []float32, domain.MemoryFilter, int) ([]domain.Memory, error)
 	autoVectorSearchHook func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	ftsSearchHook        func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
+	embeddingLookup      map[string][]float32
+	embeddingLookupErr   error
+	embeddingLookupCalls [][]string
 	bulkSoftDeleteCalls  [][]string
 	bulkSoftDeleteAgent  string
 	bulkSoftDeleteResult int64
@@ -1313,9 +1317,13 @@ func (m *memoryRepoMock) BulkCreate(ctx context.Context, memories []*domain.Memo
 func (m *memoryRepoMock) VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	m.mu.Lock()
 	m.lastVectorFilter = f
+	hook := m.vectorSearchHook
 	vectorErr := m.vectorErr
 	vectorResults := m.vectorResults
 	m.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, queryVec, f, limit)
+	}
 	if vectorErr != nil {
 		return nil, vectorErr
 	}
@@ -1481,6 +1489,27 @@ func TestDropQueryIntentFacts(t *testing.T) {
 }
 
 func (m *memoryRepoMock) CountStats(ctx context.Context) (int64, int64, error) { return 0, 0, nil }
+
+func (m *memoryRepoMock) GetEmbeddingsByID(ctx context.Context, ids []string) (map[string][]float32, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	copiedIDs := append([]string(nil), ids...)
+	m.embeddingLookupCalls = append(m.embeddingLookupCalls, copiedIDs)
+	if m.embeddingLookupErr != nil {
+		return nil, m.embeddingLookupErr
+	}
+
+	result := make(map[string][]float32, len(ids))
+	for _, id := range ids {
+		embedding := m.embeddingLookup[id]
+		if len(embedding) == 0 {
+			continue
+		}
+		result[id] = append([]float32(nil), embedding...)
+	}
+	return result, nil
+}
 
 func TestStripInjectedContext(t *testing.T) {
 	t.Parallel()

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -47,6 +47,10 @@ type MemoryService struct {
 	ingest    *IngestService
 }
 
+type memoryEmbeddingLookup interface {
+	GetEmbeddingsByID(ctx context.Context, ids []string) (map[string][]float32, error)
+}
+
 func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, embedder *embed.Embedder, autoModel string, ingestMode IngestMode) *MemoryService {
 	return &MemoryService{
 		memories:  memories,
@@ -788,6 +792,7 @@ func (s *MemoryService) secondHopAutoSearch(
 	for _, m := range seeds {
 		seedIDs[m.ID] = struct{}{}
 	}
+	s.hydrateSecondHopSeedEmbeddings(ctx, seeds)
 
 	// Launch concurrent second-hop searches using first-hop embeddings
 	// to avoid redundant embedding API calls.
@@ -850,6 +855,43 @@ func (s *MemoryService) secondHopAutoSearch(
 		return bestScore[result[i].ID] > bestScore[result[j].ID]
 	})
 	return result
+}
+
+func (s *MemoryService) hydrateSecondHopSeedEmbeddings(ctx context.Context, seeds []domain.Memory) {
+	lookup, ok := s.memories.(memoryEmbeddingLookup)
+	if !ok {
+		return
+	}
+
+	ids := make([]string, 0, len(seeds))
+	seen := make(map[string]struct{}, len(seeds))
+	for _, seed := range seeds {
+		if len(seed.Embedding) > 0 || seed.ID == "" {
+			continue
+		}
+		if _, exists := seen[seed.ID]; exists {
+			continue
+		}
+		seen[seed.ID] = struct{}{}
+		ids = append(ids, seed.ID)
+	}
+	if len(ids) == 0 {
+		return
+	}
+
+	embeddings, err := lookup.GetEmbeddingsByID(ctx, ids)
+	if err != nil {
+		slog.WarnContext(ctx, "second-hop seed embedding lookup failed", "err", err)
+		return
+	}
+	for i := range seeds {
+		if len(seeds[i].Embedding) > 0 {
+			continue
+		}
+		if embedding := embeddings[seeds[i].ID]; len(embedding) > 0 {
+			seeds[i].Embedding = embedding
+		}
+	}
 }
 
 func collectMems(kwResults, vecResults []domain.Memory) map[string]domain.Memory {

--- a/server/internal/service/memory_test.go
+++ b/server/internal/service/memory_test.go
@@ -555,6 +555,73 @@ func TestContentKeywordSearchBypassesFTSAndVector(t *testing.T) {
 	}
 }
 
+func TestSecondHopAutoSearchHydratesSeedEmbedding(t *testing.T) {
+	score := 0.99
+	seedScore := 0.8
+	vectorCalls := make(chan []float32, 1)
+	autoVectorCalls := make(chan string, 1)
+
+	memRepo := &memoryRepoMock{
+		embeddingLookup: map[string][]float32{
+			"seed-1": {0.25, 0.5},
+		},
+		vectorSearchHook: func(_ context.Context, queryVec []float32, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+			vectorCalls <- append([]float32(nil), queryVec...)
+			if f.AgentID != "agent-1" {
+				t.Errorf("VectorSearch AgentID = %q, want agent-1", f.AgentID)
+			}
+			if limit != 5 {
+				t.Errorf("VectorSearch limit = %d, want 5", limit)
+			}
+			return []domain.Memory{
+				{ID: "neighbor-1", Content: "near seed", Score: &score, MemoryType: domain.TypeInsight, State: domain.StateActive},
+			}, nil
+		},
+		autoVectorSearchHook: func(_ context.Context, queryText string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			autoVectorCalls <- queryText
+			return nil, nil
+		},
+	}
+	svc := NewMemoryService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	results := svc.secondHopAutoSearch(
+		context.Background(),
+		map[string]domain.Memory{
+			"seed-1": {ID: "seed-1", Content: "seed content", Score: &seedScore, MemoryType: domain.TypeInsight, State: domain.StateActive},
+		},
+		map[string]float64{"seed-1": 1},
+		domain.MemoryFilter{AgentID: "agent-1"},
+		5,
+		1,
+	)
+
+	if len(results) != 1 || results[0].ID != "neighbor-1" {
+		t.Fatalf("unexpected second-hop results: %+v", results)
+	}
+
+	select {
+	case got := <-vectorCalls:
+		if len(got) != 2 || got[0] != 0.25 || got[1] != 0.5 {
+			t.Fatalf("VectorSearch queryVec = %v, want [0.25 0.5]", got)
+		}
+	default:
+		t.Fatal("expected second-hop search to use hydrated seed embedding")
+	}
+
+	select {
+	case queryText := <-autoVectorCalls:
+		t.Fatalf("second-hop unexpectedly fell back to AutoVectorSearch with query %q", queryText)
+	default:
+	}
+
+	memRepo.mu.Lock()
+	lookupCalls := append([][]string(nil), memRepo.embeddingLookupCalls...)
+	memRepo.mu.Unlock()
+	if len(lookupCalls) != 1 || len(lookupCalls[0]) != 1 || lookupCalls[0][0] != "seed-1" {
+		t.Fatalf("embedding lookup calls = %#v, want [[seed-1]]", lookupCalls)
+	}
+}
+
 func TestCreateFallsBackToRawWhenLLMUnavailable(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Reduce TiDB-to-server recall traffic by avoiding unnecessary `embedding` column hydration on read paths.

- Use lean memory columns for TiDB vector search, auto vector search, keyword search, FTS post-filtering, list, and bootstrap reads.
- Add an explicit `GetEmbeddingsByID` lookup for the small set of second-hop seed memories that still need vectors.
- Keep recall scoring and TiDB vector distance ordering unchanged; embeddings remain used in SQL but are no longer shipped back with every candidate row.
- Fix brittle TiDB integration test expectations around memory type counts and timestamp ordering.

## Why

Production VPC Flow Logs showed the abnormal traffic was dominated by TiDB response traffic to EKS during recall, while app HTTP traffic and add-memory traffic were much smaller. Search rows were selecting `allColumns`, including large embeddings that are not returned to clients.

## Validation

- `make vet`
- `make build`
- `make test`
- `MNEMO_TEST_DSN='root@tcp(127.0.0.1:4000)/mem9_test?parseTime=true' make test-integration` with local `tiup playground`
