### PR TITLE
Report plugin user agents

### DIFF
--- a/claude-plugin/hooks/common.sh
+++ b/claude-plugin/hooks/common.sh
@@ -10,6 +10,7 @@ MEM9_WRITER_ID="${MEM9_WRITER_ID:-claude-code}"
 MEM9_CURL_BIN="${MEM9_CURL_BIN:-curl}"
 MEM9_AUTH_SOURCE="${MEM9_AUTH_SOURCE:-}"
 MEM9_HTTP_STATUS_MARKER="__MEM9_HTTP_STATUS__="
+MEM9_PLUGIN_USER_AGENT=""
 
 mem9_require_node() {
   command -v node >/dev/null 2>&1 || return 1
@@ -108,6 +109,22 @@ mem9_memory_base() {
   printf '%s\n' "${MEM9_API_URL%/}/v1alpha2/mem9s"
 }
 
+mem9_plugin_user_agent() {
+  if [[ -n "${MEM9_PLUGIN_USER_AGENT}" ]]; then
+    printf '%s\n' "${MEM9_PLUGIN_USER_AGENT}"
+    return 0
+  fi
+
+  local version="0.3.3"
+  local manifest="${MEM9_SCRIPT_DIR}/../.claude-plugin/plugin.json"
+  if [[ -f "${manifest}" ]] && command -v node >/dev/null 2>&1; then
+    version="$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(data.version || "0.3.3");' "${manifest}" 2>/dev/null || printf '0.3.3')"
+  fi
+
+  MEM9_PLUGIN_USER_AGENT="mem9-plugin/claude-code/${version}"
+  printf '%s\n' "${MEM9_PLUGIN_USER_AGENT}"
+}
+
 mem9_hook_get_string() {
   local hook_input="$1"
   local key="$2"
@@ -194,7 +211,9 @@ mem9_write_session_env() {
 }
 
 mem9_provision_auth() {
-  "${MEM9_CURL_BIN}" -sf --max-time 8 -X POST "${MEM9_API_URL%/}/v1alpha1/mem9s"
+  "${MEM9_CURL_BIN}" -sf --max-time 8 -X POST \
+    -H "User-Agent: $(mem9_plugin_user_agent)" \
+    "${MEM9_API_URL%/}/v1alpha1/mem9s"
 }
 
 mem9_api_request() {
@@ -211,6 +230,7 @@ mem9_api_request() {
     -H "Content-Type: application/json"
     -H "X-API-Key: ${MEM9_API_KEY}"
     -H "X-Mnemo-Agent-Id: ${MEM9_WRITER_ID}"
+    -H "User-Agent: $(mem9_plugin_user_agent)"
   )
 
   if [[ -n "${body}" ]]; then

--- a/claude-plugin/hooks/common.sh
+++ b/claude-plugin/hooks/common.sh
@@ -115,10 +115,10 @@ mem9_plugin_user_agent() {
     return 0
   fi
 
-  local version="0.3.3"
+  local version="unknown"
   local manifest="${MEM9_SCRIPT_DIR}/../.claude-plugin/plugin.json"
   if [[ -f "${manifest}" ]] && command -v node >/dev/null 2>&1; then
-    version="$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(data.version || "0.3.3");' "${manifest}" 2>/dev/null || printf '0.3.3')"
+    version="$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(data.version || "unknown");' "${manifest}" 2>/dev/null || printf 'unknown')"
   fi
 
   MEM9_PLUGIN_USER_AGENT="mem9-plugin/claude-code/${version}"

--- a/claude-plugin/hooks/common.test.sh
+++ b/claude-plugin/hooks/common.test.sh
@@ -10,7 +10,7 @@ STUB_CURL="${TMP_DIR}/curl"
 cat > "${STUB_CURL}" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
-  *"User-Agent: mem9-plugin/claude-code/0.3.3"* ) ;;
+  *"User-Agent: ${EXPECTED_MEM9_UA}"* ) ;;
   *)
     printf 'missing mem9 plugin user agent: %s\n' "$*" >&2
     exit 2
@@ -39,6 +39,8 @@ esac
 SH
 chmod +x "${STUB_CURL}"
 
+EXPECTED_MEM9_UA="mem9-plugin/claude-code/$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(data.version);' "${SCRIPT_DIR}/../.claude-plugin/plugin.json")"
+export EXPECTED_MEM9_UA
 export CLAUDE_PLUGIN_DATA="${TMP_DIR}/data"
 export MEM9_API_KEY="mem9_test"
 export MEM9_API_URL="https://api.mem9.ai"

--- a/claude-plugin/hooks/common.test.sh
+++ b/claude-plugin/hooks/common.test.sh
@@ -10,6 +10,14 @@ STUB_CURL="${TMP_DIR}/curl"
 cat > "${STUB_CURL}" <<'SH'
 #!/usr/bin/env bash
 case "$*" in
+  *"User-Agent: mem9-plugin/claude-code/0.3.3"* ) ;;
+  *)
+    printf 'missing mem9 plugin user agent: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+
+case "$*" in
   *"/v1alpha1/mem9s"*)
     cat <<'EOF'
 {"id":"mem9_new"}

