### PR TITLE
feat: add runtime state API

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MNEMO_RUNTIME_USAGE_ENABLED` | No | `false` | Enable runtime usage quota gating and console metering for memory recall/write operations |
+| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | `mem9-official` when runtime usage is enabled | Runtime usage provider discriminator returned with object-shaped `providerData` in runtime-state responses |
 | `MNEMO_RUNTIME_USAGE_BASE_URL` | Yes when enabled | — | Runtime usage service base URL. Must be `http` or `https`; query and fragment are rejected |
 | `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Yes when enabled | — | Bearer token for internal runtime usage service calls |
 | `MNEMO_RUNTIME_USAGE_TIMEOUT` | No | `3s` | Timeout for quota reservation and finalization requests |

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -621,6 +621,52 @@
         }
       }
     },
+    "/v1alpha2/mem9s/runtime-state": {
+      "get": {
+        "tags": [
+          "Runtime State v1alpha2"
+        ],
+        "operationId": "getRuntimeState",
+        "summary": "Get plugin-visible runtime quota state",
+        "description": "Returns runtime-state facts for agent plugins. Hosted deployments read provider state through the configured runtime usage provider. Provider-disabled self-host deployments return a local fallback response with the same public shape.",
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/XMnemoAgentId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RuntimeState"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
+          }
+        }
+      }
+    },
     "/v1alpha2/mem9s/memories": {
       "post": {
         "tags": [
@@ -2312,6 +2358,77 @@
           }
         }
       },
