### PR TITLE
feat(runtime): define public quota error contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ benchmark/MR-NIAH/.cache/
 .claude/
 .playwright-mcp/
 .env.tidb-local
+
+# Local superpowers workflow artifacts
+docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ vendor/
 server/bin
 server/coverage/
 server/.tmp
+.tmp/
 
 # Benchmark results
 benchmark/results/*

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2416,7 +2416,7 @@
         "description": "No content."
       },
       "RuntimeAccessBlocked": {
-        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse and includes details.runtimeQuota for mem9 quota classification and provider-supplied metadata.",
+        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse, includes mem9 quota classification under details.mem9Category, and preserves provider-supplied metadata under details.runtimeQuota.",
         "content": {
           "application/json": {
             "schema": {
@@ -2427,10 +2427,9 @@
                 "value": {
                   "error": "Runtime access is blocked.",
                   "details": {
+                    "mem9Category": "runtime_quota_denied",
                     "runtimeQuota": {
-                      "category": "runtime_quota_denied",
                       "meter": "memory_recall_requests",
-                      "providerReason": "includedQuotaExhausted",
                       "quotaGateResult": {
                         "outcome": "blocked",
                         "mode": "includedQuota",
@@ -2470,10 +2469,9 @@
                 "value": {
                   "error": "Post-quota rate limit exceeded.",
                   "details": {
+                    "mem9Category": "runtime_quota_denied",
                     "runtimeQuota": {
-                      "category": "runtime_quota_denied",
                       "meter": "memory_recall_requests",
-                      "providerReason": "postQuotaRateLimitExceeded",
                       "quotaGateResult": {
                         "outcome": "rateLimited",
                         "mode": "postQuota",
@@ -2526,10 +2524,9 @@
                 "value": {
                   "error": "Post-quota rate limit exceeded.",
                   "details": {
+                    "mem9Category": "runtime_quota_denied",
                     "runtimeQuota": {
-                      "category": "runtime_quota_denied",
                       "meter": "memory_recall_requests",
-                      "providerReason": "postQuotaRateLimitExceeded",
                       "quotaGateResult": {
                         "outcome": "rateLimited",
                         "mode": "postQuota",
@@ -3406,16 +3403,8 @@
           },
           "reason": {
             "type": "string",
-            "enum": [
-              "includedQuotaAvailable",
-              "includedQuotaExhausted",
-              "onDemandAvailable",
-              "onDemandDisabled",
-              "onDemandUnavailable",
-              "onDemandBudgetExhausted",
-              "postQuotaRateLimitExceeded",
-              "accountStateBlocked"
-            ]
+            "description": "Provider-defined quota reason. Clients should treat unknown values as opaque hints.",
+            "example": "includedQuotaExhausted"
           },
           "postQuotaRateLimit": {
             "$ref": "#/components/schemas/PostQuotaRateLimit"
@@ -3424,7 +3413,7 @@
         "additionalProperties": false
       },
       "RuntimeQuotaError": {
-        "description": "Runtime quota error response. This follows the shared ErrorResponse shape and includes mem9 quota classification metadata under details.runtimeQuota.",
+        "description": "Runtime quota error response. This follows the shared ErrorResponse shape, includes mem9 quota classification under details.mem9Category, and preserves provider-supplied metadata under details.runtimeQuota.",
         "allOf": [
           {
             "$ref": "#/components/schemas/ErrorResponse"
@@ -3445,9 +3434,16 @@
       "RuntimeQuotaErrorEnvelopeDetails": {
         "type": "object",
         "required": [
-          "runtimeQuota"
+          "mem9Category"
         ],
         "properties": {
+          "mem9Category": {
+            "type": "string",
+            "enum": [
+              "runtime_quota_denied"
+            ],
+            "description": "Stable mem9 runtime quota category for clients that need one routing condition."
+          },
           "runtimeQuota": {
             "$ref": "#/components/schemas/RuntimeQuotaErrorDetails"
           }
@@ -3464,22 +3460,8 @@
       },
       "RuntimeQuotaErrorDetails": {
         "type": "object",
-        "required": [
-          "category"
-        ],
+        "description": "Provider runtime quota details preserved by mem9 server. Specific provider quota reasons are carried by quotaGateResult.reason.",
         "properties": {
-          "category": {
-            "type": "string",
-            "enum": [
-              "runtime_quota_denied"
-            ],
-            "description": "Stable mem9 runtime quota category for clients that need one routing condition."
-          },
-          "providerReason": {
-            "type": "string",
-            "description": "Provider-defined quota reason or code. Clients should treat unknown values as opaque labels.",
-            "example": "includedQuotaExhausted"
-          },
           "meter": {
             "$ref": "#/components/schemas/RuntimeMeter"
           },

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -262,7 +262,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -339,7 +339,7 @@
             "$ref": "#/components/responses/NotFound"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -423,7 +423,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -464,7 +464,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -674,7 +674,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -759,7 +759,7 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -865,7 +865,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -917,7 +917,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -982,7 +982,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/PostQuotaRateLimited"
+            "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -2416,31 +2416,32 @@
         "description": "No content."
       },
       "RuntimeAccessBlocked": {
-        "description": "Runtime access is blocked by the configured runtime usage provider. Plugins should use details.mem9Code for quota UX routing and treat recommendedAction.providerActionCode as an opaque provider hint.",
+        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse and includes details.runtimeQuota for mem9 quota classification and provider-supplied metadata.",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/RuntimeAccessBlockedError"
+              "$ref": "#/components/schemas/RuntimeQuotaError"
             },
             "examples": {
               "runtimeAccessBlocked": {
                 "value": {
-                  "code": "runtime_access_blocked",
-                  "message": "Runtime access is blocked.",
+                  "error": "Runtime access is blocked.",
                   "details": {
-                    "retryable": false,
-                    "meter": "memory_recall_requests",
-                    "mem9Code": "runtime_quota_denied",
-                    "quotaGateResult": {
-                      "outcome": "blocked",
-                      "mode": "includedQuota",
-                      "reason": "includedQuotaExhausted"
-                    },
-                    "recommendedAction": {
-                      "type": "openUrl",
-                      "providerActionCode": "upgradePlan",
-                      "severity": "blocking",
-                      "url": "https://example.com/provider/action"
+                    "runtimeQuota": {
+                      "category": "runtime_quota_denied",
+                      "meter": "memory_recall_requests",
+                      "providerReason": "includedQuotaExhausted",
+                      "quotaGateResult": {
+                        "outcome": "blocked",
+                        "mode": "includedQuota",
+                        "reason": "includedQuotaExhausted"
+                      },
+                      "recommendedAction": {
+                        "type": "openUrl",
+                        "providerActionCode": "upgradePlan",
+                        "severity": "blocking",
+                        "url": "https://example.com/provider/action"
+                      }
                     }
                   }
                 }
@@ -2462,35 +2463,97 @@
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/PostQuotaRateLimitedError"
+              "$ref": "#/components/schemas/RuntimeQuotaError"
             },
             "examples": {
               "postQuotaRateLimited": {
                 "value": {
-                  "code": "post_quota_rate_limited",
-                  "message": "Post-quota rate limit exceeded.",
+                  "error": "Post-quota rate limit exceeded.",
                   "details": {
-                    "retryable": true,
-                    "meter": "memory_recall_requests",
-                    "mem9Code": "runtime_quota_denied",
-                    "quotaGateResult": {
-                      "outcome": "rateLimited",
-                      "mode": "postQuota",
-                      "reason": "postQuotaRateLimitExceeded",
-                      "postQuotaRateLimit": {
-                        "requestsPerMinute": 60,
-                        "windowDurationSeconds": 60,
-                        "scope": "providerWindow",
-                        "retryAfterSeconds": 20
+                    "runtimeQuota": {
+                      "category": "runtime_quota_denied",
+                      "meter": "memory_recall_requests",
+                      "providerReason": "postQuotaRateLimitExceeded",
+                      "quotaGateResult": {
+                        "outcome": "rateLimited",
+                        "mode": "postQuota",
+                        "reason": "postQuotaRateLimitExceeded",
+                        "postQuotaRateLimit": {
+                          "requestsPerMinute": 60,
+                          "windowDurationSeconds": 60,
+                          "scope": "providerWindow",
+                          "retryAfterSeconds": 20
+                        }
+                      },
+                      "recommendedAction": {
+                        "type": "openUrl",
+                        "providerActionCode": "upgradePlan",
+                        "severity": "blocking",
+                        "url": "https://example.com/provider/action"
                       }
-                    },
-                    "recommendedAction": {
-                      "type": "openUrl",
-                      "providerActionCode": "upgradePlan",
-                      "severity": "blocking",
-                      "url": "https://example.com/provider/action"
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      },
+      "MemoryRouteRateLimited": {
+        "description": "Memory route rate limit. The response can be a generic API rate-limit envelope from global middleware or a runtime usage provider post-quota rate-limit envelope.",
+        "headers": {
+          "Retry-After": {
+            "description": "Seconds or HTTP date after which the client can retry, when supplied by the generic API rate limiter or runtime usage provider.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RuntimeQuotaError"
+                },
+                {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              ]
+            },
+            "examples": {
+              "postQuotaRateLimited": {
+                "value": {
+                  "error": "Post-quota rate limit exceeded.",
+                  "details": {
+                    "runtimeQuota": {
+                      "category": "runtime_quota_denied",
+                      "meter": "memory_recall_requests",
+                      "providerReason": "postQuotaRateLimitExceeded",
+                      "quotaGateResult": {
+                        "outcome": "rateLimited",
+                        "mode": "postQuota",
+                        "reason": "postQuotaRateLimitExceeded",
+                        "postQuotaRateLimit": {
+                          "requestsPerMinute": 60,
+                          "windowDurationSeconds": 60,
+                          "scope": "providerWindow",
+                          "retryAfterSeconds": 20
+                        }
+                      },
+                      "recommendedAction": {
+                        "type": "openUrl",
+                        "providerActionCode": "upgradePlan",
+                        "severity": "blocking",
+                        "url": "https://example.com/provider/action"
+                      }
+                    }
+                  }
+                }
+              },
+              "genericApiRateLimited": {
+                "value": {
+                  "error": "rate limit exceeded"
                 }
               }
             }
@@ -3360,47 +3423,32 @@
         },
         "additionalProperties": false
       },
-      "RuntimeAccessBlockedError": {
-        "type": "object",
-        "required": [
-          "code",
-          "message",
-          "details"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "Provider error code. The canonical runtime access blocker code is runtime_access_blocked; legacy provider codes may appear during migration.",
-            "example": "runtime_access_blocked"
+      "RuntimeQuotaError": {
+        "description": "Runtime quota error response. This follows the shared ErrorResponse shape and includes mem9 quota classification metadata under details.runtimeQuota.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
           },
-          "message": {
-            "type": "string",
-            "example": "Runtime access is blocked."
-          },
-          "details": {
-            "$ref": "#/components/schemas/RuntimeQuotaErrorDetails"
+          {
+            "type": "object",
+            "required": [
+              "details"
+            ],
+            "properties": {
+              "details": {
+                "$ref": "#/components/schemas/RuntimeQuotaErrorEnvelopeDetails"
+              }
+            }
           }
-        },
-        "additionalProperties": false
+        ]
       },
-      "PostQuotaRateLimitedError": {
+      "RuntimeQuotaErrorEnvelopeDetails": {
         "type": "object",
         "required": [
-          "code",
-          "message",
-          "details"
+          "runtimeQuota"
         ],
         "properties": {
-          "code": {
-            "type": "string",
-            "description": "Provider error code for a temporary runtime quota rate limit. The canonical code is post_quota_rate_limited.",
-            "example": "post_quota_rate_limited"
-          },
-          "message": {
-            "type": "string",
-            "example": "Post-quota rate limit exceeded."
-          },
-          "details": {
+          "runtimeQuota": {
             "$ref": "#/components/schemas/RuntimeQuotaErrorDetails"
           }
         },
@@ -3417,13 +3465,20 @@
       "RuntimeQuotaErrorDetails": {
         "type": "object",
         "required": [
-          "retryable",
-          "mem9Code"
+          "category"
         ],
         "properties": {
-          "retryable": {
-            "type": "boolean",
-            "description": "Whether the same request can succeed later without a provider-side action."
+          "category": {
+            "type": "string",
+            "enum": [
+              "runtime_quota_denied"
+            ],
+            "description": "Stable mem9 runtime quota category for clients that need one routing condition."
+          },
+          "providerReason": {
+            "type": "string",
+            "description": "Provider-defined quota reason or code. Clients should treat unknown values as opaque labels.",
+            "example": "includedQuotaExhausted"
           },
           "meter": {
             "$ref": "#/components/schemas/RuntimeMeter"
@@ -3433,13 +3488,6 @@
           },
           "quotaGateResult": {
             "$ref": "#/components/schemas/RuntimeQuotaGateResult"
-          },
-          "mem9Code": {
-            "type": "string",
-            "enum": [
-              "runtime_quota_denied"
-            ],
-            "description": "Stable mem9 routing code for plugin quota UX."
           }
         },
         "additionalProperties": true

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2450,7 +2450,7 @@
         }
       },
       "PostQuotaRateLimited": {
-        "description": "Runtime usage provider returned a temporary post-quota rate limit.",
+        "description": "Runtime usage provider returned a temporary runtime quota rate limit, such as post-quota throttling.",
         "headers": {
           "Retry-After": {
             "description": "Seconds or HTTP date after which the client can retry, forwarded from the runtime usage provider when supplied.",
@@ -2498,7 +2498,7 @@
         }
       },
       "MemoryRouteRateLimited": {
-        "description": "Memory route rate limit. The response can be a generic API rate-limit envelope from global middleware or a runtime usage provider post-quota rate-limit envelope.",
+        "description": "Memory route rate limit. The response can be a generic API rate-limit envelope from global middleware or a runtime quota rate-limit envelope from the runtime usage provider.",
         "headers": {
           "Retry-After": {
             "description": "Seconds or HTTP date after which the client can retry, when supplied by the generic API rate limiter or runtime usage provider.",
@@ -3356,7 +3356,7 @@
           },
           "providerActionCode": {
             "type": "string",
-            "description": "Provider-defined action code. Clients should treat unknown values as opaque hints.",
+            "description": "Provider-defined action code. The official/reference runtime usage provider currently emits claimApiKey, upgradePlan, enableOnDemand, increaseSpendingLimit, and resolveAccountState; clients should treat any other value as an opaque provider hint.",
             "minLength": 1,
             "maxLength": 64,
             "example": "upgradePlan"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2416,7 +2416,7 @@
         "description": "No content."
       },
       "RuntimeAccessBlocked": {
-        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse, includes a stable runtime quota error classification under details.errorCategory, and exposes public runtime quota fields under details.runtimeQuota.",
+        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse, includes a stable runtime quota error classification under details.errorCategory, and exposes public runtime quota fields under details.runtimeQuota when provider details include public quota fields.",
         "content": {
           "application/json": {
             "schema": {
@@ -3407,7 +3407,7 @@
         "additionalProperties": true
       },
       "RuntimeQuotaError": {
-        "description": "Runtime quota error response. This follows the shared ErrorResponse shape, includes a stable runtime quota error classification under details.errorCategory, and exposes public runtime quota fields under details.runtimeQuota.",
+        "description": "Runtime quota error response. This follows the shared ErrorResponse shape, includes a stable runtime quota error classification under details.errorCategory, and exposes public runtime quota fields under details.runtimeQuota when provider details include public quota fields.",
         "allOf": [
           {
             "$ref": "#/components/schemas/ErrorResponse"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2416,7 +2416,7 @@
         "description": "No content."
       },
       "RuntimeAccessBlocked": {
-        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse, includes mem9 quota classification under details.mem9Category, and preserves provider-supplied metadata under details.runtimeQuota.",
+        "description": "Runtime access is blocked by the configured runtime usage provider. The body follows ErrorResponse, includes a stable runtime quota error classification under details.errorCategory, and exposes public runtime quota fields under details.runtimeQuota.",
         "content": {
           "application/json": {
             "schema": {
@@ -2427,7 +2427,7 @@
                 "value": {
                   "error": "Runtime access is blocked.",
                   "details": {
-                    "mem9Category": "runtime_quota_denied",
+                    "errorCategory": "runtime_quota_denied",
                     "runtimeQuota": {
                       "meter": "memory_recall_requests",
                       "quotaGateResult": {
@@ -2469,7 +2469,7 @@
                 "value": {
                   "error": "Post-quota rate limit exceeded.",
                   "details": {
-                    "mem9Category": "runtime_quota_denied",
+                    "errorCategory": "runtime_quota_denied",
                     "runtimeQuota": {
                       "meter": "memory_recall_requests",
                       "quotaGateResult": {
@@ -2524,7 +2524,7 @@
                 "value": {
                   "error": "Post-quota rate limit exceeded.",
                   "details": {
-                    "mem9Category": "runtime_quota_denied",
+                    "errorCategory": "runtime_quota_denied",
                     "runtimeQuota": {
                       "meter": "memory_recall_requests",
                       "quotaGateResult": {
@@ -3363,12 +3363,9 @@
           },
           "severity": {
             "type": "string",
-            "description": "How strongly clients should surface the action.",
-            "enum": [
-              "blocking",
-              "warning",
-              "info"
-            ]
+            "description": "Provider-defined action severity. Clients should treat unknown values as opaque hints.",
+            "minLength": 1,
+            "example": "blocking"
           },
           "url": {
             "type": "string",
@@ -3410,7 +3407,7 @@
         "additionalProperties": true
       },
       "RuntimeQuotaError": {
-        "description": "Runtime quota error response. This follows the shared ErrorResponse shape, includes mem9 quota classification under details.mem9Category, and preserves provider-supplied metadata under details.runtimeQuota.",
+        "description": "Runtime quota error response. This follows the shared ErrorResponse shape, includes a stable runtime quota error classification under details.errorCategory, and exposes public runtime quota fields under details.runtimeQuota.",
         "allOf": [
           {
             "$ref": "#/components/schemas/ErrorResponse"
@@ -3431,15 +3428,15 @@
       "RuntimeQuotaErrorEnvelopeDetails": {
         "type": "object",
         "required": [
-          "mem9Category"
+          "errorCategory"
         ],
         "properties": {
-          "mem9Category": {
+          "errorCategory": {
             "type": "string",
             "enum": [
               "runtime_quota_denied"
             ],
-            "description": "Stable mem9 runtime quota category for clients that need one routing condition."
+            "description": "Stable runtime quota error category for clients that need one routing condition."
           },
           "runtimeQuota": {
             "$ref": "#/components/schemas/RuntimeQuotaErrorDetails"
@@ -3457,7 +3454,7 @@
       },
       "RuntimeQuotaErrorDetails": {
         "type": "object",
-        "description": "Provider runtime quota details preserved by mem9 server. Specific provider quota reasons are carried by quotaGateResult.reason.",
+        "description": "Public runtime quota details assembled from provider reservation details. Specific provider quota reasons are carried by quotaGateResult.reason.",
         "properties": {
           "meter": {
             "$ref": "#/components/schemas/RuntimeMeter"
@@ -3469,7 +3466,7 @@
             "$ref": "#/components/schemas/RuntimeQuotaGateResult"
           }
         },
-        "additionalProperties": true
+        "additionalProperties": false
       },
       "PostQuotaRateLimit": {
         "type": "object",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -252,11 +252,17 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "402": {
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -326,8 +332,14 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "402": {
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -401,11 +413,17 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "402": {
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -436,11 +454,17 @@
           "204": {
             "description": "Memory deleted."
           },
+          "402": {
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
+          },
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
             "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -641,7 +665,7 @@
             "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
-            "$ref": "#/components/responses/RuntimeQuotaDenied"
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -650,7 +674,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/RateLimited"
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -729,13 +753,13 @@
             "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
-            "$ref": "#/components/responses/RuntimeQuotaDenied"
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
           "429": {
-            "$ref": "#/components/responses/RateLimited"
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -829,7 +853,7 @@
             "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
-            "$ref": "#/components/responses/RuntimeQuotaDenied"
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -841,7 +865,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/RateLimited"
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -881,7 +905,7 @@
             "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
-            "$ref": "#/components/responses/RuntimeQuotaDenied"
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -893,7 +917,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/RateLimited"
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -949,7 +973,7 @@
             "$ref": "#/components/responses/Unauthorized"
           },
           "402": {
-            "$ref": "#/components/responses/RuntimeQuotaDenied"
+            "$ref": "#/components/responses/RuntimeAccessBlocked"
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
@@ -958,7 +982,7 @@
             "$ref": "#/components/responses/Conflict"
           },
           "429": {
-            "$ref": "#/components/responses/RateLimited"
+            "$ref": "#/components/responses/PostQuotaRateLimited"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -2391,74 +2415,81 @@
       "NoContent": {
         "description": "No content."
       },
-      "RuntimeQuotaDenied": {
-        "description": "Runtime usage quota denied. Plugins should use details.mem9Code to enter the quota UX path and details.recommendedAction.url as the direct user action link when present.",
+      "RuntimeAccessBlocked": {
+        "description": "Runtime access is blocked by the configured runtime usage provider. Plugins should use details.mem9Code for quota UX routing and treat recommendedAction.providerActionCode as an opaque provider hint.",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/RuntimeQuotaDeniedError"
+              "$ref": "#/components/schemas/RuntimeAccessBlockedError"
             },
             "examples": {
-              "unclaimedQuotaExhausted": {
+              "runtimeAccessBlocked": {
                 "value": {
-                  "code": "quota_exhausted",
-                  "message": "Included quota is exhausted.",
+                  "code": "runtime_access_blocked",
+                  "message": "Runtime access is blocked.",
                   "details": {
                     "retryable": false,
                     "meter": "memory_recall_requests",
-                    "limitType": "includedQuota",
-                    "recommendedAction": {
-                      "bindingState": "unclaimed",
-                      "type": "claimApiKey",
-                      "url": "https://mem9.ai/console/claim?key=mk_example"
-                    },
+                    "mem9Code": "runtime_quota_denied",
                     "quotaGateResult": {
                       "outcome": "blocked",
+                      "mode": "includedQuota",
                       "reason": "includedQuotaExhausted"
                     },
-                    "mem9Code": "runtime_quota_denied"
+                    "recommendedAction": {
+                      "type": "openUrl",
+                      "providerActionCode": "upgradePlan",
+                      "severity": "blocking",
+                      "url": "https://example.com/provider/action"
+                    }
                   }
                 }
-              },
-              "claimedQuotaExhausted": {
+              }
+            }
+          }
+        }
+      },
+      "PostQuotaRateLimited": {
+        "description": "Runtime usage provider returned a temporary post-quota rate limit.",
+        "headers": {
+          "Retry-After": {
+            "description": "Seconds or HTTP date after which the client can retry, forwarded from the runtime usage provider when supplied.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PostQuotaRateLimitedError"
+            },
+            "examples": {
+              "postQuotaRateLimited": {
                 "value": {
-                  "code": "quota_exhausted",
-                  "message": "Included quota is exhausted.",
+                  "code": "post_quota_rate_limited",
+                  "message": "Post-quota rate limit exceeded.",
                   "details": {
-                    "retryable": false,
+                    "retryable": true,
                     "meter": "memory_recall_requests",
-                    "limitType": "includedQuota",
-                    "recommendedAction": {
-                      "bindingState": "claimed",
-                      "type": "upgradePlan",
-                      "url": "https://mem9.ai/console/billing/plan"
-                    },
+                    "mem9Code": "runtime_quota_denied",
                     "quotaGateResult": {
-                      "outcome": "blocked",
-                      "reason": "includedQuotaExhausted"
+                      "outcome": "rateLimited",
+                      "mode": "postQuota",
+                      "reason": "postQuotaRateLimitExceeded",
+                      "postQuotaRateLimit": {
+                        "requestsPerMinute": 60,
+                        "windowDurationSeconds": 60,
+                        "scope": "providerWindow",
+                        "retryAfterSeconds": 20
+                      }
                     },
-                    "mem9Code": "runtime_quota_denied"
-                  }
-                }
-              },
-              "spendingLimitExceeded": {
-                "value": {
-                  "code": "spending_limit_exceeded",
-                  "message": "On-demand spending limit would be exceeded.",
-                  "details": {
-                    "retryable": false,
-                    "meter": "memory_write_requests",
-                    "limitType": "spendingLimit",
                     "recommendedAction": {
-                      "bindingState": "claimed",
-                      "type": "increaseSpendingLimit",
-                      "url": "https://mem9.ai/console/billing/plan"
-                    },
-                    "quotaGateResult": {
-                      "outcome": "blocked",
-                      "reason": "onDemandBudgetExhausted"
-                    },
-                    "mem9Code": "runtime_quota_denied"
+                      "type": "openUrl",
+                      "providerActionCode": "upgradePlan",
+                      "severity": "blocking",
+                      "url": "https://example.com/provider/action"
+                    }
                   }
                 }
               }
@@ -3250,97 +3281,39 @@
           }
         }
       },
-      "RuntimeQuotaDeniedError": {
-        "type": "object",
-        "required": [
-          "code",
-          "message",
-          "details"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "Specific quota denial reason when available, or runtime_quota_denied for fallback errors.",
-            "examples": [
-              "quota_exhausted",
-              "spending_limit_exceeded",
-              "runtime_quota_denied"
-            ]
-          },
-          "message": {
-            "type": "string"
-          },
-          "details": {
-            "$ref": "#/components/schemas/RuntimeQuotaDeniedDetails"
-          }
-        }
-      },
-      "RuntimeQuotaDeniedDetails": {
-        "type": "object",
-        "required": [
-          "retryable",
-          "mem9Code"
-        ],
-        "properties": {
-          "retryable": {
-            "type": "boolean"
-          },
-          "meter": {
-            "type": "string",
-            "enum": [
-              "memory_recall_requests",
-              "memory_write_requests"
-            ]
-          },
-          "limitType": {
-            "type": "string",
-            "enum": [
-              "includedQuota",
-              "spendingLimit"
-            ]
-          },
-          "recommendedAction": {
-            "$ref": "#/components/schemas/RuntimeRecommendedAction"
-          },
-          "quotaGateResult": {
-            "$ref": "#/components/schemas/RuntimeQuotaGateResult"
-          },
-          "mem9Code": {
-            "type": "string",
-            "enum": [
-              "runtime_quota_denied"
-            ]
-          }
-        },
-        "additionalProperties": true
-      },
       "RuntimeRecommendedAction": {
         "type": "object",
         "required": [
-          "bindingState",
-          "type",
-          "url"
+          "type"
         ],
         "properties": {
-          "bindingState": {
-            "type": "string",
-            "enum": [
-              "claimed",
-              "unclaimed"
-            ]
-          },
           "type": {
             "type": "string",
+            "description": "Generic client behavior for the action.",
             "enum": [
-              "claimApiKey",
-              "upgradePlan",
-              "enableOnDemand",
-              "increaseSpendingLimit"
+              "openUrl"
+            ]
+          },
+          "providerActionCode": {
+            "type": "string",
+            "description": "Provider-defined action code. Clients should treat unknown values as opaque hints.",
+            "minLength": 1,
+            "maxLength": 64,
+            "example": "upgradePlan"
+          },
+          "severity": {
+            "type": "string",
+            "description": "How strongly clients should surface the action.",
+            "enum": [
+              "blocking",
+              "warning",
+              "info"
             ]
           },
           "url": {
             "type": "string",
-            "description": "Console URL that the plugin can show directly to the user."
+            "format": "uri",
+            "description": "Provider URL for type=openUrl. Present only when supplied by the provider response."
           }
         },
         "additionalProperties": false
@@ -3371,11 +3344,134 @@
           "reason": {
             "type": "string",
             "enum": [
+              "includedQuotaAvailable",
               "includedQuotaExhausted",
+              "onDemandAvailable",
               "onDemandDisabled",
               "onDemandUnavailable",
-              "onDemandBudgetExhausted"
+              "onDemandBudgetExhausted",
+              "postQuotaRateLimitExceeded",
+              "accountStateBlocked"
             ]
+          },
+          "postQuotaRateLimit": {
+            "$ref": "#/components/schemas/PostQuotaRateLimit"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeAccessBlockedError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "details"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Provider error code. The canonical runtime access blocker code is runtime_access_blocked; legacy provider codes may appear during migration.",
+            "example": "runtime_access_blocked"
+          },
+          "message": {
+            "type": "string",
+            "example": "Runtime access is blocked."
+          },
+          "details": {
+            "$ref": "#/components/schemas/RuntimeQuotaErrorDetails"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PostQuotaRateLimitedError": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "details"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Provider error code for a temporary runtime quota rate limit. The canonical code is post_quota_rate_limited.",
+            "example": "post_quota_rate_limited"
+          },
+          "message": {
+            "type": "string",
+            "example": "Post-quota rate limit exceeded."
+          },
+          "details": {
+            "$ref": "#/components/schemas/RuntimeQuotaErrorDetails"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeMeter": {
+        "type": "string",
+        "description": "Runtime usage meter id supplied by the provider. Clients should treat unknown values as opaque labels.",
+        "minLength": 1,
+        "maxLength": 128,
+        "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+        "example": "memory_recall_requests"
+      },
+      "RuntimeQuotaErrorDetails": {
+        "type": "object",
+        "required": [
+          "retryable",
+          "mem9Code"
+        ],
+        "properties": {
+          "retryable": {
+            "type": "boolean",
+            "description": "Whether the same request can succeed later without a provider-side action."
+          },
+          "meter": {
+            "$ref": "#/components/schemas/RuntimeMeter"
+          },
+          "recommendedAction": {
+            "$ref": "#/components/schemas/RuntimeRecommendedAction"
+          },
+          "quotaGateResult": {
+            "$ref": "#/components/schemas/RuntimeQuotaGateResult"
+          },
+          "mem9Code": {
+            "type": "string",
+            "enum": [
+              "runtime_quota_denied"
+            ],
+            "description": "Stable mem9 routing code for plugin quota UX."
+          }
+        },
+        "additionalProperties": true
+      },
+      "PostQuotaRateLimit": {
+        "type": "object",
+        "required": [
+          "requestsPerMinute",
+          "windowDurationSeconds",
+          "scope"
+        ],
+        "properties": {
+          "requestsPerMinute": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "windowDurationSeconds": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Provider-defined rate-limit window duration in seconds."
+          },
+          "scope": {
+            "type": "string",
+            "description": "Provider-defined rate-limit scope. Clients should treat unknown values as opaque labels.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+            "example": "providerWindow"
+          },
+          "retryAfterSeconds": {
+            "type": "integer",
+            "minimum": 1
           }
         },
         "additionalProperties": false

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3395,11 +3395,8 @@
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "includedQuota",
-              "onDemand",
-              "postQuota"
-            ]
+            "description": "Provider-defined quota mode. Clients should treat unknown values as opaque hints.",
+            "example": "includedQuota"
           },
           "reason": {
             "type": "string",
@@ -3410,7 +3407,7 @@
             "$ref": "#/components/schemas/PostQuotaRateLimit"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": true
       },
       "RuntimeQuotaError": {
         "description": "Runtime quota error response. This follows the shared ErrorResponse shape, includes mem9 quota classification under details.mem9Category, and preserves provider-supplied metadata under details.runtimeQuota.",

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -74,10 +74,10 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 		t.Fatalf("RuntimeQuotaError should extend ErrorResponse: %#v", runtimeQuotaErrorAllOf)
 	}
 	if !allOfRequiresProperty(runtimeQuotaErrorAllOf, "details") {
-		t.Fatalf("RuntimeQuotaError.details should be required for the runtimeQuota category: %#v", runtimeQuotaErrorAllOf)
+		t.Fatalf("RuntimeQuotaError.details should be required for the mem9 category: %#v", runtimeQuotaErrorAllOf)
 	}
 	if !allOfHasDetailsRef(runtimeQuotaErrorAllOf, "#/components/schemas/RuntimeQuotaErrorEnvelopeDetails") {
-		t.Fatalf("RuntimeQuotaError should add details.runtimeQuota via allOf: %#v", runtimeQuotaErrorAllOf)
+		t.Fatalf("RuntimeQuotaError should add quota details via allOf: %#v", runtimeQuotaErrorAllOf)
 	}
 
 	recommendedAction := objectValue(t, schemas, "RuntimeRecommendedAction")
@@ -104,9 +104,16 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	}
 
 	envelopeDetails := objectValue(t, schemas, "RuntimeQuotaErrorEnvelopeDetails")
+	if !containsString(stringSlice(t, envelopeDetails["required"]), "mem9Category") {
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.mem9Category should be required")
+	}
 	envelopeProperties := objectValue(t, envelopeDetails, "properties")
+	envelopeMem9Category := objectValue(t, envelopeProperties, "mem9Category")
+	if got, want := stringSlice(t, envelopeMem9Category["enum"]), []string{"runtime_quota_denied"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.mem9Category enum = %#v, want %#v", got, want)
+	}
 	if _, ok := envelopeProperties["runtimeQuota"]; !ok {
-		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails should namespace quota fields under runtimeQuota")
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails should expose provider runtimeQuota details")
 	}
 	if got, ok := envelopeDetails["additionalProperties"].(bool); !ok || got {
 		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.additionalProperties = %#v, want false", envelopeDetails["additionalProperties"])
@@ -116,29 +123,26 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	if got, ok := runtimeQuotaDetails["additionalProperties"].(bool); !ok || !got {
 		t.Fatalf("RuntimeQuotaErrorDetails.additionalProperties = %#v, want true", runtimeQuotaDetails["additionalProperties"])
 	}
-	if !containsString(stringSlice(t, runtimeQuotaDetails["required"]), "category") {
-		t.Fatalf("RuntimeQuotaErrorDetails.category should be required")
-	}
 	runtimeQuotaDetailProperties := objectValue(t, runtimeQuotaDetails, "properties")
-	category := objectValue(t, runtimeQuotaDetailProperties, "category")
-	if got, want := stringSlice(t, category["enum"]), []string{"runtime_quota_denied"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("RuntimeQuotaErrorDetails.category enum = %#v, want %#v", got, want)
+	if required, ok := runtimeQuotaDetails["required"]; ok {
+		if containsString(stringSlice(t, required), "mem9Category") {
+			t.Fatalf("RuntimeQuotaErrorDetails should not require mem9Category inside provider details")
+		}
 	}
-	providerReason := objectValue(t, runtimeQuotaDetailProperties, "providerReason")
-	if providerReason["type"] != "string" {
-		t.Fatalf("RuntimeQuotaErrorDetails should expose providerReason as an opaque quota hint")
-	}
-	if _, ok := providerReason["pattern"]; ok {
-		t.Fatalf("providerReason should remain provider-defined")
-	}
-	if _, ok := providerReason["enum"]; ok {
-		t.Fatalf("providerReason should remain provider-defined")
+	if _, ok := runtimeQuotaDetailProperties["mem9Category"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should keep mem9Category at the details envelope level")
 	}
 	if _, ok := runtimeQuotaDetailProperties["mem9Code"]; ok {
 		t.Fatalf("RuntimeQuotaErrorDetails should not define a mem9-specific routing code")
 	}
+	if _, ok := runtimeQuotaDetailProperties["providerReason"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should use quotaGateResult.reason for provider quota reasons")
+	}
+	if _, ok := runtimeQuotaDetailProperties["category"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should use mem9Category instead of a broad category field")
+	}
 	if _, ok := runtimeQuotaDetailProperties["code"]; ok {
-		t.Fatalf("RuntimeQuotaErrorDetails should use category instead of a broad code field")
+		t.Fatalf("RuntimeQuotaErrorDetails should use mem9Category instead of a broad code field")
 	}
 	if _, ok := runtimeQuotaDetailProperties["retryable"]; ok {
 		t.Fatalf("RuntimeQuotaErrorDetails should not define retryability separately from HTTP status and Retry-After")
@@ -158,18 +162,14 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	gateResult := objectValue(t, schemas, "RuntimeQuotaGateResult")
 	gateProperties := objectValue(t, gateResult, "properties")
 	reason := objectValue(t, gateProperties, "reason")
-	wantReasons := []string{
-		"includedQuotaAvailable",
-		"includedQuotaExhausted",
-		"onDemandAvailable",
-		"onDemandDisabled",
-		"onDemandUnavailable",
-		"onDemandBudgetExhausted",
-		"postQuotaRateLimitExceeded",
-		"accountStateBlocked",
+	if reason["type"] != "string" {
+		t.Fatalf("RuntimeQuotaGateResult.reason type = %#v, want string", reason["type"])
 	}
-	if got := stringSlice(t, reason["enum"]); !reflect.DeepEqual(got, wantReasons) {
-		t.Fatalf("RuntimeQuotaGateResult.reason enum = %#v, want %#v", got, wantReasons)
+	if _, ok := reason["enum"]; ok {
+		t.Fatalf("RuntimeQuotaGateResult.reason should remain provider-defined")
+	}
+	if _, ok := reason["pattern"]; ok {
+		t.Fatalf("RuntimeQuotaGateResult.reason should not constrain provider-defined values")
 	}
 
 	postQuotaRateLimit := objectValue(t, schemas, "PostQuotaRateLimit")

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	runtimeAccessBlockedRef = "#/components/responses/RuntimeAccessBlocked"
-	postQuotaRateLimitedRef = "#/components/responses/PostQuotaRateLimited"
-	genericRateLimitedRef   = "#/components/responses/RateLimited"
+	runtimeAccessBlockedRef   = "#/components/responses/RuntimeAccessBlocked"
+	memoryRouteRateLimitedRef = "#/components/responses/MemoryRouteRateLimited"
+	genericRateLimitedRef     = "#/components/responses/RateLimited"
 )
 
 func TestOpenAPIRuntimeQuotaResponses(t *testing.T) {
@@ -30,14 +30,14 @@ func TestOpenAPIRuntimeQuotaResponses(t *testing.T) {
 		for _, method := range route.methods {
 			responses := operationResponses(t, openapi, route.path, method)
 			assertResponseRef(t, responses, "402", runtimeAccessBlockedRef)
-			assertResponseRef(t, responses, "429", postQuotaRateLimitedRef)
+			assertResponseRef(t, responses, "429", memoryRouteRateLimitedRef)
 		}
 	}
 
 	getByIDResponses := operationResponses(t, openapi, "/v1alpha2/mem9s/memories/{id}", "get")
 	assertResponseRef(t, getByIDResponses, "429", genericRateLimitedRef)
 	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "402", runtimeAccessBlockedRef)
-	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "429", postQuotaRateLimitedRef)
+	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "429", memoryRouteRateLimitedRef)
 }
 
 func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
@@ -50,6 +50,34 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	headers := objectValue(t, postQuotaRateLimited, "headers")
 	if _, ok := headers["Retry-After"]; !ok {
 		t.Fatalf("PostQuotaRateLimited response missing Retry-After header")
+	}
+
+	memoryRouteRateLimited := objectValue(t, responses, "MemoryRouteRateLimited")
+	memoryRouteHeaders := objectValue(t, memoryRouteRateLimited, "headers")
+	if _, ok := memoryRouteHeaders["Retry-After"]; !ok {
+		t.Fatalf("MemoryRouteRateLimited response missing Retry-After header")
+	}
+	memoryRouteContent := objectValue(t, memoryRouteRateLimited, "content")
+	memoryRouteJSON := objectValue(t, memoryRouteContent, "application/json")
+	memoryRouteSchema := objectValue(t, memoryRouteJSON, "schema")
+	anyOf := objectSlice(t, memoryRouteSchema["anyOf"])
+	if !containsRef(anyOf, "#/components/schemas/RuntimeQuotaError") {
+		t.Fatalf("MemoryRouteRateLimited should include RuntimeQuotaError in anyOf: %#v", anyOf)
+	}
+	if !containsRef(anyOf, "#/components/schemas/ErrorResponse") {
+		t.Fatalf("MemoryRouteRateLimited should include generic ErrorResponse in anyOf: %#v", anyOf)
+	}
+
+	runtimeQuotaError := objectValue(t, schemas, "RuntimeQuotaError")
+	runtimeQuotaErrorAllOf := objectSlice(t, runtimeQuotaError["allOf"])
+	if !containsRef(runtimeQuotaErrorAllOf, "#/components/schemas/ErrorResponse") {
+		t.Fatalf("RuntimeQuotaError should extend ErrorResponse: %#v", runtimeQuotaErrorAllOf)
+	}
+	if !allOfRequiresProperty(runtimeQuotaErrorAllOf, "details") {
+		t.Fatalf("RuntimeQuotaError.details should be required for the runtimeQuota category: %#v", runtimeQuotaErrorAllOf)
+	}
+	if !allOfHasDetailsRef(runtimeQuotaErrorAllOf, "#/components/schemas/RuntimeQuotaErrorEnvelopeDetails") {
+		t.Fatalf("RuntimeQuotaError should add details.runtimeQuota via allOf: %#v", runtimeQuotaErrorAllOf)
 	}
 
 	recommendedAction := objectValue(t, schemas, "RuntimeRecommendedAction")
@@ -75,9 +103,45 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 		}
 	}
 
-	details := objectValue(t, schemas, "RuntimeQuotaErrorDetails")
-	if got, ok := details["additionalProperties"].(bool); !ok || !got {
-		t.Fatalf("RuntimeQuotaErrorDetails.additionalProperties = %#v, want true", details["additionalProperties"])
+	envelopeDetails := objectValue(t, schemas, "RuntimeQuotaErrorEnvelopeDetails")
+	envelopeProperties := objectValue(t, envelopeDetails, "properties")
+	if _, ok := envelopeProperties["runtimeQuota"]; !ok {
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails should namespace quota fields under runtimeQuota")
+	}
+	if got, ok := envelopeDetails["additionalProperties"].(bool); !ok || got {
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.additionalProperties = %#v, want false", envelopeDetails["additionalProperties"])
+	}
+
+	runtimeQuotaDetails := objectValue(t, schemas, "RuntimeQuotaErrorDetails")
+	if got, ok := runtimeQuotaDetails["additionalProperties"].(bool); !ok || !got {
+		t.Fatalf("RuntimeQuotaErrorDetails.additionalProperties = %#v, want true", runtimeQuotaDetails["additionalProperties"])
+	}
+	if !containsString(stringSlice(t, runtimeQuotaDetails["required"]), "category") {
+		t.Fatalf("RuntimeQuotaErrorDetails.category should be required")
+	}
+	runtimeQuotaDetailProperties := objectValue(t, runtimeQuotaDetails, "properties")
+	category := objectValue(t, runtimeQuotaDetailProperties, "category")
+	if got, want := stringSlice(t, category["enum"]), []string{"runtime_quota_denied"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RuntimeQuotaErrorDetails.category enum = %#v, want %#v", got, want)
+	}
+	providerReason := objectValue(t, runtimeQuotaDetailProperties, "providerReason")
+	if providerReason["type"] != "string" {
+		t.Fatalf("RuntimeQuotaErrorDetails should expose providerReason as an opaque quota hint")
+	}
+	if _, ok := providerReason["pattern"]; ok {
+		t.Fatalf("providerReason should remain provider-defined")
+	}
+	if _, ok := providerReason["enum"]; ok {
+		t.Fatalf("providerReason should remain provider-defined")
+	}
+	if _, ok := runtimeQuotaDetailProperties["mem9Code"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should not define a mem9-specific routing code")
+	}
+	if _, ok := runtimeQuotaDetailProperties["code"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should use category instead of a broad code field")
+	}
+	if _, ok := runtimeQuotaDetailProperties["retryable"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should not define retryability separately from HTTP status and Retry-After")
 	}
 
 	meter := objectValue(t, schemas, "RuntimeMeter")
@@ -197,10 +261,68 @@ func stringSlice(t *testing.T, value any) []string {
 	return out
 }
 
+func objectSlice(t *testing.T, value any) []map[string]any {
+	t.Helper()
+	values, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value = %T, want array", value)
+	}
+	out := make([]map[string]any, 0, len(values))
+	for _, value := range values {
+		object, ok := value.(map[string]any)
+		if !ok {
+			t.Fatalf("array value = %T, want object", value)
+		}
+		out = append(out, object)
+	}
+	return out
+}
+
 func containsString(values []string, target string) bool {
 	for _, value := range values {
 		if value == target {
 			return true
+		}
+	}
+	return false
+}
+
+func containsRef(values []map[string]any, target string) bool {
+	for _, value := range values {
+		if value["$ref"] == target {
+			return true
+		}
+	}
+	return false
+}
+
+func allOfHasDetailsRef(values []map[string]any, target string) bool {
+	for _, value := range values {
+		properties, ok := value["properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		details, ok := properties["details"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if details["$ref"] == target {
+			return true
+		}
+	}
+	return false
+}
+
+func allOfRequiresProperty(values []map[string]any, target string) bool {
+	for _, value := range values {
+		required, ok := value["required"].([]any)
+		if !ok {
+			continue
+		}
+		for _, item := range required {
+			if item == target {
+				return true
+			}
 		}
 	}
 	return false

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -1,0 +1,207 @@
+package handler
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const (
+	runtimeAccessBlockedRef = "#/components/responses/RuntimeAccessBlocked"
+	postQuotaRateLimitedRef = "#/components/responses/PostQuotaRateLimited"
+	genericRateLimitedRef   = "#/components/responses/RateLimited"
+)
+
+func TestOpenAPIRuntimeQuotaResponses(t *testing.T) {
+	openapi := loadOpenAPI(t)
+
+	for _, route := range []struct {
+		path    string
+		methods []string
+	}{
+		{"/v1alpha1/mem9s/{tenantID}/memories", []string{"post", "get"}},
+		{"/v1alpha1/mem9s/{tenantID}/memories/{id}", []string{"put", "delete"}},
+		{"/v1alpha2/mem9s/memories", []string{"post", "get"}},
+		{"/v1alpha2/mem9s/memories/{id}", []string{"put", "delete"}},
+		{"/v1alpha2/mem9s/memories/batch-delete", []string{"post"}},
+	} {
+		for _, method := range route.methods {
+			responses := operationResponses(t, openapi, route.path, method)
+			assertResponseRef(t, responses, "402", runtimeAccessBlockedRef)
+			assertResponseRef(t, responses, "429", postQuotaRateLimitedRef)
+		}
+	}
+
+	getByIDResponses := operationResponses(t, openapi, "/v1alpha2/mem9s/memories/{id}", "get")
+	assertResponseRef(t, getByIDResponses, "429", genericRateLimitedRef)
+	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "402", runtimeAccessBlockedRef)
+	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "429", postQuotaRateLimitedRef)
+}
+
+func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
+	openapi := loadOpenAPI(t)
+	components := objectValue(t, openapi, "components")
+	responses := objectValue(t, components, "responses")
+	schemas := objectValue(t, components, "schemas")
+
+	postQuotaRateLimited := objectValue(t, responses, "PostQuotaRateLimited")
+	headers := objectValue(t, postQuotaRateLimited, "headers")
+	if _, ok := headers["Retry-After"]; !ok {
+		t.Fatalf("PostQuotaRateLimited response missing Retry-After header")
+	}
+
+	recommendedAction := objectValue(t, schemas, "RuntimeRecommendedAction")
+	actionProperties := objectValue(t, recommendedAction, "properties")
+	actionType := objectValue(t, actionProperties, "type")
+	if got, want := stringSlice(t, actionType["enum"]), []string{"openUrl"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RuntimeRecommendedAction.type enum = %#v, want %#v", got, want)
+	}
+	if _, ok := actionProperties["bindingState"]; ok {
+		t.Fatalf("RuntimeRecommendedAction should not expose legacy bindingState")
+	}
+
+	providerAction := objectValue(t, actionProperties, "providerActionCode")
+	if _, ok := providerAction["enum"]; ok {
+		t.Fatalf("providerActionCode should remain provider-defined")
+	}
+	if _, ok := providerAction["pattern"]; ok {
+		t.Fatalf("providerActionCode should remain an opaque provider hint")
+	}
+	for _, legacyAction := range []string{"claimApiKey", "upgradePlan", "enableOnDemand", "increaseSpendingLimit"} {
+		if containsString(stringSlice(t, actionType["enum"]), legacyAction) {
+			t.Fatalf("RuntimeRecommendedAction.type still exposes legacy action %q", legacyAction)
+		}
+	}
+
+	details := objectValue(t, schemas, "RuntimeQuotaErrorDetails")
+	if got, ok := details["additionalProperties"].(bool); !ok || !got {
+		t.Fatalf("RuntimeQuotaErrorDetails.additionalProperties = %#v, want true", details["additionalProperties"])
+	}
+
+	meter := objectValue(t, schemas, "RuntimeMeter")
+	if meter["type"] != "string" {
+		t.Fatalf("RuntimeMeter.type = %#v, want string", meter["type"])
+	}
+	if _, ok := meter["enum"]; ok {
+		t.Fatalf("RuntimeMeter should be an opaque string without enum")
+	}
+	if meter["pattern"] == "" {
+		t.Fatalf("RuntimeMeter should define a constraining pattern")
+	}
+
+	gateResult := objectValue(t, schemas, "RuntimeQuotaGateResult")
+	gateProperties := objectValue(t, gateResult, "properties")
+	reason := objectValue(t, gateProperties, "reason")
+	wantReasons := []string{
+		"includedQuotaAvailable",
+		"includedQuotaExhausted",
+		"onDemandAvailable",
+		"onDemandDisabled",
+		"onDemandUnavailable",
+		"onDemandBudgetExhausted",
+		"postQuotaRateLimitExceeded",
+		"accountStateBlocked",
+	}
+	if got := stringSlice(t, reason["enum"]); !reflect.DeepEqual(got, wantReasons) {
+		t.Fatalf("RuntimeQuotaGateResult.reason enum = %#v, want %#v", got, wantReasons)
+	}
+
+	postQuotaRateLimit := objectValue(t, schemas, "PostQuotaRateLimit")
+	limitProperties := objectValue(t, postQuotaRateLimit, "properties")
+	windowDurationSeconds := objectValue(t, limitProperties, "windowDurationSeconds")
+	if windowDurationSeconds["minimum"] != float64(1) {
+		t.Fatalf("windowDurationSeconds.minimum = %#v, want 1", windowDurationSeconds["minimum"])
+	}
+	if _, ok := windowDurationSeconds["enum"]; ok {
+		t.Fatalf("windowDurationSeconds should not hard-code a provider window")
+	}
+	scope := objectValue(t, limitProperties, "scope")
+	if _, ok := scope["enum"]; ok {
+		t.Fatalf("post-quota rate-limit scope should be provider-defined")
+	}
+	if scope["pattern"] == "" {
+		t.Fatalf("post-quota rate-limit scope should define a constraining pattern")
+	}
+}
+
+func loadOpenAPI(t *testing.T) map[string]any {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "docs", "api", "openapi.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read OpenAPI spec: %v", err)
+	}
+	var openapi map[string]any
+	if err := json.Unmarshal(data, &openapi); err != nil {
+		t.Fatalf("parse OpenAPI spec: %v", err)
+	}
+	return openapi
+}
+
+func operationResponses(t *testing.T, openapi map[string]any, path string, method string) map[string]any {
+	t.Helper()
+	paths := objectValue(t, openapi, "paths")
+	pathItem := objectValue(t, paths, path)
+	operation := objectValue(t, pathItem, method)
+	return objectValue(t, operation, "responses")
+}
+
+func assertResponseRef(t *testing.T, responses map[string]any, status string, want string) {
+	t.Helper()
+	response := objectValue(t, responses, status)
+	if got := response["$ref"]; got != want {
+		t.Fatalf("response %s ref = %#v, want %s", status, got, want)
+	}
+}
+
+func assertNoResponseRef(t *testing.T, responses map[string]any, status string, unwanted string) {
+	t.Helper()
+	response, ok := responses[status].(map[string]any)
+	if !ok {
+		return
+	}
+	if got := response["$ref"]; got == unwanted {
+		t.Fatalf("response %s ref = %#v, want a non-runtime quota response", status, got)
+	}
+}
+
+func objectValue(t *testing.T, parent map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := parent[key]
+	if !ok {
+		t.Fatalf("missing key %q", key)
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		t.Fatalf("key %q = %T, want object", key, value)
+	}
+	return object
+}
+
+func stringSlice(t *testing.T, value any) []string {
+	t.Helper()
+	values, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value = %T, want array", value)
+	}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		text, ok := value.(string)
+		if !ok {
+			t.Fatalf("array value = %T, want string", value)
+		}
+		out = append(out, text)
+	}
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -96,6 +97,12 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	}
 	if _, ok := providerAction["pattern"]; ok {
 		t.Fatalf("providerActionCode should remain an opaque provider hint")
+	}
+	providerActionDescription, _ := providerAction["description"].(string)
+	for _, knownAction := range []string{"claimApiKey", "upgradePlan", "enableOnDemand", "increaseSpendingLimit", "resolveAccountState"} {
+		if !strings.Contains(providerActionDescription, knownAction) {
+			t.Fatalf("providerActionCode description should mention official/reference provider action %q: %q", knownAction, providerActionDescription)
+		}
 	}
 	for _, legacyAction := range []string{"claimApiKey", "upgradePlan", "enableOnDemand", "increaseSpendingLimit"} {
 		if containsString(stringSlice(t, actionType["enum"]), legacyAction) {

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -74,7 +74,7 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 		t.Fatalf("RuntimeQuotaError should extend ErrorResponse: %#v", runtimeQuotaErrorAllOf)
 	}
 	if !allOfRequiresProperty(runtimeQuotaErrorAllOf, "details") {
-		t.Fatalf("RuntimeQuotaError.details should be required for the mem9 category: %#v", runtimeQuotaErrorAllOf)
+		t.Fatalf("RuntimeQuotaError.details should be required for the error category: %#v", runtimeQuotaErrorAllOf)
 	}
 	if !allOfHasDetailsRef(runtimeQuotaErrorAllOf, "#/components/schemas/RuntimeQuotaErrorEnvelopeDetails") {
 		t.Fatalf("RuntimeQuotaError should add quota details via allOf: %#v", runtimeQuotaErrorAllOf)
@@ -102,35 +102,39 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 			t.Fatalf("RuntimeRecommendedAction.type still exposes legacy action %q", legacyAction)
 		}
 	}
+	actionSeverity := objectValue(t, actionProperties, "severity")
+	if _, ok := actionSeverity["enum"]; ok {
+		t.Fatalf("RuntimeRecommendedAction.severity should remain provider-defined")
+	}
 
 	envelopeDetails := objectValue(t, schemas, "RuntimeQuotaErrorEnvelopeDetails")
-	if !containsString(stringSlice(t, envelopeDetails["required"]), "mem9Category") {
-		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.mem9Category should be required")
+	if !containsString(stringSlice(t, envelopeDetails["required"]), "errorCategory") {
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.errorCategory should be required")
 	}
 	envelopeProperties := objectValue(t, envelopeDetails, "properties")
-	envelopeMem9Category := objectValue(t, envelopeProperties, "mem9Category")
-	if got, want := stringSlice(t, envelopeMem9Category["enum"]), []string{"runtime_quota_denied"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.mem9Category enum = %#v, want %#v", got, want)
+	envelopeErrorCategory := objectValue(t, envelopeProperties, "errorCategory")
+	if got, want := stringSlice(t, envelopeErrorCategory["enum"]), []string{"runtime_quota_denied"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.errorCategory enum = %#v, want %#v", got, want)
 	}
 	if _, ok := envelopeProperties["runtimeQuota"]; !ok {
-		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails should expose provider runtimeQuota details")
+		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails should expose public runtimeQuota details")
 	}
 	if got, ok := envelopeDetails["additionalProperties"].(bool); !ok || got {
 		t.Fatalf("RuntimeQuotaErrorEnvelopeDetails.additionalProperties = %#v, want false", envelopeDetails["additionalProperties"])
 	}
 
 	runtimeQuotaDetails := objectValue(t, schemas, "RuntimeQuotaErrorDetails")
-	if got, ok := runtimeQuotaDetails["additionalProperties"].(bool); !ok || !got {
-		t.Fatalf("RuntimeQuotaErrorDetails.additionalProperties = %#v, want true", runtimeQuotaDetails["additionalProperties"])
+	if got, ok := runtimeQuotaDetails["additionalProperties"].(bool); !ok || got {
+		t.Fatalf("RuntimeQuotaErrorDetails.additionalProperties = %#v, want false", runtimeQuotaDetails["additionalProperties"])
 	}
 	runtimeQuotaDetailProperties := objectValue(t, runtimeQuotaDetails, "properties")
 	if required, ok := runtimeQuotaDetails["required"]; ok {
-		if containsString(stringSlice(t, required), "mem9Category") {
-			t.Fatalf("RuntimeQuotaErrorDetails should not require mem9Category inside provider details")
+		if containsString(stringSlice(t, required), "errorCategory") {
+			t.Fatalf("RuntimeQuotaErrorDetails should not require errorCategory inside runtime quota details")
 		}
 	}
-	if _, ok := runtimeQuotaDetailProperties["mem9Category"]; ok {
-		t.Fatalf("RuntimeQuotaErrorDetails should keep mem9Category at the details envelope level")
+	if _, ok := runtimeQuotaDetailProperties["errorCategory"]; ok {
+		t.Fatalf("RuntimeQuotaErrorDetails should keep errorCategory at the details envelope level")
 	}
 	if _, ok := runtimeQuotaDetailProperties["mem9Code"]; ok {
 		t.Fatalf("RuntimeQuotaErrorDetails should not define a mem9-specific routing code")
@@ -139,13 +143,18 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 		t.Fatalf("RuntimeQuotaErrorDetails should use quotaGateResult.reason for provider quota reasons")
 	}
 	if _, ok := runtimeQuotaDetailProperties["category"]; ok {
-		t.Fatalf("RuntimeQuotaErrorDetails should use mem9Category instead of a broad category field")
+		t.Fatalf("RuntimeQuotaErrorDetails should use errorCategory instead of a broad category field")
 	}
 	if _, ok := runtimeQuotaDetailProperties["code"]; ok {
-		t.Fatalf("RuntimeQuotaErrorDetails should use mem9Category instead of a broad code field")
+		t.Fatalf("RuntimeQuotaErrorDetails should use errorCategory instead of a broad code field")
 	}
 	if _, ok := runtimeQuotaDetailProperties["retryable"]; ok {
 		t.Fatalf("RuntimeQuotaErrorDetails should not define retryability separately from HTTP status and Retry-After")
+	}
+	for _, property := range []string{"meter", "recommendedAction", "quotaGateResult"} {
+		if _, ok := runtimeQuotaDetailProperties[property]; !ok {
+			t.Fatalf("RuntimeQuotaErrorDetails missing public field %q", property)
+		}
 	}
 
 	meter := objectValue(t, schemas, "RuntimeMeter")

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -160,7 +160,20 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	}
 
 	gateResult := objectValue(t, schemas, "RuntimeQuotaGateResult")
+	if got, ok := gateResult["additionalProperties"].(bool); !ok || !got {
+		t.Fatalf("RuntimeQuotaGateResult.additionalProperties = %#v, want true", gateResult["additionalProperties"])
+	}
 	gateProperties := objectValue(t, gateResult, "properties")
+	mode := objectValue(t, gateProperties, "mode")
+	if mode["type"] != "string" {
+		t.Fatalf("RuntimeQuotaGateResult.mode type = %#v, want string", mode["type"])
+	}
+	if _, ok := mode["enum"]; ok {
+		t.Fatalf("RuntimeQuotaGateResult.mode should remain provider-defined")
+	}
+	if _, ok := mode["pattern"]; ok {
+		t.Fatalf("RuntimeQuotaGateResult.mode should not constrain provider-defined values")
+	}
 	reason := objectValue(t, gateProperties, "reason")
 	if reason["type"] != "string" {
 		t.Fatalf("RuntimeQuotaGateResult.reason type = %#v, want string", reason["type"])

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -57,9 +57,13 @@ func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
 func (s *Server) handleRuntimeUsageError(w http.ResponseWriter, err error) {
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
-		body := normalizeRuntimeQuotaDeniedBody(denied.ResponseBody())
+		status := denied.Status()
+		body := normalizeRuntimeQuotaErrorBody(status, denied.ResponseBody())
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusPaymentRequired)
+		if status == http.StatusTooManyRequests && denied.RetryAfter != "" {
+			w.Header().Set("Retry-After", denied.RetryAfter)
+		}
+		w.WriteHeader(status)
 		_, _ = w.Write(body)
 		return
 	}
@@ -78,19 +82,19 @@ func isRuntimeUsageError(err error) bool {
 	return errors.As(err, &denied) || errors.As(err, &unavailable) || errors.As(err, &conflict)
 }
 
-type runtimeQuotaDeniedEnvelope struct {
+type runtimeQuotaErrorEnvelope struct {
 	Code    string         `json:"code"`
 	Message string         `json:"message"`
 	Details map[string]any `json:"details"`
 }
 
-func normalizeRuntimeQuotaDeniedBody(body []byte) []byte {
+func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 	body = bytes.TrimSpace(body)
-	envelope := runtimeQuotaDeniedEnvelope{
-		Code:    "runtime_quota_denied",
-		Message: "runtime usage quota denied",
+	envelope := runtimeQuotaErrorEnvelope{
+		Code:    runtimeQuotaDefaultCode(status),
+		Message: runtimeQuotaDefaultMessage(status),
 		Details: map[string]any{
-			"retryable": false,
+			"retryable": runtimeQuotaDefaultRetryable(status),
 			"mem9Code":  "runtime_quota_denied",
 		},
 	}
@@ -114,16 +118,104 @@ func normalizeRuntimeQuotaDeniedBody(body []byte) []byte {
 		if mem9Code, ok := parsed["mem9_code"].(string); ok && mem9Code != "" {
 			envelope.Details["mem9Code"] = mem9Code
 		}
+		normalizeRuntimeQuotaRecommendedAction(envelope.Details)
 	}
 	if _, ok := envelope.Details["retryable"]; !ok {
-		envelope.Details["retryable"] = false
+		envelope.Details["retryable"] = runtimeQuotaDefaultRetryable(status)
 	}
 	if _, ok := envelope.Details["mem9Code"]; !ok {
 		envelope.Details["mem9Code"] = "runtime_quota_denied"
 	}
 	out, err := json.Marshal(envelope)
 	if err != nil {
-		return []byte(`{"code":"runtime_quota_denied","message":"runtime usage quota denied","details":{"retryable":false,"mem9Code":"runtime_quota_denied"}}`)
+		if status == http.StatusTooManyRequests {
+			return []byte(`{"code":"post_quota_rate_limited","message":"Post-quota rate limit exceeded.","details":{"retryable":true,"mem9Code":"runtime_quota_denied"}}`)
+		}
+		return []byte(`{"code":"runtime_access_blocked","message":"Runtime access is blocked.","details":{"retryable":false,"mem9Code":"runtime_quota_denied"}}`)
 	}
 	return out
+}
+
+func runtimeQuotaDefaultCode(status int) string {
+	if status == http.StatusTooManyRequests {
+		return "post_quota_rate_limited"
+	}
+	return "runtime_access_blocked"
+}
+
+func runtimeQuotaDefaultMessage(status int) string {
+	if status == http.StatusTooManyRequests {
+		return "Post-quota rate limit exceeded."
+	}
+	return "Runtime access is blocked."
+}
+
+func runtimeQuotaDefaultRetryable(status int) bool {
+	return status == http.StatusTooManyRequests
+}
+
+func normalizeRuntimeQuotaRecommendedAction(details map[string]any) {
+	if details == nil {
+		return
+	}
+	action, ok := canonicalRuntimeQuotaAction(details["recommendedAction"])
+	if !ok {
+		action = make(map[string]any)
+	}
+	if providerActionCode, ok := runtimeQuotaString(details["upgradeAction"]); ok {
+		action["type"] = "openUrl"
+		if _, exists := action["providerActionCode"]; !exists {
+			action["providerActionCode"] = providerActionCode
+		}
+	}
+	if url, ok := runtimeQuotaString(details["upgradeUrl"]); ok {
+		action["type"] = "openUrl"
+		if _, exists := action["url"]; !exists {
+			action["url"] = url
+		}
+	}
+	delete(details, "bindingState")
+	delete(details, "upgradeAction")
+	delete(details, "upgradeUrl")
+	if len(action) == 0 {
+		delete(details, "recommendedAction")
+		return
+	}
+	if _, ok := action["type"]; !ok {
+		action["type"] = "openUrl"
+	}
+	details["recommendedAction"] = action
+}
+
+func canonicalRuntimeQuotaAction(raw any) (map[string]any, bool) {
+	actionInput, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	action := make(map[string]any)
+	if actionType, ok := runtimeQuotaString(actionInput["type"]); ok {
+		action["type"] = "openUrl"
+		if actionType != "openUrl" {
+			action["providerActionCode"] = actionType
+		}
+	}
+	if providerActionCode, ok := runtimeQuotaString(actionInput["providerActionCode"]); ok {
+		action["type"] = "openUrl"
+		action["providerActionCode"] = providerActionCode
+	}
+	if severity, ok := runtimeQuotaString(actionInput["severity"]); ok {
+		action["severity"] = severity
+	}
+	if url, ok := runtimeQuotaString(actionInput["url"]); ok {
+		action["url"] = url
+	}
+	return action, true
+}
+
+func runtimeQuotaString(value any) (string, bool) {
+	text, ok := value.(string)
+	if !ok || text == "" {
+		return "", false
+	}
+	return text, true
 }

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -12,7 +12,10 @@ import (
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
-const runtimeUsagePostSuccessTimeout = 10 * time.Second
+const (
+	runtimeUsagePostSuccessTimeout = 10 * time.Second
+	runtimeQuotaPublicCategory     = "runtime_quota_denied"
+)
 
 func (s *Server) runtimeUsageEnabled() bool {
 	return s != nil && s.runtimeUsage != nil && s.runtimeUsage.Enabled()
@@ -83,64 +86,62 @@ func isRuntimeUsageError(err error) bool {
 }
 
 type runtimeQuotaErrorEnvelope struct {
-	Code    string         `json:"code"`
-	Message string         `json:"message"`
-	Details map[string]any `json:"details"`
+	Error   string         `json:"error"`
+	Details map[string]any `json:"details,omitempty"`
 }
 
 func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 	body = bytes.TrimSpace(body)
+	runtimeQuota := map[string]any{
+		"category": runtimeQuotaPublicCategory,
+	}
 	envelope := runtimeQuotaErrorEnvelope{
-		Code:    runtimeQuotaDefaultCode(status),
-		Message: runtimeQuotaDefaultMessage(status),
-		Details: map[string]any{
-			"retryable": runtimeQuotaDefaultRetryable(status),
-			"mem9Code":  "runtime_quota_denied",
-		},
+		Error: runtimeQuotaDefaultMessage(status),
 	}
 	var parsed map[string]any
 	if len(body) > 0 && json.Unmarshal(body, &parsed) == nil {
+		hasError := false
+		if errorText, ok := parsed["error"].(string); ok && errorText != "" {
+			envelope.Error = errorText
+			hasError = true
+		}
 		if code, ok := parsed["code"].(string); ok && code != "" {
-			envelope.Code = code
+			runtimeQuota["providerReason"] = code
 		}
 		if message, ok := parsed["message"].(string); ok && message != "" {
-			envelope.Message = message
-		}
-		if details, ok := parsed["details"].(map[string]any); ok {
-			envelope.Details = make(map[string]any, len(details)+2)
-			for key, value := range details {
-				envelope.Details[key] = value
+			if !hasError {
+				envelope.Error = message
 			}
 		}
-		if retryable, ok := parsed["retryable"].(bool); ok {
-			envelope.Details["retryable"] = retryable
+		if details, ok := parsed["details"].(map[string]any); ok {
+			if nested, ok := details["runtimeQuota"].(map[string]any); ok {
+				for key, value := range nested {
+					runtimeQuota[key] = value
+				}
+			} else {
+				for key, value := range details {
+					runtimeQuota[key] = value
+				}
+			}
 		}
-		if mem9Code, ok := parsed["mem9_code"].(string); ok && mem9Code != "" {
-			envelope.Details["mem9Code"] = mem9Code
+		normalizeRuntimeQuotaRecommendedAction(runtimeQuota)
+	}
+	delete(runtimeQuota, "mem9Code")
+	delete(runtimeQuota, "mem9_code")
+	runtimeQuota["category"] = runtimeQuotaPublicCategory
+	if len(runtimeQuota) > 0 {
+		envelope.Details = map[string]any{
+			"runtimeQuota": runtimeQuota,
 		}
-		normalizeRuntimeQuotaRecommendedAction(envelope.Details)
-	}
-	if _, ok := envelope.Details["retryable"]; !ok {
-		envelope.Details["retryable"] = runtimeQuotaDefaultRetryable(status)
-	}
-	if _, ok := envelope.Details["mem9Code"]; !ok {
-		envelope.Details["mem9Code"] = "runtime_quota_denied"
 	}
 	out, err := json.Marshal(envelope)
 	if err != nil {
 		if status == http.StatusTooManyRequests {
-			return []byte(`{"code":"post_quota_rate_limited","message":"Post-quota rate limit exceeded.","details":{"retryable":true,"mem9Code":"runtime_quota_denied"}}`)
+			return []byte(`{"error":"Post-quota rate limit exceeded.","details":{"runtimeQuota":{"category":"runtime_quota_denied"}}}`)
 		}
-		return []byte(`{"code":"runtime_access_blocked","message":"Runtime access is blocked.","details":{"retryable":false,"mem9Code":"runtime_quota_denied"}}`)
+		return []byte(`{"error":"Runtime access is blocked.","details":{"runtimeQuota":{"category":"runtime_quota_denied"}}}`)
 	}
 	return out
-}
-
-func runtimeQuotaDefaultCode(status int) string {
-	if status == http.StatusTooManyRequests {
-		return "post_quota_rate_limited"
-	}
-	return "runtime_access_blocked"
 }
 
 func runtimeQuotaDefaultMessage(status int) string {
@@ -148,10 +149,6 @@ func runtimeQuotaDefaultMessage(status int) string {
 		return "Post-quota rate limit exceeded."
 	}
 	return "Runtime access is blocked."
-}
-
-func runtimeQuotaDefaultRetryable(status int) bool {
-	return status == http.StatusTooManyRequests
 }
 
 func normalizeRuntimeQuotaRecommendedAction(details map[string]any) {

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	runtimeUsagePostSuccessTimeout = 10 * time.Second
-	runtimeQuotaPublicCategory     = "runtime_quota_denied"
+	runtimeQuotaPublicMem9Category = "runtime_quota_denied"
 )
 
 func (s *Server) runtimeUsageEnabled() bool {
@@ -92,9 +92,7 @@ type runtimeQuotaErrorEnvelope struct {
 
 func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 	body = bytes.TrimSpace(body)
-	runtimeQuota := map[string]any{
-		"category": runtimeQuotaPublicCategory,
-	}
+	runtimeQuota := map[string]any{}
 	envelope := runtimeQuotaErrorEnvelope{
 		Error: runtimeQuotaDefaultMessage(status),
 	}
@@ -104,9 +102,6 @@ func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 		if errorText, ok := parsed["error"].(string); ok && errorText != "" {
 			envelope.Error = errorText
 			hasError = true
-		}
-		if code, ok := parsed["code"].(string); ok && code != "" {
-			runtimeQuota["providerReason"] = code
 		}
 		if message, ok := parsed["message"].(string); ok && message != "" {
 			if !hasError {
@@ -128,18 +123,19 @@ func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 	}
 	delete(runtimeQuota, "mem9Code")
 	delete(runtimeQuota, "mem9_code")
-	runtimeQuota["category"] = runtimeQuotaPublicCategory
+	delete(runtimeQuota, "mem9Category")
+	envelope.Details = map[string]any{
+		"mem9Category": runtimeQuotaPublicMem9Category,
+	}
 	if len(runtimeQuota) > 0 {
-		envelope.Details = map[string]any{
-			"runtimeQuota": runtimeQuota,
-		}
+		envelope.Details["runtimeQuota"] = runtimeQuota
 	}
 	out, err := json.Marshal(envelope)
 	if err != nil {
 		if status == http.StatusTooManyRequests {
-			return []byte(`{"error":"Post-quota rate limit exceeded.","details":{"runtimeQuota":{"category":"runtime_quota_denied"}}}`)
+			return []byte(`{"error":"Post-quota rate limit exceeded.","details":{"mem9Category":"runtime_quota_denied"}}`)
 		}
-		return []byte(`{"error":"Runtime access is blocked.","details":{"runtimeQuota":{"category":"runtime_quota_denied"}}}`)
+		return []byte(`{"error":"Runtime access is blocked.","details":{"mem9Category":"runtime_quota_denied"}}`)
 	}
 	return out
 }

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	runtimeUsagePostSuccessTimeout = 10 * time.Second
-	runtimeQuotaPublicMem9Category = "runtime_quota_denied"
+	runtimeUsagePostSuccessTimeout  = 10 * time.Second
+	runtimeQuotaPublicErrorCategory = "runtime_quota_denied"
 )
 
 func (s *Server) runtimeUsageEnabled() bool {
@@ -98,34 +98,17 @@ func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 	}
 	var parsed map[string]any
 	if len(body) > 0 && json.Unmarshal(body, &parsed) == nil {
-		hasError := false
-		if errorText, ok := parsed["error"].(string); ok && errorText != "" {
-			envelope.Error = errorText
-			hasError = true
-		}
-		if message, ok := parsed["message"].(string); ok && message != "" {
-			if !hasError {
-				envelope.Error = message
-			}
+		if message, ok := runtimeQuotaString(parsed["message"]); ok {
+			envelope.Error = message
 		}
 		if details, ok := parsed["details"].(map[string]any); ok {
-			if nested, ok := details["runtimeQuota"].(map[string]any); ok {
-				for key, value := range nested {
-					runtimeQuota[key] = value
-				}
-			} else {
-				for key, value := range details {
-					runtimeQuota[key] = value
-				}
-			}
+			// Reservation providers return code/message/details; the public API
+			// exposes a smaller runtimeQuota contract rather than provider internals.
+			runtimeQuota = publicRuntimeQuotaDetails(details)
 		}
-		normalizeRuntimeQuotaRecommendedAction(runtimeQuota)
 	}
-	delete(runtimeQuota, "mem9Code")
-	delete(runtimeQuota, "mem9_code")
-	delete(runtimeQuota, "mem9Category")
 	envelope.Details = map[string]any{
-		"mem9Category": runtimeQuotaPublicMem9Category,
+		"errorCategory": runtimeQuotaPublicErrorCategory,
 	}
 	if len(runtimeQuota) > 0 {
 		envelope.Details["runtimeQuota"] = runtimeQuota
@@ -133,9 +116,9 @@ func normalizeRuntimeQuotaErrorBody(status int, body []byte) []byte {
 	out, err := json.Marshal(envelope)
 	if err != nil {
 		if status == http.StatusTooManyRequests {
-			return []byte(`{"error":"Post-quota rate limit exceeded.","details":{"mem9Category":"runtime_quota_denied"}}`)
+			return []byte(`{"error":"Post-quota rate limit exceeded.","details":{"errorCategory":"runtime_quota_denied"}}`)
 		}
-		return []byte(`{"error":"Runtime access is blocked.","details":{"mem9Category":"runtime_quota_denied"}}`)
+		return []byte(`{"error":"Runtime access is blocked.","details":{"errorCategory":"runtime_quota_denied"}}`)
 	}
 	return out
 }
@@ -147,60 +130,36 @@ func runtimeQuotaDefaultMessage(status int) string {
 	return "Runtime access is blocked."
 }
 
-func normalizeRuntimeQuotaRecommendedAction(details map[string]any) {
-	if details == nil {
-		return
+func publicRuntimeQuotaDetails(details map[string]any) map[string]any {
+	runtimeQuota := map[string]any{}
+	if meter, ok := runtimeQuotaString(details["meter"]); ok {
+		runtimeQuota["meter"] = meter
 	}
-	action, ok := canonicalRuntimeQuotaAction(details["recommendedAction"])
-	if !ok {
-		action = make(map[string]any)
+	if action, ok := publicRuntimeQuotaRecommendedAction(details["recommendedAction"]); ok {
+		runtimeQuota["recommendedAction"] = action
 	}
-	if providerActionCode, ok := runtimeQuotaString(details["upgradeAction"]); ok {
-		action["type"] = "openUrl"
-		if _, exists := action["providerActionCode"]; !exists {
-			action["providerActionCode"] = providerActionCode
-		}
+	if gateResult, ok := details["quotaGateResult"].(map[string]any); ok {
+		runtimeQuota["quotaGateResult"] = gateResult
 	}
-	if url, ok := runtimeQuotaString(details["upgradeUrl"]); ok {
-		action["type"] = "openUrl"
-		if _, exists := action["url"]; !exists {
-			action["url"] = url
-		}
-	}
-	delete(details, "bindingState")
-	delete(details, "upgradeAction")
-	delete(details, "upgradeUrl")
-	if len(action) == 0 {
-		delete(details, "recommendedAction")
-		return
-	}
-	if _, ok := action["type"]; !ok {
-		action["type"] = "openUrl"
-	}
-	details["recommendedAction"] = action
+	return runtimeQuota
 }
 
-func canonicalRuntimeQuotaAction(raw any) (map[string]any, bool) {
+func publicRuntimeQuotaRecommendedAction(raw any) (map[string]any, bool) {
 	actionInput, ok := raw.(map[string]any)
 	if !ok {
 		return nil, false
 	}
-	action := make(map[string]any)
-	if actionType, ok := runtimeQuotaString(actionInput["type"]); ok {
-		action["type"] = "openUrl"
-		if actionType != "openUrl" {
-			action["providerActionCode"] = actionType
+	actionType, ok := runtimeQuotaString(actionInput["type"])
+	if !ok || actionType != "openUrl" {
+		return nil, false
+	}
+	action := map[string]any{
+		"type": actionType,
+	}
+	for _, key := range []string{"providerActionCode", "severity", "url"} {
+		if value, ok := runtimeQuotaString(actionInput[key]); ok {
+			action[key] = value
 		}
-	}
-	if providerActionCode, ok := runtimeQuotaString(actionInput["providerActionCode"]); ok {
-		action["type"] = "openUrl"
-		action["providerActionCode"] = providerActionCode
-	}
-	if severity, ok := runtimeQuotaString(actionInput["severity"]); ok {
-		action["severity"] = severity
-	}
-	if url, ok := runtimeQuotaString(actionInput["url"]); ok {
-		action["url"] = url
 	}
 	return action, true
 }

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -14,7 +14,6 @@ func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyRecommendedAction(t *t
 			"code":"quota_exhausted",
 			"message":"Included quota is exhausted.",
 			"details":{
-				"retryable":false,
 				"meter":"memory_recall_requests",
 				"limitType":"includedQuota",
 				"recommendedAction":{
@@ -30,27 +29,30 @@ func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyRecommendedAction(t *t
 		}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
-	if got["code"] != "quota_exhausted" || got["message"] != "Included quota is exhausted." {
+	if got["error"] != "Included quota is exhausted." {
 		t.Fatalf("unexpected envelope: %#v", got)
 	}
-	if _, ok := got["mem9_code"]; ok {
-		t.Fatalf("mem9_code should live under details: %#v", got)
+	for _, key := range []string{"code", "message", "mem9_code"} {
+		if _, ok := got[key]; ok {
+			t.Fatalf("%q should not be exposed at the top level: %#v", key, got)
+		}
 	}
-	details := got["details"].(map[string]any)
-	recommendedAction := details["recommendedAction"].(map[string]any)
-	quotaGateResult := details["quotaGateResult"].(map[string]any)
-	if details["meter"] != "memory_recall_requests" ||
+	runtimeQuota := runtimeQuotaDetails(t, got)
+	recommendedAction := runtimeQuota["recommendedAction"].(map[string]any)
+	quotaGateResult := runtimeQuota["quotaGateResult"].(map[string]any)
+	if runtimeQuota["category"] != "runtime_quota_denied" ||
+		runtimeQuota["meter"] != "memory_recall_requests" ||
+		runtimeQuota["providerReason"] != "quota_exhausted" ||
 		recommendedAction["type"] != "openUrl" ||
 		recommendedAction["providerActionCode"] != "upgradePlan" ||
 		recommendedAction["url"] != "https://example.com/provider/billing/plan" ||
 		quotaGateResult["outcome"] != "blocked" ||
-		quotaGateResult["reason"] != "includedQuotaExhausted" ||
-		details["mem9Code"] != "runtime_quota_denied" {
-		t.Fatalf("unexpected details: %#v", details)
+		quotaGateResult["reason"] != "includedQuotaExhausted" {
+		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 	for _, key := range []string{"upgradeAction", "bindingState", "upgradeUrl"} {
-		if _, ok := details[key]; ok {
-			t.Fatalf("legacy flat action field %q should be absent: %#v", key, details)
+		if _, ok := runtimeQuota[key]; ok {
+			t.Fatalf("legacy flat action field %q should be absent: %#v", key, runtimeQuota)
 		}
 	}
 	if _, ok := recommendedAction["bindingState"]; ok {
@@ -63,7 +65,6 @@ func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyFlatAction(t *testing.
 			"code":"spending_limit_exceeded",
 			"message":"Spending limit reached.",
 			"details":{
-				"retryable":false,
 				"meter":"memory_write_requests",
 				"upgradeAction":"increaseSpendingLimit",
 				"upgradeUrl":"https://example.com/provider/spending-limit"
@@ -71,16 +72,16 @@ func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyFlatAction(t *testing.
 		}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
-	details := got["details"].(map[string]any)
-	recommendedAction := details["recommendedAction"].(map[string]any)
+	runtimeQuota := runtimeQuotaDetails(t, got)
+	recommendedAction := runtimeQuota["recommendedAction"].(map[string]any)
 	if recommendedAction["type"] != "openUrl" ||
 		recommendedAction["providerActionCode"] != "increaseSpendingLimit" ||
 		recommendedAction["url"] != "https://example.com/provider/spending-limit" {
 		t.Fatalf("unexpected recommended action: %#v", recommendedAction)
 	}
 	for _, key := range []string{"upgradeAction", "upgradeUrl"} {
-		if _, ok := details[key]; ok {
-			t.Fatalf("legacy flat action field %q should be absent: %#v", key, details)
+		if _, ok := runtimeQuota[key]; ok {
+			t.Fatalf("legacy flat action field %q should be absent: %#v", key, runtimeQuota)
 		}
 	}
 }
@@ -97,8 +98,8 @@ func TestNormalizeRuntimeQuotaErrorBodyDoesNotSynthesizeActionURL(t *testing.T) 
 		}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
-	details := got["details"].(map[string]any)
-	recommendedAction := details["recommendedAction"].(map[string]any)
+	runtimeQuota := runtimeQuotaDetails(t, got)
+	recommendedAction := runtimeQuota["recommendedAction"].(map[string]any)
 	if recommendedAction["type"] != "openUrl" || recommendedAction["providerActionCode"] != "claimApiKey" {
 		t.Fatalf("unexpected recommended action: %#v", recommendedAction)
 	}
@@ -107,47 +108,53 @@ func TestNormalizeRuntimeQuotaErrorBodyDoesNotSynthesizeActionURL(t *testing.T) 
 	}
 }
 
-func TestNormalizeRuntimeQuotaErrorBodyMovesLegacyMem9Code(t *testing.T) {
+func TestNormalizeRuntimeQuotaErrorBodyDropsLegacyMem9Code(t *testing.T) {
 	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
 			"code":"quota_exhausted",
 			"message":"Included quota is exhausted.",
-			"retryable":false,
+			"details":{
+				"mem9Code":"runtime_quota_denied",
+				"mem9_code":"runtime_quota_denied",
+				"meter":"memory_recall_requests"
+			},
 		"mem9_code":"runtime_quota_denied"
 		}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
 	if _, ok := got["mem9_code"]; ok {
-		t.Fatalf("mem9_code should live under details: %#v", got)
+		t.Fatalf("mem9_code should not be exposed at the top level: %#v", got)
 	}
-	details := got["details"].(map[string]any)
-	if details["retryable"] != false || details["mem9Code"] != "runtime_quota_denied" {
-		t.Fatalf("unexpected details: %#v", details)
+	runtimeQuota := runtimeQuotaDetails(t, got)
+	if _, ok := runtimeQuota["mem9Code"]; ok {
+		t.Fatalf("mem9Code should not be exposed in runtimeQuota: %#v", runtimeQuota)
+	}
+	if _, ok := runtimeQuota["mem9_code"]; ok {
+		t.Fatalf("mem9_code should not be exposed in runtimeQuota: %#v", runtimeQuota)
+	}
+	if runtimeQuota["category"] != "runtime_quota_denied" ||
+		runtimeQuota["providerReason"] != "quota_exhausted" ||
+		runtimeQuota["meter"] != "memory_recall_requests" {
+		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
 
 func TestNormalizeRuntimeQuotaErrorBodyUsesFallbackByStatus(t *testing.T) {
 	tests := []struct {
-		name      string
-		status    int
-		body      []byte
-		code      string
-		message   string
-		retryable bool
+		name    string
+		status  int
+		body    []byte
+		message string
 	}{
 		{
-			name:      "runtime access blocked",
-			status:    http.StatusPaymentRequired,
-			code:      "runtime_access_blocked",
-			message:   "Runtime access is blocked.",
-			retryable: false,
+			name:    "runtime access blocked",
+			status:  http.StatusPaymentRequired,
+			message: "Runtime access is blocked.",
 		},
 		{
-			name:      "post quota rate limited",
-			status:    http.StatusTooManyRequests,
-			body:      []byte("not-json"),
-			code:      "post_quota_rate_limited",
-			message:   "Post-quota rate limit exceeded.",
-			retryable: true,
+			name:    "post quota rate limited",
+			status:  http.StatusTooManyRequests,
+			body:    []byte("not-json"),
+			message: "Post-quota rate limit exceeded.",
 		},
 	}
 	for _, tt := range tests {
@@ -155,12 +162,17 @@ func TestNormalizeRuntimeQuotaErrorBodyUsesFallbackByStatus(t *testing.T) {
 			body := normalizeRuntimeQuotaErrorBody(tt.status, tt.body)
 
 			got := decodeRuntimeQuotaErrorBody(t, body)
-			if got["code"] != tt.code || got["message"] != tt.message {
+			if got["error"] != tt.message {
 				t.Fatalf("unexpected fallback envelope: %#v", got)
 			}
-			details := got["details"].(map[string]any)
-			if details["retryable"] != tt.retryable || details["mem9Code"] != "runtime_quota_denied" {
-				t.Fatalf("unexpected fallback details: %#v", details)
+			for _, key := range []string{"code", "message"} {
+				if _, ok := got[key]; ok {
+					t.Fatalf("%q should not be exposed at the top level: %#v", key, got)
+				}
+			}
+			runtimeQuota := runtimeQuotaDetails(t, got)
+			if runtimeQuota["category"] != "runtime_quota_denied" {
+				t.Fatalf("fallback should include stable runtime quota category: %#v", runtimeQuota)
 			}
 		})
 	}
@@ -188,14 +200,14 @@ func TestHandleRuntimeUsageErrorReturnsPostQuotaRateLimit(t *testing.T) {
 		t.Fatalf("Retry-After = %q, want 20", got)
 	}
 	got := decodeRuntimeQuotaErrorBody(t, recorder.Body.Bytes())
-	if got["code"] != "post_quota_rate_limited" || got["message"] != "Post-quota rate limit exceeded." {
+	if got["error"] != "Post-quota rate limit exceeded." {
 		t.Fatalf("unexpected envelope: %#v", got)
 	}
-	details := got["details"].(map[string]any)
-	if details["retryable"] != true ||
-		details["mem9Code"] != "runtime_quota_denied" ||
-		details["meter"] != "memory_recall_requests" {
-		t.Fatalf("unexpected details: %#v", details)
+	runtimeQuota := runtimeQuotaDetails(t, got)
+	if runtimeQuota["category"] != "runtime_quota_denied" ||
+		runtimeQuota["providerReason"] != "post_quota_rate_limited" ||
+		runtimeQuota["meter"] != "memory_recall_requests" {
+		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
 
@@ -206,4 +218,17 @@ func decodeRuntimeQuotaErrorBody(t *testing.T, body []byte) map[string]any {
 		t.Fatalf("response is not valid JSON: %v", err)
 	}
 	return got
+}
+
+func runtimeQuotaDetails(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	details, ok := body["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("details missing from response: %#v", body)
+	}
+	runtimeQuota, ok := details["runtimeQuota"].(map[string]any)
+	if !ok {
+		t.Fatalf("details.runtimeQuota missing from response: %#v", body)
+	}
+	return runtimeQuota
 }

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -9,24 +9,36 @@ import (
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
-func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyRecommendedAction(t *testing.T) {
+func TestNormalizeRuntimeQuotaErrorBodyAssemblesPublicRuntimeQuotaFields(t *testing.T) {
 	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
-			"code":"quota_exhausted",
-			"message":"Included quota is exhausted.",
-			"details":{
-				"meter":"memory_recall_requests",
-				"limitType":"includedQuota",
-				"recommendedAction":{
-					"bindingState":"claimed",
-					"type":"upgradePlan",
-					"url":"https://example.com/provider/billing/plan"
-				},
-				"quotaGateResult":{
-					"outcome":"blocked",
-				"reason":"includedQuotaExhausted"
+		"code":"quota_exhausted",
+		"error":"provider error should be ignored",
+		"message":"Included quota is exhausted.",
+		"details":{
+			"meter":"memory_recall_requests",
+			"retryable":false,
+			"limitType":"includedQuota",
+			"mem9Code":"runtime_quota_denied",
+			"mem9_code":"runtime_quota_denied",
+			"mem9Category":"runtime_quota_denied",
+			"upgradeAction":"upgradePlan",
+			"upgradeUrl":"https://example.com/provider/legacy-plan",
+			"recommendedAction":{
+				"bindingState":"claimed",
+				"type":"openUrl",
+				"providerActionCode":"upgradePlan",
+				"severity":"blocking",
+				"url":"https://example.com/provider/billing/plan"
+			},
+			"quotaGateResult":{
+				"outcome":"blocked",
+				"mode":"includedQuota",
+				"reason":"includedQuotaExhausted",
+				"providerExtension":"kept"
 			}
-		}
-		}`))
+		},
+		"mem9_code":"runtime_quota_denied"
+	}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
 	if got["error"] != "Included quota is exhausted." {
@@ -37,64 +49,68 @@ func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyRecommendedAction(t *t
 			t.Fatalf("%q should not be exposed at the top level: %#v", key, got)
 		}
 	}
+	if quotaErrorCategory(t, got) != "runtime_quota_denied" {
+		t.Fatalf("details.errorCategory should include stable runtime quota category: %#v", got)
+	}
+
 	runtimeQuota := runtimeQuotaDetails(t, got)
 	recommendedAction := runtimeQuota["recommendedAction"].(map[string]any)
 	quotaGateResult := runtimeQuota["quotaGateResult"].(map[string]any)
-	if quotaMem9Category(t, got) != "runtime_quota_denied" ||
-		runtimeQuota["meter"] != "memory_recall_requests" ||
+	if runtimeQuota["meter"] != "memory_recall_requests" ||
 		recommendedAction["type"] != "openUrl" ||
 		recommendedAction["providerActionCode"] != "upgradePlan" ||
+		recommendedAction["severity"] != "blocking" ||
 		recommendedAction["url"] != "https://example.com/provider/billing/plan" ||
 		quotaGateResult["outcome"] != "blocked" ||
-		quotaGateResult["reason"] != "includedQuotaExhausted" {
+		quotaGateResult["mode"] != "includedQuota" ||
+		quotaGateResult["reason"] != "includedQuotaExhausted" ||
+		quotaGateResult["providerExtension"] != "kept" {
 		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
-	for _, key := range []string{"upgradeAction", "bindingState", "upgradeUrl"} {
+	for _, key := range []string{"retryable", "limitType", "upgradeAction", "bindingState", "upgradeUrl", "mem9Code", "mem9_code", "mem9Category"} {
 		if _, ok := runtimeQuota[key]; ok {
-			t.Fatalf("legacy flat action field %q should be absent: %#v", key, runtimeQuota)
+			t.Fatalf("non-public runtime quota field %q should be absent: %#v", key, runtimeQuota)
 		}
 	}
 	if _, ok := recommendedAction["bindingState"]; ok {
-		t.Fatalf("legacy bindingState should be absent from action: %#v", recommendedAction)
+		t.Fatalf("non-public action field should be absent: %#v", recommendedAction)
 	}
 }
 
-func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyFlatAction(t *testing.T) {
+func TestNormalizeRuntimeQuotaErrorBodyIgnoresNonContractActionShapes(t *testing.T) {
 	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
-			"code":"spending_limit_exceeded",
-			"message":"Spending limit reached.",
-			"details":{
-				"meter":"memory_write_requests",
-				"upgradeAction":"increaseSpendingLimit",
-				"upgradeUrl":"https://example.com/provider/spending-limit"
+		"code":"runtime_access_blocked",
+		"message":"Runtime access is blocked.",
+		"details":{
+			"meter":"memory_recall_requests",
+			"recommendedAction":{
+				"type":"claimApiKey",
+				"url":"https://example.com/provider/claim"
 			}
-		}`))
+		}
+	}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
 	runtimeQuota := runtimeQuotaDetails(t, got)
-	recommendedAction := runtimeQuota["recommendedAction"].(map[string]any)
-	if recommendedAction["type"] != "openUrl" ||
-		recommendedAction["providerActionCode"] != "increaseSpendingLimit" ||
-		recommendedAction["url"] != "https://example.com/provider/spending-limit" {
-		t.Fatalf("unexpected recommended action: %#v", recommendedAction)
+	if _, ok := runtimeQuota["recommendedAction"]; ok {
+		t.Fatalf("non-contract recommendedAction should be absent: %#v", runtimeQuota)
 	}
-	for _, key := range []string{"upgradeAction", "upgradeUrl"} {
-		if _, ok := runtimeQuota[key]; ok {
-			t.Fatalf("legacy flat action field %q should be absent: %#v", key, runtimeQuota)
-		}
+	if runtimeQuota["meter"] != "memory_recall_requests" {
+		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
 
 func TestNormalizeRuntimeQuotaErrorBodyDoesNotSynthesizeActionURL(t *testing.T) {
 	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
-			"code":"runtime_access_blocked",
-			"message":"Runtime access is blocked.",
-			"details":{
-				"recommendedAction":{
-					"type":"claimApiKey"
-				}
+		"code":"runtime_access_blocked",
+		"message":"Runtime access is blocked.",
+		"details":{
+			"recommendedAction":{
+				"type":"openUrl",
+				"providerActionCode":"claimApiKey"
 			}
-		}`))
+		}
+	}`))
 
 	got := decodeRuntimeQuotaErrorBody(t, body)
 	runtimeQuota := runtimeQuotaDetails(t, got)
@@ -104,43 +120,6 @@ func TestNormalizeRuntimeQuotaErrorBodyDoesNotSynthesizeActionURL(t *testing.T) 
 	}
 	if _, ok := recommendedAction["url"]; ok {
 		t.Fatalf("url should only be present when supplied: %#v", recommendedAction)
-	}
-}
-
-func TestNormalizeRuntimeQuotaErrorBodyDropsLegacyMem9Code(t *testing.T) {
-	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
-			"code":"quota_exhausted",
-			"message":"Included quota is exhausted.",
-			"details":{
-				"mem9Code":"runtime_quota_denied",
-				"mem9_code":"runtime_quota_denied",
-				"meter":"memory_recall_requests"
-			},
-		"mem9_code":"runtime_quota_denied"
-		}`))
-
-	got := decodeRuntimeQuotaErrorBody(t, body)
-	if _, ok := got["mem9_code"]; ok {
-		t.Fatalf("mem9_code should not be exposed at the top level: %#v", got)
-	}
-	if quotaMem9Category(t, got) != "runtime_quota_denied" {
-		t.Fatalf("details.mem9Category should include stable mem9 category: %#v", got)
-	}
-	runtimeQuota := runtimeQuotaDetails(t, got)
-	if _, ok := runtimeQuota["mem9Code"]; ok {
-		t.Fatalf("mem9Code should not be exposed in runtimeQuota: %#v", runtimeQuota)
-	}
-	if _, ok := runtimeQuota["mem9_code"]; ok {
-		t.Fatalf("mem9_code should not be exposed in runtimeQuota: %#v", runtimeQuota)
-	}
-	if _, ok := runtimeQuota["providerReason"]; ok {
-		t.Fatalf("providerReason should not duplicate provider quotaGateResult.reason: %#v", runtimeQuota)
-	}
-	if _, ok := runtimeQuota["mem9Category"]; ok {
-		t.Fatalf("mem9Category should be owned by details, not runtimeQuota: %#v", runtimeQuota)
-	}
-	if runtimeQuota["meter"] != "memory_recall_requests" {
-		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
 
@@ -162,6 +141,24 @@ func TestNormalizeRuntimeQuotaErrorBodyUsesFallbackByStatus(t *testing.T) {
 			body:    []byte("not-json"),
 			message: "Post-quota rate limit exceeded.",
 		},
+		{
+			name:    "json without contract fields",
+			status:  http.StatusPaymentRequired,
+			body:    []byte(`{"code":"runtime_access_blocked"}`),
+			message: "Runtime access is blocked.",
+		},
+		{
+			name:    "json without message",
+			status:  http.StatusTooManyRequests,
+			body:    []byte(`{"code":"post_quota_rate_limited"}`),
+			message: "Post-quota rate limit exceeded.",
+		},
+		{
+			name:    "json without details",
+			status:  http.StatusPaymentRequired,
+			body:    []byte(`{"code":"runtime_access_blocked","message":"Provider message should be ignored."}`),
+			message: "Provider message should be ignored.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -176,14 +173,39 @@ func TestNormalizeRuntimeQuotaErrorBodyUsesFallbackByStatus(t *testing.T) {
 					t.Fatalf("%q should not be exposed at the top level: %#v", key, got)
 				}
 			}
-			if quotaMem9Category(t, got) != "runtime_quota_denied" {
-				t.Fatalf("fallback should include stable runtime quota mem9 category: %#v", got)
+			if quotaErrorCategory(t, got) != "runtime_quota_denied" {
+				t.Fatalf("fallback should include stable runtime quota error category: %#v", got)
 			}
 			details := quotaEnvelopeDetails(t, got)
 			if _, ok := details["runtimeQuota"]; ok {
-				t.Fatalf("fallback without provider details should not synthesize runtimeQuota: %#v", got)
+				t.Fatalf("fallback without contract details should not synthesize runtimeQuota: %#v", got)
 			}
 		})
+	}
+}
+
+func TestNormalizeRuntimeQuotaErrorBodyUsesStatusMessageFallbackWithDetails(t *testing.T) {
+	body := normalizeRuntimeQuotaErrorBody(http.StatusTooManyRequests, []byte(`{
+		"code":"post_quota_rate_limited",
+		"details":{
+			"meter":"memory_recall_requests",
+			"quotaGateResult":{
+				"outcome":"rateLimited",
+				"reason":"postQuotaRateLimitExceeded"
+			}
+		}
+	}`))
+
+	got := decodeRuntimeQuotaErrorBody(t, body)
+	if got["error"] != "Post-quota rate limit exceeded." {
+		t.Fatalf("unexpected fallback envelope: %#v", got)
+	}
+	if quotaErrorCategory(t, got) != "runtime_quota_denied" {
+		t.Fatalf("fallback should include stable runtime quota error category: %#v", got)
+	}
+	runtimeQuota := runtimeQuotaDetails(t, got)
+	if runtimeQuota["meter"] != "memory_recall_requests" {
+		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
 
@@ -212,13 +234,10 @@ func TestHandleRuntimeUsageErrorReturnsPostQuotaRateLimit(t *testing.T) {
 	if got["error"] != "Post-quota rate limit exceeded." {
 		t.Fatalf("unexpected envelope: %#v", got)
 	}
-	if quotaMem9Category(t, got) != "runtime_quota_denied" {
-		t.Fatalf("details.mem9Category should include stable mem9 category: %#v", got)
+	if quotaErrorCategory(t, got) != "runtime_quota_denied" {
+		t.Fatalf("details.errorCategory should include stable runtime quota category: %#v", got)
 	}
 	runtimeQuota := runtimeQuotaDetails(t, got)
-	if _, ok := runtimeQuota["mem9Category"]; ok {
-		t.Fatalf("mem9Category should be owned by details, not runtimeQuota: %#v", runtimeQuota)
-	}
 	if runtimeQuota["meter"] != "memory_recall_requests" {
 		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
@@ -243,14 +262,14 @@ func runtimeQuotaDetails(t *testing.T, body map[string]any) map[string]any {
 	return runtimeQuota
 }
 
-func quotaMem9Category(t *testing.T, body map[string]any) string {
+func quotaErrorCategory(t *testing.T, body map[string]any) string {
 	t.Helper()
 	details := quotaEnvelopeDetails(t, body)
-	mem9Category, ok := details["mem9Category"].(string)
+	errorCategory, ok := details["errorCategory"].(string)
 	if !ok {
-		t.Fatalf("details.mem9Category missing from response: %#v", body)
+		t.Fatalf("details.errorCategory missing from response: %#v", body)
 	}
-	return mem9Category
+	return errorCategory
 }
 
 func quotaEnvelopeDetails(t *testing.T, body map[string]any) map[string]any {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -40,9 +40,8 @@ func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyRecommendedAction(t *t
 	runtimeQuota := runtimeQuotaDetails(t, got)
 	recommendedAction := runtimeQuota["recommendedAction"].(map[string]any)
 	quotaGateResult := runtimeQuota["quotaGateResult"].(map[string]any)
-	if runtimeQuota["category"] != "runtime_quota_denied" ||
+	if quotaMem9Category(t, got) != "runtime_quota_denied" ||
 		runtimeQuota["meter"] != "memory_recall_requests" ||
-		runtimeQuota["providerReason"] != "quota_exhausted" ||
 		recommendedAction["type"] != "openUrl" ||
 		recommendedAction["providerActionCode"] != "upgradePlan" ||
 		recommendedAction["url"] != "https://example.com/provider/billing/plan" ||
@@ -124,6 +123,9 @@ func TestNormalizeRuntimeQuotaErrorBodyDropsLegacyMem9Code(t *testing.T) {
 	if _, ok := got["mem9_code"]; ok {
 		t.Fatalf("mem9_code should not be exposed at the top level: %#v", got)
 	}
+	if quotaMem9Category(t, got) != "runtime_quota_denied" {
+		t.Fatalf("details.mem9Category should include stable mem9 category: %#v", got)
+	}
 	runtimeQuota := runtimeQuotaDetails(t, got)
 	if _, ok := runtimeQuota["mem9Code"]; ok {
 		t.Fatalf("mem9Code should not be exposed in runtimeQuota: %#v", runtimeQuota)
@@ -131,9 +133,13 @@ func TestNormalizeRuntimeQuotaErrorBodyDropsLegacyMem9Code(t *testing.T) {
 	if _, ok := runtimeQuota["mem9_code"]; ok {
 		t.Fatalf("mem9_code should not be exposed in runtimeQuota: %#v", runtimeQuota)
 	}
-	if runtimeQuota["category"] != "runtime_quota_denied" ||
-		runtimeQuota["providerReason"] != "quota_exhausted" ||
-		runtimeQuota["meter"] != "memory_recall_requests" {
+	if _, ok := runtimeQuota["providerReason"]; ok {
+		t.Fatalf("providerReason should not duplicate provider quotaGateResult.reason: %#v", runtimeQuota)
+	}
+	if _, ok := runtimeQuota["mem9Category"]; ok {
+		t.Fatalf("mem9Category should be owned by details, not runtimeQuota: %#v", runtimeQuota)
+	}
+	if runtimeQuota["meter"] != "memory_recall_requests" {
 		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
@@ -170,9 +176,12 @@ func TestNormalizeRuntimeQuotaErrorBodyUsesFallbackByStatus(t *testing.T) {
 					t.Fatalf("%q should not be exposed at the top level: %#v", key, got)
 				}
 			}
-			runtimeQuota := runtimeQuotaDetails(t, got)
-			if runtimeQuota["category"] != "runtime_quota_denied" {
-				t.Fatalf("fallback should include stable runtime quota category: %#v", runtimeQuota)
+			if quotaMem9Category(t, got) != "runtime_quota_denied" {
+				t.Fatalf("fallback should include stable runtime quota mem9 category: %#v", got)
+			}
+			details := quotaEnvelopeDetails(t, got)
+			if _, ok := details["runtimeQuota"]; ok {
+				t.Fatalf("fallback without provider details should not synthesize runtimeQuota: %#v", got)
 			}
 		})
 	}
@@ -203,10 +212,14 @@ func TestHandleRuntimeUsageErrorReturnsPostQuotaRateLimit(t *testing.T) {
 	if got["error"] != "Post-quota rate limit exceeded." {
 		t.Fatalf("unexpected envelope: %#v", got)
 	}
+	if quotaMem9Category(t, got) != "runtime_quota_denied" {
+		t.Fatalf("details.mem9Category should include stable mem9 category: %#v", got)
+	}
 	runtimeQuota := runtimeQuotaDetails(t, got)
-	if runtimeQuota["category"] != "runtime_quota_denied" ||
-		runtimeQuota["providerReason"] != "post_quota_rate_limited" ||
-		runtimeQuota["meter"] != "memory_recall_requests" {
+	if _, ok := runtimeQuota["mem9Category"]; ok {
+		t.Fatalf("mem9Category should be owned by details, not runtimeQuota: %#v", runtimeQuota)
+	}
+	if runtimeQuota["meter"] != "memory_recall_requests" {
 		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
 	}
 }
@@ -222,13 +235,29 @@ func decodeRuntimeQuotaErrorBody(t *testing.T, body []byte) map[string]any {
 
 func runtimeQuotaDetails(t *testing.T, body map[string]any) map[string]any {
 	t.Helper()
-	details, ok := body["details"].(map[string]any)
-	if !ok {
-		t.Fatalf("details missing from response: %#v", body)
-	}
+	details := quotaEnvelopeDetails(t, body)
 	runtimeQuota, ok := details["runtimeQuota"].(map[string]any)
 	if !ok {
 		t.Fatalf("details.runtimeQuota missing from response: %#v", body)
 	}
 	return runtimeQuota
+}
+
+func quotaMem9Category(t *testing.T, body map[string]any) string {
+	t.Helper()
+	details := quotaEnvelopeDetails(t, body)
+	mem9Category, ok := details["mem9Category"].(string)
+	if !ok {
+		t.Fatalf("details.mem9Category missing from response: %#v", body)
+	}
+	return mem9Category
+}
+
+func quotaEnvelopeDetails(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	details, ok := body["details"].(map[string]any)
+	if !ok {
+		t.Fatalf("details missing from response: %#v", body)
+	}
+	return details
 }

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -2,30 +2,34 @@ package handler
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
-func TestNormalizeRuntimeQuotaDeniedBodyPreservesConsoleDetails(t *testing.T) {
-	body := normalizeRuntimeQuotaDeniedBody([]byte(`{
-		"code":"quota_exhausted",
-		"message":"Included quota is exhausted.",
-		"details":{
-			"retryable":false,
-			"meter":"memory_recall_requests",
-			"limitType":"includedQuota",
-			"recommendedAction":{
-				"bindingState":"claimed",
-				"type":"upgradePlan",
-				"url":"https://console.example.com/console/billing/plan"
-			},
-			"quotaGateResult":{
-				"outcome":"blocked",
+func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyRecommendedAction(t *testing.T) {
+	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
+			"code":"quota_exhausted",
+			"message":"Included quota is exhausted.",
+			"details":{
+				"retryable":false,
+				"meter":"memory_recall_requests",
+				"limitType":"includedQuota",
+				"recommendedAction":{
+					"bindingState":"claimed",
+					"type":"upgradePlan",
+					"url":"https://example.com/provider/billing/plan"
+				},
+				"quotaGateResult":{
+					"outcome":"blocked",
 				"reason":"includedQuotaExhausted"
 			}
 		}
-	}`))
+		}`))
 
-	got := decodeRuntimeQuotaDeniedBody(t, body)
+	got := decodeRuntimeQuotaErrorBody(t, body)
 	if got["code"] != "quota_exhausted" || got["message"] != "Included quota is exhausted." {
 		t.Fatalf("unexpected envelope: %#v", got)
 	}
@@ -36,9 +40,9 @@ func TestNormalizeRuntimeQuotaDeniedBodyPreservesConsoleDetails(t *testing.T) {
 	recommendedAction := details["recommendedAction"].(map[string]any)
 	quotaGateResult := details["quotaGateResult"].(map[string]any)
 	if details["meter"] != "memory_recall_requests" ||
-		recommendedAction["type"] != "upgradePlan" ||
-		recommendedAction["bindingState"] != "claimed" ||
-		recommendedAction["url"] != "https://console.example.com/console/billing/plan" ||
+		recommendedAction["type"] != "openUrl" ||
+		recommendedAction["providerActionCode"] != "upgradePlan" ||
+		recommendedAction["url"] != "https://example.com/provider/billing/plan" ||
 		quotaGateResult["outcome"] != "blocked" ||
 		quotaGateResult["reason"] != "includedQuotaExhausted" ||
 		details["mem9Code"] != "runtime_quota_denied" {
@@ -49,17 +53,69 @@ func TestNormalizeRuntimeQuotaDeniedBodyPreservesConsoleDetails(t *testing.T) {
 			t.Fatalf("legacy flat action field %q should be absent: %#v", key, details)
 		}
 	}
+	if _, ok := recommendedAction["bindingState"]; ok {
+		t.Fatalf("legacy bindingState should be absent from action: %#v", recommendedAction)
+	}
 }
 
-func TestNormalizeRuntimeQuotaDeniedBodyMovesLegacyMem9Code(t *testing.T) {
-	body := normalizeRuntimeQuotaDeniedBody([]byte(`{
-		"code":"quota_exhausted",
-		"message":"Included quota is exhausted.",
-		"retryable":false,
-		"mem9_code":"runtime_quota_denied"
-	}`))
+func TestNormalizeRuntimeQuotaErrorBodyCanonicalizesLegacyFlatAction(t *testing.T) {
+	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
+			"code":"spending_limit_exceeded",
+			"message":"Spending limit reached.",
+			"details":{
+				"retryable":false,
+				"meter":"memory_write_requests",
+				"upgradeAction":"increaseSpendingLimit",
+				"upgradeUrl":"https://example.com/provider/spending-limit"
+			}
+		}`))
 
-	got := decodeRuntimeQuotaDeniedBody(t, body)
+	got := decodeRuntimeQuotaErrorBody(t, body)
+	details := got["details"].(map[string]any)
+	recommendedAction := details["recommendedAction"].(map[string]any)
+	if recommendedAction["type"] != "openUrl" ||
+		recommendedAction["providerActionCode"] != "increaseSpendingLimit" ||
+		recommendedAction["url"] != "https://example.com/provider/spending-limit" {
+		t.Fatalf("unexpected recommended action: %#v", recommendedAction)
+	}
+	for _, key := range []string{"upgradeAction", "upgradeUrl"} {
+		if _, ok := details[key]; ok {
+			t.Fatalf("legacy flat action field %q should be absent: %#v", key, details)
+		}
+	}
+}
+
+func TestNormalizeRuntimeQuotaErrorBodyDoesNotSynthesizeActionURL(t *testing.T) {
+	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
+			"code":"runtime_access_blocked",
+			"message":"Runtime access is blocked.",
+			"details":{
+				"recommendedAction":{
+					"type":"claimApiKey"
+				}
+			}
+		}`))
+
+	got := decodeRuntimeQuotaErrorBody(t, body)
+	details := got["details"].(map[string]any)
+	recommendedAction := details["recommendedAction"].(map[string]any)
+	if recommendedAction["type"] != "openUrl" || recommendedAction["providerActionCode"] != "claimApiKey" {
+		t.Fatalf("unexpected recommended action: %#v", recommendedAction)
+	}
+	if _, ok := recommendedAction["url"]; ok {
+		t.Fatalf("url should only be present when supplied: %#v", recommendedAction)
+	}
+}
+
+func TestNormalizeRuntimeQuotaErrorBodyMovesLegacyMem9Code(t *testing.T) {
+	body := normalizeRuntimeQuotaErrorBody(http.StatusPaymentRequired, []byte(`{
+			"code":"quota_exhausted",
+			"message":"Included quota is exhausted.",
+			"retryable":false,
+		"mem9_code":"runtime_quota_denied"
+		}`))
+
+	got := decodeRuntimeQuotaErrorBody(t, body)
 	if _, ok := got["mem9_code"]; ok {
 		t.Fatalf("mem9_code should live under details: %#v", got)
 	}
@@ -69,20 +125,81 @@ func TestNormalizeRuntimeQuotaDeniedBodyMovesLegacyMem9Code(t *testing.T) {
 	}
 }
 
-func TestNormalizeRuntimeQuotaDeniedBodyUsesFallback(t *testing.T) {
-	body := normalizeRuntimeQuotaDeniedBody(nil)
-
-	got := decodeRuntimeQuotaDeniedBody(t, body)
-	if got["code"] != "runtime_quota_denied" || got["message"] != "runtime usage quota denied" {
-		t.Fatalf("unexpected fallback envelope: %#v", got)
+func TestNormalizeRuntimeQuotaErrorBodyUsesFallbackByStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    int
+		body      []byte
+		code      string
+		message   string
+		retryable bool
+	}{
+		{
+			name:      "runtime access blocked",
+			status:    http.StatusPaymentRequired,
+			code:      "runtime_access_blocked",
+			message:   "Runtime access is blocked.",
+			retryable: false,
+		},
+		{
+			name:      "post quota rate limited",
+			status:    http.StatusTooManyRequests,
+			body:      []byte("not-json"),
+			code:      "post_quota_rate_limited",
+			message:   "Post-quota rate limit exceeded.",
+			retryable: true,
+		},
 	}
-	details := got["details"].(map[string]any)
-	if details["retryable"] != false || details["mem9Code"] != "runtime_quota_denied" {
-		t.Fatalf("unexpected fallback details: %#v", details)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := normalizeRuntimeQuotaErrorBody(tt.status, tt.body)
+
+			got := decodeRuntimeQuotaErrorBody(t, body)
+			if got["code"] != tt.code || got["message"] != tt.message {
+				t.Fatalf("unexpected fallback envelope: %#v", got)
+			}
+			details := got["details"].(map[string]any)
+			if details["retryable"] != tt.retryable || details["mem9Code"] != "runtime_quota_denied" {
+				t.Fatalf("unexpected fallback details: %#v", details)
+			}
+		})
 	}
 }
 
-func decodeRuntimeQuotaDeniedBody(t *testing.T, body []byte) map[string]any {
+func TestHandleRuntimeUsageErrorReturnsPostQuotaRateLimit(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	server := &Server{}
+	server.handleRuntimeUsageError(recorder, &runtimeusage.QuotaDeniedError{
+		StatusCode: http.StatusTooManyRequests,
+		RetryAfter: "20",
+		Body: []byte(`{
+			"code":"post_quota_rate_limited",
+			"message":"Post-quota rate limit exceeded.",
+			"details":{
+				"meter":"memory_recall_requests"
+			}
+		}`),
+	})
+
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", recorder.Code)
+	}
+	if got := recorder.Header().Get("Retry-After"); got != "20" {
+		t.Fatalf("Retry-After = %q, want 20", got)
+	}
+	got := decodeRuntimeQuotaErrorBody(t, recorder.Body.Bytes())
+	if got["code"] != "post_quota_rate_limited" || got["message"] != "Post-quota rate limit exceeded." {
+		t.Fatalf("unexpected envelope: %#v", got)
+	}
+	details := got["details"].(map[string]any)
+	if details["retryable"] != true ||
+		details["mem9Code"] != "runtime_quota_denied" ||
+		details["meter"] != "memory_recall_requests" {
+		t.Fatalf("unexpected details: %#v", details)
+	}
+}
+
+func decodeRuntimeQuotaErrorBody(t *testing.T, body []byte) map[string]any {
 	t.Helper()
 	var got map[string]any
 	if err := json.Unmarshal(body, &got); err != nil {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -34,7 +34,7 @@ func (c *HTTPClient) Reserve(ctx context.Context, subject Subject, operationID s
 		"units": op.Units,
 	}
 	var reservation Reservation
-	if err := c.doJSON(ctx, http.MethodPut, "/api/internal/quota/reservations/"+operationID, subject, body, &reservation); err != nil {
+	if err := c.doJSON(ctx, http.MethodPut, "/api/internal/quota/reservations/"+operationID, subject, body, &reservation, true); err != nil {
 		return nil, err
 	}
 	return &reservation, nil
@@ -47,10 +47,10 @@ func (c *HTTPClient) FinalizeReservation(ctx context.Context, subject Subject, o
 	if reason != "" {
 		body["reason"] = reason
 	}
-	return c.doJSON(ctx, http.MethodPatch, "/api/internal/quota/reservations/"+operationID, subject, body, nil)
+	return c.doJSON(ctx, http.MethodPatch, "/api/internal/quota/reservations/"+operationID, subject, body, nil, false)
 }
 
-func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Subject, body any, out any) error {
+func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Subject, body any, out any, classifyQuotaStatuses bool) error {
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("runtime usage marshal request: %w", err)
@@ -70,7 +70,7 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 
-	if resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests {
+	if classifyQuotaStatuses && (resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests) {
 		return &QuotaDeniedError{
 			StatusCode: resp.StatusCode,
 			Body:       respBody,

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -94,14 +94,15 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 func isRuntimeQuotaDenialResponse(status int, body []byte) bool {
 	switch status {
 	case http.StatusPaymentRequired:
+		return true
 	case http.StatusTooManyRequests:
 	default:
 		return false
 	}
 
 	// Reservation providers return code/message/details envelopes. Code values
-	// are provider-defined, so classification uses the required envelope plus
-	// quota detail shape rather than provider-specific code strings.
+	// are provider-defined, so 429 classification uses the required envelope
+	// plus quota detail shape rather than provider-specific code strings.
 	var envelope struct {
 		Code    string         `json:"code"`
 		Message string         `json:"message"`

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -70,8 +70,12 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 
-	if resp.StatusCode == http.StatusPaymentRequired {
-		return &QuotaDeniedError{StatusCode: resp.StatusCode, Body: respBody}
+	if resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests {
+		return &QuotaDeniedError{
+			StatusCode: resp.StatusCode,
+			Body:       respBody,
+			RetryAfter: strings.TrimSpace(resp.Header.Get("Retry-After")),
+		}
 	}
 	if resp.StatusCode == http.StatusConflict {
 		return &ConflictError{StatusCode: resp.StatusCode, Body: respBody}

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -70,7 +70,7 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	defer resp.Body.Close()
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 
-	if classifyQuotaStatuses && (resp.StatusCode == http.StatusPaymentRequired || resp.StatusCode == http.StatusTooManyRequests) {
+	if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
 		return &QuotaDeniedError{
 			StatusCode: resp.StatusCode,
 			Body:       respBody,
@@ -89,4 +89,47 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		}
 	}
 	return nil
+}
+
+func isRuntimeQuotaDenialResponse(status int, body []byte) bool {
+	switch status {
+	case http.StatusPaymentRequired:
+	case http.StatusTooManyRequests:
+	default:
+		return false
+	}
+
+	// Reservation providers return code/message/details envelopes. Code values
+	// are provider-defined, so classification uses the required envelope plus
+	// quota detail shape rather than provider-specific code strings.
+	var envelope struct {
+		Code    string         `json:"code"`
+		Message string         `json:"message"`
+		Details map[string]any `json:"details"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return false
+	}
+	if strings.TrimSpace(envelope.Code) == "" || strings.TrimSpace(envelope.Message) == "" {
+		return false
+	}
+	if !hasRuntimeQuotaString(envelope.Details, "meter") {
+		return false
+	}
+	gateResult, ok := envelope.Details["quotaGateResult"].(map[string]any)
+	if !ok {
+		return false
+	}
+	if !hasRuntimeQuotaString(gateResult, "outcome") {
+		return false
+	}
+	if !hasRuntimeQuotaString(gateResult, "reason") {
+		return false
+	}
+	return true
+}
+
+func hasRuntimeQuotaString(fields map[string]any, name string) bool {
+	value, ok := fields[name].(string)
+	return ok && strings.TrimSpace(value) != ""
 }

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -131,6 +131,29 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 	}
 }
 
+func TestHTTPClientFinalizeReservationTreatsRateLimitAsUnavailable(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPatch {
+			t.Fatalf("method = %s, want PATCH", req.Method)
+		}
+		if req.URL.Path != "/api/internal/quota/reservations/op-finalize" {
+			t.Fatalf("path = %s", req.URL.Path)
+		}
+		return statusJSONResponse(http.StatusTooManyRequests, `{"error":"rate limited"}`, http.Header{"Retry-After": []string{"20"}}), nil
+	})}
+
+	err := client.FinalizeReservation(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-finalize", ReservationStatusCommitted, reservationCommitReason)
+	var denied *QuotaDeniedError
+	if errors.As(err, &denied) {
+		t.Fatalf("FinalizeReservation error = %T, want non-quota finalization failure", err)
+	}
+	var unavailable *UnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("FinalizeReservation error = %T, want UnavailableError", err)
+	}
+}
+
 func jsonResponse(body string) *http.Response {
 	return statusJSONResponse(http.StatusOK, body, http.Header{"Content-Type": []string{"application/json"}})
 }

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -97,6 +97,16 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 			body:   `{"code":"provider_runtime_blocked","message":"Runtime access is blocked.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"blocked","mode":"includedQuota","reason":"includedQuotaExhausted"}}}`,
 		},
 		{
+			name:   "payment required legacy body",
+			status: http.StatusPaymentRequired,
+			body:   `{"error":"quota exhausted"}`,
+		},
+		{
+			name:   "payment required empty body",
+			status: http.StatusPaymentRequired,
+			body:   ``,
+		},
+		{
 			name:       "post quota rate limit",
 			status:     http.StatusTooManyRequests,
 			body:       `{"code":"provider_post_quota_throttled","message":"Post-quota rate limit exceeded.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`,
@@ -124,7 +134,11 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 			if denied.RetryAfter != tt.retryAfter {
 				t.Fatalf("RetryAfter = %q, want %q", denied.RetryAfter, tt.retryAfter)
 			}
-			if string(denied.ResponseBody()) != tt.body {
+			if tt.body == "" {
+				if !strings.Contains(string(denied.ResponseBody()), "Runtime access is blocked.") {
+					t.Fatalf("ResponseBody() = %s, want fallback runtime access message", denied.ResponseBody())
+				}
+			} else if string(denied.ResponseBody()) != tt.body {
 				t.Fatalf("ResponseBody() = %s, want %s", denied.ResponseBody(), tt.body)
 			}
 		})

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -94,12 +94,12 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 		{
 			name:   "payment required",
 			status: http.StatusPaymentRequired,
-			body:   `{"code":"runtime_access_blocked","message":"Runtime access is blocked."}`,
+			body:   `{"code":"provider_runtime_blocked","message":"Runtime access is blocked.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"blocked","mode":"includedQuota","reason":"includedQuotaExhausted"}}}`,
 		},
 		{
 			name:       "post quota rate limit",
 			status:     http.StatusTooManyRequests,
-			body:       `{"code":"post_quota_rate_limited","message":"Post-quota rate limit exceeded."}`,
+			body:       `{"code":"provider_post_quota_throttled","message":"Post-quota rate limit exceeded.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`,
 			retryAfter: "20",
 		},
 	}
@@ -126,6 +126,57 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 			}
 			if string(denied.ResponseBody()) != tt.body {
 				t.Fatalf("ResponseBody() = %s, want %s", denied.ResponseBody(), tt.body)
+			}
+		})
+	}
+}
+
+func TestHTTPClientReserveTreatsGenericRateLimitAsUnavailable(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		header http.Header
+	}{
+		{
+			name: "gateway rate limit",
+			body: `{"error":"rate limited"}`,
+		},
+		{
+			name: "empty body",
+			body: ``,
+		},
+		{
+			name: "invalid json",
+			body: `{`,
+		},
+		{
+			name:   "quota-like code without quota details",
+			body:   `{"code":"post_quota_rate_limited","message":"rate limited","details":{"retryable":true}}`,
+			header: http.Header{"Retry-After": []string{"20"}},
+		},
+		{
+			name: "quota details without message",
+			body: `{"code":"provider_post_quota_throttled","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","reason":"postQuotaRateLimitExceeded"}}}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return statusJSONResponse(http.StatusTooManyRequests, tt.body, tt.header), nil
+			})}
+
+			_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-rate-limited", Operation{
+				Meter: MeterMemoryRecallRequests,
+				Units: 1,
+			})
+			var denied *QuotaDeniedError
+			if errors.As(err, &denied) {
+				t.Fatalf("Reserve error = %T, want non-quota unavailable failure", err)
+			}
+			var unavailable *UnavailableError
+			if !errors.As(err, &unavailable) {
+				t.Fatalf("Reserve error = %T, want UnavailableError", err)
 			}
 		})
 	}

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -3,6 +3,7 @@ package runtimeusage
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -83,10 +84,67 @@ func TestHTTPClientReserveDecodesRemainingIncludedUnits(t *testing.T) {
 	}
 }
 
+func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		retryAfter string
+	}{
+		{
+			name:   "payment required",
+			status: http.StatusPaymentRequired,
+			body:   `{"code":"runtime_access_blocked","message":"Runtime access is blocked."}`,
+		},
+		{
+			name:       "post quota rate limit",
+			status:     http.StatusTooManyRequests,
+			body:       `{"code":"post_quota_rate_limited","message":"Post-quota rate limit exceeded."}`,
+			retryAfter: "20",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return statusJSONResponse(tt.status, tt.body, http.Header{"Retry-After": []string{tt.retryAfter}}), nil
+			})}
+
+			_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-denied", Operation{
+				Meter: MeterMemoryRecallRequests,
+				Units: 1,
+			})
+			var denied *QuotaDeniedError
+			if !errors.As(err, &denied) {
+				t.Fatalf("Reserve error = %T, want QuotaDeniedError", err)
+			}
+			if denied.Status() != tt.status {
+				t.Fatalf("Status() = %d, want %d", denied.Status(), tt.status)
+			}
+			if denied.RetryAfter != tt.retryAfter {
+				t.Fatalf("RetryAfter = %q, want %q", denied.RetryAfter, tt.retryAfter)
+			}
+			if string(denied.ResponseBody()) != tt.body {
+				t.Fatalf("ResponseBody() = %s, want %s", denied.ResponseBody(), tt.body)
+			}
+		})
+	}
+}
+
 func jsonResponse(body string) *http.Response {
+	return statusJSONResponse(http.StatusOK, body, http.Header{"Content-Type": []string{"application/json"}})
+}
+
+func statusJSONResponse(status int, body string, header http.Header) *http.Response {
+	if header == nil {
+		header = make(http.Header)
+	}
+	if header.Get("Content-Type") == "" {
+		header.Set("Content-Type", "application/json")
+	}
 	return &http.Response{
-		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		StatusCode: status,
+		Header:     header,
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -150,7 +150,7 @@ func (e *QuotaDeniedError) ResponseBody() []byte {
 		body, _ := json.Marshal(map[string]any{
 			"error": defaultQuotaDeniedMessage(e.Status()),
 			"details": map[string]any{
-				"mem9Category": "runtime_quota_denied",
+				"errorCategory": "runtime_quota_denied",
 			},
 		})
 		return body

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -148,11 +148,11 @@ func (e *QuotaDeniedError) Error() string {
 func (e *QuotaDeniedError) ResponseBody() []byte {
 	if len(e.Body) == 0 {
 		body, _ := json.Marshal(map[string]any{
-			"code":    defaultQuotaDeniedCode(e.Status()),
-			"message": defaultQuotaDeniedMessage(e.Status()),
+			"error": defaultQuotaDeniedMessage(e.Status()),
 			"details": map[string]any{
-				"retryable": defaultQuotaDeniedRetryable(e.Status()),
-				"mem9Code":  "runtime_quota_denied",
+				"runtimeQuota": map[string]any{
+					"category": "runtime_quota_denied",
+				},
 			},
 		})
 		return body
@@ -167,22 +167,11 @@ func (e *QuotaDeniedError) Status() int {
 	return http.StatusPaymentRequired
 }
 
-func defaultQuotaDeniedCode(status int) string {
-	if status == http.StatusTooManyRequests {
-		return "post_quota_rate_limited"
-	}
-	return "runtime_access_blocked"
-}
-
 func defaultQuotaDeniedMessage(status int) string {
 	if status == http.StatusTooManyRequests {
 		return "Post-quota rate limit exceeded."
 	}
 	return "Runtime access is blocked."
-}
-
-func defaultQuotaDeniedRetryable(status int) bool {
-	return status == http.StatusTooManyRequests
 }
 
 type UnavailableError struct {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -150,9 +150,7 @@ func (e *QuotaDeniedError) ResponseBody() []byte {
 		body, _ := json.Marshal(map[string]any{
 			"error": defaultQuotaDeniedMessage(e.Status()),
 			"details": map[string]any{
-				"runtimeQuota": map[string]any{
-					"category": "runtime_quota_denied",
-				},
+				"mem9Category": "runtime_quota_denied",
 			},
 		})
 		return body

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -138,6 +138,7 @@ type QuotaClient interface {
 type QuotaDeniedError struct {
 	StatusCode int
 	Body       []byte
+	RetryAfter string
 }
 
 func (e *QuotaDeniedError) Error() string {
@@ -147,13 +148,41 @@ func (e *QuotaDeniedError) Error() string {
 func (e *QuotaDeniedError) ResponseBody() []byte {
 	if len(e.Body) == 0 {
 		body, _ := json.Marshal(map[string]any{
-			"code":      "runtime_quota_denied",
-			"message":   "runtime usage quota denied",
-			"retryable": false,
+			"code":    defaultQuotaDeniedCode(e.Status()),
+			"message": defaultQuotaDeniedMessage(e.Status()),
+			"details": map[string]any{
+				"retryable": defaultQuotaDeniedRetryable(e.Status()),
+				"mem9Code":  "runtime_quota_denied",
+			},
 		})
 		return body
 	}
 	return append([]byte(nil), e.Body...)
+}
+
+func (e *QuotaDeniedError) Status() int {
+	if e != nil && e.StatusCode == http.StatusTooManyRequests {
+		return http.StatusTooManyRequests
+	}
+	return http.StatusPaymentRequired
+}
+
+func defaultQuotaDeniedCode(status int) string {
+	if status == http.StatusTooManyRequests {
+		return "post_quota_rate_limited"
+	}
+	return "runtime_access_blocked"
+}
+
+func defaultQuotaDeniedMessage(status int) string {
+	if status == http.StatusTooManyRequests {
+		return "Post-quota rate limit exceeded."
+	}
+	return "Runtime access is blocked."
+}
+
+func defaultQuotaDeniedRetryable(status int) bool {
+	return status == http.StatusTooManyRequests
 }
 
 type UnavailableError struct {
@@ -183,7 +212,7 @@ func (e *ConflictError) Error() string {
 func HTTPStatus(err error) int {
 	var denied *QuotaDeniedError
 	if errors.As(err, &denied) {
-		return http.StatusPaymentRequired
+		return denied.Status()
 	}
 	var conflict *ConflictError
 	if errors.As(err, &conflict) {


### PR DESCRIPTION
## Summary

- classify runtime usage reservation `402` responses and quota-shaped reservation `429` responses as quota outcomes in mem9 server
- normalize public memory-route quota responses so they keep the shared `{ "error": string }` outer shape
- document runtime quota error classification under `details.errorCategory`, public runtime quota fields under `details.runtimeQuota` when available from provider details, and `Retry-After` on runtime quota `429`

Closes #382.

## Why This Is Separate

This PR establishes the server contract first so plugin-specific parser and UX work can rebase onto a stable public API. It keeps the runtime quota error category in `details.errorCategory` and provider business semantics behind `details.runtimeQuota` fields such as `quotaGateResult.reason`, `recommendedAction.providerActionCode`, `RuntimeMeter`, and post-quota rate-limit `scope`.

## Public Contract

- `402` is a blocking runtime access outcome.
- `429` on memory routes can be either the existing generic API rate limit or a temporary runtime quota rate limit.
- All quota errors keep the existing shared top-level `error` field used by other mem9 server errors.
- `details.errorCategory=runtime_quota_denied` is the stable runtime quota error classifier.
- Public runtime quota fields, when available from provider details, are namespaced under `details.runtimeQuota`.
- Clients can branch on `details.errorCategory`; when `details.runtimeQuota` is present, they can parse the typed quota payload there.
- Provider reason/action fields remain opaque provider hints.
- `recommendedAction.providerActionCode` is provider-defined. The official/reference runtime usage provider currently emits `claimApiKey`, `upgradePlan`, `enableOnDemand`, `increaseSpendingLimit`, and `resolveAccountState`; clients may recognize those values while treating any other value as an opaque hint.
- `details.runtimeQuota.quotaGateResult.mode` and `reason` are documented as provider-defined, without mem9 enums.
- `Retry-After` is forwarded on public runtime quota `429` responses when the runtime usage provider supplies it.

## Compatibility

- Provider runtime quota responses must include `code`, `message`, and `details`; `code` values remain provider-defined. The official/reference runtime usage provider currently emits `runtime_access_blocked` for `402` and `post_quota_rate_limited` for `429`.
- Provider `message` becomes the public `error`.
- Status-derived fallback messages apply only after a response has already been classified as `QuotaDeniedError`; malformed reservation `402` responses stay on the quota-denial path, while malformed reservation `429` bodies and reservation `429` bodies without quota detail shape stay on the runtime-usage availability path.
- Provider reservation `details.meter`, `details.recommendedAction` values that match the public action schema, and `details.quotaGateResult` are assembled under public `details.runtimeQuota` after the provider response satisfies the reservation quota contract. Malformed reservation `402` responses still block, with `details.runtimeQuota` omitted.
- Provider `code` remains internal/provider metadata and is not emitted in the public envelope.
- Provider-supplied URLs are preserved when present under `details.recommendedAction.url`; the server does not synthesize action URLs.
- Runtime quota-denial classification is scoped to all reservation `402` responses and reservation `429` responses with quota detail shape: `details.meter` plus `details.quotaGateResult.outcome` and `reason`.
- Generic reservation `429` responses remain runtime-usage availability failures, so fail-open policy can treat dependency throttling as unavailable.
- Finalization failures remain finalization/runtime-usage availability errors after the user operation has succeeded.

## OpenAPI

- Adds `RuntimeAccessBlocked` and `PostQuotaRateLimited` responses based on the shared `ErrorResponse` outer shape.
- Adds `MemoryRouteRateLimited` for memory route `429` responses, with `anyOf` covering generic API rate limits and runtime quota metadata.
- Keeps get-by-id routes on their existing non-runtime-quota behavior.
- Adds focused OpenAPI contract tests for route refs and schema constraints.

## Validation

- `git diff --check`
- `node -e 'const fs=require("fs"); JSON.parse(fs.readFileSync("docs/api/openapi.json","utf8")); console.log("openapi json ok")'`
- `go test -count=1 ./internal/runtimeusage ./internal/handler` from `server/`

## Follow-up

The plugin runtime quota PR should rebase after this lands and consume the server contract for parser/UX behavior.