--- a/claude-plugin/skills/recall/SKILL.md
+++ b/claude-plugin/skills/recall/SKILL.md
@@ -27,6 +27,10 @@ api_key="${read_api_key_and_base_url%%	*}"
 base_url="${read_api_key_and_base_url#*	}"
 test -n "$api_key"
 test -n "$base_url"
+plugin_version="unknown"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+  plugin_version="$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(data.version || "unknown");' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json")"
+fi
 
 query='REPLACE_WITH_SEARCH_QUERY'
 encoded_query="$(printf '%s' "$query" | node -e 'const fs=require("node:fs"); const raw=fs.readFileSync(0,"utf8").trim(); process.stdout.write(encodeURIComponent(raw));')"
@@ -35,7 +39,7 @@ curl -sf --max-time 8 \
   -H "Content-Type: application/json" \
   -H "X-API-Key: ${api_key}" \
   -H "X-Mnemo-Agent-Id: claude-code" \
-  -H "User-Agent: mem9-plugin/claude-code/0.3.3" \
+  -H "User-Agent: mem9-plugin/claude-code/${plugin_version}" \
   "${base_url%/}/v1alpha2/mem9s/memories?q=${encoded_query}&limit=10"
 ```
 

--- a/claude-plugin/skills/recall/SKILL.md
+++ b/claude-plugin/skills/recall/SKILL.md
@@ -35,6 +35,7 @@ curl -sf --max-time 8 \
   -H "Content-Type: application/json" \
   -H "X-API-Key: ${api_key}" \
   -H "X-Mnemo-Agent-Id: claude-code" \
+  -H "User-Agent: mem9-plugin/claude-code/0.3.3" \
   "${base_url%/}/v1alpha2/mem9s/memories?q=${encoded_query}&limit=10"
 ```
 

--- a/claude-plugin/skills/setup/SKILL.md
+++ b/claude-plugin/skills/setup/SKILL.md
@@ -35,7 +35,9 @@ plugin_data_dir="${CLAUDE_PLUGIN_DATA}"
 test -n "$plugin_data_dir"
 node -e 'process.exit(Number(process.versions.node.split(".")[0]) >= 18 ? 0 : 1)'
 
-response="$(curl -sf --max-time 8 -X POST https://api.mem9.ai/v1alpha1/mem9s)"
+response="$(curl -sf --max-time 8 -X POST \
+  -H "User-Agent: mem9-plugin/claude-code/0.3.3" \
+  https://api.mem9.ai/v1alpha1/mem9s)"
 api_key="$(printf '%s' "$response" | node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(0,"utf8")); process.stdout.write(data.id || "");')"
 test -n "$api_key"
 

