### PR TITLE
chore(plugins): add npm publish workflows

### DIFF
--- a/.github/workflows/publish-openclaw-plugin.yml
+++ b/.github/workflows/publish-openclaw-plugin.yml
@@ -39,6 +39,29 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
+      - name: Resolve npm dist tag
+        id: npm-tag
+        run: |
+          set -euo pipefail
+          version="${{ steps.package.outputs.version }}"
+          tag="latest"
+          case "${version}" in
+            *-alpha|*-alpha.*)
+              tag="alpha"
+              ;;
+            *-beta|*-beta.*)
+              tag="beta"
+              ;;
+            *-rc|*-rc.*)
+              tag="rc"
+              ;;
+            *-*)
+              echo "::error::Unsupported prerelease channel in ${version}; use alpha, beta, or rc."
+              exit 1
+              ;;
+          esac
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Check npm token
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -77,4 +100,4 @@ jobs:
         working-directory: openclaw-plugin
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --tag "${{ steps.npm-tag.outputs.tag }}"

--- a/.github/workflows/publish-openclaw-plugin.yml
+++ b/.github/workflows/publish-openclaw-plugin.yml
@@ -41,26 +41,31 @@ jobs:
 
       - name: Resolve npm dist tag
         id: npm-tag
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.package.outputs.version }}"
-          tag="latest"
-          case "${version}" in
-            *-alpha|*-alpha.*)
-              tag="alpha"
-              ;;
-            *-beta|*-beta.*)
-              tag="beta"
-              ;;
-            *-rc|*-rc.*)
-              tag="rc"
-              ;;
-            *-*)
-              echo "::error::Unsupported prerelease channel in ${version}; use alpha, beta, or rc."
-              exit 1
-              ;;
-          esac
-          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const version = process.env.PACKAGE_VERSION ?? "";
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+)(?:\.\d+)?)?$/.exec(version);
+
+          if (!match) {
+            console.error(`::error::Unsupported package version format: ${version}`);
+            process.exit(1);
+          }
+
+          const channel = match[4];
+          const tag = channel ?? "latest";
+          if (!["latest", "alpha", "beta", "rc"].includes(tag)) {
+            console.error(`::error::Unsupported prerelease channel in ${version}; use alpha, beta, or rc.`);
+            process.exit(1);
+          }
+
+          fs.appendFileSync(outputPath, `tag=${tag}\n`);
+          NODE
 
       - name: Check npm token
         env:

--- a/.github/workflows/publish-openclaw-plugin.yml
+++ b/.github/workflows/publish-openclaw-plugin.yml
@@ -1,0 +1,80 @@
+name: Publish OpenClaw plugin
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @mem9/mem9
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require main branch
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::Run this workflow from main."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Read package version
+        id: package
+        working-directory: openclaw-plugin
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check npm token
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::Missing NPM_TOKEN repository secret."
+            exit 1
+          fi
+
+      - name: Check package version is unpublished
+        run: |
+          set -euo pipefail
+          if npm view "@mem9/mem9@${{ steps.package.outputs.version }}" version >/dev/null 2>&1; then
+            echo "::error::@mem9/mem9@${{ steps.package.outputs.version }} already exists on npm."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: openclaw-plugin
+        run: npm install --no-audit --no-fund
+
+      - name: Run tests
+        working-directory: openclaw-plugin
+        run: npm test
+
+      - name: Typecheck
+        working-directory: openclaw-plugin
+        run: npm run typecheck
+
+      - name: Pack check
+        working-directory: openclaw-plugin
+        run: npm pack --dry-run
+
+      - name: Publish
+        working-directory: openclaw-plugin
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/.github/workflows/publish-openclaw-plugin.yml
+++ b/.github/workflows/publish-openclaw-plugin.yml
@@ -26,9 +26,9 @@ jobs:
           ref: main
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Read package version

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -27,9 +27,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -1,0 +1,87 @@
+name: Publish OpenCode plugin
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @mem9/opencode
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require main branch
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::Run this workflow from main."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Use local main branch
+        run: git switch -C main origin/main
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Read package version
+        id: package
+        working-directory: opencode-plugin
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('./package.json').version")"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check npm token
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NPM_TOKEN}" ]; then
+            echo "::error::Missing NPM_TOKEN repository secret."
+            exit 1
+          fi
+
+      - name: Check package version is unpublished
+        run: |
+          set -euo pipefail
+          if npm view "@mem9/opencode@${{ steps.package.outputs.version }}" version >/dev/null 2>&1; then
+            echo "::error::@mem9/opencode@${{ steps.package.outputs.version }} already exists on npm."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: opencode-plugin
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare npm publish token
+        working-directory: opencode-plugin
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf 'NPM_ACCESSTOKEN=%s\n' "${NPM_TOKEN}" > .publish.env
+
+      - name: Publish
+        working-directory: opencode-plugin
+        run: pnpm run publish:release current
+
+      - name: Clean publish token file
+        if: always()
+        working-directory: opencode-plugin
+        run: rm -f .publish.env

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -44,6 +44,29 @@ jobs:
           version="$(node -p "require('./package.json').version")"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