+      "RuntimeState": {
+        "description": "Plugin-visible runtime quota state. Provider-disabled deployments return the same shape with notMetered budgets.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RuntimeStateResponse"
+            },
+            "examples": {
+              "providerDisabled": {
+                "value": {
+                  "mem9ApiKey": {
+                    "status": "active"
+                  },
+                  "meters": [
+                    {
+                      "meter": "memory_recall_requests",
+                      "quotaGateResult": {
+                        "outcome": "allowed",
+                        "mode": "notMetered",
+                        "reason": "runtimeUsageDisabled"
+                      },
+                      "budgets": [
+                        {
+                          "type": "notMetered",
+                          "state": "unlimited",
+                          "measure": {
+                            "kind": "count",
+                            "quantity": "request",
+                            "scale": 1
+                          },
+                          "period": {
+                            "type": "none"
+                          },
+                          "capacity": {
+                            "type": "unlimited"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "meter": "memory_write_requests",
+                      "quotaGateResult": {
+                        "outcome": "allowed",
+                        "mode": "notMetered",
+                        "reason": "runtimeUsageDisabled"
+                      },
+                      "budgets": [
+                        {
+                          "type": "notMetered",
+                          "state": "unlimited",
+                          "measure": {
+                            "kind": "count",
+                            "quantity": "request",
+                            "scale": 1
+                          },
+                          "period": {
+                            "type": "none"
+                          },
+                          "capacity": {
+                            "type": "unlimited"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "BadRequest": {
         "description": "Invalid request. For v1alpha2 API-key routes this also includes missing, invalid, or inactive X-API-Key values returned by the authentication middleware.",
         "content": {
@@ -2612,6 +2729,221 @@
             "$ref": "#/components/schemas/KeyStatus"
           }
         }
+      },
+      "RuntimeStateResponse": {
+        "type": "object",
+        "required": [
+          "mem9ApiKey",
+          "meters"
+        ],
+        "properties": {
+          "mem9ApiKey": {
+            "$ref": "#/components/schemas/RuntimeStateAPIKey"
+          },
+          "meters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuntimeStateMeter"
+            },
+            "minItems": 2
+          },
+          "recommendedAction": {
+            "$ref": "#/components/schemas/RuntimeRecommendedAction"
+          },
+          "providerData": {
+            "type": "object",
+            "description": "Optional hosted-provider details. Plugins can ignore this object unless they explicitly support provider-specific UI.",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStateAPIKey": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "inactive",
+              "unknown"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStateMeter": {
+        "type": "object",
+        "required": [
+          "meter",
+          "budgets"
+        ],
+        "properties": {
+          "meter": {
+            "$ref": "#/components/schemas/RuntimeMeter"
+          },
+          "quotaGateResult": {
+            "$ref": "#/components/schemas/RuntimeQuotaGateResult"
+          },
+          "budgets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuntimeStatusBudget"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStatusBudget": {
+        "type": "object",
+        "required": [
+          "type",
+          "state",
+          "measure",
+          "period",
+          "capacity"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "includedQuota",
+              "spendingLimit",
+              "credits",
+              "notMetered",
+              "unknown",
+              "providerManaged"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "ok",
+              "warning",
+              "exhausted",
+              "unlimited",
+              "unknown",
+              "providerManaged"
+            ]
+          },
+          "measure": {
+            "$ref": "#/components/schemas/RuntimeStatusMeasure"
+          },
+          "period": {
+            "$ref": "#/components/schemas/RuntimeStatusPeriod"
+          },
+          "capacity": {
+            "$ref": "#/components/schemas/RuntimeStatusCapacity"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/RuntimeStatusUsage"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStatusMeasure": {
+        "type": "object",
+        "required": [
+          "kind",
+          "quantity",
+          "scale"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "count",
+              "currency",
+              "unknown"
+            ]
+          },
+          "quantity": {
+            "type": "string",
+            "description": "Unit quantity, such as request, USD, or a provider-defined value."
+          },
+          "scale": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Raw values are expressed in this scale. For example, request uses scale 1 and USD cents use scale 100."
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStatusPeriod": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "calendarMonth",
+              "fixedWindow",
+              "none",
+              "unknown",
+              "providerManaged"
+            ]
+          },
+          "startAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Exclusive period end when known."
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStatusCapacity": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "limited",
+              "unlimited",
+              "unknown",
+              "providerManaged"
+            ]
+          },
+          "value": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeStatusUsage": {
+        "type": "object",
+        "properties": {
+          "used": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "remaining": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "percent": {
+            "type": "number",
+            "format": "double",
+            "minimum": 0,
+            "description": "Used percentage for limited budgets when the provider can compute it."
+          }
+        },
+        "additionalProperties": false
       },
       "StatusResponse": {
         "type": "object",

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -628,7 +628,7 @@
         ],
         "operationId": "getRuntimeState",
         "summary": "Get plugin-visible runtime quota state",
-        "description": "Returns runtime-state facts for agent plugins. Hosted deployments read provider state through the configured runtime usage provider. Provider-disabled self-host deployments return a local fallback response with the same public shape.",
+        "description": "Returns runtime-state facts for agent plugins. This route uses local API-key status resolution and does not depend on tenant data DB resolution. Hosted deployments read provider state through the configured runtime usage provider. Provider-disabled self-host deployments return a local fallback response with the same public shape.",
         "security": [
           {
             "ApiKeyAuth": []
@@ -2747,12 +2747,20 @@
             },
             "minItems": 2
           },
+          "providerId": {
+            "type": "string",
+            "description": "Optional provider discriminator for providerData. Clients should interpret providerData only when they recognize this value.",
+            "minLength": 1,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
+            "example": "mem9-official"
+          },
           "recommendedAction": {
             "$ref": "#/components/schemas/RuntimeRecommendedAction"
           },
           "providerData": {
             "type": "object",
-            "description": "Optional hosted-provider details. Plugins can ignore this object unless they explicitly support provider-specific UI.",
+            "description": "Optional hosted-provider details. Present only when providerId is also present. Plugins should ignore this object unless they explicitly recognize providerId.",
             "additionalProperties": true
           }
         },

--- a/docs/design/mem9-runtime-usage-client-proposal.md
+++ b/docs/design/mem9-runtime-usage-client-proposal.md
@@ -28,6 +28,7 @@ mem9-server uses these runtime usage service internal endpoints:
 1. `PUT /api/internal/quota/reservations/{operationId}`
 2. `PATCH /api/internal/quota/reservations/{operationId}`
 3. `PUT /api/internal/metering/events/{operationId}`
+4. `GET /api/internal/mem9-api-key/state`
 
 There is no quota adjustment endpoint in the current contract. Deletes and
 batch deletes are treated as normal write requests and emit `memoryDeleted`

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -9,7 +9,7 @@ last_updated: 2026-07-06
 
 Add `GET /v1alpha2/mem9s/runtime-state` to mem9-server for agent plugins.
 The endpoint returns plugin-visible runtime quota facts using the same core
-shape as console-server's internal provider state endpoint:
+shape as the configured runtime usage provider state endpoint:
 `mem9ApiKey`, `meters`, `budgets`, optional `quotaGateResult`, optional
 `recommendedAction`, optional `providerId`, and optional `providerData`.
 
@@ -32,9 +32,9 @@ flowchart LR
     Manager --> UnknownFallback["provider unavailable fallback<br/>providerManaged / unknown"]
   end
 
-  subgraph Console["mem9-console-server"]
+  subgraph Provider["Configured runtime usage provider"]
     ProviderClient --> ProviderState["GET /api/internal/mem9-api-key/state"]
-    ProviderState --> QuotaStore["quota state store"]
+    ProviderState --> QuotaStore["runtime quota state"]
   end
 ```
 

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -11,10 +11,12 @@ Add `GET /v1alpha2/mem9s/runtime-state` to mem9-server for agent plugins.
 The endpoint returns plugin-visible runtime quota facts using the same core
 shape as console-server's internal provider state endpoint:
 `mem9ApiKey`, `meters`, `budgets`, optional `quotaGateResult`, optional
-`recommendedAction`, and optional `providerData`.
+`recommendedAction`, optional `providerId`, and optional `providerData`.
 
 Runtime usage enforcement stays on the reservation plane. Runtime-state is a
 read plane for warning tiers, constrained-mode notices, and provider actions.
+The route uses local API-key status resolution only; tenant data DB resolution
+belongs to data-plane memory/import/webhook/session routes.
 
 ## Flow
 
@@ -23,7 +25,8 @@ flowchart LR
   Plugin["Agent plugin"] --> PublicAPI["GET /v1alpha2/mem9s/runtime-state"]
 
   subgraph Mem9["mem9 server"]
-    PublicAPI --> Manager["runtimeusage.Manager"]
+    PublicAPI --> KeyStatus["local key/status resolver"]
+    KeyStatus --> Manager["runtimeusage.Manager"]
     Manager --> DisabledFallback["provider disabled fallback<br/>notMetered / unlimited"]
     Manager --> ProviderClient["runtime usage HTTP client"]
     Manager --> UnknownFallback["provider unavailable fallback<br/>providerManaged / unknown"]
@@ -45,14 +48,19 @@ Authorization: Bearer <MNEMO_RUNTIME_USAGE_INTERNAL_SECRET>
 X-API-Key: <public mem9 API key subject>
 ```
 
-The response is passed through as the public runtime-state core. mem9-server
-fills missing provider defaults only where required for a stable public shape:
-unknown API-key status and provider-managed unknown budgets.
+The response is mapped into the public runtime-state core. mem9-server keeps
+`mem9ApiKey.status` from local key/status resolution, fills missing provider
+defaults only where required for a stable public shape, and returns configured
+`providerId` with object-shaped `providerData`.
+
+`MNEMO_RUNTIME_USAGE_PROVIDER_ID` controls the public provider discriminator.
+When runtime usage is enabled and the env var is omitted, mem9-server uses
+`mem9-official`.
 
 ## Provider-Disabled Fallback
 
-When runtime usage is disabled, mem9-server returns a local fallback with both
-known meters:
+When runtime usage is disabled, mem9-server returns the local key status and a
+local fallback with both known meters:
 
 ```json
 {
@@ -99,9 +107,13 @@ known meters:
 ## Provider-Unavailable Fallback
 
 When runtime usage is enabled and the provider state read fails, mem9-server
-returns HTTP `200` with provider-managed unknown budgets for both meters. This
-keeps plugin warmup and status refresh flows usable while memory route
-reservation enforcement continues to use the existing runtime usage settings.
+returns HTTP `200` with the local key status and provider-managed unknown
+budgets for both meters. This keeps plugin warmup and status refresh flows
+usable while memory route reservation enforcement continues to use the existing
+runtime usage settings.
+
+Non-object `providerData` from upstream is treated as an invalid provider state
+response and uses this fallback.
 
 ## Domain Terms
 
@@ -113,3 +125,5 @@ reservation enforcement continues to use the existing runtime usage settings.
   configured.
 - Provider-unavailable fallback: hosted response shape used when state lookup
   fails.
+- Provider ID: public discriminator for interpreting provider-specific
+  `providerData`.

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -1,0 +1,115 @@
+---
+title: mem9-server Runtime State API
+status: draft
+created: 2026-07-06
+last_updated: 2026-07-06
+---
+
+## Summary
+
+Add `GET /v1alpha2/mem9s/runtime-state` to mem9-server for agent plugins.
+The endpoint returns plugin-visible runtime quota facts using the same core
+shape as console-server's internal provider state endpoint:
+`mem9ApiKey`, `meters`, `budgets`, optional `quotaGateResult`, optional
+`recommendedAction`, and optional `providerData`.
+
+Runtime usage enforcement stays on the reservation plane. Runtime-state is a
+read plane for warning tiers, constrained-mode notices, and provider actions.
+
+## Flow
+
+```mermaid
+flowchart LR
+  Plugin["Agent plugin"] --> PublicAPI["GET /v1alpha2/mem9s/runtime-state"]
+
+  subgraph Mem9["mem9 server"]
+    PublicAPI --> Manager["runtimeusage.Manager"]
+    Manager --> DisabledFallback["provider disabled fallback<br/>notMetered / unlimited"]
+    Manager --> ProviderClient["runtime usage HTTP client"]
+    Manager --> UnknownFallback["provider unavailable fallback<br/>providerManaged / unknown"]
+  end
+
+  subgraph Console["mem9-console-server"]
+    ProviderClient --> ProviderState["GET /api/internal/mem9-api-key/state"]
+    ProviderState --> QuotaStore["quota state store"]
+  end
+```
+
+## Runtime-Enabled Behavior
+
+When `MNEMO_RUNTIME_USAGE_ENABLED=true`, mem9-server calls:
+
+```text
+GET /api/internal/mem9-api-key/state
+Authorization: Bearer <MNEMO_RUNTIME_USAGE_INTERNAL_SECRET>
+X-API-Key: <public mem9 API key subject>
+```
+
+The response is passed through as the public runtime-state core. mem9-server
+fills missing provider defaults only where required for a stable public shape:
+unknown API-key status and provider-managed unknown budgets.
+
+## Provider-Disabled Fallback
+
+When runtime usage is disabled, mem9-server returns a local fallback with both
+known meters:
+
+```json
+{
+  "mem9ApiKey": { "status": "active" },
+  "meters": [
+    {
+      "meter": "memory_recall_requests",
+      "quotaGateResult": {
+        "outcome": "allowed",
+        "mode": "notMetered",
+        "reason": "runtimeUsageDisabled"
+      },
+      "budgets": [
+        {
+          "type": "notMetered",
+          "state": "unlimited",
+          "measure": { "kind": "count", "quantity": "request", "scale": 1 },
+          "period": { "type": "none" },
+          "capacity": { "type": "unlimited" }
+        }
+      ]
+    },
+    {
+      "meter": "memory_write_requests",
+      "quotaGateResult": {
+        "outcome": "allowed",
+        "mode": "notMetered",
+        "reason": "runtimeUsageDisabled"
+      },
+      "budgets": [
+        {
+          "type": "notMetered",
+          "state": "unlimited",
+          "measure": { "kind": "count", "quantity": "request", "scale": 1 },
+          "period": { "type": "none" },
+          "capacity": { "type": "unlimited" }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Provider-Unavailable Fallback
+
+When runtime usage is enabled and the provider state read fails, mem9-server
+returns HTTP `200` with provider-managed unknown budgets for both meters. This
+keeps plugin warmup and status refresh flows usable while memory route
+reservation enforcement continues to use the existing runtime usage settings.
+
+## Domain Terms
+
+- Runtime-state read plane: advisory state used by plugins for notices and
+  action links.
+- Reservation plane: authoritative runtime enforcement path used before recall
+  and write operations.
+- Provider-disabled fallback: self-host response where runtime usage is not
+  configured.
+- Provider-unavailable fallback: hosted response shape used when state lookup
+  fails.

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -191,6 +191,7 @@ func main() {
 	runtimeUsageClient := runtimeusage.NewHTTPClient(cfg.RuntimeUsageBaseURL, cfg.RuntimeUsageInternalSecret, cfg.RuntimeUsageTimeout)
 	runtimeUsageManager := runtimeusage.NewManager(runtimeusage.Config{
 		Enabled:         cfg.RuntimeUsageEnabled,
+		ProviderID:      cfg.RuntimeUsageProviderID,
 		BaseURL:         cfg.RuntimeUsageBaseURL,
 		InternalSecret:  cfg.RuntimeUsageInternalSecret,
 		Timeout:         cfg.RuntimeUsageTimeout,

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	// RuntimeUsage enables commercial SaaS quota gating plus runtime usage
 	// service metering. Runtime usage metering uses RuntimeUsageBaseURL, not MeteringURL.
 	RuntimeUsageEnabled         bool
+	RuntimeUsageProviderID      string
 	RuntimeUsageBaseURL         string
 	RuntimeUsageInternalSecret  string `json:"-"`
 	RuntimeUsageTimeout         time.Duration
@@ -146,6 +147,7 @@ func Load() (*Config, error) {
 	runtimeUsageEnabled := envBool("MNEMO_RUNTIME_USAGE_ENABLED", false)
 	runtimeUsageFailOpen := envBool("MNEMO_RUNTIME_USAGE_FAIL_OPEN", false)
 	runtimeUsageOutboxEnabled, runtimeUsageOutboxSet := envBoolWithSet("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED", runtimeUsageEnabled)
+	runtimeUsageProviderID := ""
 	runtimeUsageBaseURL := ""
 	if runtimeUsageEnabled {
 		var err error
@@ -153,6 +155,7 @@ func Load() (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
+		runtimeUsageProviderID = strings.TrimSpace(envOr("MNEMO_RUNTIME_USAGE_PROVIDER_ID", "mem9-official"))
 		if strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")) == "" {
 			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET is required when MNEMO_RUNTIME_USAGE_ENABLED=true")
 		}
@@ -200,6 +203,7 @@ func Load() (*Config, error) {
 		MeteringURL:                      meteringURL,
 		MeteringFlushInterval:            envDuration("MNEMO_METERING_FLUSH_INTERVAL", 10*time.Second),
 		RuntimeUsageEnabled:              runtimeUsageEnabled,
+		RuntimeUsageProviderID:           runtimeUsageProviderID,
 		RuntimeUsageBaseURL:              runtimeUsageBaseURL,
 		RuntimeUsageInternalSecret:       strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")),
 		RuntimeUsageTimeout:              envDuration("MNEMO_RUNTIME_USAGE_TIMEOUT", 3*time.Second),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -177,6 +177,9 @@ func TestLoad_RuntimeUsageConfig(t *testing.T) {
 	if !cfg.RuntimeUsageEnabled {
 		t.Fatal("RuntimeUsageEnabled = false, want true")
 	}
+	if cfg.RuntimeUsageProviderID != "mem9-official" {
+		t.Fatalf("RuntimeUsageProviderID = %q, want mem9-official", cfg.RuntimeUsageProviderID)
+	}
 	if cfg.RuntimeUsageBaseURL != "https://runtime-usage.example.com/internal" {
 		t.Fatalf("RuntimeUsageBaseURL = %q", cfg.RuntimeUsageBaseURL)
 	}
@@ -200,6 +203,22 @@ func TestLoad_RuntimeUsageConfig(t *testing.T) {
 	}
 	if cfg.MeteringEnabled {
 		t.Fatal("MeteringEnabled = true, want false; runtime usage metering must not require MNEMO_METERING_ENABLED")
+	}
+}
+
+func TestLoad_RuntimeUsageProviderID(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_PROVIDER_ID", "provider-x")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RuntimeUsageProviderID != "provider-x" {
+		t.Fatalf("RuntimeUsageProviderID = %q, want provider-x", cfg.RuntimeUsageProviderID)
 	}
 }
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -265,6 +265,7 @@ func (s *Server) Router(
 	r.Route("/v1alpha2/mem9s", func(r chi.Router) {
 		r.Use(apiKeyMW)
 
+		r.Get("/runtime-state", s.getRuntimeState)
 		r.Post("/memories", s.createMemory)
 		r.Get("/memories", s.listMemories)
 		r.Get("/memories/{id}", s.getMemory)

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -219,6 +219,7 @@ func (s *Server) Router(
 
 	// Key status validates X-API-Key against control-plane state only.
 	r.Get("/v1alpha2/status", s.getKeyStatus)
+	r.Get("/v1alpha2/mem9s/runtime-state", s.getRuntimeState)
 
 	r.Post("/v1alpha2/space-chains", s.createSpaceChain)
 	r.Get("/v1alpha2/space-chains/by-key", s.getSpaceChainByKey)
@@ -265,7 +266,6 @@ func (s *Server) Router(
 	r.Route("/v1alpha2/mem9s", func(r chi.Router) {
 		r.Use(apiKeyMW)
 
-		r.Get("/runtime-state", s.getRuntimeState)
 		r.Post("/memories", s.createMemory)
 		r.Get("/memories", s.listMemories)
 		r.Get("/memories/{id}", s.getMemory)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -428,6 +428,9 @@ type captureRuntimeUsageManager struct {
 }
 
 func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
+func (m *captureRuntimeUsageManager) RuntimeState(context.Context, runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+	return runtimeusage.RuntimeUsageDisabledState(), nil
+}
 func (m *captureRuntimeUsageManager) BeforeRecall(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeRecallCalls++
 	m.beforeRecallSubjects = append(m.beforeRecallSubjects, subject)

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -219,6 +219,60 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	}
 }
 
+func TestOpenAPIRuntimeStateContract(t *testing.T) {
+	openapi := loadOpenAPI(t)
+	responses := operationResponses(t, openapi, "/v1alpha2/mem9s/runtime-state", "get")
+	assertResponseRef(t, responses, "200", "#/components/responses/RuntimeState")
+	assertResponseRef(t, responses, "400", "#/components/responses/BadRequest")
+	assertResponseRef(t, responses, "429", "#/components/responses/RateLimited")
+	assertResponseRef(t, responses, "503", "#/components/responses/ServiceUnavailable")
+
+	components := objectValue(t, openapi, "components")
+	schemas := objectValue(t, components, "schemas")
+
+	state := objectValue(t, schemas, "RuntimeStateResponse")
+	if got, want := stringSlice(t, state["required"]), []string{"mem9ApiKey", "meters"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("RuntimeStateResponse.required = %#v, want %#v", got, want)
+	}
+	stateProperties := objectValue(t, state, "properties")
+	if _, ok := stateProperties["recommendedAction"]; !ok {
+		t.Fatalf("RuntimeStateResponse should expose recommendedAction")
+	}
+	if _, ok := stateProperties["providerData"]; !ok {
+		t.Fatalf("RuntimeStateResponse should expose optional providerData")
+	}
+	meters := objectValue(t, stateProperties, "meters")
+	if meters["minItems"] != float64(2) {
+		t.Fatalf("RuntimeStateResponse.meters.minItems = %#v, want 2", meters["minItems"])
+	}
+
+	meter := objectValue(t, schemas, "RuntimeStateMeter")
+	meterRequired := stringSlice(t, meter["required"])
+	for _, field := range []string{"meter", "budgets"} {
+		if !containsString(meterRequired, field) {
+			t.Fatalf("RuntimeStateMeter.required missing %q: %#v", field, meterRequired)
+		}
+	}
+	if containsString(meterRequired, "quotaGateResult") {
+		t.Fatalf("RuntimeStateMeter.quotaGateResult should stay optional")
+	}
+
+	budget := objectValue(t, schemas, "RuntimeStatusBudget")
+	budgetProperties := objectValue(t, budget, "properties")
+	budgetType := objectValue(t, budgetProperties, "type")
+	for _, value := range []string{"includedQuota", "spendingLimit", "credits", "notMetered", "unknown", "providerManaged"} {
+		if !containsString(stringSlice(t, budgetType["enum"]), value) {
+			t.Fatalf("RuntimeStatusBudget.type enum missing %q", value)
+		}
+	}
+	budgetState := objectValue(t, budgetProperties, "state")
+	for _, value := range []string{"ok", "warning", "exhausted", "unlimited", "unknown", "providerManaged"} {
+		if !containsString(stringSlice(t, budgetState["enum"]), value) {
+			t.Fatalf("RuntimeStatusBudget.state enum missing %q", value)
+		}
+	}
+}
+
 func loadOpenAPI(t *testing.T) map[string]any {
 	t.Helper()
 	path := filepath.Join("..", "..", "..", "docs", "api", "openapi.json")

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -238,8 +238,16 @@ func TestOpenAPIRuntimeStateContract(t *testing.T) {
 	if _, ok := stateProperties["recommendedAction"]; !ok {
 		t.Fatalf("RuntimeStateResponse should expose recommendedAction")
 	}
+	if _, ok := stateProperties["providerId"]; !ok {
+		t.Fatalf("RuntimeStateResponse should expose optional providerId")
+	}
 	if _, ok := stateProperties["providerData"]; !ok {
 		t.Fatalf("RuntimeStateResponse should expose optional providerData")
+	}
+	providerData := objectValue(t, stateProperties, "providerData")
+	providerDataDescription, _ := providerData["description"].(string)
+	if !strings.Contains(providerDataDescription, "providerId") {
+		t.Fatalf("RuntimeStateResponse.providerData description should require providerId pairing: %q", providerDataDescription)
 	}
 	meters := objectValue(t, stateProperties, "meters")
 	if meters["minItems"] != float64(2) {

--- a/server/internal/handler/runtime_state.go
+++ b/server/internal/handler/runtime_state.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
+)
+
+func (s *Server) getRuntimeState(w http.ResponseWriter, r *http.Request) {
+	if s == nil || s.runtimeUsage == nil {
+		respond(w, http.StatusOK, runtimeusage.RuntimeUsageDisabledState())
+		return
+	}
+
+	state, err := s.runtimeUsage.RuntimeState(r.Context(), subjectFromAuth(authInfo(r)))
+	if err != nil {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.WarnContext(r.Context(), "runtime state fallback returned",
+			"err", err,
+		)
+		state = runtimeusage.RuntimeStateProviderUnavailable()
+	}
+	respond(w, http.StatusOK, state)
+}

--- a/server/internal/handler/runtime_state.go
+++ b/server/internal/handler/runtime_state.go
@@ -8,12 +8,19 @@ import (
 )
 
 func (s *Server) getRuntimeState(w http.ResponseWriter, r *http.Request) {
+	resolution, ok := s.resolveAPIKeyStatus(w, r)
+	if !ok {
+		return
+	}
+	subject := subjectFromAuth(resolution.Auth)
+	subject.APIKeyStatus = string(resolution.Status)
+
 	if s == nil || s.runtimeUsage == nil {
-		respond(w, http.StatusOK, runtimeusage.RuntimeUsageDisabledState())
+		respond(w, http.StatusOK, runtimeusage.RuntimeUsageDisabledState(subject.APIKeyStatus))
 		return
 	}
 
-	state, err := s.runtimeUsage.RuntimeState(r.Context(), subjectFromAuth(authInfo(r)))
+	state, err := s.runtimeUsage.RuntimeState(r.Context(), subject)
 	if err != nil {
 		logger := s.logger
 		if logger == nil {
@@ -22,7 +29,7 @@ func (s *Server) getRuntimeState(w http.ResponseWriter, r *http.Request) {
 		logger.WarnContext(r.Context(), "runtime state fallback returned",
 			"err", err,
 		)
-		state = runtimeusage.RuntimeStateProviderUnavailable()
+		state = runtimeusage.RuntimeStateProviderUnavailable(subject.APIKeyStatus)
 	}
 	respond(w, http.StatusOK, state)
 }

--- a/server/internal/handler/runtime_state_test.go
+++ b/server/internal/handler/runtime_state_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
-	"github.com/qiffang/mnemos/server/internal/middleware"
+	"github.com/qiffang/mnemos/server/internal/encrypt"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
 )
@@ -38,22 +38,35 @@ func (c *runtimeStateQuotaClient) FinalizeReservation(context.Context, runtimeus
 }
 
 func TestGetRuntimeStateReturnsDisabledFallback(t *testing.T) {
-	router := runtimeStateRouter(nil, &domain.AuthInfo{
-		TenantID:      "tenant-a",
-		ClusterID:     "cluster-a",
-		APIKeySubject: "mem9_test",
+	apiKeyMWCalled := false
+	router := runtimeStateRouter(t, nil, &domain.Tenant{
+		ID:        "tenant-a",
+		ClusterID: "cluster-a",
+		Status:    domain.TenantActive,
+	}, nil, func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiKeyMWCalled = true
+			respondError(w, http.StatusServiceUnavailable, "data-plane auth should not run")
+		})
 	})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	req.Header.Set("X-API-Key", "mem9_test")
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
+	if apiKeyMWCalled {
+		t.Fatal("apiKeyMW called for runtime-state route")
+	}
 	var state runtimeusage.RuntimeState
 	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
+	}
+	if state.Mem9APIKey.Status != runtimeusage.RuntimeAPIKeyStatusActive {
+		t.Fatalf("status = %q, want active", state.Mem9APIKey.Status)
 	}
 	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
 	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryWriteRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
@@ -61,7 +74,8 @@ func TestGetRuntimeStateReturnsDisabledFallback(t *testing.T) {
 
 func TestGetRuntimeStateCallsProviderWhenEnabled(t *testing.T) {
 	client := &runtimeStateQuotaClient{state: runtimeusage.RuntimeState{
-		Mem9APIKey: runtimeusage.RuntimeStateAPIKey{Status: runtimeusage.RuntimeAPIKeyStatusActive},
+		Mem9APIKey:   runtimeusage.RuntimeStateAPIKey{Status: runtimeusage.RuntimeAPIKeyStatusUnknown},
+		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
 		Meters: []runtimeusage.RuntimeStateMeter{{
 			Meter: runtimeusage.MeterMemoryRecallRequests,
 			Budgets: []runtimeusage.RuntimeStatusBudget{{
@@ -77,17 +91,17 @@ func TestGetRuntimeStateCallsProviderWhenEnabled(t *testing.T) {
 			}},
 		}},
 	}}
-	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())
-	auth := &domain.AuthInfo{
-		TenantID:      "tenant-a",
-		ClusterID:     "cluster-a",
-		APIKeySubject: "mem9_test",
-		AgentName:     "Codex",
-	}
-	router := runtimeStateRouter(manager, auth)
+	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true, ProviderID: "mem9-official"}, client, nil, slog.Default())
+	router := runtimeStateRouter(t, manager, &domain.Tenant{
+		ID:        "tenant-a",
+		ClusterID: "cluster-a",
+		Status:    domain.TenantActive,
+	}, nil, nil)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	req.Header.Set("X-API-Key", "mem9_test")
+	req.Header.Set("X-Mnemo-Agent-Id", "agent-a")
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -97,7 +111,7 @@ func TestGetRuntimeStateCallsProviderWhenEnabled(t *testing.T) {
 		t.Fatalf("subjects = %+v, want one", client.subjects)
 	}
 	got := client.subjects[0]
-	if got.TenantID != auth.TenantID || got.ClusterID != auth.ClusterID || got.APIKeySubject != auth.APIKeySubject || got.AgentName != auth.AgentName {
+	if got.TenantID != "tenant-a" || got.ClusterID != "cluster-a" || got.APIKeySubject != "mem9_test" || got.AgentName != "agent-a" || got.APIKeyStatus != runtimeusage.RuntimeAPIKeyStatusActive {
 		t.Fatalf("subject = %+v, want auth-derived subject", got)
 	}
 
@@ -105,20 +119,27 @@ func TestGetRuntimeStateCallsProviderWhenEnabled(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
+	if state.Mem9APIKey.Status != runtimeusage.RuntimeAPIKeyStatusActive {
+		t.Fatalf("status = %q, want local active status", state.Mem9APIKey.Status)
+	}
+	if state.ProviderID != "mem9-official" {
+		t.Fatalf("ProviderID = %q, want mem9-official", state.ProviderID)
+	}
 	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
 }
 
-func TestGetRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
+func TestGetRuntimeStateFallsBackWithLocalStatusWhenProviderUnavailable(t *testing.T) {
 	client := &runtimeStateQuotaClient{err: errors.New("provider timeout")}
 	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())
-	router := runtimeStateRouter(manager, &domain.AuthInfo{
-		TenantID:      "tenant-a",
-		ClusterID:     "cluster-a",
-		APIKeySubject: "mem9_test",
-	})
+	router := runtimeStateRouter(t, manager, &domain.Tenant{
+		ID:        "tenant-a",
+		ClusterID: "cluster-a",
+		Status:    domain.TenantProvisioning,
+	}, nil, nil)
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	req.Header.Set("X-API-Key", "mem9_test")
 	router.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
@@ -128,25 +149,103 @@ func TestGetRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if state.Mem9APIKey.Status != runtimeusage.RuntimeAPIKeyStatusUnknown {
-		t.Fatalf("status = %q, want unknown", state.Mem9APIKey.Status)
+	if state.Mem9APIKey.Status != runtimeusage.RuntimeAPIKeyStatusInactive {
+		t.Fatalf("status = %q, want inactive", state.Mem9APIKey.Status)
 	}
 	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeProviderManaged, runtimeusage.RuntimeBudgetStateProviderManaged)
 	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryWriteRequests, runtimeusage.RuntimeBudgetTypeProviderManaged, runtimeusage.RuntimeBudgetStateProviderManaged)
 }
 
-func runtimeStateRouter(manager runtimeusage.Manager, auth *domain.AuthInfo) http.Handler {
-	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default())
+func TestGetRuntimeStateKeyStatusErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiKey   string
+		tenant   *domain.Tenant
+		wantCode int
+	}{
+		{
+			name:     "missing key",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:     "unknown key",
+			apiKey:   "missing",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "deleted key",
+			apiKey:   "deleted",
+			tenant:   &domain.Tenant{ID: "tenant-a", Status: domain.TenantDeleted},
+			wantCode: http.StatusNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := runtimeStateRouter(t, nil, tt.tenant, nil, nil)
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+			if tt.apiKey != "" {
+				req.Header.Set("X-API-Key", tt.apiKey)
+			}
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantCode {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tt.wantCode, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestGetRuntimeStateUsesChainKeySubjectWithoutDataPlaneAuth(t *testing.T) {
+	client := &runtimeStateQuotaClient{state: runtimeusage.RuntimeUsageDisabledState()}
+	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())
+	chains := &runtimeStateSpaceChainRepo{status: domain.KeyStatusActive}
+	router := runtimeStateRouter(t, manager, nil, service.NewSpaceChainService(chains), func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("apiKeyMW called for chain runtime-state route")
+		})
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	req.Header.Set("X-API-Key", domain.ChainKeyPrefix+"runtime")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if chains.getByKeyCalls != 0 {
+		t.Fatalf("GetByKey calls = %d, want 0", chains.getByKeyCalls)
+	}
+	if len(client.subjects) != 1 || client.subjects[0].APIKeySubject != domain.ChainKeyPrefix+"runtime" || client.subjects[0].APIKeyStatus != runtimeusage.RuntimeAPIKeyStatusActive {
+		t.Fatalf("subjects = %+v, want chain API key subject", client.subjects)
+	}
+}
+
+func runtimeStateRouter(t *testing.T, manager runtimeusage.Manager, tenant *domain.Tenant, chains *service.SpaceChainService, apiKeyMW func(http.Handler) http.Handler) http.Handler {
+	t.Helper()
+	tenantSvc := service.NewTenantService(
+		&handlerTenantRepo{getTenant: tenant},
+		nil,
+		nil,
+		slog.Default(),
+		"",
+		0,
+		0,
+		false,
+		encrypt.NewPlainEncryptor(),
+	)
+	srv := NewServer(tenantSvc, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default()).
+		WithSpaceChainService(chains, 0.8)
 	if manager != nil {
 		srv.WithRuntimeUsage(manager)
 	}
 	pass := func(next http.Handler) http.Handler { return next }
-	authMW := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r.WithContext(middleware.WithAuthContext(r.Context(), auth)))
-		})
+	if apiKeyMW == nil {
+		apiKeyMW = pass
 	}
-	return srv.Router(pass, pass, authMW, pass)
+	return srv.Router(pass, pass, apiKeyMW, pass)
 }
 
 func assertRuntimeStateMeter(t *testing.T, state runtimeusage.RuntimeState, meter string, budgetType string, budgetState string) {
@@ -165,4 +264,53 @@ func assertRuntimeStateMeter(t *testing.T, state runtimeusage.RuntimeState, mete
 		return
 	}
 	t.Fatalf("meter %s missing from %+v", meter, state.Meters)
+}
+
+type runtimeStateSpaceChainRepo struct {
+	status        domain.KeyStatus
+	err           error
+	getByKeyCalls int
+}
+
+func (r *runtimeStateSpaceChainRepo) Create(context.Context, *domain.SpaceChain, *domain.SpaceChainBinding) error {
+	return nil
+}
+func (r *runtimeStateSpaceChainRepo) GetByID(context.Context, string) (*domain.SpaceChain, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *runtimeStateSpaceChainRepo) GetByKey(context.Context, string) (*domain.SpaceChain, error) {
+	r.getByKeyCalls++
+	return nil, domain.ErrNotFound
+}
+func (r *runtimeStateSpaceChainRepo) GetByKeyIncludingDisabled(context.Context, string) (*domain.SpaceChain, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *runtimeStateSpaceChainRepo) Update(context.Context, *domain.SpaceChain) error { return nil }
+func (r *runtimeStateSpaceChainRepo) SoftDelete(context.Context, string, string) error { return nil }
+func (r *runtimeStateSpaceChainRepo) CreateBinding(context.Context, *domain.SpaceChainBinding) error {
+	return nil
+}
+func (r *runtimeStateSpaceChainRepo) ListBindings(context.Context, string) ([]domain.SpaceChainBinding, error) {
+	return nil, nil
+}
+func (r *runtimeStateSpaceChainRepo) DisableBinding(context.Context, string, string, string) error {
+	return nil
+}
+func (r *runtimeStateSpaceChainRepo) ListNodes(context.Context, string) ([]domain.SpaceChainNode, error) {
+	return nil, nil
+}
+func (r *runtimeStateSpaceChainRepo) ReplaceNodes(context.Context, string, []domain.SpaceChainNode) error {
+	return nil
+}
+func (r *runtimeStateSpaceChainRepo) UpdateNodeRoutingPolicy(context.Context, string, string, bool, string, bool) (*domain.SpaceChainNode, error) {
+	return nil, domain.ErrNotFound
+}
+func (r *runtimeStateSpaceChainRepo) RemoveNodeByExternalSpaceID(context.Context, string) error {
+	return nil
+}
+func (r *runtimeStateSpaceChainRepo) KeyStatus(context.Context, string) (domain.KeyStatus, error) {
+	if r.err != nil {
+		return "", r.err
+	}
+	return r.status, nil
 }

--- a/server/internal/handler/runtime_state_test.go
+++ b/server/internal/handler/runtime_state_test.go
@@ -1,0 +1,168 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/middleware"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
+	"github.com/qiffang/mnemos/server/internal/service"
+)
+
+type runtimeStateQuotaClient struct {
+	state    runtimeusage.RuntimeState
+	err      error
+	subjects []runtimeusage.Subject
+}
+
+func (c *runtimeStateQuotaClient) RuntimeState(_ context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+	c.subjects = append(c.subjects, subject)
+	if c.err != nil {
+		return runtimeusage.RuntimeState{}, c.err
+	}
+	return c.state, nil
+}
+
+func (c *runtimeStateQuotaClient) Reserve(context.Context, runtimeusage.Subject, string, runtimeusage.Operation) (*runtimeusage.Reservation, error) {
+	return nil, nil
+}
+
+func (c *runtimeStateQuotaClient) FinalizeReservation(context.Context, runtimeusage.Subject, string, string, string) error {
+	return nil
+}
+
+func TestGetRuntimeStateReturnsDisabledFallback(t *testing.T) {
+	router := runtimeStateRouter(nil, &domain.AuthInfo{
+		TenantID:      "tenant-a",
+		ClusterID:     "cluster-a",
+		APIKeySubject: "mem9_test",
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var state runtimeusage.RuntimeState
+	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
+	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryWriteRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
+}
+
+func TestGetRuntimeStateCallsProviderWhenEnabled(t *testing.T) {
+	client := &runtimeStateQuotaClient{state: runtimeusage.RuntimeState{
+		Mem9APIKey: runtimeusage.RuntimeStateAPIKey{Status: runtimeusage.RuntimeAPIKeyStatusActive},
+		Meters: []runtimeusage.RuntimeStateMeter{{
+			Meter: runtimeusage.MeterMemoryRecallRequests,
+			Budgets: []runtimeusage.RuntimeStatusBudget{{
+				Type:  runtimeusage.RuntimeBudgetTypeNotMetered,
+				State: runtimeusage.RuntimeBudgetStateUnlimited,
+				Measure: runtimeusage.RuntimeStatusMeasure{
+					Kind:     runtimeusage.RuntimeMeasureKindCount,
+					Quantity: "request",
+					Scale:    1,
+				},
+				Period:   runtimeusage.RuntimeStatusPeriod{Type: runtimeusage.RuntimePeriodTypeNone},
+				Capacity: runtimeusage.RuntimeStatusCapacity{Type: runtimeusage.RuntimeCapacityTypeUnlimited},
+			}},
+		}},
+	}}
+	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())
+	auth := &domain.AuthInfo{
+		TenantID:      "tenant-a",
+		ClusterID:     "cluster-a",
+		APIKeySubject: "mem9_test",
+		AgentName:     "Codex",
+	}
+	router := runtimeStateRouter(manager, auth)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if len(client.subjects) != 1 {
+		t.Fatalf("subjects = %+v, want one", client.subjects)
+	}
+	got := client.subjects[0]
+	if got.TenantID != auth.TenantID || got.ClusterID != auth.ClusterID || got.APIKeySubject != auth.APIKeySubject || got.AgentName != auth.AgentName {
+		t.Fatalf("subject = %+v, want auth-derived subject", got)
+	}
+
+	var state runtimeusage.RuntimeState
+	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
+}
+
+func TestGetRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
+	client := &runtimeStateQuotaClient{err: errors.New("provider timeout")}
+	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())
+	router := runtimeStateRouter(manager, &domain.AuthInfo{
+		TenantID:      "tenant-a",
+		ClusterID:     "cluster-a",
+		APIKeySubject: "mem9_test",
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var state runtimeusage.RuntimeState
+	if err := json.Unmarshal(rec.Body.Bytes(), &state); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if state.Mem9APIKey.Status != runtimeusage.RuntimeAPIKeyStatusUnknown {
+		t.Fatalf("status = %q, want unknown", state.Mem9APIKey.Status)
+	}
+	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeProviderManaged, runtimeusage.RuntimeBudgetStateProviderManaged)
+	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryWriteRequests, runtimeusage.RuntimeBudgetTypeProviderManaged, runtimeusage.RuntimeBudgetStateProviderManaged)
+}
+
+func runtimeStateRouter(manager runtimeusage.Manager, auth *domain.AuthInfo) http.Handler {
+	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.Default())
+	if manager != nil {
+		srv.WithRuntimeUsage(manager)
+	}
+	pass := func(next http.Handler) http.Handler { return next }
+	authMW := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(middleware.WithAuthContext(r.Context(), auth)))
+		})
+	}
+	return srv.Router(pass, pass, authMW, pass)
+}
+
+func assertRuntimeStateMeter(t *testing.T, state runtimeusage.RuntimeState, meter string, budgetType string, budgetState string) {
+	t.Helper()
+	for _, item := range state.Meters {
+		if item.Meter != meter {
+			continue
+		}
+		if len(item.Budgets) != 1 {
+			t.Fatalf("%s budgets = %+v, want one", meter, item.Budgets)
+		}
+		got := item.Budgets[0]
+		if got.Type != budgetType || got.State != budgetState {
+			t.Fatalf("%s budget = %+v, want type=%s state=%s", meter, got, budgetType, budgetState)
+		}
+		return
+	}
+	t.Fatalf("meter %s missing from %+v", meter, state.Meters)
+}

--- a/server/internal/handler/tenant.go
+++ b/server/internal/handler/tenant.go
@@ -27,6 +27,11 @@ type keyStatusResponse struct {
 	Status domain.KeyStatus `json:"status"`
 }
 
+type apiKeyStatusResolution struct {
+	Status domain.KeyStatus
+	Auth   *domain.AuthInfo
+}
+
 func (s *Server) provisionMem9s(w http.ResponseWriter, r *http.Request) {
 	result, err := s.tenant.Provision(r.Context(), service.ProvisionRequest{
 		UTM: normalizeUTMParams(r.URL.Query()),
@@ -70,20 +75,23 @@ func normalizeUTMParams(values url.Values) map[string]string {
 }
 
 func (s *Server) getKeyStatus(w http.ResponseWriter, r *http.Request) {
+	resolution, ok := s.resolveAPIKeyStatus(w, r)
+	if !ok {
+		return
+	}
+	respond(w, http.StatusOK, keyStatusResponse{Status: resolution.Status})
+}
+
+func (s *Server) resolveAPIKeyStatus(w http.ResponseWriter, r *http.Request) (apiKeyStatusResolution, bool) {
 	apiKey := strings.TrimSpace(r.Header.Get(middleware.APIKeyHeader))
 	if apiKey == "" {
 		respondError(w, http.StatusUnauthorized, "missing or malformed X-API-Key")
-		return
+		return apiKeyStatusResolution{}, false
 	}
-	if s.tenant == nil {
-		respondError(w, http.StatusInternalServerError, "auth backend unavailable")
-		return
-	}
-
 	if strings.HasPrefix(apiKey, domain.ChainKeyPrefix) {
 		if s.chains == nil {
 			respondError(w, http.StatusInternalServerError, "auth backend unavailable")
-			return
+			return apiKeyStatusResolution{}, false
 		}
 		status, err := s.chains.KeyStatus(r.Context(), apiKey)
 		if err != nil {
@@ -98,13 +106,23 @@ func (s *Server) getKeyStatus(w http.ResponseWriter, r *http.Request) {
 				logger.ErrorContext(r.Context(), "chain key status lookup failed", "err", err)
 				respondError(w, http.StatusInternalServerError, "auth backend unavailable")
 			}
-			return
+			return apiKeyStatusResolution{}, false
 		}
-		respond(w, http.StatusOK, keyStatusResponse{Status: status})
-		return
+		auth := &domain.AuthInfo{
+			APIKeySubject: apiKey,
+			AgentName:     r.Header.Get(middleware.AgentIDHeader),
+			Chain: &domain.ChainAuth{
+				APIKey: apiKey,
+			},
+		}
+		return apiKeyStatusResolution{Status: status, Auth: auth}, true
 	}
 
-	status, err := s.tenant.KeyStatus(r.Context(), apiKey)
+	if s.tenant == nil {
+		respondError(w, http.StatusInternalServerError, "auth backend unavailable")
+		return apiKeyStatusResolution{}, false
+	}
+	statusResult, err := s.tenant.ResolveAPIKeyStatus(r.Context(), apiKey)
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrNotFound):
@@ -117,10 +135,15 @@ func (s *Server) getKeyStatus(w http.ResponseWriter, r *http.Request) {
 			logger.ErrorContext(r.Context(), "key status lookup failed", "err", err)
 			respondError(w, http.StatusInternalServerError, "auth backend unavailable")
 		}
-		return
+		return apiKeyStatusResolution{}, false
 	}
-
-	respond(w, http.StatusOK, keyStatusResponse{Status: status})
+	auth := &domain.AuthInfo{
+		TenantID:      statusResult.TenantID,
+		ClusterID:     statusResult.ClusterID,
+		APIKeySubject: apiKey,
+		AgentName:     r.Header.Get(middleware.AgentIDHeader),
+	}
+	return apiKeyStatusResolution{Status: statusResult.Status, Auth: auth}, true
 }
 
 func (s *Server) getTenantInfo(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -50,18 +50,33 @@ func (c *HTTPClient) FinalizeReservation(ctx context.Context, subject Subject, o
 	return c.doJSON(ctx, http.MethodPatch, "/api/internal/quota/reservations/"+operationID, subject, body, nil, false)
 }
 
-func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Subject, body any, out any, classifyQuotaStatuses bool) error {
-	payload, err := json.Marshal(body)
-	if err != nil {
-		return fmt.Errorf("runtime usage marshal request: %w", err)
+func (c *HTTPClient) RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error) {
+	var state RuntimeState
+	if err := c.doJSON(ctx, http.MethodGet, "/api/internal/mem9-api-key/state", subject, nil, &state, false); err != nil {
+		return RuntimeState{}, err
 	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(payload))
+	state.SetProviderDefaults()
+	return state, nil
+}
+
+func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Subject, body any, out any, classifyQuotaStatuses bool) error {
+	var reqBody io.Reader
+	if body != nil {
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("runtime usage marshal request: %w", err)
+		}
+		reqBody = bytes.NewReader(payload)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reqBody)
 	if err != nil {
 		return fmt.Errorf("runtime usage build request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.internalSecret)
 	req.Header.Set("X-API-Key", subject.APIKeySubject)
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 
 	resp, err := c.client.Do(req)
 	if err != nil {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -55,6 +55,9 @@ func (c *HTTPClient) RuntimeState(ctx context.Context, subject Subject) (Runtime
 	if err := c.doJSON(ctx, http.MethodGet, "/api/internal/mem9-api-key/state", subject, nil, &state, false); err != nil {
 		return RuntimeState{}, err
 	}
+	if err := state.NormalizeProviderData(); err != nil {
+		return RuntimeState{}, &UnavailableError{Err: err}
+	}
 	state.SetProviderDefaults()
 	return state, nil
 }

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -53,6 +53,66 @@ func TestHTTPClientReserveAllowsNullRemainingIncludedUnits(t *testing.T) {
 	}
 }
 
+func TestHTTPClientRuntimeStateCallsProviderStateEndpoint(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", req.Method)
+		}
+		if req.URL.Path != "/api/internal/mem9-api-key/state" {
+			t.Fatalf("path = %s", req.URL.Path)
+		}
+		if got := req.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want bearer secret", got)
+		}
+		if got := req.Header.Get("X-API-Key"); got != "api-key-subject" {
+			t.Fatalf("X-API-Key = %q", got)
+		}
+		if got := req.Header.Get("Content-Type"); got != "" {
+			t.Fatalf("Content-Type = %q, want empty", got)
+		}
+		if req.Body != nil {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("ReadAll body: %v", err)
+			}
+			if len(body) != 0 {
+				t.Fatalf("body = %q, want empty", body)
+			}
+		}
+		return jsonResponse(`{
+			"mem9ApiKey": {"status": "active"},
+			"meters": [{
+				"meter": "memory_recall_requests",
+				"quotaGateResult": {"outcome": "allowed", "mode": "includedQuota", "reason": "includedQuotaAvailable"},
+				"budgets": [{
+					"type": "includedQuota",
+					"state": "ok",
+					"measure": {"kind": "count", "quantity": "request", "scale": 1},
+					"period": {"type": "calendarMonth", "startAt": "2026-07-01T00:00:00Z", "endAt": "2026-08-01T00:00:00Z"},
+					"capacity": {"type": "limited", "value": 1000},
+					"usage": {"used": 20, "remaining": 980, "percent": 2}
+				}]
+			}],
+			"providerData": {"bindingState": "claimed"}
+		}`), nil
+	})}
+
+	state, err := client.RuntimeState(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	if err != nil {
+		t.Fatalf("RuntimeState: %v", err)
+	}
+	if state.Mem9APIKey.Status != RuntimeAPIKeyStatusActive {
+		t.Fatalf("status = %q, want active", state.Mem9APIKey.Status)
+	}
+	if !hasRuntimeStateMeter(state, MeterMemoryRecallRequests) {
+		t.Fatalf("meters = %+v, want recall meter", state.Meters)
+	}
+	if !strings.Contains(string(state.ProviderData), "bindingState") || !strings.Contains(string(state.ProviderData), "claimed") {
+		t.Fatalf("ProviderData = %s, want binding state", state.ProviderData)
+	}
+}
+
 func TestHTTPClientReserveDecodesRemainingIncludedUnits(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
@@ -235,4 +295,13 @@ func statusJSONResponse(status int, body string, header http.Header) *http.Respo
 		Header:     header,
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
+}
+
+func hasRuntimeStateMeter(state RuntimeState, meter string) bool {
+	for _, item := range state.Meters {
+		if item.Meter == meter {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -113,6 +113,23 @@ func TestHTTPClientRuntimeStateCallsProviderStateEndpoint(t *testing.T) {
 	}
 }
 
+func TestHTTPClientRuntimeStateRejectsNonObjectProviderData(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(`{
+			"mem9ApiKey": {"status": "active"},
+			"meters": [],
+			"providerData": ["unexpected"]
+		}`), nil
+	})}
+
+	_, err := client.RuntimeState(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	var unavailable *UnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("RuntimeState error = %T, want UnavailableError", err)
+	}
+}
+
 func TestHTTPClientReserveDecodesRemainingIncludedUnits(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -41,8 +42,8 @@ func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *
 type noopManager struct{}
 
 func (noopManager) Enabled() bool { return false }
-func (noopManager) RuntimeState(context.Context, Subject) (RuntimeState, error) {
-	return RuntimeUsageDisabledState(), nil
+func (noopManager) RuntimeState(_ context.Context, subject Subject) (RuntimeState, error) {
+	return RuntimeUsageDisabledState(subject.APIKeyStatus), nil
 }
 func (noopManager) BeforeRecall(context.Context, Subject) (*OperationLease, error) {
 	return nil, nil
@@ -83,9 +84,20 @@ func (m *manager) RuntimeState(ctx context.Context, subject Subject) (RuntimeSta
 			"cluster_id", subject.ClusterID,
 			"err", err,
 		)
-		return RuntimeStateProviderUnavailable(), nil
+		return RuntimeStateProviderUnavailable(subject.APIKeyStatus), nil
 	}
 	state.SetProviderDefaults()
+	if subject.APIKeyStatus != "" {
+		state.Mem9APIKey.Status = subject.APIKeyStatus
+	}
+	if len(state.ProviderData) > 0 {
+		providerID := strings.TrimSpace(m.cfg.ProviderID)
+		if providerID == "" {
+			state.ProviderData = nil
+		} else {
+			state.ProviderID = providerID
+		}
+	}
 	return state, nil
 }
 

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -41,6 +41,9 @@ func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *
 type noopManager struct{}
 
 func (noopManager) Enabled() bool { return false }
+func (noopManager) RuntimeState(context.Context, Subject) (RuntimeState, error) {
+	return RuntimeUsageDisabledState(), nil
+}
 func (noopManager) BeforeRecall(context.Context, Subject) (*OperationLease, error) {
 	return nil, nil
 }
@@ -71,6 +74,20 @@ func (noopManager) AfterMemoryDeleteSuccess(context.Context, *OperationLease, Me
 func (noopManager) AfterMemoryDeleteFailure(context.Context, *OperationLease, error) {}
 
 func (m *manager) Enabled() bool { return true }
+
+func (m *manager) RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error) {
+	state, err := m.client.RuntimeState(ctx, subject)
+	if err != nil {
+		m.logger.WarnContext(ctx, "runtime usage state provider unavailable",
+			"tenant_id", subject.TenantID,
+			"cluster_id", subject.ClusterID,
+			"err", err,
+		)
+		return RuntimeStateProviderUnavailable(), nil
+	}
+	state.SetProviderDefaults()
+	return state, nil
+}
 
 func (m *manager) BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error) {
 	return m.reserve(ctx, subject, MeterMemoryRecallRequests, 1)

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -2,6 +2,7 @@ package runtimeusage
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/qiffang/mnemos/server/internal/metering"
@@ -102,7 +103,8 @@ func (s *fakeOutboxStore) MarkUnknownAfterCrash(context.Context, string, string)
 }
 
 func TestNoopManagerRuntimeStateReturnsDisabledFallback(t *testing.T) {
-	manager := NewManager(Config{Enabled: false}, nil, nil, nil)
+	quota := &fakeQuotaClient{}
+	manager := NewManager(Config{Enabled: false}, quota, nil, nil)
 
 	state, err := manager.RuntimeState(context.Background(), Subject{APIKeySubject: "mem9_test"})
 	if err != nil {
@@ -110,11 +112,23 @@ func TestNoopManagerRuntimeStateReturnsDisabledFallback(t *testing.T) {
 	}
 	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
 	assertFallbackMeter(t, state, MeterMemoryWriteRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
+
+	lease, err := manager.BeforeRecall(context.Background(), Subject{APIKeySubject: "mem9_test"})
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	if lease != nil {
+		t.Fatalf("BeforeRecall lease = %+v, want nil", lease)
+	}
+	if len(quota.stateSubjects) != 0 || len(quota.reserveOps) != 0 || len(quota.finalized) != 0 {
+		t.Fatalf("disabled manager called provider: %+v", quota)
+	}
 }
 
 func TestManagerRuntimeStateUsesProvider(t *testing.T) {
 	quota := &fakeQuotaClient{state: RuntimeState{
-		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusActive},
+		Mem9APIKey:   RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
+		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
 		Meters: []RuntimeStateMeter{{
 			Meter: MeterMemoryRecallRequests,
 			Budgets: []RuntimeStatusBudget{{
@@ -130,8 +144,8 @@ func TestManagerRuntimeStateUsesProvider(t *testing.T) {
 			}},
 		}},
 	}}
-	manager := NewManager(Config{Enabled: true}, quota, nil, nil)
-	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "mem9_test"}
+	manager := NewManager(Config{Enabled: true, ProviderID: "mem9-official"}, quota, nil, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "mem9_test", APIKeyStatus: RuntimeAPIKeyStatusActive}
 
 	state, err := manager.RuntimeState(context.Background(), subject)
 	if err != nil {
@@ -140,6 +154,12 @@ func TestManagerRuntimeStateUsesProvider(t *testing.T) {
 	if len(quota.stateSubjects) != 1 || quota.stateSubjects[0] != subject {
 		t.Fatalf("state subjects = %+v, want [%+v]", quota.stateSubjects, subject)
 	}
+	if state.Mem9APIKey.Status != RuntimeAPIKeyStatusActive {
+		t.Fatalf("status = %q, want local active status", state.Mem9APIKey.Status)
+	}
+	if state.ProviderID != "mem9-official" {
+		t.Fatalf("ProviderID = %q, want mem9-official", state.ProviderID)
+	}
 	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
 }
 
@@ -147,12 +167,12 @@ func TestManagerRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
 	quota := &fakeQuotaClient{stateErr: &UnavailableError{Err: errString("timeout")}}
 	manager := NewManager(Config{Enabled: true}, quota, nil, nil)
 
-	state, err := manager.RuntimeState(context.Background(), Subject{TenantID: "tenant-a", APIKeySubject: "mem9_test"})
+	state, err := manager.RuntimeState(context.Background(), Subject{TenantID: "tenant-a", APIKeySubject: "mem9_test", APIKeyStatus: RuntimeAPIKeyStatusInactive})
 	if err != nil {
 		t.Fatalf("RuntimeState: %v", err)
 	}
-	if state.Mem9APIKey.Status != RuntimeAPIKeyStatusUnknown {
-		t.Fatalf("status = %q, want unknown", state.Mem9APIKey.Status)
+	if state.Mem9APIKey.Status != RuntimeAPIKeyStatusInactive {
+		t.Fatalf("status = %q, want inactive", state.Mem9APIKey.Status)
 	}
 	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeProviderManaged, RuntimeBudgetStateProviderManaged)
 	assertFallbackMeter(t, state, MeterMemoryWriteRequests, RuntimeBudgetTypeProviderManaged, RuntimeBudgetStateProviderManaged)

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -11,9 +11,23 @@ type fakeQuotaClient struct {
 	reserveOps       []Operation
 	finalized        []string
 	finalizeSubjects []Subject
+	state            RuntimeState
+	stateSubjects    []Subject
 	err              error
+	stateErr         error
 	reserveErr       error
 	finalizeErr      error
+}
+
+func (c *fakeQuotaClient) RuntimeState(_ context.Context, subject Subject) (RuntimeState, error) {
+	c.stateSubjects = append(c.stateSubjects, subject)
+	if c.stateErr != nil {
+		return RuntimeState{}, c.stateErr
+	}
+	if c.err != nil {
+		return RuntimeState{}, c.err
+	}
+	return c.state, nil
 }
 
 func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID string, op Operation) (*Reservation, error) {
@@ -85,6 +99,63 @@ func (s *fakeOutboxStore) MarkOperationRetryableFailure(_ context.Context, _ str
 func (s *fakeOutboxStore) MarkUnknownAfterCrash(context.Context, string, string) error {
 	s.unknown++
 	return nil
+}
+
+func TestNoopManagerRuntimeStateReturnsDisabledFallback(t *testing.T) {
+	manager := NewManager(Config{Enabled: false}, nil, nil, nil)
+
+	state, err := manager.RuntimeState(context.Background(), Subject{APIKeySubject: "mem9_test"})
+	if err != nil {
+		t.Fatalf("RuntimeState: %v", err)
+	}
+	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
+	assertFallbackMeter(t, state, MeterMemoryWriteRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
+}
+
+func TestManagerRuntimeStateUsesProvider(t *testing.T) {
+	quota := &fakeQuotaClient{state: RuntimeState{
+		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusActive},
+		Meters: []RuntimeStateMeter{{
+			Meter: MeterMemoryRecallRequests,
+			Budgets: []RuntimeStatusBudget{{
+				Type:  RuntimeBudgetTypeNotMetered,
+				State: RuntimeBudgetStateUnlimited,
+				Measure: RuntimeStatusMeasure{
+					Kind:     RuntimeMeasureKindCount,
+					Quantity: "request",
+					Scale:    1,
+				},
+				Period:   RuntimeStatusPeriod{Type: RuntimePeriodTypeNone},
+				Capacity: RuntimeStatusCapacity{Type: RuntimeCapacityTypeUnlimited},
+			}},
+		}},
+	}}
+	manager := NewManager(Config{Enabled: true}, quota, nil, nil)
+	subject := Subject{TenantID: "tenant-a", ClusterID: "cluster-a", APIKeySubject: "mem9_test"}
+
+	state, err := manager.RuntimeState(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("RuntimeState: %v", err)
+	}
+	if len(quota.stateSubjects) != 1 || quota.stateSubjects[0] != subject {
+		t.Fatalf("state subjects = %+v, want [%+v]", quota.stateSubjects, subject)
+	}
+	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
+}
+
+func TestManagerRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
+	quota := &fakeQuotaClient{stateErr: &UnavailableError{Err: errString("timeout")}}
+	manager := NewManager(Config{Enabled: true}, quota, nil, nil)
+
+	state, err := manager.RuntimeState(context.Background(), Subject{TenantID: "tenant-a", APIKeySubject: "mem9_test"})
+	if err != nil {
+		t.Fatalf("RuntimeState: %v", err)
+	}
+	if state.Mem9APIKey.Status != RuntimeAPIKeyStatusUnknown {
+		t.Fatalf("status = %q, want unknown", state.Mem9APIKey.Status)
+	}
+	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeProviderManaged, RuntimeBudgetStateProviderManaged)
+	assertFallbackMeter(t, state, MeterMemoryWriteRequests, RuntimeBudgetTypeProviderManaged, RuntimeBudgetStateProviderManaged)
 }
 
 func TestManagerRecallCommitsBeforeMetering(t *testing.T) {
@@ -445,4 +516,22 @@ func TestManagerReleaseUsesConsoleSpecReason(t *testing.T) {
 	if len(outbox.retryReasons) != 1 || outbox.retryReasons[0] != "recallFailed: context deadline exceeded" {
 		t.Fatalf("retry reasons = %+v, want local failure detail", outbox.retryReasons)
 	}
+}
+
+func assertFallbackMeter(t *testing.T, state RuntimeState, meter string, budgetType string, budgetState string) {
+	t.Helper()
+	for _, item := range state.Meters {
+		if item.Meter != meter {
+			continue
+		}
+		if len(item.Budgets) != 1 {
+			t.Fatalf("%s budgets = %+v, want one", meter, item.Budgets)
+		}
+		got := item.Budgets[0]
+		if got.Type != budgetType || got.State != budgetState {
+			t.Fatalf("%s budget = %+v, want type=%s state=%s", meter, got, budgetType, budgetState)
+		}
+		return
+	}
+	t.Fatalf("meter %s missing from %+v", meter, state.Meters)
 }

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -1,6 +1,7 @@
 package runtimeusage
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -30,8 +31,9 @@ const (
 )
 
 const (
-	RuntimeAPIKeyStatusActive  = "active"
-	RuntimeAPIKeyStatusUnknown = "unknown"
+	RuntimeAPIKeyStatusActive   = "active"
+	RuntimeAPIKeyStatusInactive = "inactive"
+	RuntimeAPIKeyStatusUnknown  = "unknown"
 
 	RuntimeBudgetTypeNotMetered      = "notMetered"
 	RuntimeBudgetTypeUnknown         = "unknown"
@@ -61,6 +63,7 @@ const (
 
 type Config struct {
 	Enabled         bool
+	ProviderID      string
 	BaseURL         string
 	InternalSecret  string
 	Timeout         time.Duration
@@ -76,6 +79,7 @@ type Subject struct {
 	TenantID      string
 	ClusterID     string
 	APIKeySubject string
+	APIKeyStatus  string
 	AgentName     string
 }
 
@@ -106,6 +110,7 @@ type Reservation struct {
 type RuntimeState struct {
 	Mem9APIKey        RuntimeStateAPIKey        `json:"mem9ApiKey"`
 	Meters            []RuntimeStateMeter       `json:"meters"`
+	ProviderID        string                    `json:"providerId,omitempty"`
 	RecommendedAction *RuntimeRecommendedAction `json:"recommendedAction,omitempty"`
 	ProviderData      json.RawMessage           `json:"providerData,omitempty"`
 }
@@ -159,9 +164,9 @@ type RuntimeRecommendedAction struct {
 	URL                string `json:"url,omitempty"`
 }
 
-func RuntimeUsageDisabledState() RuntimeState {
+func RuntimeUsageDisabledState(statuses ...string) RuntimeState {
 	return RuntimeState{
-		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusActive},
+		Mem9APIKey: RuntimeStateAPIKey{Status: runtimeAPIKeyStatus(RuntimeAPIKeyStatusActive, statuses...)},
 		Meters: []RuntimeStateMeter{
 			notMeteredStateMeter(MeterMemoryRecallRequests),
 			notMeteredStateMeter(MeterMemoryWriteRequests),
@@ -169,14 +174,24 @@ func RuntimeUsageDisabledState() RuntimeState {
 	}
 }
 
-func RuntimeStateProviderUnavailable() RuntimeState {
+func RuntimeStateProviderUnavailable(statuses ...string) RuntimeState {
 	return RuntimeState{
-		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
+		Mem9APIKey: RuntimeStateAPIKey{Status: runtimeAPIKeyStatus(RuntimeAPIKeyStatusUnknown, statuses...)},
 		Meters: []RuntimeStateMeter{
 			unknownStateMeter(MeterMemoryRecallRequests),
 			unknownStateMeter(MeterMemoryWriteRequests),
 		},
 	}
+}
+
+func runtimeAPIKeyStatus(defaultStatus string, statuses ...string) string {
+	for _, status := range statuses {
+		switch status {
+		case RuntimeAPIKeyStatusActive, RuntimeAPIKeyStatusInactive, RuntimeAPIKeyStatusUnknown:
+			return status
+		}
+	}
+	return defaultStatus
 }
 
 func (s *RuntimeState) SetProviderDefaults() {
@@ -203,6 +218,23 @@ func (s *RuntimeState) SetProviderDefaults() {
 	if !seenMeters[MeterMemoryWriteRequests] {
 		s.Meters = append(s.Meters, unknownStateMeter(MeterMemoryWriteRequests))
 	}
+}
+
+func (s *RuntimeState) NormalizeProviderData() error {
+	raw := bytes.TrimSpace(s.ProviderData)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		s.ProviderData = nil
+		return nil
+	}
+	if raw[0] != '{' {
+		return fmt.Errorf("runtime state providerData must be a JSON object")
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return fmt.Errorf("runtime state providerData object: %w", err)
+	}
+	s.ProviderData = append(json.RawMessage(nil), raw...)
+	return nil
 }
 
 func notMeteredStateMeter(meter string) RuntimeStateMeter {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -29,6 +29,36 @@ const (
 	reservationReleaseTimeout            = "timeout"
 )
 
+const (
+	RuntimeAPIKeyStatusActive  = "active"
+	RuntimeAPIKeyStatusUnknown = "unknown"
+
+	RuntimeBudgetTypeNotMetered      = "notMetered"
+	RuntimeBudgetTypeUnknown         = "unknown"
+	RuntimeBudgetTypeProviderManaged = "providerManaged"
+
+	RuntimeBudgetStateUnlimited       = "unlimited"
+	RuntimeBudgetStateUnknown         = "unknown"
+	RuntimeBudgetStateProviderManaged = "providerManaged"
+
+	RuntimeMeasureKindCount   = "count"
+	RuntimeMeasureKindUnknown = "unknown"
+
+	RuntimePeriodTypeNone            = "none"
+	RuntimePeriodTypeUnknown         = "unknown"
+	RuntimePeriodTypeProviderManaged = "providerManaged"
+
+	RuntimeCapacityTypeUnlimited       = "unlimited"
+	RuntimeCapacityTypeUnknown         = "unknown"
+	RuntimeCapacityTypeProviderManaged = "providerManaged"
+
+	RuntimeGateOutcomeAllowed = "allowed"
+
+	RuntimeGateModeNotMetered = "notMetered"
+
+	RuntimeGateReasonRuntimeUsageDisabled = "runtimeUsageDisabled"
+)
+
 type Config struct {
 	Enabled         bool
 	BaseURL         string
@@ -71,6 +101,159 @@ type Reservation struct {
 	RemainingIncludedUnits *int64    `json:"remainingIncludedUnits"`
 	ReservedUnits          int64     `json:"reservedUnits"`
 	OverageAllowed         bool      `json:"overageAllowed"`
+}
+
+type RuntimeState struct {
+	Mem9APIKey        RuntimeStateAPIKey        `json:"mem9ApiKey"`
+	Meters            []RuntimeStateMeter       `json:"meters"`
+	RecommendedAction *RuntimeRecommendedAction `json:"recommendedAction,omitempty"`
+	ProviderData      json.RawMessage           `json:"providerData,omitempty"`
+}
+
+type RuntimeStateAPIKey struct {
+	Status string `json:"status"`
+}
+
+type RuntimeStateMeter struct {
+	Meter           string                `json:"meter"`
+	QuotaGateResult map[string]any        `json:"quotaGateResult,omitempty"`
+	Budgets         []RuntimeStatusBudget `json:"budgets"`
+}
+
+type RuntimeStatusBudget struct {
+	Type     string                `json:"type"`
+	State    string                `json:"state"`
+	Measure  RuntimeStatusMeasure  `json:"measure"`
+	Period   RuntimeStatusPeriod   `json:"period"`
+	Capacity RuntimeStatusCapacity `json:"capacity"`
+	Usage    *RuntimeStatusUsage   `json:"usage,omitempty"`
+}
+
+type RuntimeStatusMeasure struct {
+	Kind     string `json:"kind"`
+	Quantity string `json:"quantity"`
+	Scale    int64  `json:"scale"`
+}
+
+type RuntimeStatusPeriod struct {
+	Type    string     `json:"type"`
+	StartAt *time.Time `json:"startAt,omitempty"`
+	EndAt   *time.Time `json:"endAt,omitempty"`
+}
+
+type RuntimeStatusCapacity struct {
+	Type  string `json:"type"`
+	Value *int64 `json:"value,omitempty"`
+}
+
+type RuntimeStatusUsage struct {
+	Used      *int64   `json:"used,omitempty"`
+	Remaining *int64   `json:"remaining,omitempty"`
+	Percent   *float64 `json:"percent,omitempty"`
+}
+
+type RuntimeRecommendedAction struct {
+	Type               string `json:"type"`
+	ProviderActionCode string `json:"providerActionCode,omitempty"`
+	Severity           string `json:"severity,omitempty"`
+	URL                string `json:"url,omitempty"`
+}
+
+func RuntimeUsageDisabledState() RuntimeState {
+	return RuntimeState{
+		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusActive},
+		Meters: []RuntimeStateMeter{
+			notMeteredStateMeter(MeterMemoryRecallRequests),
+			notMeteredStateMeter(MeterMemoryWriteRequests),
+		},
+	}
+}
+
+func RuntimeStateProviderUnavailable() RuntimeState {
+	return RuntimeState{
+		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
+		Meters: []RuntimeStateMeter{
+			unknownStateMeter(MeterMemoryRecallRequests),
+			unknownStateMeter(MeterMemoryWriteRequests),
+		},
+	}
+}
+
+func (s *RuntimeState) SetProviderDefaults() {
+	if s.Mem9APIKey.Status == "" {
+		s.Mem9APIKey.Status = RuntimeAPIKeyStatusUnknown
+	}
+	if len(s.Meters) == 0 {
+		s.Meters = []RuntimeStateMeter{
+			unknownStateMeter(MeterMemoryRecallRequests),
+			unknownStateMeter(MeterMemoryWriteRequests),
+		}
+		return
+	}
+	seenMeters := make(map[string]bool, len(s.Meters))
+	for i := range s.Meters {
+		seenMeters[s.Meters[i].Meter] = true
+		if len(s.Meters[i].Budgets) == 0 {
+			s.Meters[i].Budgets = []RuntimeStatusBudget{providerManagedBudget()}
+		}
+	}
+	if !seenMeters[MeterMemoryRecallRequests] {
+		s.Meters = append(s.Meters, unknownStateMeter(MeterMemoryRecallRequests))
+	}
+	if !seenMeters[MeterMemoryWriteRequests] {
+		s.Meters = append(s.Meters, unknownStateMeter(MeterMemoryWriteRequests))
+	}
+}
+
+func notMeteredStateMeter(meter string) RuntimeStateMeter {
+	return RuntimeStateMeter{
+		Meter: meter,
+		QuotaGateResult: map[string]any{
+			"outcome": RuntimeGateOutcomeAllowed,
+			"mode":    RuntimeGateModeNotMetered,
+			"reason":  RuntimeGateReasonRuntimeUsageDisabled,
+		},
+		Budgets: []RuntimeStatusBudget{{
+			Type:  RuntimeBudgetTypeNotMetered,
+			State: RuntimeBudgetStateUnlimited,
+			Measure: RuntimeStatusMeasure{
+				Kind:     RuntimeMeasureKindCount,
+				Quantity: "request",
+				Scale:    1,
+			},
+			Period: RuntimeStatusPeriod{
+				Type: RuntimePeriodTypeNone,
+			},
+			Capacity: RuntimeStatusCapacity{
+				Type: RuntimeCapacityTypeUnlimited,
+			},
+		}},
+	}
+}
+
+func unknownStateMeter(meter string) RuntimeStateMeter {
+	return RuntimeStateMeter{
+		Meter:   meter,
+		Budgets: []RuntimeStatusBudget{providerManagedBudget()},
+	}
+}
+
+func providerManagedBudget() RuntimeStatusBudget {
+	return RuntimeStatusBudget{
+		Type:  RuntimeBudgetTypeProviderManaged,
+		State: RuntimeBudgetStateProviderManaged,
+		Measure: RuntimeStatusMeasure{
+			Kind:     RuntimeMeasureKindUnknown,
+			Quantity: "provider-defined",
+			Scale:    1,
+		},
+		Period: RuntimeStatusPeriod{
+			Type: RuntimePeriodTypeProviderManaged,
+		},
+		Capacity: RuntimeStatusCapacity{
+			Type: RuntimeCapacityTypeProviderManaged,
+		},
+	}
 }
 
 type RecallResult struct {
@@ -116,6 +299,7 @@ type OutboxStore interface {
 
 type Manager interface {
 	Enabled() bool
+	RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error)
 	BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error)
 	AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error
 	AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error)
@@ -131,6 +315,7 @@ type Manager interface {
 }
 
 type QuotaClient interface {
+	RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error)
 	Reserve(ctx context.Context, subject Subject, operationID string, op Operation) (*Reservation, error)
 	FinalizeReservation(ctx context.Context, subject Subject, operationID string, status string, reason string) error
 }

--- a/server/internal/service/tenant.go
+++ b/server/internal/service/tenant.go
@@ -39,6 +39,12 @@ type TenantService struct {
 	encryptor   encrypt.Encryptor
 }
 
+type APIKeyStatusResult struct {
+	Status    domain.KeyStatus
+	TenantID  string
+	ClusterID string
+}
+
 func NewTenantService(
 	tenants repository.TenantRepo,
 	provisioner tenant.Provisioner,
@@ -70,20 +76,28 @@ func (s *TenantService) WithUTMRepo(r utmRepo) *TenantService {
 
 // KeyStatus validates a candidate API key against the control-plane tenant row.
 func (s *TenantService) KeyStatus(ctx context.Context, apiKey string) (domain.KeyStatus, error) {
+	result, err := s.ResolveAPIKeyStatus(ctx, apiKey)
+	if err != nil {
+		return "", err
+	}
+	return result.Status, nil
+}
+
+func (s *TenantService) ResolveAPIKeyStatus(ctx context.Context, apiKey string) (APIKeyStatusResult, error) {
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
-		return "", &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
+		return APIKeyStatusResult{}, &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
 	}
 	if s.tenants == nil {
-		return "", fmt.Errorf("tenant repository not configured")
+		return APIKeyStatusResult{}, fmt.Errorf("tenant repository not configured")
 	}
 
 	t, err := s.tenants.GetByID(ctx, apiKey)
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
-			return "", domain.ErrNotFound
+			return APIKeyStatusResult{}, domain.ErrNotFound
 		}
-		return "", fmt.Errorf("get tenant for key status: %w", err)
+		return APIKeyStatusResult{}, fmt.Errorf("get tenant for key status: %w", err)
 	}
 
 	if t.DeletedAt != nil {
@@ -92,24 +106,29 @@ func (s *TenantService) KeyStatus(ctx context.Context, apiKey string) (domain.Ke
 				"status", t.Status,
 			)
 		}
-		return "", domain.ErrNotFound
+		return APIKeyStatusResult{}, domain.ErrNotFound
 	}
 
+	result := APIKeyStatusResult{
+		TenantID:  t.ID,
+		ClusterID: t.ClusterID,
+	}
 	switch t.Status {
 	case domain.TenantActive:
-		return domain.KeyStatusActive, nil
+		result.Status = domain.KeyStatusActive
 	case domain.TenantProvisioning, domain.TenantSuspended:
-		return domain.KeyStatusInactive, nil
+		result.Status = domain.KeyStatusInactive
 	case domain.TenantDeleted:
-		return "", domain.ErrNotFound
+		return APIKeyStatusResult{}, domain.ErrNotFound
 	default:
 		if s.logger != nil {
 			s.logger.WarnContext(ctx, "unknown tenant status for key status",
 				"status", t.Status,
 			)
 		}
-		return domain.KeyStatusInactive, nil
+		result.Status = domain.KeyStatusInactive
 	}
+	return result, nil
 }
 
 // ProvisionResult is the output of Provision.


### PR DESCRIPTION
## What Changed
- Adds `GET /v1alpha2/mem9s/runtime-state` for plugin-visible runtime quota state.
- Uses local API-key status/subject resolution for runtime-state, without tenant data DB resolution.
- Calls the configured runtime usage provider `GET /api/internal/mem9-api-key/state` when runtime usage is enabled.
- Returns local fallback state for provider-disabled deployments and provider-managed unknown meter state when provider reads fail.
- Adds `providerId` for provider-specific `providerData`, plus OpenAPI/docs/tests.

## Architecture
```mermaid
flowchart LR
  Plugin["Agent plugins"] --> PublicAPI["GET /v1alpha2/mem9s/runtime-state"]
  PublicAPI --> KeyStatus["Local key/status resolver<br/>no tenant data DB"]
  KeyStatus --> Handler["handler.getRuntimeState"]
  Handler --> Manager["runtimeusage.Manager"]

  Manager -->|"runtime usage disabled"| DisabledFallback["Local fallback<br/>local key status + notMetered / unlimited"]
  Manager -->|"runtime usage enabled"| ProviderClient["runtimeusage.HTTPClient"]
  ProviderClient --> ProviderAPI["Configured runtime usage provider<br/>GET /api/internal/mem9-api-key/state"]
  ProviderAPI --> ProviderState["Provider state<br/>meters / budgets / actions / providerData"]
  ProviderClient -->|"state read failed or malformed providerData"| UnknownFallback["Provider-unavailable fallback<br/>local key status + providerManaged / unknown"]

  DisabledFallback --> Response["RuntimeStateResponse"]
  ProviderState --> Response
  UnknownFallback --> Response
```

## RuntimeStateResponse Shape
Required top-level fields are `mem9ApiKey` and `meters`. `mem9ApiKey.status` always comes from local key-status resolution. Known inactive keys return `200` with `mem9ApiKey.status=inactive`; missing/unknown/deleted keys return the same error semantics as `/v1alpha2/status`.

```jsonc
{
  "mem9ApiKey": {
    "status": "active | inactive | unknown"
  },
  "meters": [
    {
      "meter": "memory_recall_requests | memory_write_requests | provider-defined",
      "quotaGateResult": {
        "outcome": "allowed | blocked | rateLimited",
        "mode": "provider-defined",
        "reason": "provider-defined",
        "postQuotaRateLimit": {
          "requestsPerMinute": 60,
          "windowDurationSeconds": 60,
          "scope": "provider-defined",
          "retryAfterSeconds": 20
        }
      },
      "budgets": [
        {
          "type": "includedQuota | spendingLimit | credits | notMetered | unknown | providerManaged",
          "state": "ok | warning | exhausted | unlimited | unknown | providerManaged",
          "measure": {
            "kind": "count | currency | unknown",
            "quantity": "request | USD | provider-defined",
            "scale": 1
          },
          "period": {
            "type": "calendarMonth | fixedWindow | none | unknown | providerManaged",
            "startAt": "2026-07-01T00:00:00Z",
            "endAt": "2026-08-01T00:00:00Z"
          },
          "capacity": {
            "type": "limited | unlimited | unknown | providerManaged",
            "value": 1000
          },
          "usage": {
            "used": 800,
            "remaining": 200,
            "percent": 80
          }
        }
      ]
    }
  ],
  "providerId": "mem9-official",
  "recommendedAction": {
    "type": "openUrl",
    "providerActionCode": "upgradePlan",
    "severity": "blocking",
    "url": "https://example.com/provider/action"
  },
  "providerData": {
    "bindingState": "claimed"
  }
}
```

### Runtime usage disabled fallback
```json
{
  "mem9ApiKey": {
    "status": "active"
  },
  "meters": [
    {
      "meter": "memory_recall_requests",
      "quotaGateResult": {
        "outcome": "allowed",
        "mode": "notMetered",
        "reason": "runtimeUsageDisabled"
      },
      "budgets": [
        {
          "type": "notMetered",
          "state": "unlimited",
          "measure": {
            "kind": "count",
            "quantity": "request",
            "scale": 1
          },
          "period": {
            "type": "none"
          },
          "capacity": {
            "type": "unlimited"
          }
        }
      ]
    },
    {
      "meter": "memory_write_requests",
      "quotaGateResult": {
        "outcome": "allowed",
        "mode": "notMetered",
        "reason": "runtimeUsageDisabled"
      },
      "budgets": [
        {
          "type": "notMetered",
          "state": "unlimited",
          "measure": {
            "kind": "count",
            "quantity": "request",
            "scale": 1
          },
          "period": {
            "type": "none"
          },
          "capacity": {
            "type": "unlimited"
          }
        }
      ]
    }
  ]
}
```

### Runtime usage enabled provider success
```json
{
  "mem9ApiKey": {
    "status": "active"
  },
  "meters": [
    {
      "meter": "memory_recall_requests",
      "quotaGateResult": {
        "outcome": "allowed",
        "mode": "includedQuota",
        "reason": "includedQuotaAvailable"
      },
      "budgets": [
        {
          "type": "includedQuota",
          "state": "warning",
          "measure": {
            "kind": "count",
            "quantity": "request",
            "scale": 1
          },
          "period": {
            "type": "calendarMonth",
            "startAt": "2026-07-01T00:00:00Z",
            "endAt": "2026-08-01T00:00:00Z"
          },
          "capacity": {
            "type": "limited",
            "value": 1000
          },
          "usage": {
            "used": 820,
            "remaining": 180,
            "percent": 82
          }
        }
      ]
    },
    {
      "meter": "memory_write_requests",
      "quotaGateResult": {
        "outcome": "allowed",
        "mode": "onDemand",
        "reason": "includedQuotaExhaustedOnDemandAvailable"
      },
      "budgets": [
        {
          "type": "includedQuota",
          "state": "exhausted",
          "measure": {
            "kind": "count",
            "quantity": "request",
            "scale": 1
          },
          "period": {
            "type": "calendarMonth",
            "startAt": "2026-07-01T00:00:00Z",
            "endAt": "2026-08-01T00:00:00Z"
          },
          "capacity": {
            "type": "limited",
            "value": 500
          },
          "usage": {
            "used": 500,
            "remaining": 0,
            "percent": 100
          }
        },
        {
          "type": "spendingLimit",
          "state": "ok",
          "measure": {
            "kind": "currency",
            "quantity": "USD",
            "scale": 100
          },
          "period": {
            "type": "calendarMonth",
            "startAt": "2026-07-01T00:00:00Z",
            "endAt": "2026-08-01T00:00:00Z"
          },
          "capacity": {
            "type": "limited",
            "value": 5000
          },
          "usage": {
            "used": 1200,
            "remaining": 3800,
            "percent": 24
          }
        }
      ]
    }
  ],
  "providerId": "mem9-official",
  "recommendedAction": {
    "type": "openUrl",
    "providerActionCode": "upgradePlan",
    "severity": "warning",
    "url": "https://console.mem9.ai/console/billing/plan"
  },
  "providerData": {
    "bindingState": "claimed",
    "planSku": "starter"
  }
}
```

### Runtime usage enabled provider unavailable fallback
```json
{
  "mem9ApiKey": {
    "status": "active"
  },
  "meters": [
    {
      "meter": "memory_recall_requests",
      "budgets": [
        {
          "type": "providerManaged",
          "state": "providerManaged",
          "measure": {
            "kind": "unknown",
            "quantity": "provider-defined",
            "scale": 1
          },
          "period": {
            "type": "providerManaged"
          },
          "capacity": {
            "type": "providerManaged"
          }
        }
      ]
    },
    {
      "meter": "memory_write_requests",
      "budgets": [
        {
          "type": "providerManaged",
          "state": "providerManaged",
          "measure": {
            "kind": "unknown",
            "quantity": "provider-defined",
            "scale": 1
          },
          "period": {
            "type": "providerManaged"
          },
          "capacity": {
            "type": "providerManaged"
          }
        }
      ]
    }
  ]
}
```

## Review Path
1. Start with `server/internal/handler/tenant.go` and `server/internal/handler/runtime_state.go` for key/status-only runtime-state auth.
2. Check `server/internal/runtimeusage/types.go`, `client.go`, and `manager.go` for local status fallback and `providerId` / `providerData` handling.
3. Check `server/internal/handler/runtime_state_test.go`, `server/internal/runtimeusage/*_test.go`, and `server/internal/config/config_test.go` for the review-driven coverage.
4. Check `docs/api/openapi.json`, `docs/design/runtime-state-api.md`, and public contract issue #386 for the API contract.

## Validation
- `go test -count=1 ./internal/config ./internal/service ./internal/runtimeusage ./internal/handler`
- `make test`

Closes #386.
