### PR TITLE
Add homepage paid plan notice

### DIFF
--- a/site/src/components/TopBanner.astro
+++ b/site/src/components/TopBanner.astro
@@ -1,0 +1,85 @@
+---
+import type { SiteTopBannerCopy } from '../content/site';
+
+interface Props {
+  banner: SiteTopBannerCopy;
+}
+
+const { banner } = Astro.props;
+const pricingHref = '/pricing/';
+---
+
+<aside
+  class="top-banner"
+  aria-label={banner.ariaLabel}
+  data-i18n-attr="aria-label:topBanner.ariaLabel"
+>
+  <div class="container top-banner-inner">
+    <div class="top-banner-copy">
+      <p>
+        <span data-i18n="topBanner.bodyBeforeLink">{banner.bodyBeforeLink}</span><a
+          href={pricingHref}
+          data-i18n="topBanner.pricingLinkLabel"
+        >{banner.pricingLinkLabel}</a><span data-i18n="topBanner.bodyAfterLink">{banner.bodyAfterLink}</span>
+      </p>
+    </div>
+  </div>
+</aside>
+
+<style>
+  .top-banner {
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg-elevated) 92%, var(--text) 8%);
+  }
+
+  .top-banner-inner {
+    display: flex;
+    align-items: center;
+    min-height: 3rem;
+    padding-top: 0.45rem;
+    padding-bottom: 0.45rem;
+  }
+
+  .top-banner-copy {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+  }
+
+  .top-banner-copy p {
+    min-width: 0;
+    color: var(--text-dim);
+    font-size: 0.92rem;
+    line-height: 1.4;
+  }
+
+  .top-banner-copy a {
+    color: var(--text);
+    font-weight: 700;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 0.18em;
+  }
+
+  .top-banner-copy a:hover,
+  .top-banner-copy a:focus-visible {
+    color: var(--text);
+    opacity: 1;
+  }
+
+  @media (max-width: 720px) {
+    .top-banner-inner {
+      align-items: start;
+      padding-top: 0.75rem;
+      padding-bottom: 0.75rem;
+    }
+
+    .top-banner-copy {
+      align-items: flex-start;
+    }
+
+    .top-banner-copy p {
+      font-size: 0.9rem;
+    }
+  }
+</style>

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -62,6 +62,13 @@ export interface SiteNavCopy {
   contact: string;
 }
 
+export interface SiteTopBannerCopy {
+  bodyBeforeLink: string;
+  pricingLinkLabel: string;
+  bodyAfterLink: string;
+  ariaLabel: string;
+}
+
 export interface SiteHeroHighlight {
   title: string;
   description: string;
@@ -423,6 +430,7 @@ export interface SiteCopyFeedback {
 export interface SiteDictionary {
   meta: SiteMeta;
   nav: SiteNavCopy;
+  topBanner: SiteTopBannerCopy;
   hero: SiteHeroCopy;
   trust: SiteTrustCopy;
   features: SiteFeaturesCopy;
@@ -6129,6 +6137,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       releaseNotes: 'Release Notes',
       contact: 'Contact Us',
     },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        ' is coming soon. Unclaimed trial API keys will be rate-limited after the free quota. Sign in and claim your API key to upgrade your plan for more usage.',
+      ariaLabel: 'Hosted API key migration notice',
+    },
     hero: {
       eyebrow: 'MEM9.AI',
       titleLead: 'Unlimited memory',
@@ -6490,6 +6505,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       releaseNotes: '发布说明',
       contact: '联系我们',
     },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        ' 即将上线。未绑定的试用期 API Key 超出免费额度后将受到 Rate Limit 限制。请登录并绑定您的 API Key，升级 Plan 以获得更多用量。',
+      ariaLabel: '托管 API Key 迁移公告',
+    },
     hero: {
       eyebrow: 'MEM9.AI',
       titleLead: '无限记忆',
@@ -6836,6 +6858,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       howItWork: 'How it work',
       releaseNotes: '發布說明',
       contact: '聯絡我們',
+    },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        ' 即將上線。未綁定的試用期 API Key 超出免費額度後將受到 Rate Limit 限制。請登入並綁定您的 API Key，升級 Plan 以取得更多用量。',
+      ariaLabel: '託管 API Key 遷移公告',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -7188,6 +7217,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       howItWork: 'How it work',
       releaseNotes: 'リリースノート',
       contact: 'お問い合わせ',
+    },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        ' はまもなく開始されます。未請求の試用 API Key は、無料枠を超えると Rate Limit の対象になります。サインインして API Key を請求し、Plan をアップグレードすると利用量を増やせます。',
+      ariaLabel: 'ホスト型 API Key 移行のお知らせ',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -7546,6 +7582,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       releaseNotes: '릴리스 노트',
       contact: '문의하기',
     },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        '이 곧 시작됩니다. 연결되지 않은 평가판 API Key는 무료 한도를 초과하면 Rate Limit이 적용됩니다. 로그인해 API Key를 연결하고 Plan을 업그레이드하면 더 많이 사용할 수 있습니다.',
+      ariaLabel: '호스팅 API Key 이전 안내',
+    },
     hero: {
       eyebrow: 'MEM9.AI',
       titleLead: '무제한 메모리',
@@ -7899,6 +7942,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       howItWork: 'How it work',
       releaseNotes: 'Catatan Rilis',
       contact: 'Hubungi Kami',
+    },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        ' akan segera diluncurkan. Trial API Key yang belum diklaim akan terkena Rate Limit setelah melewati kuota gratis. Masuk dan klaim API Key Anda untuk upgrade Plan agar mendapat kuota lebih besar.',
+      ariaLabel: 'Pemberitahuan migrasi API Key terkelola',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -8256,6 +8306,13 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       howItWork: 'How it work',
       releaseNotes: 'บันทึกการเผยแพร่',
       contact: 'ติดต่อเรา',
+    },
+    topBanner: {
+      bodyBeforeLink: '',
+      pricingLinkLabel: 'mem9 Billing',
+      bodyAfterLink:
+        ' กำลังจะเปิดใช้งาน Trial API Key ที่ยังไม่ได้ claim จะถูก Rate Limit เมื่อเกินโควต้าฟรี เข้าสู่ระบบและ claim API Key เพื่ออัปเกรด Plan และเพิ่มปริมาณการใช้งาน',
+      ariaLabel: 'ประกาศการย้าย API Key ที่โฮสต์อยู่',
     },
     hero: {
       eyebrow: 'MEM9.AI',

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import TopBanner from '../components/TopBanner.astro';
 import Navbar from '../components/Navbar.astro';
 import Hero from '../components/Hero.astro';
 import Features from '../components/Features.astro';
@@ -15,6 +16,7 @@ const copy = siteCopy[DEFAULT_LOCALE];
 ---
 
 <Layout meta={copy.meta} locale={DEFAULT_LOCALE}>
+  <TopBanner banner={copy.topBanner} />
   <Navbar
     nav={copy.nav}
     aria={copy.aria}


### PR DESCRIPTION
## What Changed
- Homepage: adds a top-of-page paid plan notice before the navigation.
- Site copy: localizes the notice across supported locales through the existing content layer.

## Why
- Free hosted API keys will have usage limits when paid plans launch.
- The banner points users to the existing Console login path without adding another CTA.

## Review Path
1. Start with `site/src/content/site.ts` for the localized banner copy.
2. Check `site/src/components/TopBanner.astro` for the lightweight banner layout.
3. Finish with `site/src/pages/index.astro` for the homepage insertion point.

## Validation
- `git diff --check upstream/main...HEAD`
- `npm run build`
- `npx tsc --noEmit`