--- a/claude-plugin/skills/setup/SKILL.md
+++ b/claude-plugin/skills/setup/SKILL.md
@@ -34,9 +34,13 @@ set -euo pipefail
 plugin_data_dir="${CLAUDE_PLUGIN_DATA}"
 test -n "$plugin_data_dir"
 node -e 'process.exit(Number(process.versions.node.split(".")[0]) >= 18 ? 0 : 1)'
+plugin_version="unknown"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+  plugin_version="$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(data.version || "unknown");' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json")"
+fi
 
 response="$(curl -sf --max-time 8 -X POST \
-  -H "User-Agent: mem9-plugin/claude-code/0.3.3" \
+  -H "User-Agent: mem9-plugin/claude-code/${plugin_version}" \
   https://api.mem9.ai/v1alpha1/mem9s)"
 api_key="$(printf '%s' "$response" | node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(0,"utf8")); process.stdout.write(data.id || "");')"
 test -n "$api_key"

--- a/claude-plugin/skills/store/SKILL.md
+++ b/claude-plugin/skills/store/SKILL.md
@@ -27,12 +27,16 @@ api_key="${read_api_key_and_base_url%%	*}"
 base_url="${read_api_key_and_base_url#*	}"
 test -n "$api_key"
 test -n "$base_url"
+plugin_version="unknown"
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+  plugin_version="$(node -e 'const fs=require("node:fs"); const data=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(data.version || "unknown");' "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json")"
+fi
 
 curl -sf --max-time 8 \
   -H "Content-Type: application/json" \
   -H "X-API-Key: ${api_key}" \
   -H "X-Mnemo-Agent-Id: claude-code" \
-  -H "User-Agent: mem9-plugin/claude-code/0.3.3" \
+  -H "User-Agent: mem9-plugin/claude-code/${plugin_version}" \
   -d '{"content":"REPLACE_WITH_MEMORY"}' \
   "${base_url%/}/v1alpha2/mem9s/memories"
 ```

--- a/claude-plugin/skills/store/SKILL.md
+++ b/claude-plugin/skills/store/SKILL.md
@@ -32,6 +32,7 @@ curl -sf --max-time 8 \
   -H "Content-Type: application/json" \
   -H "X-API-Key: ${api_key}" \
   -H "X-Mnemo-Agent-Id: claude-code" \
+  -H "User-Agent: mem9-plugin/claude-code/0.3.3" \
   -d '{"content":"REPLACE_WITH_MEMORY"}' \
   "${base_url%/}/v1alpha2/mem9s/memories"
 ```

--- a/codex-plugin/lib/http.mjs
+++ b/codex-plugin/lib/http.mjs
@@ -1,6 +1,25 @@
 // @ts-nocheck
 
+import { readFileSync } from "node:fs";
+
 import { DEFAULT_REQUEST_TIMEOUT_MS } from "./config.mjs";
