### PR TITLE
feat: add runtime-state notices to plugins

### DIFF
--- a/claude-plugin/hooks/common.sh
+++ b/claude-plugin/hooks/common.sh
@@ -263,6 +263,25 @@ mem9_quota_notice_from_body() {
   printf '%s' "${body}" | node "${MEM9_SCRIPT_DIR}/lib/quota-error.mjs" notice "${operation}" "${status}" 2>/dev/null || true
 }
 
+mem9_runtime_state_notice() {
+  local hook_name="${1:-SessionStart}"
+  local response
+  local notice
+
+  if ! response="$(mem9_api_get "/runtime-state" 2>/dev/null)"; then
+    mem9_debug "${hook_name}" "runtime_state_failed" \
+      "auth_source" "${MEM9_AUTH_SOURCE:-unknown}"
+    return 0
+  fi
+
+  notice="$(printf '%s' "${response}" | node "${MEM9_SCRIPT_DIR}/lib/runtime-state.mjs" 2>/dev/null || true)"
+  if [[ -n "${notice}" ]]; then
+    mem9_debug "${hook_name}" "runtime_state_notice" \
+      "auth_source" "${MEM9_AUTH_SOURCE:-unknown}"
+    printf '%s' "${notice}"
+  fi
+}
+
 mem9_ingest_transcript() {
   local hook_name="$1"
   local hook_input="$2"

--- a/claude-plugin/hooks/common.test.sh
+++ b/claude-plugin/hooks/common.test.sh
@@ -9,10 +9,25 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 STUB_CURL="${TMP_DIR}/curl"
 cat > "${STUB_CURL}" <<'SH'
 #!/usr/bin/env bash
-cat <<'EOF'
+case "$*" in
+  *"/v1alpha1/mem9s"*)
+    cat <<'EOF'
+{"id":"mem9_new"}
+EOF
+    ;;
+  *"/runtime-state"*)
+    cat <<'EOF'
+{"mem9ApiKey":{"status":"active"},"meters":[{"meter":"memory_recall_requests","budgets":[{"type":"includedQuota","state":"warning","usage":{"percent":82,"remaining":18},"capacity":{"type":"limited","value":100}}]}]}
+200
+EOF
+    ;;
+  *)
+    cat <<'EOF'
 {"error":"Post-quota rate limit exceeded.","details":{"errorCategory":"runtime_quota_denied","runtimeQuota":{"meter":"memory_recall_requests"}}}
 429
 EOF
+    ;;
+esac
 SH
 chmod +x "${STUB_CURL}"
 
@@ -48,3 +63,36 @@ case "${notice}" in
     exit 1
     ;;
 esac
+
+runtime_notice="$(mem9_runtime_state_notice "SessionStart")"
+case "${runtime_notice}" in
+  *"mem9 recall is at 82% of its included quota"* ) ;;
+  *)
+    printf 'expected runtime-state guidance, got: %s\n' "${runtime_notice}" >&2
+    exit 1
+    ;;
+esac
+
+SESSION_ENV_FILE="${TMP_DIR}/session.env"
+session_output="$(
+  printf '{"source":"startup"}' | env -u MEM9_API_KEY \
+    CLAUDE_PLUGIN_DATA="${TMP_DIR}/session-data" \
+    CLAUDE_ENV_FILE="${SESSION_ENV_FILE}" \
+    MEM9_API_URL="https://api.mem9.ai" \
+    MEM9_CURL_BIN="${STUB_CURL}" \
+    MEM9_WRITER_ID="claude-code-test" \
+    bash "${SCRIPT_DIR}/session-start.sh"
+)"
+
+case "${session_output}" in
+  *"Initialized automatically."*"mem9 recall is at 82% of its included quota"* ) ;;
+  *)
+    printf 'expected auto-provision runtime-state guidance, got: %s\n' "${session_output}" >&2
+    exit 1
+    ;;
+esac
+
+if ! grep -q 'MEM9_API_KEY=mem9_new' "${SESSION_ENV_FILE}"; then
+  printf 'expected session env file to include provisioned api key\n' >&2
+  exit 1
+fi

--- a/claude-plugin/hooks/common.test.sh
+++ b/claude-plugin/hooks/common.test.sh
@@ -73,6 +73,18 @@ case "${runtime_notice}" in
     ;;
 esac
 
+inactive_notice="$(
+  printf '{"mem9ApiKey":{"status":"inactive"},"meters":[{"meter":"memory_recall_requests","budgets":[{"type":"includedQuota","state":"unlimited"}]}]}' \
+    | node "${SCRIPT_DIR}/lib/runtime-state.mjs"
+)"
+case "${inactive_notice}" in
+  *"Mem9 API key is inactive"*"rerun mem9 setup or create a new mem9 API key"* ) ;;
+  *)
+    printf 'expected inactive API key guidance, got: %s\n' "${inactive_notice}" >&2
+    exit 1
+    ;;
+esac
+
 SESSION_ENV_FILE="${TMP_DIR}/session.env"
 session_output="$(
   printf '{"source":"startup"}' | env -u MEM9_API_KEY \