+      - name: Resolve npm dist tag
+        id: npm-tag
+        run: |
+          set -euo pipefail
+          version="${{ steps.package.outputs.version }}"
+          tag="latest"
+          case "${version}" in
+            *-alpha|*-alpha.*)
+              tag="alpha"
+              ;;
+            *-beta|*-beta.*)
+              tag="beta"
+              ;;
+            *-rc|*-rc.*)
+              tag="rc"
+              ;;
+            *-*)
+              echo "::error::Unsupported prerelease channel in ${version}; use alpha, beta, or rc."
+              exit 1
+              ;;
+          esac
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
       - name: Check npm token
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -82,4 +105,4 @@ jobs:
         working-directory: opencode-plugin
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm publish --access public --tag latest --no-git-checks
+        run: pnpm publish --access public --tag "${{ steps.npm-tag.outputs.tag }}" --no-git-checks

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -26,9 +26,6 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Use local main branch
-        run: git switch -C main origin/main
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -79,7 +76,7 @@ jobs:
 
       - name: Publish
         working-directory: opencode-plugin
-        run: pnpm run publish:release current
+        run: pnpm run publish:release current --skip-branch-check
 
       - name: Clean publish token file
         if: always()

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -66,19 +66,20 @@ jobs:
         working-directory: opencode-plugin
         run: pnpm install --frozen-lockfile
 
-      - name: Prepare npm publish token
+      - name: Run tests
         working-directory: opencode-plugin
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          set -euo pipefail
-          printf 'NPM_ACCESSTOKEN=%s\n' "${NPM_TOKEN}" > .publish.env
+        run: pnpm test
+
+      - name: Typecheck
+        working-directory: opencode-plugin
+        run: pnpm run typecheck
+
+      - name: Pack check
+        working-directory: opencode-plugin
+        run: pnpm run pack:check
 
       - name: Publish
         working-directory: opencode-plugin
-        run: pnpm run publish:release current --skip-branch-check
-
-      - name: Clean publish token file
-        if: always()
-        working-directory: opencode-plugin
-        run: rm -f .publish.env
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --tag latest --no-git-checks

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
+          registry-url: "https://registry.npmjs.org"
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/publish-opencode-plugin.yml
+++ b/.github/workflows/publish-opencode-plugin.yml
@@ -46,26 +46,31 @@ jobs:
 
       - name: Resolve npm dist tag
         id: npm-tag
+        env:
+          PACKAGE_VERSION: ${{ steps.package.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ steps.package.outputs.version }}"
-          tag="latest"
-          case "${version}" in
-            *-alpha|*-alpha.*)
-              tag="alpha"
-              ;;
-            *-beta|*-beta.*)
-              tag="beta"
-              ;;
-            *-rc|*-rc.*)
-              tag="rc"
-              ;;
-            *-*)
-              echo "::error::Unsupported prerelease channel in ${version}; use alpha, beta, or rc."
-              exit 1
-              ;;
-          esac
-          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+          node <<'NODE'
+          const fs = require("node:fs");
+
+          const version = process.env.PACKAGE_VERSION ?? "";
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+)(?:\.\d+)?)?$/.exec(version);
+
+          if (!match) {
+            console.error(`::error::Unsupported package version format: ${version}`);
+            process.exit(1);
+          }
+
+          const channel = match[4];
+          const tag = channel ?? "latest";
+          if (!["latest", "alpha", "beta", "rc"].includes(tag)) {
+            console.error(`::error::Unsupported prerelease channel in ${version}; use alpha, beta, or rc.`);
+            process.exit(1);
+          }
+
+          fs.appendFileSync(outputPath, `tag=${tag}\n`);
+          NODE
 
       - name: Check npm token
         env:

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/mem9",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "OpenClaw shared memory plugin — cloud-persistent memory with hybrid vector + keyword search via mnemo-server",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What Changed

- Added a manual `Publish OpenClaw plugin` workflow for `@mem9/mem9`.
- Added a manual `Publish OpenCode plugin` workflow for `@mem9/opencode`.
- Bumped `openclaw-plugin/package.json` from `0.4.12` to `0.4.13`, because `@mem9/mem9@0.4.12` already exists on npm and npm versions cannot be republished.

## Release Model

Both workflows are `workflow_dispatch` only and require running from `main`. The package version is read from the checked-out `main` branch, so publishing happens from the source that was reviewed and merged.

Both workflows derive the npm dist-tag from the package version before publishing:

- stable versions publish with `latest`
- `-alpha` / `-alpha.N` versions publish with `alpha`
- `-beta` / `-beta.N` versions publish with `beta`
- `-rc` / `-rc.N` versions publish with `rc`
- any other prerelease channel fails before publish

### OpenClaw

The OpenClaw workflow:

1. reads `openclaw-plugin/package.json`
2. resolves the npm dist-tag from the package version
3. verifies `@mem9/mem9@0.4.13` is not already on npm
4. installs dependencies in the workflow runner
5. runs `npm test`, `npm run typecheck`, and `npm pack --dry-run`
6. publishes with `npm publish --access public --tag <resolved-tag>`

### OpenCode

The OpenCode workflow:

1. reads `opencode-plugin/package.json`
2. resolves the npm dist-tag from the package version
3. verifies `@mem9/opencode@0.1.4` is not already on npm
4. installs dependencies with `pnpm install --frozen-lockfile`
5. runs `pnpm test`, `pnpm run typecheck`, and `pnpm run pack:check`
6. publishes with `pnpm publish --access public --tag <resolved-tag> --no-git-checks`

## Required Secret

- `NPM_TOKEN`: npm token with publish permission for the `@mem9` scope packages `@mem9/mem9` and `@mem9/opencode`.

`NPM_TOKEN` is the GitHub Actions secret name used by both workflows through `NODE_AUTH_TOKEN`.

## Validation

- Parsed both workflow YAML files locally with Ruby YAML.
- Ran `git diff --check`.
- Confirmed `@mem9/mem9@0.4.13` is missing from npm.
- Confirmed `@mem9/opencode@0.1.4` is missing from npm.

I did not run `npm install`, `pnpm install`, `npm publish`, or `pnpm publish` locally.