+
+const CODEX_PLUGIN_VERSION_FALLBACK = "0.2.5";
+
+function readCodexPluginVersion() {
+  try {
+    const manifest = JSON.parse(
+      readFileSync(new URL("../.codex-plugin/plugin.json", import.meta.url), "utf8"),
+    );
+    return typeof manifest.version === "string" && manifest.version.trim()
+      ? manifest.version.trim()
+      : CODEX_PLUGIN_VERSION_FALLBACK;
+  } catch {
+    return CODEX_PLUGIN_VERSION_FALLBACK;
+  }
+}
+
+export const MEM9_PLUGIN_USER_AGENT = `mem9-plugin/codex/${readCodexPluginVersion()}`;
 
 /**
  * @typedef {{
@@ -91,6 +110,7 @@ export function mem9Headers(apiKey, agentId) {
     "Content-Type": "application/json",
     "X-API-Key": apiKey,
     "X-Mnemo-Agent-Id": agentId,
+    "User-Agent": MEM9_PLUGIN_USER_AGENT,
   };
 }
 

--- a/codex-plugin/lib/http.mjs
+++ b/codex-plugin/lib/http.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 
 import { DEFAULT_REQUEST_TIMEOUT_MS } from "./config.mjs";
 
-const CODEX_PLUGIN_VERSION_FALLBACK = "0.2.5";
+const CODEX_PLUGIN_VERSION_FALLBACK = "unknown";
 
 function readCodexPluginVersion() {
   try {

--- a/codex-plugin/skills/setup/scripts/setup.mjs
+++ b/codex-plugin/skills/setup/scripts/setup.mjs
@@ -27,6 +27,7 @@ import {
   resolveCodexHome,
   resolveMem9Home,
 } from "../../../lib/config.mjs";
+import { MEM9_PLUGIN_USER_AGENT } from "../../../lib/http.mjs";
 import { resolveProjectRoot } from "../../../lib/project-root.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -1536,6 +1537,7 @@ async function provisionApiKey({
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "User-Agent": MEM9_PLUGIN_USER_AGENT,
       },
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/codex-plugin/tests/plugin-files.test.mjs
+++ b/codex-plugin/tests/plugin-files.test.mjs
@@ -12,11 +12,10 @@ test("plugin manifest exposes mem9 setup skill and basic metadata", () => {
   );
 
   assert.equal(manifest.name, "mem9");
-  assert.equal(manifest.version, "0.2.5");
+  assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
   assert.equal(manifest.skills, "./skills/");
   assert.equal(typeof manifest.description, "string");
   assert.match(manifest.description, /\$mem9:setup/);
-  assert.equal(packageManifest.version, "0.2.5");
   assert.equal(packageManifest.version, manifest.version);
   assert.equal(packageManifest.engines.node, ">=22");
   assert.equal(packageManifest.files.includes("lib/"), true);

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -8,7 +8,7 @@ import {
   main,
   runRecall,
 } from "../skills/recall/scripts/recall.mjs";
-import { Mem9HttpError } from "../lib/http.mjs";
+import { MEM9_PLUGIN_USER_AGENT, Mem9HttpError } from "../lib/http.mjs";
 import { buildRuntimeIssueMessage } from "../lib/skill-runtime.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
@@ -126,7 +126,7 @@ test("runRecall calls mem9 with the current runtime and prints a safe summary", 
         "Content-Type": "application/json",
         "X-API-Key": "key-search",
         "X-Mnemo-Agent-Id": "codex",
-        "User-Agent": "mem9-plugin/codex/0.2.5",
+        "User-Agent": MEM9_PLUGIN_USER_AGENT,
       },
       timeoutMs: 15200,
     });

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -126,6 +126,7 @@ test("runRecall calls mem9 with the current runtime and prints a safe summary", 
         "Content-Type": "application/json",
         "X-API-Key": "key-search",
         "X-Mnemo-Agent-Id": "codex",
+        "User-Agent": "mem9-plugin/codex/0.2.5",
       },
       timeoutMs: 15200,
     });

--- a/codex-plugin/tests/setup.test.mjs
+++ b/codex-plugin/tests/setup.test.mjs
@@ -25,6 +25,7 @@ import {
   renderHooksTemplate,
   runSetup,
 } from "../skills/setup/scripts/setup.mjs";
+import { MEM9_PLUGIN_USER_AGENT } from "../lib/http.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
 function writeJson(filePath, value) {
@@ -795,7 +796,7 @@ test("profile create provisions an API key without printing it", async () => {
     mkdirSync(codexHome, { recursive: true });
     mkdirSync(mem9Home, { recursive: true });
 
-    /** @type {Array<{url: string, method: string}>} */
+    /** @type {Array<{url: string, method: string, userAgent: string}>} */
     const fetchCalls = [];
 
     const result = await runSetup(
@@ -819,6 +820,7 @@ test("profile create provisions an API key without printing it", async () => {
           fetchCalls.push({
             url: String(url),
             method: String(init?.method ?? "GET"),
+            userAgent: String(init?.headers?.["User-Agent"] ?? ""),
           });
 
           return {
@@ -845,6 +847,7 @@ test("profile create provisions an API key without printing it", async () => {
       {
         url: "https://api.mem9.ai/v1alpha1/mem9s",
         method: "POST",
+        userAgent: MEM9_PLUGIN_USER_AGENT,
       },
     ]);
     assert.equal(

--- a/codex-plugin/tests/store.test.mjs
+++ b/codex-plugin/tests/store.test.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { buildRuntimeIssueMessage } from "../lib/skill-runtime.mjs";
-import { Mem9HttpError } from "../lib/http.mjs";
+import { MEM9_PLUGIN_USER_AGENT, Mem9HttpError } from "../lib/http.mjs";
 import { main, runStore } from "../skills/store/scripts/store.mjs";
 import { createTempRoot } from "./test-temp.mjs";
 
@@ -92,7 +92,7 @@ test("runStore posts a synchronous memory create and prints a safe summary", asy
         "Content-Type": "application/json",
         "X-API-Key": "key-save",
         "X-Mnemo-Agent-Id": "codex",
-        "User-Agent": "mem9-plugin/codex/0.2.5",
+        "User-Agent": MEM9_PLUGIN_USER_AGENT,
       },
       body: JSON.stringify({
         content: "The user prefers concise release notes.",

--- a/codex-plugin/tests/store.test.mjs
+++ b/codex-plugin/tests/store.test.mjs
@@ -92,6 +92,7 @@ test("runStore posts a synchronous memory create and prints a safe summary", asy
         "Content-Type": "application/json",
         "X-API-Key": "key-save",
         "X-Mnemo-Agent-Id": "codex",
+        "User-Agent": "mem9-plugin/codex/0.2.5",
       },
       body: JSON.stringify({
         content: "The user prefers concise release notes.",

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -1,8 +1,29 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { ServerBackend } from "./server-backend.js";
 import { Mem9HttpError, parseRuntimeQuotaDenied } from "./quota-error.js";
+
+function readPackageVersion(): string {
+  for (const relativePath of ["./package.json", "../package.json"]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+      );
+      if (typeof pkg.version === "string" && pkg.version.trim()) {
+        return pkg.version.trim();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return "unknown";
+}
+
+const packageVersion = readPackageVersion();
+const expectedUserAgent = `mem9-plugin/openclaw/${packageVersion}`;
 
 test("register forwards only utm_* params during create-new provision", async () => {
   const originalFetch = globalThis.fetch;
@@ -41,7 +62,7 @@ test("register forwards only utm_* params during create-new provision", async ()
     assert.equal(url.searchParams.get("utm_campaign"), "spring");
     assert.equal(url.searchParams.has("foo"), false);
     assert.equal(url.searchParams.has("utm_medium"), false);
-    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/openclaw/0.4.14");
+    assert.equal(requestHeaders?.get("User-Agent"), expectedUserAgent);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -107,7 +128,7 @@ test("runtime-state uses the public v1alpha2 path", async () => {
     assert.equal(requestedURL, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
     assert.equal(requestHeaders?.get("X-API-Key"), "space-key");
     assert.equal(requestHeaders?.get("X-Mnemo-Agent-Id"), "agent-1");
-    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/openclaw/0.4.14");
+    assert.equal(requestHeaders?.get("User-Agent"), expectedUserAgent);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/openclaw-plugin/server-backend.test.ts
+++ b/openclaw-plugin/server-backend.test.ts
@@ -7,9 +7,11 @@ import { Mem9HttpError, parseRuntimeQuotaDenied } from "./quota-error.js";
 test("register forwards only utm_* params during create-new provision", async () => {
   const originalFetch = globalThis.fetch;
   let requestedURL = "";
+  let requestHeaders: Headers | undefined;
 
   globalThis.fetch = async (input, init) => {
     requestedURL = String(input);
+    requestHeaders = new Headers(init?.headers);
     assert.equal(init?.method, "POST");
 
     return new Response(JSON.stringify({ id: "space-1" }), {
@@ -39,6 +41,7 @@ test("register forwards only utm_* params during create-new provision", async ()
     assert.equal(url.searchParams.get("utm_campaign"), "spring");
     assert.equal(url.searchParams.has("foo"), false);
     assert.equal(url.searchParams.has("utm_medium"), false);
+    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/openclaw/0.4.14");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -104,6 +107,7 @@ test("runtime-state uses the public v1alpha2 path", async () => {
     assert.equal(requestedURL, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
     assert.equal(requestHeaders?.get("X-API-Key"), "space-key");
     assert.equal(requestHeaders?.get("X-Mnemo-Agent-Id"), "agent-1");
+    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/openclaw/0.4.14");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -21,6 +21,7 @@ type ProvisionMem9sResponse = {
 
 export const DEFAULT_TIMEOUT_MS = 8_000;
 export const DEFAULT_SEARCH_TIMEOUT_MS = 15_000;
+const MEM9_PLUGIN_USER_AGENT = "mem9-plugin/openclaw/0.4.14";
 
 export interface BackendTimeouts {
   defaultTimeoutMs?: number;
@@ -72,6 +73,9 @@ export class ServerBackend implements MemoryBackend {
     const qs = query.toString();
     const resp = await fetch(this.baseUrl + "/v1alpha1/mem9s" + (qs ? `?${qs}` : ""), {
       method: "POST",
+      headers: {
+        "User-Agent": MEM9_PLUGIN_USER_AGENT,
+      },
       signal: AbortSignal.timeout(this.timeouts.defaultTimeoutMs),
     });
 
@@ -182,6 +186,7 @@ export class ServerBackend implements MemoryBackend {
       "Content-Type": "application/json",
       "X-Mnemo-Agent-Id": this.agentName,
       "X-API-Key": this.apiKey,
+      "User-Agent": MEM9_PLUGIN_USER_AGENT,
     };
     return fetch(url, {
       method,

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import type { MemoryBackend } from "./backend.js";
 import type {
   Memory,
@@ -21,7 +23,24 @@ type ProvisionMem9sResponse = {
 
 export const DEFAULT_TIMEOUT_MS = 8_000;
 export const DEFAULT_SEARCH_TIMEOUT_MS = 15_000;
-const MEM9_PLUGIN_USER_AGENT = "mem9-plugin/openclaw/0.4.14";
+const MEM9_PLUGIN_USER_AGENT = `mem9-plugin/openclaw/${readPackageVersion()}`;
+
+function readPackageVersion(): string {
+  for (const relativePath of ["./package.json", "../package.json"]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+      );
+      if (typeof pkg.version === "string" && pkg.version.trim()) {
+        return pkg.version.trim();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return "unknown";
+}
 
 export interface BackendTimeouts {
   defaultTimeoutMs?: number;

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from "node:fs";
-
 import type {
   IngestInput,
   IngestResult,
@@ -19,25 +17,7 @@ import {
   messageFromErrorBody,
   parseJsonOrUndefined,
 } from "./quota-error.ts";
-
-const MEM9_PLUGIN_USER_AGENT = `mem9-plugin/opencode/${readPackageVersion()}`;
-
-function readPackageVersion(): string {
-  for (const relativePath of ["../../package.json", "../../../package.json"]) {
-    try {
-      const pkg = JSON.parse(
-        readFileSync(new URL(relativePath, import.meta.url), "utf8"),
-      );
-      if (typeof pkg.version === "string" && pkg.version.trim()) {
-        return pkg.version.trim();
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  return "unknown";
-}
+import { MEM9_PLUGIN_USER_AGENT } from "../shared/plugin-user-agent.ts";
 
 function normalizeTimeoutMs(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import type {
   IngestInput,
   IngestResult,
@@ -18,7 +20,24 @@ import {
   parseJsonOrUndefined,
 } from "./quota-error.ts";
 
-const MEM9_PLUGIN_USER_AGENT = "mem9-plugin/opencode/0.1.5";
+const MEM9_PLUGIN_USER_AGENT = `mem9-plugin/opencode/${readPackageVersion()}`;
+
+function readPackageVersion(): string {
+  for (const relativePath of ["../../package.json", "../../../package.json"]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+      );
+      if (typeof pkg.version === "string" && pkg.version.trim()) {
+        return pkg.version.trim();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return "unknown";
+}
 
 function normalizeTimeoutMs(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -18,6 +18,8 @@ import {
   parseJsonOrUndefined,
 } from "./quota-error.ts";
 
+const MEM9_PLUGIN_USER_AGENT = "mem9-plugin/opencode/0.1.5";
+
 function normalizeTimeoutMs(value: number | undefined, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return fallback;
@@ -72,6 +74,7 @@ export class ServerBackend implements MemoryBackend {
       "Content-Type": "application/json",
       "X-Mnemo-Agent-Id": this.agentName,
       "X-API-Key": this.apiKey,
+      "User-Agent": MEM9_PLUGIN_USER_AGENT,
     };
     const resp = await fetch(url, {
       method,

--- a/opencode-plugin/src/shared/plugin-user-agent.ts
+++ b/opencode-plugin/src/shared/plugin-user-agent.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+
+function readPackageVersion(): string {
+  for (const relativePath of ["../../package.json", "../../../package.json"]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+      );
+      if (typeof pkg.version === "string" && pkg.version.trim()) {
+        return pkg.version.trim();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return "unknown";
+}
+
+export const MEM9_PLUGIN_USER_AGENT = `mem9-plugin/opencode/${readPackageVersion()}`;

--- a/opencode-plugin/src/shared/setup-files.ts
+++ b/opencode-plugin/src/shared/setup-files.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { Mem9ResolvedPaths } from "./platform-paths.ts";
 import { parseCredentialsFile, stringifyCredentialsFile } from "./credentials-store.ts";
 import { DEFAULT_SCOPE_CONFIG } from "./defaults.ts";
+import { MEM9_PLUGIN_USER_AGENT } from "./plugin-user-agent.ts";
 import {
   DEFAULT_API_URL,
   type Mem9ConfigFile,
@@ -472,6 +473,7 @@ export async function provisionApiKey(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "User-Agent": MEM9_PLUGIN_USER_AGENT,
       },
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -1,8 +1,29 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import { ServerBackend } from "../src/server/server-backend.js";
 import { Mem9HttpError, parseRuntimeQuotaDenied } from "../src/server/quota-error.js";
+
+function readPackageVersion(): string {
+  for (const relativePath of ["../package.json", "../../package.json"]) {
+    try {
+      const pkg = JSON.parse(
+        readFileSync(new URL(relativePath, import.meta.url), "utf8"),
+      );
+      if (typeof pkg.version === "string" && pkg.version.trim()) {
+        return pkg.version.trim();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return "unknown";
+}
+
+const packageVersion = readPackageVersion();
+const expectedUserAgent = `mem9-plugin/opencode/${packageVersion}`;
 
 async function withPatchedAbortSignalTimeout(
   run: (capturedTimeouts: number[]) => Promise<void>,
@@ -46,7 +67,7 @@ test("ServerBackend uses X-API-Key and v1alpha2 paths", async () => {
     await backend.search({ q: "hello" });
     assert.equal(requestURL.includes("/v1alpha2/mem9s/memories"), true);
     assert.equal(requestHeaders?.get("X-API-Key"), "mk_demo");
-    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/opencode/0.1.5");
+    assert.equal(requestHeaders?.get("User-Agent"), expectedUserAgent);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -72,7 +93,7 @@ test("ServerBackend fetches runtime-state through the public v1alpha2 path", asy
     assert.equal(requestURL, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
     assert.equal(requestHeaders?.get("X-API-Key"), "mk_demo");
     assert.equal(requestHeaders?.get("X-Mnemo-Agent-Id"), "opencode");
-    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/opencode/0.1.5");
+    assert.equal(requestHeaders?.get("User-Agent"), expectedUserAgent);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -46,6 +46,7 @@ test("ServerBackend uses X-API-Key and v1alpha2 paths", async () => {
     await backend.search({ q: "hello" });
     assert.equal(requestURL.includes("/v1alpha2/mem9s/memories"), true);
     assert.equal(requestHeaders?.get("X-API-Key"), "mk_demo");
+    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/opencode/0.1.5");
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -71,6 +72,7 @@ test("ServerBackend fetches runtime-state through the public v1alpha2 path", asy
     assert.equal(requestURL, "https://api.mem9.ai/v1alpha2/mem9s/runtime-state");
     assert.equal(requestHeaders?.get("X-API-Key"), "mk_demo");
     assert.equal(requestHeaders?.get("X-Mnemo-Agent-Id"), "opencode");
+    assert.equal(requestHeaders?.get("User-Agent"), "mem9-plugin/opencode/0.1.5");
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/opencode-plugin/tests/setup-files.test.ts
+++ b/opencode-plugin/tests/setup-files.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import test from "node:test";
 import { resolveMem9Paths } from "../src/shared/platform-paths.js";
+import { MEM9_PLUGIN_USER_AGENT } from "../src/shared/plugin-user-agent.js";
 import {
   loadSetupState,
   provisionApiKey,
@@ -324,6 +325,10 @@ test("provisionApiKey requests a new API key from mem9", async () => {
       assert.equal(
         (init?.headers as Record<string, string>)["Content-Type"],
         "application/json",
+      );
+      assert.equal(
+        (init?.headers as Record<string, string>)["User-Agent"],
+        MEM9_PLUGIN_USER_AGENT,
       );
 
       return new Response(JSON.stringify({ id: "mk_generated" }), {


### PR DESCRIPTION
## What Changed
- Claude plugin sends `User-Agent: mem9-plugin/claude-code/<version>` on hook and manual skill requests.
- Codex sends `mem9-plugin/codex/<version>` on runtime requests and setup API-key provisioning.
- OpenCode sends `mem9-plugin/opencode/<version>` on runtime requests and setup API-key provisioning.
- OpenClaw sends `mem9-plugin/openclaw/<version>` on mem9 API calls.
- Versions are read from each plugin metadata source, and tests assert provisioning, runtime-state, recall, and store coverage.

## Why
- Server-side logic will use User-Agent to identify the calling plugin and version.
- Existing auth headers and request payloads stay unchanged.
- Metadata-derived versions avoid drift during future release bumps.

## Review Path
1. Start with `codex-plugin/lib/http.mjs` and `codex-plugin/skills/setup/scripts/setup.mjs`.
2. Check `opencode-plugin/src/shared/plugin-user-agent.ts`, `opencode-plugin/src/server/server-backend.ts`, and `opencode-plugin/src/shared/setup-files.ts`.
3. Check `claude-plugin/hooks/common.sh` and the Claude manual skill snippets.
4. Finish with OpenClaw and the updated plugin tests.

## Validation
- `bash -n claude-plugin/hooks/common.sh claude-plugin/hooks/pre-compact.sh claude-plugin/hooks/session-end.sh claude-plugin/hooks/session-start.sh claude-plugin/hooks/stop.sh claude-plugin/hooks/user-prompt-submit.sh`
- `bash claude-plugin/hooks/common.test.sh`
- `pnpm --dir codex-plugin test -- setup.test.mjs`
- `pnpm --dir codex-plugin typecheck`
- `cd openclaw-plugin && npm test && npm run typecheck`
- `node opencode-plugin/scripts/test.mjs`
- `cd opencode-plugin && node node_modules/typescript/lib/tsc.js --noEmit`
- `git diff --check -- claude-plugin codex-plugin openclaw-plugin opencode-plugin`
- mem9 plugin quota e2e, `agent=core`, `quota_scenario=runtime_state_notice`: https://github.com/mem9-ai/mem9-tester/actions/runs/29001900260

## Notes
- Local `pnpm --dir opencode-plugin ...` commands are currently blocked before script execution by pnpm build-script approval for `msgpackr-extract`; the equivalent direct Node test and TypeScript commands above pass.