--- a/claude-plugin/hooks/lib/runtime-state.mjs
+++ b/claude-plugin/hooks/lib/runtime-state.mjs
@@ -104,6 +104,15 @@ function formatRuntimeStateNotice(runtimeState) {
 
   const action = normalizeAction(runtimeState.recommendedAction);
   const candidates = [];
+  const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
+
+  if (text(mem9ApiKey.status) === "inactive") {
+    candidates.push({
+      priority: 65,
+      action,
+      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+    });
+  }
 
   if (action && (text(action.severity) || text(action.url))) {
     candidates.push({

--- a/claude-plugin/hooks/lib/runtime-state.mjs
+++ b/claude-plugin/hooks/lib/runtime-state.mjs
@@ -41,6 +41,10 @@ function modeLabel(mode) {
   return "provider-managed runtime";
 }
 
+function warningMessage(detail) {
+  return `${detail}. In your reply, include this exact mem9 warning detail: ${detail}.`;
+}
+
 function normalizeAction(input) {
   const action = isRecord(input) ? input : {};
   const providerActionCode = text(action.providerActionCode);
@@ -107,18 +111,20 @@ function formatRuntimeStateNotice(runtimeState) {
   const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
 
   if (text(mem9ApiKey.status) === "inactive") {
+    const detail = "Mem9 API key is inactive; rerun mem9 setup or create a new mem9 API key before memory access can continue";
     candidates.push({
       priority: 65,
       action,
-      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+      message: warningMessage(detail),
     });
   }
 
   if (action && (text(action.severity) || text(action.url))) {
+    const detail = "Mem9 needs account or billing attention";
     candidates.push({
       priority: action.severity === "blocking" ? 50 : 20,
       action,
-      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+      message: warningMessage(detail),
     });
   }
 
@@ -132,22 +138,25 @@ function formatRuntimeStateNotice(runtimeState) {
     const mode = text(gate.mode);
 
     if (outcome === "blocked") {
+      const detail = `${feature} is blocked by runtime quota and needs attention before memory access can continue`;
       candidates.push({
         priority: 60,
         action,
-        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+        message: warningMessage(detail),
       });
     } else if (outcome === "rateLimited") {
+      const detail = `${feature} has reached its temporary runtime rate limit and needs a retry later`;
       candidates.push({
         priority: 55,
         action,
-        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+        message: warningMessage(detail),
       });
     } else if (mode === "onDemand" || mode === "postQuota") {
+      const detail = `${feature} is in constrained mode and using ${modeLabel(mode)}`;
       candidates.push({
         priority: 40,
         action,
-        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+        message: warningMessage(detail),
       });
     }
 
@@ -163,10 +172,11 @@ function formatRuntimeStateNotice(runtimeState) {
         && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
 
       if (state === "exhausted") {
+        const detail = `${feature} has exhausted its ${label} and is in constrained mode`;
         candidates.push({
           priority: 45,
           action,
-          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+          message: warningMessage(detail),
         });
       } else if (
         (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
@@ -178,7 +188,7 @@ function formatRuntimeStateNotice(runtimeState) {
         candidates.push({
           priority: 35,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is almost out of runtime quota`),
         });
       } else if (
         state === "warning"
@@ -190,7 +200,7 @@ function formatRuntimeStateNotice(runtimeState) {
         candidates.push({
           priority: 25,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is nearing its runtime quota`),
         });
       }
     }

--- a/claude-plugin/hooks/lib/runtime-state.mjs
+++ b/claude-plugin/hooks/lib/runtime-state.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+// runtime-state.mjs - Format mem9 runtime-state payloads for hooks.
+
+import { readFileSync } from "node:fs";
+
+const WARNING_PERCENT = 80;
+const URGENT_PERCENT = 95;
+
+function isRecord(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numberValue(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function compactNumber(value) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function meterLabel(meter) {
+  if (meter === "memory_recall_requests") return "mem9 recall";
+  if (meter === "memory_write_requests") return "mem9 memory saving";
+  return "mem9 memory";
+}
+
+function budgetLabel(budgetType) {
+  if (budgetType === "includedQuota") return "included quota";
+  if (budgetType === "spendingLimit") return "spending limit";
+  if (budgetType === "credits") return "credit balance";
+  return "runtime quota";
+}
+
+function modeLabel(mode) {
+  if (mode === "onDemand") return "on-demand usage";
+  if (mode === "postQuota") return "the post-quota request lane";
+  return "provider-managed runtime";
+}
+
+function normalizeAction(input) {
+  const action = isRecord(input) ? input : {};
+  const providerActionCode = text(action.providerActionCode);
+  const severity = text(action.severity);
+  const type = text(action.type);
+  const url = text(action.url);
+
+  if (!providerActionCode && !severity && !type && !url) {
+    return null;
+  }
+
+  return {
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+function actionInstruction(action) {
+  const providerActionCode = text(action?.providerActionCode);
+  const url = text(action?.url);
+
+  if (!url) {
+    return providerActionCode
+      ? " Ask them to open the mem9 console to resolve the account or billing state."
+      : "";
+  }
+
+  if (providerActionCode === "claimApiKey") {
+    return ` Ask them to open this link to sign in or create a mem9 account and claim this API key: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "upgradePlan") {
+    return ` Ask them to open this link to upgrade their mem9 plan and get more included usage: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "increaseSpendingLimit") {
+    return ` Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "enableOnDemand") {
+    return ` Ask them to open this link to enable billing or on-demand usage for mem9: ${url}. Include the link exactly as written.`;
+  }
+  return ` Ask them to open this mem9 link to resolve the account or billing state: ${url}. Include the link exactly as written.`;
+}
+
+function budgetNumbers(budget) {
+  const usage = isRecord(budget.usage) ? budget.usage : {};
+  const capacity = isRecord(budget.capacity) ? budget.capacity : {};
+  const capacityValue = text(capacity.type) === "limited"
+    ? numberValue(capacity.value)
+    : null;
+
+  return {
+    percent: numberValue(usage.percent),
+    remaining: numberValue(usage.remaining),
+    capacity: capacityValue != null && capacityValue > 0 ? capacityValue : null,
+  };
+}
+
+function formatRuntimeStateNotice(runtimeState) {
+  if (!isRecord(runtimeState)) return "";
+
+  const action = normalizeAction(runtimeState.recommendedAction);
+  const candidates = [];
+
+  if (action && (text(action.severity) || text(action.url))) {
+    candidates.push({
+      priority: action.severity === "blocking" ? 50 : 20,
+      action,
+      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+    });
+  }
+
+  const meters = Array.isArray(runtimeState.meters) ? runtimeState.meters : [];
+  for (const rawMeter of meters) {
+    if (!isRecord(rawMeter)) continue;
+
+    const feature = meterLabel(text(rawMeter.meter));
+    const gate = isRecord(rawMeter.quotaGateResult) ? rawMeter.quotaGateResult : {};
+    const outcome = text(gate.outcome);
+    const mode = text(gate.mode);
+
+    if (outcome === "blocked") {
+      candidates.push({
+        priority: 60,
+        action,
+        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+      });
+    } else if (outcome === "rateLimited") {
+      candidates.push({
+        priority: 55,
+        action,
+        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+      });
+    } else if (mode === "onDemand" || mode === "postQuota") {
+      candidates.push({
+        priority: 40,
+        action,
+        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+      });
+    }
+
+    const budgets = Array.isArray(rawMeter.budgets) ? rawMeter.budgets : [];
+    for (const rawBudget of budgets) {
+      if (!isRecord(rawBudget)) continue;
+
+      const label = budgetLabel(text(rawBudget.type));
+      const state = text(rawBudget.state);
+      const numbers = budgetNumbers(rawBudget);
+      const absoluteUrgent = numbers.capacity != null
+        && numbers.remaining != null
+        && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
+
+      if (state === "exhausted") {
+        candidates.push({
+          priority: 45,
+          action,
+          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+        });
+      } else if (
+        (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
+        || absoluteUrgent
+      ) {
+        const usage = numbers.remaining != null
+          ? `has ${compactNumber(numbers.remaining)} units remaining in its ${label}`
+          : `is at ${compactNumber(numbers.percent ?? URGENT_PERCENT)}% of its ${label}`;
+        candidates.push({
+          priority: 35,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+        });
+      } else if (
+        state === "warning"
+        || (numbers.percent != null && numbers.percent >= WARNING_PERCENT)
+      ) {
+        const usage = numbers.percent != null
+          ? `is at ${compactNumber(numbers.percent)}% of its ${label}`
+          : `is nearing its ${label}`;
+        candidates.push({
+          priority: 25,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+        });
+      }
+    }
+  }
+
+  candidates.sort((left, right) => right.priority - left.priority);
+  const selected = candidates[0];
+  return selected
+    ? `${selected.message}${actionInstruction(selected.action)}`
+    : "";
+}
+
+function readPayload() {
+  const raw = readFileSync(0, "utf8");
+  if (!raw.trim()) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+const notice = formatRuntimeStateNotice(readPayload());
+if (notice) {
+  process.stdout.write(notice);
+}

--- a/claude-plugin/hooks/session-start.sh
+++ b/claude-plugin/hooks/session-start.sh
@@ -29,6 +29,10 @@ if mem9_load_auth 2>/dev/null; then
   mem9_debug "SessionStart" "auth_ready" \
     "source" "${SESSION_SOURCE}" \
     "auth_source" "${MEM9_AUTH_SOURCE:-unknown}"
+  runtime_state_notice="$(mem9_runtime_state_notice "SessionStart")"
+  if [[ -n "${runtime_state_notice}" ]]; then
+    mem9_emit_context "SessionStart" "${runtime_state_notice}"
+  fi
   exit 0
 else
   load_auth_status=$?
@@ -63,8 +67,16 @@ if ! mem9_write_auth "${api_key}"; then
   exit 0
 fi
 
+MEM9_API_KEY="${api_key}"
+MEM9_AUTH_SOURCE="auto_provisioned"
+export MEM9_API_KEY MEM9_AUTH_SOURCE
 mem9_write_session_env "${api_key}" || true
 mem9_debug "SessionStart" "initialized" \
   "source" "${SESSION_SOURCE}" \
   "auth_source" "auto_provisioned"
-mem9_emit_context "SessionStart" "[mem9] Initialized automatically."
+runtime_state_notice="$(mem9_runtime_state_notice "SessionStart")"
+if [[ -n "${runtime_state_notice}" ]]; then
+  mem9_emit_context "SessionStart" "[mem9] Initialized automatically. ${runtime_state_notice}"
+else
+  mem9_emit_context "SessionStart" "[mem9] Initialized automatically."
+fi

--- a/codex-plugin/hooks/session-start.mjs
+++ b/codex-plugin/hooks/session-start.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { loadRuntimeStateFromDisk } from "../lib/config.mjs";
+import { resolveRuntimeStateNotice } from "../lib/runtime-state.mjs";
 import { resolveUpgradeNotice } from "../lib/update-check.mjs";
 import { appendDebugError, appendDebugLog } from "./shared/debug.mjs";
 import { hookAdditionalContext } from "./shared/format.mjs";
@@ -116,16 +117,39 @@ export function appendUpgradeNotice(message, upgradeNotice) {
 }
 
 /**
- * @param {{state?: SessionStartState, setupCommand?: string, upgradeNotice?: string}} [input]
+ * @param {string} message
+ * @param {string} runtimeStateNotice
+ * @returns {string}
+ */
+export function appendRuntimeStateNotice(message, runtimeStateNotice) {
+  const base = String(message ?? "").trim();
+  const notice = String(runtimeStateNotice ?? "").trim();
+
+  if (!notice) {
+    return base;
+  }
+
+  if (!base) {
+    return notice;
+  }
+
+  return `${base} ${notice}`;
+}
+
+/**
+ * @param {{state?: SessionStartState, setupCommand?: string, upgradeNotice?: string, runtimeStateNotice?: string}} [input]
  * @returns {Promise<string>}
  */
 export async function runSessionStart(input = {}) {
-  const message = appendUpgradeNotice(
-    buildSessionStartMessage(
-      input.state ?? { configSource: "global", issueCode: "missing_config" },
-      input.setupCommand,
+  const message = appendRuntimeStateNotice(
+    appendUpgradeNotice(
+      buildSessionStartMessage(
+        input.state ?? { configSource: "global", issueCode: "missing_config" },
+        input.setupCommand,
+      ),
+      input.upgradeNotice ?? "",
     ),
-    input.upgradeNotice ?? "",
+    input.runtimeStateNotice ?? "",
   );
   return hookAdditionalContext("SessionStart", message);
 }
@@ -191,6 +215,20 @@ export async function main() {
         : "",
     },
   });
+  const shouldResolveRuntimeStateNotice = state.issueCode === "ready";
+  const runtimeStateNotice = shouldResolveRuntimeStateNotice
+    ? await resolveRuntimeStateNotice({
+      runtime: state.runtime,
+      debug(stage, fields) {
+        appendDebugLog({
+          hook: "SessionStart",
+          stage,
+          ...debugContext,
+          fields,
+        });
+      },
+    })
+    : "";
 
   return runSessionStart({
     state: {
@@ -203,6 +241,7 @@ export async function main() {
       issueCode: state.issueCode,
     },
     upgradeNotice: upgradeNotice.message,
+    runtimeStateNotice,
   });
 }
 

--- a/codex-plugin/lib/runtime-state.mjs
+++ b/codex-plugin/lib/runtime-state.mjs
@@ -182,6 +182,15 @@ export function formatRuntimeStateNotice(runtimeState) {
   const action = normalizeAction(runtimeState.recommendedAction);
   /** @type {{priority: number, message: string, action?: RuntimeRecommendedAction | null}[]} */
   const candidates = [];
+  const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
+
+  if (text(mem9ApiKey.status) === "inactive") {
+    candidates.push({
+      priority: 65,
+      action,
+      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+    });
+  }
 
   if (action && (text(action.severity) || text(action.url))) {
     candidates.push({

--- a/codex-plugin/lib/runtime-state.mjs
+++ b/codex-plugin/lib/runtime-state.mjs
@@ -1,0 +1,328 @@
+// @ts-check
+
+import { buildMem9Url, mem9FetchJson, mem9Headers } from "./http.mjs";
+
+const WARNING_PERCENT = 80;
+const URGENT_PERCENT = 95;
+
+/**
+ * @typedef {{
+ *   baseUrl: string,
+ *   apiKey: string,
+ *   agentId: string,
+ *   defaultTimeoutMs: number,
+ * }} RuntimeStateRuntime
+ */
+
+/**
+ * @typedef {{
+ *   providerActionCode?: string,
+ *   severity?: string,
+ *   type?: string,
+ *   url?: string,
+ * }} RuntimeRecommendedAction
+ */
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function text(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function numberValue(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * @param {number} value
+ * @returns {string}
+ */
+function compactNumber(value) {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+/**
+ * @param {string} meter
+ * @returns {string}
+ */
+function meterLabel(meter) {
+  if (meter === "memory_recall_requests") {
+    return "mem9 recall";
+  }
+  if (meter === "memory_write_requests") {
+    return "mem9 memory saving";
+  }
+  return "mem9 memory";
+}
+
+/**
+ * @param {string} budgetType
+ * @returns {string}
+ */
+function budgetLabel(budgetType) {
+  if (budgetType === "includedQuota") {
+    return "included quota";
+  }
+  if (budgetType === "spendingLimit") {
+    return "spending limit";
+  }
+  if (budgetType === "credits") {
+    return "credit balance";
+  }
+  return "runtime quota";
+}
+
+/**
+ * @param {string} mode
+ * @returns {string}
+ */
+function modeLabel(mode) {
+  if (mode === "onDemand") {
+    return "on-demand usage";
+  }
+  if (mode === "postQuota") {
+    return "the post-quota request lane";
+  }
+  return "provider-managed runtime";
+}
+
+/**
+ * @param {unknown} input
+ * @returns {RuntimeRecommendedAction | null}
+ */
+function normalizeAction(input) {
+  const action = isRecord(input) ? input : {};
+  const providerActionCode = text(action.providerActionCode);
+  const severity = text(action.severity);
+  const type = text(action.type);
+  const url = text(action.url);
+
+  if (!providerActionCode && !severity && !type && !url) {
+    return null;
+  }
+
+  return {
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+/**
+ * @param {RuntimeRecommendedAction | null | undefined} action
+ * @returns {string}
+ */
+function actionInstruction(action) {
+  const providerActionCode = text(action?.providerActionCode);
+  const url = text(action?.url);
+
+  if (!url) {
+    return providerActionCode
+      ? " Ask them to open the mem9 console to resolve the account or billing state."
+      : "";
+  }
+
+  if (providerActionCode === "claimApiKey") {
+    return ` Ask them to open this link to sign in or create a mem9 account and claim this API key: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "upgradePlan") {
+    return ` Ask them to open this link to upgrade their mem9 plan and get more included usage: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "increaseSpendingLimit") {
+    return ` Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "enableOnDemand") {
+    return ` Ask them to open this link to enable billing or on-demand usage for mem9: ${url}. Include the link exactly as written.`;
+  }
+  return ` Ask them to open this mem9 link to resolve the account or billing state: ${url}. Include the link exactly as written.`;
+}
+
+/**
+ * @param {Record<string, unknown>} budget
+ * @returns {{percent: number | null, remaining: number | null, capacity: number | null}}
+ */
+function budgetNumbers(budget) {
+  const usage = isRecord(budget.usage) ? budget.usage : {};
+  const capacity = isRecord(budget.capacity) ? budget.capacity : {};
+  const capacityValue = text(capacity.type) === "limited"
+    ? numberValue(capacity.value)
+    : null;
+
+  return {
+    percent: numberValue(usage.percent),
+    remaining: numberValue(usage.remaining),
+    capacity: capacityValue != null && capacityValue > 0 ? capacityValue : null,
+  };
+}
+
+/**
+ * @param {unknown} runtimeState
+ * @returns {string}
+ */
+export function formatRuntimeStateNotice(runtimeState) {
+  if (!isRecord(runtimeState)) {
+    return "";
+  }
+
+  const action = normalizeAction(runtimeState.recommendedAction);
+  /** @type {{priority: number, message: string, action?: RuntimeRecommendedAction | null}[]} */
+  const candidates = [];
+
+  if (action && (text(action.severity) || text(action.url))) {
+    candidates.push({
+      priority: action.severity === "blocking" ? 50 : 20,
+      action,
+      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+    });
+  }
+
+  const meters = Array.isArray(runtimeState.meters) ? runtimeState.meters : [];
+  for (const rawMeter of meters) {
+    if (!isRecord(rawMeter)) {
+      continue;
+    }
+
+    const feature = meterLabel(text(rawMeter.meter));
+    const gate = isRecord(rawMeter.quotaGateResult) ? rawMeter.quotaGateResult : {};
+    const outcome = text(gate.outcome);
+    const mode = text(gate.mode);
+
+    if (outcome === "blocked") {
+      candidates.push({
+        priority: 60,
+        action,
+        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+      });
+    } else if (outcome === "rateLimited") {
+      candidates.push({
+        priority: 55,
+        action,
+        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+      });
+    } else if (mode === "onDemand" || mode === "postQuota") {
+      candidates.push({
+        priority: 40,
+        action,
+        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+      });
+    }
+
+    const budgets = Array.isArray(rawMeter.budgets) ? rawMeter.budgets : [];
+    for (const rawBudget of budgets) {
+      if (!isRecord(rawBudget)) {
+        continue;
+      }
+
+      const label = budgetLabel(text(rawBudget.type));
+      const state = text(rawBudget.state);
+      const numbers = budgetNumbers(rawBudget);
+      const absoluteUrgent = numbers.capacity != null
+        && numbers.remaining != null
+        && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
+
+      if (state === "exhausted") {
+        candidates.push({
+          priority: 45,
+          action,
+          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+        });
+      } else if (
+        (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
+        || absoluteUrgent
+      ) {
+        const usage = numbers.remaining != null
+          ? `has ${compactNumber(numbers.remaining)} units remaining in its ${label}`
+          : `is at ${compactNumber(numbers.percent ?? URGENT_PERCENT)}% of its ${label}`;
+        candidates.push({
+          priority: 35,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+        });
+      } else if (
+        state === "warning"
+        || (numbers.percent != null && numbers.percent >= WARNING_PERCENT)
+      ) {
+        const usage = numbers.percent != null
+          ? `is at ${compactNumber(numbers.percent)}% of its ${label}`
+          : `is nearing its ${label}`;
+        candidates.push({
+          priority: 25,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+        });
+      }
+    }
+  }
+
+  candidates.sort((left, right) => right.priority - left.priority);
+  const selected = candidates[0];
+  return selected
+    ? `${selected.message}${actionInstruction(selected.action)}`
+    : "";
+}
+
+/**
+ * @param {string} baseUrl
+ * @returns {string}
+ */
+export function buildRuntimeStateUrl(baseUrl) {
+  return buildMem9Url(baseUrl, "v1alpha2/mem9s/runtime-state").toString();
+}
+
+/**
+ * @param {{
+ *   runtime: RuntimeStateRuntime,
+ *   fetchState?: (url: string, options: {timeoutMs: number}) => Promise<unknown>,
+ *   debug?: (stage: string, fields?: Record<string, string | number | boolean | null | undefined>) => void,
+ * }} input
+ * @returns {Promise<string>}
+ */
+export async function resolveRuntimeStateNotice(input) {
+  const debug = input.debug ?? (() => {});
+  if (!input.runtime.apiKey) {
+    debug("runtime_state_skipped_missing_api_key");
+    return "";
+  }
+
+  const fetchState = input.fetchState ?? ((url, options) =>
+    mem9FetchJson(url, {
+      method: "GET",
+      headers: mem9Headers(input.runtime.apiKey, input.runtime.agentId),
+      timeoutMs: options.timeoutMs,
+    }));
+
+  try {
+    debug("runtime_state_request", {
+      timeoutMs: input.runtime.defaultTimeoutMs,
+    });
+    const state = await fetchState(
+      buildRuntimeStateUrl(input.runtime.baseUrl),
+      { timeoutMs: input.runtime.defaultTimeoutMs },
+    );
+    const notice = formatRuntimeStateNotice(state);
+    debug("runtime_state_response", {
+      hasNotice: Boolean(notice),
+    });
+    return notice;
+  } catch (error) {
+    debug("runtime_state_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return "";
+  }
+}

--- a/codex-plugin/lib/runtime-state.mjs
+++ b/codex-plugin/lib/runtime-state.mjs
@@ -101,6 +101,14 @@ function modeLabel(mode) {
 }
 
 /**
+ * @param {string} detail
+ * @returns {string}
+ */
+function warningMessage(detail) {
+  return `${detail}. In your reply, include this exact mem9 warning detail: ${detail}.`;
+}
+
+/**
  * @param {unknown} input
  * @returns {RuntimeRecommendedAction | null}
  */
@@ -185,18 +193,20 @@ export function formatRuntimeStateNotice(runtimeState) {
   const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
 
   if (text(mem9ApiKey.status) === "inactive") {
+    const detail = "Mem9 API key is inactive; rerun mem9 setup or create a new mem9 API key before memory access can continue";
     candidates.push({
       priority: 65,
       action,
-      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+      message: warningMessage(detail),
     });
   }
 
   if (action && (text(action.severity) || text(action.url))) {
+    const detail = "Mem9 needs account or billing attention";
     candidates.push({
       priority: action.severity === "blocking" ? 50 : 20,
       action,
-      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+      message: warningMessage(detail),
     });
   }
 
@@ -212,22 +222,25 @@ export function formatRuntimeStateNotice(runtimeState) {
     const mode = text(gate.mode);
 
     if (outcome === "blocked") {
+      const detail = `${feature} is blocked by runtime quota and needs attention before memory access can continue`;
       candidates.push({
         priority: 60,
         action,
-        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+        message: warningMessage(detail),
       });
     } else if (outcome === "rateLimited") {
+      const detail = `${feature} has reached its temporary runtime rate limit and needs a retry later`;
       candidates.push({
         priority: 55,
         action,
-        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+        message: warningMessage(detail),
       });
     } else if (mode === "onDemand" || mode === "postQuota") {
+      const detail = `${feature} is in constrained mode and using ${modeLabel(mode)}`;
       candidates.push({
         priority: 40,
         action,
-        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+        message: warningMessage(detail),
       });
     }
 
@@ -245,10 +258,11 @@ export function formatRuntimeStateNotice(runtimeState) {
         && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
 
       if (state === "exhausted") {
+        const detail = `${feature} has exhausted its ${label} and is in constrained mode`;
         candidates.push({
           priority: 45,
           action,
-          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+          message: warningMessage(detail),
         });
       } else if (
         (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
@@ -260,7 +274,7 @@ export function formatRuntimeStateNotice(runtimeState) {
         candidates.push({
           priority: 35,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is almost out of runtime quota`),
         });
       } else if (
         state === "warning"
@@ -272,7 +286,7 @@ export function formatRuntimeStateNotice(runtimeState) {
         candidates.push({
           priority: 25,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is nearing its runtime quota`),
         });
       }
     }

--- a/codex-plugin/tests/runtime-state.test.mjs
+++ b/codex-plugin/tests/runtime-state.test.mjs
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildRuntimeStateUrl,
+  formatRuntimeStateNotice,
+  resolveRuntimeStateNotice,
+} from "../lib/runtime-state.mjs";
+
+test("buildRuntimeStateUrl targets the public runtime-state endpoint", () => {
+  assert.equal(
+    buildRuntimeStateUrl("https://api.mem9.ai"),
+    "https://api.mem9.ai/v1alpha2/mem9s/runtime-state",
+  );
+});
+
+test("formatRuntimeStateNotice renders an 80 percent warning", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "warning",
+            usage: { used: 820, remaining: 180, percent: 82 },
+            capacity: { type: "limited", value: 1000 },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(notice, /mem9 recall is at 82% of its included quota/);
+  assert.match(notice, /briefly tell the user/);
+});
+
+test("formatRuntimeStateNotice renders absolute-unit urgent usage", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_write_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "ok",
+            usage: { used: 96, remaining: 4, percent: 96 },
+            capacity: { type: "limited", value: 100 },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(notice, /mem9 memory saving has 4 units remaining/);
+  assert.match(notice, /almost out of runtime quota/);
+});
+
+test("formatRuntimeStateNotice prefers constrained mode over lower warnings", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "warning",
+            usage: { used: 810, remaining: 190, percent: 81 },
+            capacity: { type: "limited", value: 1000 },
+          },
+        ],
+      },
+      {
+        meter: "memory_write_requests",
+        quotaGateResult: {
+          outcome: "allowed",
+          mode: "onDemand",
+          reason: "includedQuotaExhaustedOnDemandAvailable",
+        },
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "exhausted",
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(notice, /mem9 memory saving has exhausted its included quota/);
+  assert.doesNotMatch(notice, /mem9 recall is at 81%/);
+});
+
+test("formatRuntimeStateNotice appends provider action guidance", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "blocked",
+          mode: "includedQuota",
+          reason: "includedQuotaExhausted",
+        },
+        budgets: [],
+      },
+    ],
+    recommendedAction: {
+      type: "openUrl",
+      providerActionCode: "upgradePlan",
+      severity: "blocking",
+      url: "https://console.mem9.ai/console/billing/plan",
+    },
+  });
+
+  assert.match(notice, /mem9 recall is blocked by runtime quota/);
+  assert.match(notice, /upgrade their mem9 plan/);
+  assert.match(notice, /https:\/\/console\.mem9\.ai\/console\/billing\/plan/);
+});
+
+test("resolveRuntimeStateNotice is fail-soft", async () => {
+  /** @type {string[]} */
+  const debugStages = [];
+  const notice = await resolveRuntimeStateNotice({
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "mem9_test",
+      agentId: "codex",
+      defaultTimeoutMs: 1234,
+    },
+    debug(stage) {
+      debugStages.push(stage);
+    },
+    async fetchState() {
+      throw new Error("timeout");
+    },
+  });
+
+  assert.equal(notice, "");
+  assert.deepEqual(debugStages, [
+    "runtime_state_request",
+    "runtime_state_failed",
+  ]);
+});
+
+test("resolveRuntimeStateNotice fetches runtime-state with timeout", async () => {
+  let capturedUrl = "";
+  let capturedTimeout = 0;
+  const notice = await resolveRuntimeStateNotice({
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "mem9_test",
+      agentId: "codex",
+      defaultTimeoutMs: 4321,
+    },
+    async fetchState(url, options) {
+      capturedUrl = url;
+      capturedTimeout = options.timeoutMs;
+      return {
+        meters: [
+          {
+            meter: "memory_recall_requests",
+            budgets: [
+              {
+                type: "includedQuota",
+                state: "warning",
+                usage: { percent: 88 },
+              },
+            ],
+          },
+        ],
+      };
+    },
+  });
+
+  assert.equal(capturedUrl, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
+  assert.equal(capturedTimeout, 4321);
+  assert.match(notice, /mem9 recall is at 88%/);
+});

--- a/codex-plugin/tests/runtime-state.test.mjs
+++ b/codex-plugin/tests/runtime-state.test.mjs
@@ -33,7 +33,7 @@ test("formatRuntimeStateNotice renders an 80 percent warning", () => {
   });
 
   assert.match(notice, /mem9 recall is at 82% of its included quota/);
-  assert.match(notice, /briefly tell the user/);
+  assert.match(notice, /include this exact mem9 warning detail/);
 });
 
 test("formatRuntimeStateNotice renders absolute-unit urgent usage", () => {

--- a/codex-plugin/tests/runtime-state.test.mjs
+++ b/codex-plugin/tests/runtime-state.test.mjs
@@ -121,6 +121,33 @@ test("formatRuntimeStateNotice appends provider action guidance", () => {
   assert.match(notice, /https:\/\/console\.mem9\.ai\/console\/billing\/plan/);
 });
 
+test("formatRuntimeStateNotice renders inactive API key guidance", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "inactive" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "unlimited",
+          },
+        ],
+      },
+    ],
+    recommendedAction: {
+      type: "openUrl",
+      providerActionCode: "claimApiKey",
+      severity: "blocking",
+      url: "https://console.mem9.ai/console/api-keys",
+    },
+  });
+
+  assert.match(notice, /Mem9 API key is inactive/);
+  assert.match(notice, /rerun mem9 setup or create a new mem9 API key/);
+  assert.match(notice, /claim this API key/);
+});
+
 test("resolveRuntimeStateNotice is fail-soft", async () => {
   /** @type {string[]} */
   const debugStages = [];

--- a/codex-plugin/tests/session-start.test.mjs
+++ b/codex-plugin/tests/session-start.test.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createServer } from "node:http";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import test from "node:test";
 
 import {
+  appendRuntimeStateNotice,
   appendUpgradeNotice,
   buildSessionStartMessage,
   runSessionStart,
@@ -54,6 +56,53 @@ async function runNodeHook(scriptPath, input) {
 
     child.stdin.end(input.input);
   });
+}
+
+/**
+ * @param {string} tempRoot
+ * @param {string} baseUrl
+ */
+function createReadyRuntimeLayout(tempRoot, baseUrl) {
+  const cwd = path.join(tempRoot, "workspace");
+  const codexHome = path.join(tempRoot, "codex-home");
+  const mem9Home = path.join(tempRoot, "mem9-home");
+
+  mkdirSync(cwd, { recursive: true });
+  writeJson(path.join(codexHome, "mem9", "install.json"), {
+    schemaVersion: 1,
+    marketplaceName: "mem9-ai",
+    pluginName: "mem9",
+    shimVersion: 1,
+  });
+  mkdirSync(
+    path.join(codexHome, "plugins", "cache", "mem9-ai", "mem9", "local"),
+    { recursive: true },
+  );
+  writeFileSync(path.join(codexHome, "config.toml"), "\n");
+  writeJson(path.join(codexHome, "mem9", "config.json"), {
+    schemaVersion: 1,
+    profileId: "default",
+    defaultTimeoutMs: 2_000,
+    updateCheck: {
+      enabled: false,
+    },
+  });
+  writeJson(path.join(mem9Home, ".credentials.json"), {
+    schemaVersion: 1,
+    profiles: {
+      default: {
+        label: "Default",
+        baseUrl,
+        apiKey: "key-1",
+      },
+    },
+  });
+
+  return {
+    cwd,
+    codexHome,
+    mem9Home,
+  };
 }
 
 test("session start emits ready context for a project override", async () => {
@@ -115,6 +164,33 @@ test("session start appends upgrade notices after the runtime message", async ()
   assert.match(message, /global default config/);
   assert.match(message, /mem9 upgraded to v0\.2\.0/);
   assert.ok(message.indexOf("global default config") < message.indexOf("mem9 upgraded to v0.2.0"));
+});
+
+test("session start appends runtime-state notice after upgrade notices", async () => {
+  const output = await runSessionStart({
+    state: {
+      configSource: "global",
+      profileId: "default",
+      issueCode: "ready",
+    },
+    upgradeNotice: "mem9 upgraded to v0.2.0. Restart picked it up.",
+    runtimeStateNotice: "mem9 recall is at 82% of its included quota.",
+  });
+
+  const parsed = JSON.parse(output);
+  const message = parsed.hookSpecificOutput.additionalContext;
+  assert.match(message, /global default config/);
+  assert.match(message, /mem9 upgraded to v0\.2\.0/);
+  assert.match(message, /mem9 recall is at 82%/);
+  assert.ok(message.indexOf("global default config") < message.indexOf("mem9 upgraded to v0.2.0"));
+  assert.ok(message.indexOf("mem9 upgraded to v0.2.0") < message.indexOf("mem9 recall is at 82%"));
+});
+
+test("appendRuntimeStateNotice preserves an empty base message", () => {
+  assert.equal(
+    appendRuntimeStateNotice("", "mem9 recall is near the included quota."),
+    "mem9 recall is near the included quota.",
+  );
 });
 
 test("session start keeps repair guidance ahead of upgrade notices", () => {
@@ -226,6 +302,72 @@ test("session start skips upgrade state writes when runtime is not ready", async
     assert.equal(result.code, 0);
     assert.equal(existsSync(path.join(codexHome, "mem9", "state.json")), false);
   } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test("session start entrypoint fetches runtime-state when ready", async () => {
+  const tempRoot = createTempRoot("session-start-runtime-state");
+  let requestUrl = "";
+  let apiKey = "";
+  let agentId = "";
+  const server = createServer((req, res) => {
+    requestUrl = req.url ?? "";
+    apiKey = String(req.headers["x-api-key"] ?? "");
+    agentId = String(req.headers["x-mnemo-agent-id"] ?? "");
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify({
+      mem9ApiKey: { status: "active" },
+      meters: [
+        {
+          meter: "memory_recall_requests",
+          budgets: [
+            {
+              type: "includedQuota",
+              state: "warning",
+              usage: { used: 820, remaining: 180, percent: 82 },
+              capacity: { type: "limited", value: 1000 },
+            },
+          ],
+        },
+      ],
+    }));
+  });
+
+  try {
+    await new Promise((resolve) => {
+      server.listen(0, "127.0.0.1", () => resolve(undefined));
+    });
+    const address = server.address();
+    assert.ok(address && typeof address === "object");
+    const runtime = createReadyRuntimeLayout(
+      tempRoot,
+      `http://127.0.0.1:${address.port}`,
+    );
+
+    const result = await runNodeHook(SESSION_START_ENTRY, {
+      cwd: runtime.cwd,
+      env: {
+        ...process.env,
+        CODEX_HOME: runtime.codexHome,
+        MEM9_HOME: runtime.mem9Home,
+      },
+      input: JSON.stringify({ cwd: runtime.cwd }),
+    });
+
+    assert.equal(result.code, 0);
+    assert.equal(requestUrl, "/v1alpha2/mem9s/runtime-state");
+    assert.equal(apiKey, "key-1");
+    assert.equal(agentId, "codex");
+    const parsed = JSON.parse(result.stdout);
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /mem9 recall is at 82% of its included quota/,
+    );
+  } finally {
+    await new Promise((resolve) => {
+      server.close(() => resolve(undefined));
+    });
     rmSync(tempRoot, { recursive: true, force: true });
   }
 });

--- a/openclaw-plugin/backend.ts
+++ b/openclaw-plugin/backend.ts
@@ -38,4 +38,5 @@ export interface MemoryBackend {
    * POST /v1alpha{1,2}/mem9s/.../memories (messages body) → LLM extraction + reconciliation.
    */
   ingest(input: IngestInput): Promise<IngestResult>;
+  runtimeState(): Promise<unknown>;
 }

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -13,6 +13,7 @@
 
 import { isPendingProvisionError, type MemoryBackend } from "./backend.js";
 import { formatRuntimeQuotaNotice } from "./quota-error.js";
+import { formatRuntimeStateNotice } from "./runtime-state.js";
 import type { Memory, IngestMessage } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -215,6 +216,7 @@ export function registerHooks(
 ): void {
   const maxIngestBytes = options?.maxIngestBytes ?? DEFAULT_MAX_INGEST_BYTES;
   let loggedMissingConversationAccess = false;
+  let runtimeStateNoticeShown = false;
 
   // --------------------------------------------------------------------------
   // before_prompt_build — inject relevant memories into every LLM call
@@ -245,6 +247,16 @@ export function registerHooks(
           return;
         }
 
+        let runtimeStateNotice = "";
+        if (!runtimeStateNoticeShown) {
+          runtimeStateNoticeShown = true;
+          try {
+            runtimeStateNotice = formatRuntimeStateNotice(await backend.runtimeState());
+          } catch {
+            runtimeStateNotice = "";
+          }
+        }
+
         const result = await backend.search({ q: recallQuery, limit: MAX_INJECT });
         const memories = result.data ?? [];
         if (options?.debug) {
@@ -253,12 +265,19 @@ export function registerHooks(
           );
         }
 
-        if (memories.length === 0) return;
+        if (memories.length === 0) {
+          return runtimeStateNotice
+            ? { prependContext: runtimeStateNotice }
+            : undefined;
+        }
 
         logger.info(`[mem9] Injecting ${memories.length} memories into prompt context`);
+        const memoriesBlock = formatMemoriesBlock(memories);
 
         return {
-          prependContext: formatMemoriesBlock(memories),
+          prependContext: runtimeStateNotice
+            ? `${runtimeStateNotice}\n\n${memoriesBlock}`
+            : memoriesBlock,
         };
       } catch (err) {
         if (isPendingProvisionError(err)) {

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -241,14 +241,26 @@ test("memory tools return structured runtime quota denial payloads", async () =>
 test("before_prompt_build forwards the prompt as q during recall search", async () => {
   const originalFetch = globalThis.fetch;
   const apiUrl = uniqueApiUrl("before-prompt-q");
-  let requestedURL = "";
+  let runtimeStateRequestURL = "";
+  let memoryRequestURL = "";
   let requestCount = 0;
 
   globalThis.fetch = async (input, init) => {
-    requestedURL = String(input);
+    const requestURL = String(input);
     requestCount += 1;
     assert.equal(init?.method, "GET");
 
+    if (requestURL.endsWith("/v1alpha2/mem9s/runtime-state")) {
+      runtimeStateRequestURL = requestURL;
+      return new Response(JSON.stringify({ mem9ApiKey: { status: "active" }, meters: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
+    memoryRequestURL = requestURL;
     return new Response(
       JSON.stringify({
         memories: [
@@ -283,8 +295,9 @@ test("before_prompt_build forwards the prompt as q during recall search", async 
     const prompt = "remember alpha";
     const hookResult = await beforePromptBuild({ prompt }) as { prependContext?: string } | undefined;
 
-    assert.equal(requestCount, 1);
-    const url = new URL(requestedURL);
+    assert.equal(requestCount, 2);
+    assert.equal(runtimeStateRequestURL, `${apiUrl}/v1alpha2/mem9s/runtime-state`);
+    const url = new URL(memoryRequestURL);
     assert.equal(url.origin + url.pathname, `${apiUrl}/v1alpha2/mem9s/memories`);
     assert.equal(url.searchParams.get("q"), prompt);
     assert.equal(url.searchParams.get("limit"), "10");
@@ -566,14 +579,24 @@ test("formatRuntimeQuotaNotice renders write meter guidance", () => {
 test("before_prompt_build strips OpenClaw metadata wrappers before recall search", async () => {
   const originalFetch = globalThis.fetch;
   const apiUrl = uniqueApiUrl("before-prompt-sanitized-q");
-  let requestedURL = "";
+  let memoryRequestURL = "";
   let requestCount = 0;
 
   globalThis.fetch = async (input, init) => {
-    requestedURL = String(input);
+    const requestURL = String(input);
     requestCount += 1;
     assert.equal(init?.method, "GET");
 
+    if (requestURL.endsWith("/v1alpha2/mem9s/runtime-state")) {
+      return new Response(JSON.stringify({ mem9ApiKey: { status: "active" }, meters: [] }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    }
+
+    memoryRequestURL = requestURL;
     return new Response(
       JSON.stringify({
         memories: [
@@ -634,8 +657,8 @@ test("before_prompt_build strips OpenClaw metadata wrappers before recall search
 
     const hookResult = await beforePromptBuild({ prompt }) as { prependContext?: string } | undefined;
 
-    assert.equal(requestCount, 1);
-    const url = new URL(requestedURL);
+    assert.equal(requestCount, 2);
+    const url = new URL(memoryRequestURL);
     assert.equal(url.searchParams.get("q"), "经过了今天的努力，我把mem9的LoCoMo Benchmark从63%提升到了70%+");
     assert.equal(typeof hookResult?.prependContext, "string");
   } finally {

--- a/openclaw-plugin/index.ts
+++ b/openclaw-plugin/index.ts
@@ -795,5 +795,8 @@ class LazyServerBackend implements MemoryBackend {
   async ingest(input: IngestInput): Promise<IngestResult> {
     return (await this.resolve()).ingest(input);
   }
+  async runtimeState(): Promise<unknown> {
+    return (await this.resolve()).runtimeState();
+  }
 }
 export default mnemoPlugin;

--- a/openclaw-plugin/runtime-state.test.ts
+++ b/openclaw-plugin/runtime-state.test.ts
@@ -43,3 +43,23 @@ test("formatRuntimeStateNotice prefers blocking provider actions", () => {
     1,
   );
 });
+
+test("formatRuntimeStateNotice renders inactive API key guidance", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "inactive" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "unlimited",
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(notice, /Mem9 API key is inactive/);
+  assert.match(notice, /rerun mem9 setup or create a new mem9 API key/);
+});

--- a/openclaw-plugin/runtime-state.test.ts
+++ b/openclaw-plugin/runtime-state.test.ts
@@ -36,7 +36,7 @@ test("formatRuntimeStateNotice prefers blocking provider actions", () => {
     meters: [],
   });
 
-  assert.match(notice, /runtime account action/);
+  assert.match(notice, /account or billing attention/);
   assert.match(notice, /upgrade their mem9 plan/);
   assert.equal(
     notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,

--- a/openclaw-plugin/runtime-state.test.ts
+++ b/openclaw-plugin/runtime-state.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatRuntimeStateNotice } from "./runtime-state.js";
+
+test("formatRuntimeStateNotice renders included quota warnings", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "warning",
+            usage: { percent: 82, remaining: 18 },
+            capacity: { type: "limited", value: 100 },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(notice, /mem9 recall is at 82% of its included quota/);
+  assert.match(notice, /nearing its runtime quota/);
+});
+
+test("formatRuntimeStateNotice prefers blocking provider actions", () => {
+  const notice = formatRuntimeStateNotice({
+    recommendedAction: {
+      providerActionCode: "upgradePlan",
+      severity: "blocking",
+      type: "openUrl",
+      url: "https://console.mem9.ai/console/billing/plan",
+    },
+    meters: [],
+  });
+
+  assert.match(notice, /runtime account action/);
+  assert.match(notice, /upgrade their mem9 plan/);
+  assert.equal(
+    notice.match(/https:\/\/console\.mem9\.ai\/console\/billing\/plan/g)?.length,
+    1,
+  );
+});

--- a/openclaw-plugin/runtime-state.ts
+++ b/openclaw-plugin/runtime-state.ts
@@ -1,0 +1,202 @@
+const WARNING_PERCENT = 80;
+const URGENT_PERCENT = 95;
+
+interface RuntimeRecommendedAction {
+  providerActionCode?: string;
+  severity?: string;
+  type?: string;
+  url?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function compactNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function meterLabel(meter: string): string {
+  if (meter === "memory_recall_requests") return "mem9 recall";
+  if (meter === "memory_write_requests") return "mem9 memory saving";
+  return "mem9 memory";
+}
+
+function budgetLabel(budgetType: string): string {
+  if (budgetType === "includedQuota") return "included quota";
+  if (budgetType === "spendingLimit") return "spending limit";
+  if (budgetType === "credits") return "credit balance";
+  return "runtime quota";
+}
+
+function modeLabel(mode: string): string {
+  if (mode === "onDemand") return "on-demand usage";
+  if (mode === "postQuota") return "the post-quota request lane";
+  return "provider-managed runtime";
+}
+
+function normalizeAction(input: unknown): RuntimeRecommendedAction | null {
+  const action = isRecord(input) ? input : {};
+  const providerActionCode = text(action.providerActionCode);
+  const severity = text(action.severity);
+  const type = text(action.type);
+  const url = text(action.url);
+
+  if (!providerActionCode && !severity && !type && !url) return null;
+  return {
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+function actionInstruction(action: RuntimeRecommendedAction | null | undefined): string {
+  const providerActionCode = text(action?.providerActionCode);
+  const url = text(action?.url);
+
+  if (!url) {
+    return providerActionCode
+      ? " Ask them to open the mem9 console to resolve the account or billing state."
+      : "";
+  }
+
+  if (providerActionCode === "claimApiKey") {
+    return ` Ask them to open this link to sign in or create a mem9 account and claim this API key: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "upgradePlan") {
+    return ` Ask them to open this link to upgrade their mem9 plan and get more included usage: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "increaseSpendingLimit") {
+    return ` Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "enableOnDemand") {
+    return ` Ask them to open this link to enable billing or on-demand usage for mem9: ${url}. Include the link exactly as written.`;
+  }
+  return ` Ask them to open this mem9 link to resolve the account or billing state: ${url}. Include the link exactly as written.`;
+}
+
+function budgetNumbers(budget: Record<string, unknown>): {
+  percent: number | null;
+  remaining: number | null;
+  capacity: number | null;
+} {
+  const usage = isRecord(budget.usage) ? budget.usage : {};
+  const capacity = isRecord(budget.capacity) ? budget.capacity : {};
+  const capacityValue = text(capacity.type) === "limited"
+    ? numberValue(capacity.value)
+    : null;
+
+  return {
+    percent: numberValue(usage.percent),
+    remaining: numberValue(usage.remaining),
+    capacity: capacityValue != null && capacityValue > 0 ? capacityValue : null,
+  };
+}
+
+export function formatRuntimeStateNotice(runtimeState: unknown): string {
+  if (!isRecord(runtimeState)) return "";
+
+  const action = normalizeAction(runtimeState.recommendedAction);
+  const candidates: Array<{
+    priority: number;
+    message: string;
+    action?: RuntimeRecommendedAction | null;
+  }> = [];
+
+  if (action && (text(action.severity) || text(action.url))) {
+    candidates.push({
+      priority: action.severity === "blocking" ? 50 : 20,
+      action,
+      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+    });
+  }
+
+  const meters = Array.isArray(runtimeState.meters) ? runtimeState.meters : [];
+  for (const rawMeter of meters) {
+    if (!isRecord(rawMeter)) continue;
+
+    const feature = meterLabel(text(rawMeter.meter));
+    const gate = isRecord(rawMeter.quotaGateResult) ? rawMeter.quotaGateResult : {};
+    const outcome = text(gate.outcome);
+    const mode = text(gate.mode);
+
+    if (outcome === "blocked") {
+      candidates.push({
+        priority: 60,
+        action,
+        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+      });
+    } else if (outcome === "rateLimited") {
+      candidates.push({
+        priority: 55,
+        action,
+        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+      });
+    } else if (mode === "onDemand" || mode === "postQuota") {
+      candidates.push({
+        priority: 40,
+        action,
+        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+      });
+    }
+
+    const budgets = Array.isArray(rawMeter.budgets) ? rawMeter.budgets : [];
+    for (const rawBudget of budgets) {
+      if (!isRecord(rawBudget)) continue;
+
+      const label = budgetLabel(text(rawBudget.type));
+      const state = text(rawBudget.state);
+      const numbers = budgetNumbers(rawBudget);
+      const absoluteUrgent = numbers.capacity != null
+        && numbers.remaining != null
+        && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
+
+      if (state === "exhausted") {
+        candidates.push({
+          priority: 45,
+          action,
+          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+        });
+      } else if (
+        (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
+        || absoluteUrgent
+      ) {
+        const usage = numbers.remaining != null
+          ? `has ${compactNumber(numbers.remaining)} units remaining in its ${label}`
+          : `is at ${compactNumber(numbers.percent ?? URGENT_PERCENT)}% of its ${label}`;
+        candidates.push({
+          priority: 35,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+        });
+      } else if (
+        state === "warning"
+        || (numbers.percent != null && numbers.percent >= WARNING_PERCENT)
+      ) {
+        const usage = numbers.percent != null
+          ? `is at ${compactNumber(numbers.percent)}% of its ${label}`
+          : `is nearing its ${label}`;
+        candidates.push({
+          priority: 25,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+        });
+      }
+    }
+  }
+
+  candidates.sort((left, right) => right.priority - left.priority);
+  const selected = candidates[0];
+  return selected
+    ? `${selected.message}${actionInstruction(selected.action)}`
+    : "";
+}

--- a/openclaw-plugin/runtime-state.ts
+++ b/openclaw-plugin/runtime-state.ts
@@ -111,6 +111,15 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
     message: string;
     action?: RuntimeRecommendedAction | null;
   }> = [];
+  const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
+
+  if (text(mem9ApiKey.status) === "inactive") {
+    candidates.push({
+      priority: 65,
+      action,
+      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+    });
+  }
 
   if (action && (text(action.severity) || text(action.url))) {
     candidates.push({

--- a/openclaw-plugin/runtime-state.ts
+++ b/openclaw-plugin/runtime-state.ts
@@ -43,6 +43,10 @@ function modeLabel(mode: string): string {
   return "provider-managed runtime";
 }
 
+function warningMessage(detail: string): string {
+  return `${detail}. In your reply, include this exact mem9 warning detail: ${detail}.`;
+}
+
 function normalizeAction(input: unknown): RuntimeRecommendedAction | null {
   const action = isRecord(input) ? input : {};
   const providerActionCode = text(action.providerActionCode);
@@ -114,18 +118,20 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
   const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
 
   if (text(mem9ApiKey.status) === "inactive") {
+    const detail = "Mem9 API key is inactive; rerun mem9 setup or create a new mem9 API key before memory access can continue";
     candidates.push({
       priority: 65,
       action,
-      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+      message: warningMessage(detail),
     });
   }
 
   if (action && (text(action.severity) || text(action.url))) {
+    const detail = "Mem9 needs account or billing attention";
     candidates.push({
       priority: action.severity === "blocking" ? 50 : 20,
       action,
-      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+      message: warningMessage(detail),
     });
   }
 
@@ -139,22 +145,25 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
     const mode = text(gate.mode);
 
     if (outcome === "blocked") {
+      const detail = `${feature} is blocked by runtime quota and needs attention before memory access can continue`;
       candidates.push({
         priority: 60,
         action,
-        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+        message: warningMessage(detail),
       });
     } else if (outcome === "rateLimited") {
+      const detail = `${feature} has reached its temporary runtime rate limit and needs a retry later`;
       candidates.push({
         priority: 55,
         action,
-        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+        message: warningMessage(detail),
       });
     } else if (mode === "onDemand" || mode === "postQuota") {
+      const detail = `${feature} is in constrained mode and using ${modeLabel(mode)}`;
       candidates.push({
         priority: 40,
         action,
-        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+        message: warningMessage(detail),
       });
     }
 
@@ -170,10 +179,11 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
         && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
 
       if (state === "exhausted") {
+        const detail = `${feature} has exhausted its ${label} and is in constrained mode`;
         candidates.push({
           priority: 45,
           action,
-          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+          message: warningMessage(detail),
         });
       } else if (
         (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
@@ -185,7 +195,7 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
         candidates.push({
           priority: 35,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is almost out of runtime quota`),
         });
       } else if (
         state === "warning"
@@ -197,7 +207,7 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
         candidates.push({
           priority: 25,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is nearing its runtime quota`),
         });
       }
     }

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -82,6 +82,33 @@ test("normal memory requests do not append provision query params", async () => 
   }
 });
 
+test("runtime-state uses the public v1alpha2 path", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestedURL = "";
+  let requestHeaders: Headers | undefined;
+
+  globalThis.fetch = async (input, init) => {
+    requestedURL = String(input);
+    requestHeaders = new Headers(init?.headers);
+
+    return new Response(JSON.stringify({ mem9ApiKey: { status: "active" }, meters: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "space-key", "agent-1");
+    await backend.runtimeState();
+
+    assert.equal(requestedURL, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
+    assert.equal(requestHeaders?.get("X-API-Key"), "space-key");
+    assert.equal(requestHeaders?.get("X-Mnemo-Agent-Id"), "agent-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("normal memory requests reject malformed success JSON", async () => {
   const originalFetch = globalThis.fetch;
 

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -167,6 +167,10 @@ export class ServerBackend implements MemoryBackend {
     return this.request<IngestResult>("POST", this.memoryPath("/memories"), input);
   }
 
+  async runtimeState(): Promise<unknown> {
+    return this.request<unknown>("GET", this.memoryPath("/runtime-state"));
+  }
+
   private async requestRaw(
     method: string,
     path: string,

--- a/opencode-plugin/src/server/backend.ts
+++ b/opencode-plugin/src/server/backend.ts
@@ -36,4 +36,5 @@ export interface MemoryBackend {
   remove(id: string): Promise<boolean>;
   listRecent(limit: number): Promise<Memory[]>;
   ingest(input: IngestInput): Promise<IngestResult>;
+  runtimeState(): Promise<unknown>;
 }

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -282,6 +282,14 @@ export function buildHooks(
         Date.now(),
         fallbackAgentID,
       );
+      if (!state.latestPrompt) {
+        await options.debugLogger?.("recall.skip", {
+          sessionID: input.sessionID,
+          reason: "no_captured_prompt",
+        });
+        return;
+      }
+
       if (!state.runtimeStateNoticeShown) {
         state.runtimeStateNoticeShown = true;
         try {
@@ -293,14 +301,6 @@ export function buildHooks(
         } catch {
           // Runtime-state warmup is advisory and must stay fail-soft.
         }
-      }
-
-      if (!state.latestPrompt) {
-        await options.debugLogger?.("recall.skip", {
-          sessionID: input.sessionID,
-          reason: "no_captured_prompt",
-        });
-        return;
       }
 
       const query = buildRecallQuery(state.latestPrompt);

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -6,6 +6,7 @@ import { submitMessagesForIngest } from "./ingest/submit.ts";
 import { formatRuntimeQuotaNotice, parseRuntimeQuotaDenied } from "./quota-error.ts";
 import { formatRecallBlock } from "./recall/format.ts";
 import { buildRecallQuery } from "./recall/query.ts";
+import { formatRuntimeStateNotice } from "./runtime-state.ts";
 import type { SessionTranscriptLoader } from "./session-transcript.ts";
 
 const MAX_RECALL_RESULTS = 10;
@@ -26,6 +27,7 @@ interface SessionState {
   lastIngestFingerprint: string | null;
   pendingIngestFingerprint: string | null;
   agentID: string;
+  runtimeStateNoticeShown: boolean;
   updatedAt: number;
 }
 
@@ -108,6 +110,7 @@ function ensureSessionState(
     lastIngestFingerprint: null,
     pendingIngestFingerprint: null,
     agentID: fallbackAgentID,
+    runtimeStateNoticeShown: false,
     updatedAt: now,
   };
   cache.set(sessionID, state);
@@ -273,8 +276,26 @@ export function buildHooks(
 
       pruneSessionState(sessionStateByID, Date.now());
 
-      const state = sessionStateByID.get(input.sessionID);
-      if (!state || !state.latestPrompt) {
+      const state = ensureSessionState(
+        sessionStateByID,
+        input.sessionID,
+        Date.now(),
+        fallbackAgentID,
+      );
+      if (!state.runtimeStateNoticeShown) {
+        state.runtimeStateNoticeShown = true;
+        try {
+          const runtimeState = await backend.runtimeState();
+          const notice = formatRuntimeStateNotice(runtimeState);
+          if (notice) {
+            output.system.push(notice);
+          }
+        } catch {
+          // Runtime-state warmup is advisory and must stay fail-soft.
+        }
+      }
+
+      if (!state.latestPrompt) {
         await options.debugLogger?.("recall.skip", {
           sessionID: input.sessionID,
           reason: "no_captured_prompt",

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -19,6 +19,8 @@ const COMPACTION_HINT =
 
 type ChatMessageHook = NonNullable<Hooks["chat.message"]>;
 type ChatMessageOutput = Parameters<ChatMessageHook>[1];
+type MessagesTransformHook = NonNullable<Hooks["experimental.chat.messages.transform"]>;
+type MessagesTransformOutput = Parameters<MessagesTransformHook>[1];
 type EventHook = NonNullable<Hooks["event"]>;
 type EventInput = Parameters<EventHook>[0];
 
@@ -64,6 +66,43 @@ function extractLatestUserPrompt(parts: ChatMessageOutput["parts"]): string | nu
   }
 
   return chunks.length > 0 ? chunks.join("\n\n") : null;
+}
+
+function findLatestUserMessage(
+  messages: MessagesTransformOutput["messages"],
+): MessagesTransformOutput["messages"][number] | null {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message?.info.role === "user") {
+      return message;
+    }
+  }
+  return null;
+}
+
+function runtimeStateNoticeText(notice: string): string {
+  return [
+    "<mem9-status-warning>",
+    notice,
+    "</mem9-status-warning>",
+  ].join("\n");
+}
+
+async function consumeRuntimeStateNotice(
+  state: SessionState,
+  backend: MemoryBackend,
+): Promise<string> {
+  if (state.runtimeStateNoticeShown) {
+    return "";
+  }
+  state.runtimeStateNoticeShown = true;
+
+  try {
+    return formatRuntimeStateNotice(await backend.runtimeState());
+  } catch {
+    // Runtime-state warmup is advisory and must stay fail-soft.
+    return "";
+  }
 }
 
 function pruneSessionState(cache: Map<string, SessionState>, now: number): void {
@@ -215,6 +254,7 @@ export function buildHooks(
   Hooks,
   | "chat.message"
   | "event"
+  | "experimental.chat.messages.transform"
   | "experimental.chat.system.transform"
   | "experimental.session.compacting"
 > {
@@ -252,6 +292,43 @@ export function buildHooks(
         promptLength: prompt.length,
       });
     },
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const latestUserMessage = findLatestUserMessage(output.messages);
+      if (!latestUserMessage) {
+        return;
+      }
+
+      const now = Date.now();
+      pruneSessionState(sessionStateByID, now);
+      const state = ensureSessionState(
+        sessionStateByID,
+        latestUserMessage.info.sessionID,
+        now,
+        fallbackAgentID,
+      );
+      if (latestUserMessage.info.role === "user") {
+        state.agentID = resolveAgentID(latestUserMessage.info.agent, state.agentID);
+      }
+
+      const prompt = extractLatestUserPrompt(latestUserMessage.parts);
+      if (prompt) {
+        state.latestPrompt = prompt;
+      }
+
+      const notice = await consumeRuntimeStateNotice(state, backend);
+      if (!notice) {
+        return;
+      }
+
+      latestUserMessage.parts.push({
+        id: `prt_mem9_runtime_state_${latestUserMessage.info.id}`,
+        sessionID: latestUserMessage.info.sessionID,
+        messageID: latestUserMessage.info.id,
+        type: "text",
+        text: runtimeStateNoticeText(notice),
+        metadata: { source: "mem9-runtime-state" },
+      } as MessagesTransformOutput["messages"][number]["parts"][number]);
+    },
     event: async (input) => {
       if (input.event.type !== "session.idle") {
         return;
@@ -282,25 +359,13 @@ export function buildHooks(
         Date.now(),
         fallbackAgentID,
       );
+
       if (!state.latestPrompt) {
         await options.debugLogger?.("recall.skip", {
           sessionID: input.sessionID,
           reason: "no_captured_prompt",
         });
         return;
-      }
-
-      if (!state.runtimeStateNoticeShown) {
-        state.runtimeStateNoticeShown = true;
-        try {
-          const runtimeState = await backend.runtimeState();
-          const notice = formatRuntimeStateNotice(runtimeState);
-          if (notice) {
-            output.system.push(notice);
-          }
-        } catch {
-          // Runtime-state warmup is advisory and must stay fail-soft.
-        }
       }
 
       const query = buildRecallQuery(state.latestPrompt);

--- a/opencode-plugin/src/server/ingest/select.ts
+++ b/opencode-plugin/src/server/ingest/select.ts
@@ -1,10 +1,14 @@
 import type { IngestMessage } from "../backend.ts";
 
 const RELEVANT_MEMORIES_BLOCK_RE = /<relevant-memories>[\s\S]*?(<\/relevant-memories>|$)/g;
+const MEM9_STATUS_WARNING_BLOCK_RE = /<mem9-status-warning>[\s\S]*?(<\/mem9-status-warning>|$)/g;
 const MAX_INGEST_MESSAGES = 12;
 
 function cleanMessageContent(content: string): string {
-  return content.replace(RELEVANT_MEMORIES_BLOCK_RE, "").trim();
+  return content
+    .replace(RELEVANT_MEMORIES_BLOCK_RE, "")
+    .replace(MEM9_STATUS_WARNING_BLOCK_RE, "")
+    .trim();
 }
 
 export function selectMessagesForIngest(messages: IngestMessage[]): IngestMessage[] {

--- a/opencode-plugin/src/server/runtime-state.ts
+++ b/opencode-plugin/src/server/runtime-state.ts
@@ -1,0 +1,202 @@
+const WARNING_PERCENT = 80;
+const URGENT_PERCENT = 95;
+
+interface RuntimeRecommendedAction {
+  providerActionCode?: string;
+  severity?: string;
+  type?: string;
+  url?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function compactNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1);
+}
+
+function meterLabel(meter: string): string {
+  if (meter === "memory_recall_requests") return "mem9 recall";
+  if (meter === "memory_write_requests") return "mem9 memory saving";
+  return "mem9 memory";
+}
+
+function budgetLabel(budgetType: string): string {
+  if (budgetType === "includedQuota") return "included quota";
+  if (budgetType === "spendingLimit") return "spending limit";
+  if (budgetType === "credits") return "credit balance";
+  return "runtime quota";
+}
+
+function modeLabel(mode: string): string {
+  if (mode === "onDemand") return "on-demand usage";
+  if (mode === "postQuota") return "the post-quota request lane";
+  return "provider-managed runtime";
+}
+
+function normalizeAction(input: unknown): RuntimeRecommendedAction | null {
+  const action = isRecord(input) ? input : {};
+  const providerActionCode = text(action.providerActionCode);
+  const severity = text(action.severity);
+  const type = text(action.type);
+  const url = text(action.url);
+
+  if (!providerActionCode && !severity && !type && !url) return null;
+  return {
+    ...(providerActionCode ? { providerActionCode } : {}),
+    ...(severity ? { severity } : {}),
+    ...(type ? { type } : {}),
+    ...(url ? { url } : {}),
+  };
+}
+
+function actionInstruction(action: RuntimeRecommendedAction | null | undefined): string {
+  const providerActionCode = text(action?.providerActionCode);
+  const url = text(action?.url);
+
+  if (!url) {
+    return providerActionCode
+      ? " Ask them to open the mem9 console to resolve the account or billing state."
+      : "";
+  }
+
+  if (providerActionCode === "claimApiKey") {
+    return ` Ask them to open this link to sign in or create a mem9 account and claim this API key: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "upgradePlan") {
+    return ` Ask them to open this link to upgrade their mem9 plan and get more included usage: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "increaseSpendingLimit") {
+    return ` Ask them to open this link to increase the mem9 spending limit or adjust billing settings: ${url}. Include the link exactly as written.`;
+  }
+  if (providerActionCode === "enableOnDemand") {
+    return ` Ask them to open this link to enable billing or on-demand usage for mem9: ${url}. Include the link exactly as written.`;
+  }
+  return ` Ask them to open this mem9 link to resolve the account or billing state: ${url}. Include the link exactly as written.`;
+}
+
+function budgetNumbers(budget: Record<string, unknown>): {
+  percent: number | null;
+  remaining: number | null;
+  capacity: number | null;
+} {
+  const usage = isRecord(budget.usage) ? budget.usage : {};
+  const capacity = isRecord(budget.capacity) ? budget.capacity : {};
+  const capacityValue = text(capacity.type) === "limited"
+    ? numberValue(capacity.value)
+    : null;
+
+  return {
+    percent: numberValue(usage.percent),
+    remaining: numberValue(usage.remaining),
+    capacity: capacityValue != null && capacityValue > 0 ? capacityValue : null,
+  };
+}
+
+export function formatRuntimeStateNotice(runtimeState: unknown): string {
+  if (!isRecord(runtimeState)) return "";
+
+  const action = normalizeAction(runtimeState.recommendedAction);
+  const candidates: Array<{
+    priority: number;
+    message: string;
+    action?: RuntimeRecommendedAction | null;
+  }> = [];
+
+  if (action && (text(action.severity) || text(action.url))) {
+    candidates.push({
+      priority: action.severity === "blocking" ? 50 : 20,
+      action,
+      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+    });
+  }
+
+  const meters = Array.isArray(runtimeState.meters) ? runtimeState.meters : [];
+  for (const rawMeter of meters) {
+    if (!isRecord(rawMeter)) continue;
+
+    const feature = meterLabel(text(rawMeter.meter));
+    const gate = isRecord(rawMeter.quotaGateResult) ? rawMeter.quotaGateResult : {};
+    const outcome = text(gate.outcome);
+    const mode = text(gate.mode);
+
+    if (outcome === "blocked") {
+      candidates.push({
+        priority: 60,
+        action,
+        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+      });
+    } else if (outcome === "rateLimited") {
+      candidates.push({
+        priority: 55,
+        action,
+        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+      });
+    } else if (mode === "onDemand" || mode === "postQuota") {
+      candidates.push({
+        priority: 40,
+        action,
+        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+      });
+    }
+
+    const budgets = Array.isArray(rawMeter.budgets) ? rawMeter.budgets : [];
+    for (const rawBudget of budgets) {
+      if (!isRecord(rawBudget)) continue;
+
+      const label = budgetLabel(text(rawBudget.type));
+      const state = text(rawBudget.state);
+      const numbers = budgetNumbers(rawBudget);
+      const absoluteUrgent = numbers.capacity != null
+        && numbers.remaining != null
+        && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
+
+      if (state === "exhausted") {
+        candidates.push({
+          priority: 45,
+          action,
+          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+        });
+      } else if (
+        (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
+        || absoluteUrgent
+      ) {
+        const usage = numbers.remaining != null
+          ? `has ${compactNumber(numbers.remaining)} units remaining in its ${label}`
+          : `is at ${compactNumber(numbers.percent ?? URGENT_PERCENT)}% of its ${label}`;
+        candidates.push({
+          priority: 35,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+        });
+      } else if (
+        state === "warning"
+        || (numbers.percent != null && numbers.percent >= WARNING_PERCENT)
+      ) {
+        const usage = numbers.percent != null
+          ? `is at ${compactNumber(numbers.percent)}% of its ${label}`
+          : `is nearing its ${label}`;
+        candidates.push({
+          priority: 25,
+          action,
+          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+        });
+      }
+    }
+  }
+
+  candidates.sort((left, right) => right.priority - left.priority);
+  const selected = candidates[0];
+  return selected
+    ? `${selected.message}${actionInstruction(selected.action)}`
+    : "";
+}

--- a/opencode-plugin/src/server/runtime-state.ts
+++ b/opencode-plugin/src/server/runtime-state.ts
@@ -111,6 +111,15 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
     message: string;
     action?: RuntimeRecommendedAction | null;
   }> = [];
+  const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
+
+  if (text(mem9ApiKey.status) === "inactive") {
+    candidates.push({
+      priority: 65,
+      action,
+      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+    });
+  }
 
   if (action && (text(action.severity) || text(action.url))) {
     candidates.push({

--- a/opencode-plugin/src/server/runtime-state.ts
+++ b/opencode-plugin/src/server/runtime-state.ts
@@ -43,6 +43,10 @@ function modeLabel(mode: string): string {
   return "provider-managed runtime";
 }
 
+function warningMessage(detail: string): string {
+  return `${detail}. In your reply, include this exact mem9 warning detail: ${detail}.`;
+}
+
 function normalizeAction(input: unknown): RuntimeRecommendedAction | null {
   const action = isRecord(input) ? input : {};
   const providerActionCode = text(action.providerActionCode);
@@ -114,18 +118,20 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
   const mem9ApiKey = isRecord(runtimeState.mem9ApiKey) ? runtimeState.mem9ApiKey : {};
 
   if (text(mem9ApiKey.status) === "inactive") {
+    const detail = "Mem9 API key is inactive; rerun mem9 setup or create a new mem9 API key before memory access can continue";
     candidates.push({
       priority: 65,
       action,
-      message: "Mem9 API key is inactive. In your reply, briefly tell the user to rerun mem9 setup or create a new mem9 API key before memory access can continue.",
+      message: warningMessage(detail),
     });
   }
 
   if (action && (text(action.severity) || text(action.url))) {
+    const detail = "Mem9 needs account or billing attention";
     candidates.push({
       priority: action.severity === "blocking" ? 50 : 20,
       action,
-      message: "Mem9 has a runtime account action available. In your reply, briefly tell the user that mem9 needs account or billing attention.",
+      message: warningMessage(detail),
     });
   }
 
@@ -139,22 +145,25 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
     const mode = text(gate.mode);
 
     if (outcome === "blocked") {
+      const detail = `${feature} is blocked by runtime quota and needs attention before memory access can continue`;
       candidates.push({
         priority: 60,
         action,
-        message: `${feature} is blocked by runtime quota. In your reply, briefly tell the user that ${feature} needs attention before memory access can continue.`,
+        message: warningMessage(detail),
       });
     } else if (outcome === "rateLimited") {
+      const detail = `${feature} has reached its temporary runtime rate limit and needs a retry later`;
       candidates.push({
         priority: 55,
         action,
-        message: `${feature} has reached its temporary runtime rate limit. In your reply, briefly tell the user that ${feature} needs a retry later.`,
+        message: warningMessage(detail),
       });
     } else if (mode === "onDemand" || mode === "postQuota") {
+      const detail = `${feature} is in constrained mode and using ${modeLabel(mode)}`;
       candidates.push({
         priority: 40,
         action,
-        message: `${feature} is in constrained mode and using ${modeLabel(mode)}. In your reply, briefly tell the user that ${feature} is running in constrained mode.`,
+        message: warningMessage(detail),
       });
     }
 
@@ -170,10 +179,11 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
         && numbers.remaining <= Math.max(5, numbers.capacity * 0.02);
 
       if (state === "exhausted") {
+        const detail = `${feature} has exhausted its ${label} and is in constrained mode`;
         candidates.push({
           priority: 45,
           action,
-          message: `${feature} has exhausted its ${label}. In your reply, briefly tell the user that ${feature} is in constrained mode.`,
+          message: warningMessage(detail),
         });
       } else if (
         (numbers.percent != null && numbers.percent >= URGENT_PERCENT)
@@ -185,7 +195,7 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
         candidates.push({
           priority: 35,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is almost out of runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is almost out of runtime quota`),
         });
       } else if (
         state === "warning"
@@ -197,7 +207,7 @@ export function formatRuntimeStateNotice(runtimeState: unknown): string {
         candidates.push({
           priority: 25,
           action,
-          message: `${feature} ${usage}. In your reply, briefly tell the user that ${feature} is nearing its runtime quota.`,
+          message: warningMessage(`${feature} ${usage} and is nearing its runtime quota`),
         });
       }
     }

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -171,4 +171,8 @@ export class ServerBackend implements MemoryBackend {
     const result = await this.search({ limit, offset: 0 });
     return result.memories;
   }
+
+  async runtimeState(): Promise<unknown> {
+    return this.request<unknown>("GET", this.memoryPath("/runtime-state"));
+  }
 }

--- a/opencode-plugin/tests/ingest.test.ts
+++ b/opencode-plugin/tests/ingest.test.ts
@@ -94,6 +94,9 @@ function createBackend(options: {
         memories_changed: input.messages.length,
       };
     },
+    async runtimeState(): Promise<unknown> {
+      return null;
+    },
   };
 }
 

--- a/opencode-plugin/tests/ingest.test.ts
+++ b/opencode-plugin/tests/ingest.test.ts
@@ -155,6 +155,10 @@ test("selectMessagesForIngest strips injected memory blocks and keeps the latest
 1. Stale memory
 </relevant-memories>
 
+<mem9-status-warning>
+Mem9 API key is inactive.
+</mem9-status-warning>
+
 Keep this request.
 `,
     },

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -660,6 +660,54 @@ test("buildHooks renders runtime-state notice once per session", async () => {
   assert.equal(secondOutput.system.some((entry) => entry.includes("runtime quota")), false);
 });
 
+test("buildHooks waits for a captured prompt before rendering runtime-state notice", async () => {
+  let runtimeStateCalls = 0;
+  let searchCalls = 0;
+  const hooks = buildHooks(
+    createBackend(
+      async (input) => {
+        searchCalls += 1;
+        return {
+          memories: [],
+          total: 0,
+          limit: input.limit ?? 0,
+          offset: input.offset ?? 0,
+        };
+      },
+      async () => {
+        runtimeStateCalls += 1;
+        return {
+          mem9ApiKey: { status: "inactive" },
+        };
+      },
+    ),
+  );
+
+  const onChatMessage = hooks["chat.message"];
+  const onSystemTransform = hooks["experimental.chat.system.transform"];
+  assert.ok(onChatMessage);
+  assert.ok(onSystemTransform);
+
+  const earlyOutput = createSystemTransformOutput([]);
+  await onSystemTransform(createSystemTransformInput("session-runtime-before-prompt"), earlyOutput);
+
+  assert.equal(runtimeStateCalls, 0);
+  assert.equal(searchCalls, 0);
+  assert.deepEqual(earlyOutput.system, []);
+
+  await onChatMessage(
+    createChatMessageInput("session-runtime-before-prompt"),
+    createChatMessageOutput([textPart("Before deployment, check mem9 status.")]),
+  );
+
+  const promptOutput = createSystemTransformOutput([]);
+  await onSystemTransform(createSystemTransformInput("session-runtime-before-prompt"), promptOutput);
+
+  assert.equal(runtimeStateCalls, 1);
+  assert.equal(searchCalls, 1);
+  assert.match(promptOutput.system[0] ?? "", /Mem9 API key is inactive/);
+});
+
 test("formatRuntimeQuotaNotice renders spending limit guidance", () => {
   const notice = formatRuntimeQuotaNotice(
     new Mem9HttpError(

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -56,6 +56,7 @@ function runtimeQuotaPayload(error: string, runtimeQuota: Record<string, unknown
 
 function createBackend(
   searchImpl?: (input: SearchInput) => Promise<SearchResult>,
+  runtimeStateImpl?: () => Promise<unknown>,
 ): MemoryBackend {
   return {
     async store(_input: CreateMemoryInput): Promise<StoreResult> {
@@ -87,6 +88,9 @@ function createBackend(
     },
     async ingest(_input: IngestInput): Promise<IngestResult> {
       throw new Error("ingest should not be called in recall tests");
+    },
+    async runtimeState(): Promise<unknown> {
+      return runtimeStateImpl ? runtimeStateImpl() : null;
     },
   };
 }
@@ -602,6 +606,58 @@ test("buildHooks renders runtime quota denial action in recall context", async (
     debugEvents.map((entry) => entry.event),
     ["recall.capture", "recall.request", "recall.quota_denied"],
   );
+});
+
+test("buildHooks renders runtime-state notice once per session", async () => {
+  let runtimeStateCalls = 0;
+  const hooks = buildHooks(
+    createBackend(
+      async (input) => ({
+        memories: [],
+        total: 0,
+        limit: input.limit ?? 0,
+        offset: input.offset ?? 0,
+      }),
+      async () => {
+        runtimeStateCalls += 1;
+        return {
+          mem9ApiKey: { status: "active" },
+          meters: [
+            {
+              meter: "memory_recall_requests",
+              budgets: [
+                {
+                  type: "includedQuota",
+                  state: "warning",
+                  usage: { used: 820, remaining: 180, percent: 82 },
+                  capacity: { type: "limited", value: 1000 },
+                },
+              ],
+            },
+          ],
+        };
+      },
+    ),
+  );
+
+  const onChatMessage = hooks["chat.message"];
+  const onSystemTransform = hooks["experimental.chat.system.transform"];
+  assert.ok(onChatMessage);
+  assert.ok(onSystemTransform);
+
+  await onChatMessage(
+    createChatMessageInput("session-runtime-state"),
+    createChatMessageOutput([textPart("Find relevant project context.")]),
+  );
+
+  const firstOutput = createSystemTransformOutput([]);
+  await onSystemTransform(createSystemTransformInput("session-runtime-state"), firstOutput);
+  const secondOutput = createSystemTransformOutput([]);
+  await onSystemTransform(createSystemTransformInput("session-runtime-state"), secondOutput);
+
+  assert.equal(runtimeStateCalls, 1);
+  assert.match(firstOutput.system[0] ?? "", /mem9 recall is at 82% of its included quota/);
+  assert.equal(secondOutput.system.some((entry) => entry.includes("runtime quota")), false);
 });
 
 test("formatRuntimeQuotaNotice renders spending limit guidance", () => {

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -23,6 +23,8 @@ import type {
 type ChatMessageHook = NonNullable<Hooks["chat.message"]>;
 type ChatMessageInput = Parameters<ChatMessageHook>[0];
 type ChatMessageOutput = Parameters<ChatMessageHook>[1];
+type MessagesTransformHook = NonNullable<Hooks["experimental.chat.messages.transform"]>;
+type MessagesTransformOutput = Parameters<MessagesTransformHook>[1];
 type SystemTransformHook = NonNullable<Hooks["experimental.chat.system.transform"]>;
 type SystemTransformInput = Parameters<SystemTransformHook>[0];
 type SystemTransformOutput = Parameters<SystemTransformHook>[1];
@@ -135,6 +137,27 @@ function createSystemTransformInput(sessionID: string): SystemTransformInput {
 
 function createSystemTransformOutput(system: string[] = []): SystemTransformOutput {
   return { system };
+}
+
+function createMessagesTransformOutput(
+  sessionID: string,
+  parts: ChatMessageOutput["parts"],
+): MessagesTransformOutput {
+  return {
+    messages: [
+      {
+        info: {
+          id: "msg-runtime-state",
+          sessionID,
+          role: "user",
+          time: { created: 0 },
+          agent: "build",
+          model: { providerID: "openai", modelID: "gpt-test" },
+        } as MessagesTransformOutput["messages"][number]["info"],
+        parts: parts as MessagesTransformOutput["messages"][number]["parts"],
+      },
+    ],
+  };
 }
 
 function createSessionCompactingInput(sessionID: string): SessionCompactingInput {
@@ -608,16 +631,20 @@ test("buildHooks renders runtime quota denial action in recall context", async (
   );
 });
 
-test("buildHooks renders runtime-state notice once per session", async () => {
+test("buildHooks appends runtime-state notice to latest user message once per session", async () => {
   let runtimeStateCalls = 0;
+  let searchCalls = 0;
   const hooks = buildHooks(
     createBackend(
-      async (input) => ({
-        memories: [],
-        total: 0,
-        limit: input.limit ?? 0,
-        offset: input.offset ?? 0,
-      }),
+      async (input) => {
+        searchCalls += 1;
+        return {
+          memories: [],
+          total: 0,
+          limit: input.limit ?? 0,
+          offset: input.offset ?? 0,
+        };
+      },
       async () => {
         runtimeStateCalls += 1;
         return {
@@ -640,72 +667,38 @@ test("buildHooks renders runtime-state notice once per session", async () => {
     ),
   );
 
-  const onChatMessage = hooks["chat.message"];
-  const onSystemTransform = hooks["experimental.chat.system.transform"];
-  assert.ok(onChatMessage);
-  assert.ok(onSystemTransform);
+  const onMessagesTransform = hooks["experimental.chat.messages.transform"];
+  assert.ok(onMessagesTransform);
 
-  await onChatMessage(
-    createChatMessageInput("session-runtime-state"),
-    createChatMessageOutput([textPart("Find relevant project context.")]),
+  const firstOutput = createMessagesTransformOutput(
+    "session-runtime-state",
+    [textPart("Find relevant project context.")],
   );
+  await onMessagesTransform({}, firstOutput);
 
-  const firstOutput = createSystemTransformOutput([]);
-  await onSystemTransform(createSystemTransformInput("session-runtime-state"), firstOutput);
-  const secondOutput = createSystemTransformOutput([]);
-  await onSystemTransform(createSystemTransformInput("session-runtime-state"), secondOutput);
+  const secondOutput = createMessagesTransformOutput(
+    "session-runtime-state",
+    [textPart("Check again.")],
+  );
+  await onMessagesTransform({}, secondOutput);
+
+  const injectedPart = firstOutput.messages[0]?.parts.find(
+    (part) => part.type === "text" && part.text.includes("<mem9-status-warning>"),
+  );
 
   assert.equal(runtimeStateCalls, 1);
-  assert.match(firstOutput.system[0] ?? "", /mem9 recall is at 82% of its included quota/);
-  assert.equal(secondOutput.system.some((entry) => entry.includes("runtime quota")), false);
-});
-
-test("buildHooks waits for a captured prompt before rendering runtime-state notice", async () => {
-  let runtimeStateCalls = 0;
-  let searchCalls = 0;
-  const hooks = buildHooks(
-    createBackend(
-      async (input) => {
-        searchCalls += 1;
-        return {
-          memories: [],
-          total: 0,
-          limit: input.limit ?? 0,
-          offset: input.offset ?? 0,
-        };
-      },
-      async () => {
-        runtimeStateCalls += 1;
-        return {
-          mem9ApiKey: { status: "inactive" },
-        };
-      },
-    ),
-  );
-
-  const onChatMessage = hooks["chat.message"];
-  const onSystemTransform = hooks["experimental.chat.system.transform"];
-  assert.ok(onChatMessage);
-  assert.ok(onSystemTransform);
-
-  const earlyOutput = createSystemTransformOutput([]);
-  await onSystemTransform(createSystemTransformInput("session-runtime-before-prompt"), earlyOutput);
-
-  assert.equal(runtimeStateCalls, 0);
   assert.equal(searchCalls, 0);
-  assert.deepEqual(earlyOutput.system, []);
-
-  await onChatMessage(
-    createChatMessageInput("session-runtime-before-prompt"),
-    createChatMessageOutput([textPart("Before deployment, check mem9 status.")]),
+  assert.ok(injectedPart);
+  assert.match(
+    injectedPart.type === "text" ? injectedPart.text : "",
+    /mem9 recall is at 82% of its included quota/,
   );
-
-  const promptOutput = createSystemTransformOutput([]);
-  await onSystemTransform(createSystemTransformInput("session-runtime-before-prompt"), promptOutput);
-
-  assert.equal(runtimeStateCalls, 1);
-  assert.equal(searchCalls, 1);
-  assert.match(promptOutput.system[0] ?? "", /Mem9 API key is inactive/);
+  assert.equal(
+    secondOutput.messages[0]?.parts.some(
+      (part) => part.type === "text" && part.text.includes("<mem9-status-warning>"),
+    ),
+    false,
+  );
 });
 
 test("formatRuntimeQuotaNotice renders spending limit guidance", () => {

--- a/opencode-plugin/tests/runtime-state.test.ts
+++ b/opencode-plugin/tests/runtime-state.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { formatRuntimeStateNotice } from "../src/server/runtime-state.js";
+
+test("formatRuntimeStateNotice renders warning and urgent budget notices", () => {
+  const warning = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "warning",
+            usage: { used: 820, remaining: 180, percent: 82 },
+            capacity: { type: "limited", value: 1000 },
+          },
+        ],
+      },
+    ],
+  });
+  const urgent = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_write_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "ok",
+            usage: { used: 96, remaining: 4, percent: 96 },
+            capacity: { type: "limited", value: 100 },
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(warning, /mem9 recall is at 82% of its included quota/);
+  assert.match(urgent, /mem9 memory saving has 4 units remaining/);
+});
+
+test("formatRuntimeStateNotice renders provider action guidance", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "active" },
+    meters: [
+      {
+        meter: "memory_recall_requests",
+        quotaGateResult: {
+          outcome: "blocked",
+          mode: "includedQuota",
+        },
+        budgets: [],
+      },
+    ],
+    recommendedAction: {
+      type: "openUrl",
+      providerActionCode: "upgradePlan",
+      severity: "blocking",
+      url: "https://console.mem9.ai/console/billing/plan",
+    },
+  });
+
+  assert.match(notice, /mem9 recall is blocked by runtime quota/);
+  assert.match(notice, /upgrade their mem9 plan/);
+  assert.match(notice, /https:\/\/console\.mem9\.ai\/console\/billing\/plan/);
+});

--- a/opencode-plugin/tests/runtime-state.test.ts
+++ b/opencode-plugin/tests/runtime-state.test.ts
@@ -66,3 +66,23 @@ test("formatRuntimeStateNotice renders provider action guidance", () => {
   assert.match(notice, /upgrade their mem9 plan/);
   assert.match(notice, /https:\/\/console\.mem9\.ai\/console\/billing\/plan/);
 });
+
+test("formatRuntimeStateNotice renders inactive API key guidance", () => {
+  const notice = formatRuntimeStateNotice({
+    mem9ApiKey: { status: "inactive" },
+    meters: [
+      {
+        meter: "memory_write_requests",
+        budgets: [
+          {
+            type: "includedQuota",
+            state: "unlimited",
+          },
+        ],
+      },
+    ],
+  });
+
+  assert.match(notice, /Mem9 API key is inactive/);
+  assert.match(notice, /rerun mem9 setup or create a new mem9 API key/);
+});

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -51,6 +51,31 @@ test("ServerBackend uses X-API-Key and v1alpha2 paths", async () => {
   }
 });
 
+test("ServerBackend fetches runtime-state through the public v1alpha2 path", async () => {
+  const originalFetch = globalThis.fetch;
+  let requestURL = "";
+  let requestHeaders: Headers | undefined;
+
+  globalThis.fetch = async (input, init) => {
+    requestURL = String(input);
+    requestHeaders = new Headers(init?.headers);
+    return new Response(JSON.stringify({ mem9ApiKey: { status: "active" }, meters: [] }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    await backend.runtimeState();
+    assert.equal(requestURL, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
+    assert.equal(requestHeaders?.get("X-API-Key"), "mk_demo");
+    assert.equal(requestHeaders?.get("X-Mnemo-Agent-Id"), "opencode");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("ServerBackend uses searchTimeoutMs for search and defaultTimeoutMs for writes", async () => {
   const originalFetch = globalThis.fetch;
 

--- a/opencode-plugin/tests/tools.test.ts
+++ b/opencode-plugin/tests/tools.test.ts
@@ -57,6 +57,9 @@ function createBackend(): MemoryBackend {
     async ingest(_input: IngestInput): Promise<IngestResult> {
       return { status: "ok" };
     },
+    async runtimeState(): Promise<unknown> {
+      return null;
+    },
   };
 }
 


### PR DESCRIPTION
## What Changed
- Added runtime-state warmup notices for Claude Code, Codex, OpenClaw, and OpenCode plugins.
- Each plugin calls `GET /v1alpha2/mem9s/runtime-state` through its existing API/backend path and renders one advisory notice for warning, urgent, constrained, blocked, rate-limited, inactive API key, or provider action states.
- Runtime-state notices now ask the model to include the exact mem9 warning detail, preserving concrete tier data such as `82%`, `4 units remaining`, constrained mode, runtime rate limits, blocked quota, and action URLs.
- OpenCode injects the runtime-state notice into the latest user message via `experimental.chat.messages.transform`, then strips the injected status block from later ingest selection.
- Runtime-state fetch failures stay fail-soft; existing hard quota-denial handling stays on memory request paths.

## Plugin Injection Points
- Claude Code: `SessionStart(startup)` checks runtime state once after auth is ready or auto-provision succeeds, then emits the notice via `additionalContext`.
- Codex: `SessionStart` checks runtime state once when the runtime state is `ready`, then appends the notice after the setup/upgrade message.
- OpenClaw: the first valid `before_prompt_build` call checks runtime state once and prepends the notice to prompt context.
- OpenCode: the first message transform per session checks runtime state once and appends a `<mem9-status-warning>` text part to the latest user message.

## Notice Examples
Warning at 82% included quota:
```text
mem9 recall is at 82% of its included quota and is nearing its runtime quota. In your reply, include this exact mem9 warning detail: mem9 recall is at 82% of its included quota and is nearing its runtime quota.
```

Urgent remaining quota:
```text
mem9 recall has 4 units remaining in its included quota and is almost out of runtime quota. In your reply, include this exact mem9 warning detail: mem9 recall has 4 units remaining in its included quota and is almost out of runtime quota.
```

Constrained mode:
```text
mem9 recall is in constrained mode and using the post-quota request lane. In your reply, include this exact mem9 warning detail: mem9 recall is in constrained mode and using the post-quota request lane.
```

Blocked by runtime quota:
```text
mem9 recall is blocked by runtime quota and needs attention before memory access can continue. In your reply, include this exact mem9 warning detail: mem9 recall is blocked by runtime quota and needs attention before memory access can continue.
```

Inactive API key:
```text
Mem9 API key is inactive; rerun mem9 setup or create a new mem9 API key before memory access can continue. In your reply, include this exact mem9 warning detail: Mem9 API key is inactive; rerun mem9 setup or create a new mem9 API key before memory access can continue.
```

Provider action URL:
```text
Mem9 needs account or billing attention. In your reply, include this exact mem9 warning detail: Mem9 needs account or billing attention. Ask them to open this link to upgrade their mem9 plan and get more included usage: https://console.mem9.ai/console/billing/plan. Include the link exactly as written.
```

## Architecture
```mermaid
flowchart LR
  Endpoint["GET /v1alpha2/mem9s/runtime-state"]
  Claude["Claude SessionStart(startup)"] --> Endpoint
  Codex["Codex SessionStart"] --> Endpoint
  OpenCode["OpenCode first messages transform per session"] --> Endpoint
  OpenClaw["OpenClaw first before_prompt_build"] --> Endpoint
  Endpoint --> Formatter["Plugin-local runtime-state formatter"]
  Formatter --> Notice["One exact-detail advisory notice"]
  Notice --> ClaudeCtx["Claude additionalContext"]
  Notice --> CodexCtx["Codex session-start context"]
  Notice --> OpenClawCtx["OpenClaw prompt context"]
  Notice --> OpenCodeMsg["OpenCode latest user message part"]
```

## RuntimeStateResponse Shape Consumed
```ts
type RuntimeStateResponse = {
  mem9ApiKey?: { status?: string };
  recommendedAction?: {
    providerActionCode?: string;
    severity?: string;
    type?: string;
    url?: string;
  };
  meters?: Array<{
    meter?: string;
    quotaGateResult?: { outcome?: string; mode?: string };
    budgets?: Array<{
      type?: string;
      state?: string;
      usage?: { percent?: number; remaining?: number };
      capacity?: { type?: string; value?: number };
    }>;
  }>;
};
```

## Related Plugin PRs
- Hermes plugin: https://github.com/mem9-ai/mem9-hermes-plugin/pull/6
- Dify plugin: https://github.com/mem9-ai/mem9-dify-plugin/pull/6
- Tester E2E PR: https://github.com/mem9-ai/mem9-tester/pull/16

## Review Path
1. Start with `codex-plugin/lib/runtime-state.mjs`, `claude-plugin/hooks/lib/runtime-state.mjs`, `openclaw-plugin/runtime-state.ts`, and `opencode-plugin/src/server/runtime-state.ts`.
2. Review each plugin injection point: Claude `session-start.sh`, Codex `session-start.mjs`, OpenClaw `hooks.ts`, OpenCode `hooks.ts`.
3. Check formatter tests and the OpenCode ingest stripping path.
4. Finish with tester PR #16 for real E2E coverage.

## Validation
- `cd codex-plugin && npm test -- runtime-state.test.mjs` -> success
- `cd openclaw-plugin && npm test` -> success
- `cd opencode-plugin && npm test -- runtime-state.test.ts` -> success
- `cd claude-plugin && bash hooks/common.test.sh` -> success
- Core `runtime_state_all` CI (Codex, Claude Code, OpenCode) -> success: https://github.com/mem9-ai/mem9-tester/actions/runs/28923308207
