### PR TITLE
chore(plugins): bump plugin versions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "mem9",
       "source": "./claude-plugin",
       "description": "Persistent cloud memory for Claude Code with automatic recall, transcript ingest, and on-demand setup, recall, and store skills.",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "homepage": "https://mem9.ai",
       "repository": "https://github.com/mem9-ai/mem9",
       "license": "Apache-2.0"

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Persistent cloud memory for Claude Code. Requires Node.js 18+, auto-initializes auth on startup, recalls memories on each user turn, and uploads structured conversation turns to mem9.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Persistent memory for Codex. Run $mem9:setup once, then mem9 recalls before prompts and saves recent turns on stop.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/package.json
+++ b/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/codex-plugin",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Persistent memory for Codex with setup-driven hooks, prompt recall, and stop-time save.",
   "type": "module",
   "license": "Apache-2.0",

--- a/codex-plugin/tests/plugin-files.test.mjs
+++ b/codex-plugin/tests/plugin-files.test.mjs
@@ -12,11 +12,11 @@ test("plugin manifest exposes mem9 setup skill and basic metadata", () => {
   );
 
   assert.equal(manifest.name, "mem9");
-  assert.equal(manifest.version, "0.2.4");
+  assert.equal(manifest.version, "0.2.5");
   assert.equal(manifest.skills, "./skills/");
   assert.equal(typeof manifest.description, "string");
   assert.match(manifest.description, /\$mem9:setup/);
-  assert.equal(packageManifest.version, "0.2.4");
+  assert.equal(packageManifest.version, "0.2.5");
   assert.equal(packageManifest.version, manifest.version);
   assert.equal(packageManifest.engines.node, ">=22");
   assert.equal(packageManifest.files.includes("lib/"), true);

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/mem9",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "OpenClaw shared memory plugin — cloud-persistent memory with hybrid vector + keyword search via mnemo-server",
   "type": "module",
   "license": "Apache-2.0",

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/opencode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## What Changed
- Bump Codex plugin from 0.2.4 to 0.2.5 and sync the Codex plugin manifest/test fixture.
- Bump Claude Code plugin from 0.3.2 to 0.3.3 and sync the Claude marketplace entry.
- Bump OpenClaw plugin from 0.4.13 to 0.4.14.
- Bump OpenCode plugin from 0.1.4 to 0.1.5.

## Validation
- Not run; version-only metadata change.