### PR TITLE
Add dismissible billing banner

### DIFF
--- a/site/src/components/TopBanner.astro
+++ b/site/src/components/TopBanner.astro
@@ -7,12 +7,17 @@ interface Props {
 
 const { banner } = Astro.props;
 const pricingHref = '/pricing/';
+const noticeId = 'billing-launch-v1';
+const dismissTTLMS = 24 * 60 * 60 * 1000;
 ---
 
 <aside
   class="top-banner"
   aria-label={banner.ariaLabel}
   data-i18n-attr="aria-label:topBanner.ariaLabel"
+  data-top-banner
+  data-notice-id={noticeId}
+  data-dismiss-ttl-ms={dismissTTLMS}
 >
   <div class="container top-banner-inner">
     <div class="top-banner-copy">
@@ -23,6 +28,18 @@ const pricingHref = '/pricing/';
         >{banner.pricingLinkLabel}</a><span data-i18n="topBanner.bodyAfterLink">{banner.bodyAfterLink}</span>
       </p>
     </div>
+    <button
+      type="button"
+      class="top-banner-dismiss"
+      aria-label={banner.dismissLabel}
+      title={banner.dismissLabel}
+      data-top-banner-dismiss
+      data-i18n-attr="aria-label:topBanner.dismissLabel;title:topBanner.dismissLabel"
+    >
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M3.9 3.9 12.1 12.1M12.1 3.9 3.9 12.1" />
+      </svg>
+    </button>
   </div>
 </aside>
 
@@ -33,7 +50,9 @@ const pricingHref = '/pricing/';
   }
 
   .top-banner-inner {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.75rem;
     align-items: center;
     min-height: 3rem;
     padding-top: 0.45rem;
@@ -65,6 +84,44 @@ const pricingHref = '/pricing/';
   .top-banner-copy a:focus-visible {
     color: var(--text);
     opacity: 1;
+  }
+
+  .top-banner-dismiss {
+    appearance: none;
+    -webkit-appearance: none;
+    display: inline-flex;
+    width: 2rem;
+    height: 2rem;
+    margin: 0;
+    padding: 0;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    border-radius: 0.5rem;
+    background: transparent;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.18s ease, background-color 0.18s ease, border-color 0.18s ease;
+  }
+
+  .top-banner-dismiss:hover,
+  .top-banner-dismiss:focus-visible {
+    border-color: var(--border);
+    background: var(--button-active-bg);
+    color: var(--text);
+  }
+
+  .top-banner-dismiss:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .top-banner-dismiss svg {
+    width: 1rem;
+    height: 1rem;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
   }
 
   @media (max-width: 720px) {

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -67,6 +67,7 @@ export interface SiteTopBannerCopy {
   pricingLinkLabel: string;
   bodyAfterLink: string;
   ariaLabel: string;
+  dismissLabel: string;
 }
 
 export interface SiteHeroHighlight {
@@ -6143,6 +6144,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         ' is coming soon. Unclaimed trial API keys will be rate-limited after the free quota. Sign in and claim your API key to upgrade your plan for more usage.',
       ariaLabel: 'Hosted API key migration notice',
+      dismissLabel: 'Dismiss banner',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -6511,6 +6513,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         ' 即将上线。未绑定的试用期 API Key 超出免费额度后将受到 Rate Limit 限制。请登录并绑定您的 API Key，升级 Plan 以获得更多用量。',
       ariaLabel: '托管 API Key 迁移公告',
+      dismissLabel: '关闭公告',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -6865,6 +6868,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         ' 即將上線。未綁定的試用期 API Key 超出免費額度後將受到 Rate Limit 限制。請登入並綁定您的 API Key，升級 Plan 以取得更多用量。',
       ariaLabel: '託管 API Key 遷移公告',
+      dismissLabel: '關閉公告',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -7224,6 +7228,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         ' はまもなく開始されます。未請求の試用 API Key は、無料枠を超えると Rate Limit の対象になります。サインインして API Key を請求し、Plan をアップグレードすると利用量を増やせます。',
       ariaLabel: 'ホスト型 API Key 移行のお知らせ',
+      dismissLabel: 'お知らせを閉じる',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -7588,6 +7593,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         '이 곧 시작됩니다. 연결되지 않은 평가판 API Key는 무료 한도를 초과하면 Rate Limit이 적용됩니다. 로그인해 API Key를 연결하고 Plan을 업그레이드하면 더 많이 사용할 수 있습니다.',
       ariaLabel: '호스팅 API Key 이전 안내',
+      dismissLabel: '공지 닫기',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -7949,6 +7955,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         ' akan segera diluncurkan. Trial API Key yang belum diklaim akan terkena Rate Limit setelah melewati kuota gratis. Masuk dan klaim API Key Anda untuk upgrade Plan agar mendapat kuota lebih besar.',
       ariaLabel: 'Pemberitahuan migrasi API Key terkelola',
+      dismissLabel: 'Tutup pengumuman',
     },
     hero: {
       eyebrow: 'MEM9.AI',
@@ -8313,6 +8320,7 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       bodyAfterLink:
         ' กำลังจะเปิดใช้งาน Trial API Key ที่ยังไม่ได้ claim จะถูก Rate Limit เมื่อเกินโควต้าฟรี เข้าสู่ระบบและ claim API Key เพื่ออัปเกรด Plan และเพิ่มปริมาณการใช้งาน',
       ariaLabel: 'ประกาศการย้าย API Key ที่โฮสต์อยู่',
+      dismissLabel: 'ปิดประกาศ',
     },
     hero: {
       eyebrow: 'MEM9.AI',

--- a/site/src/scripts/site-ui.ts
+++ b/site/src/scripts/site-ui.ts
@@ -21,6 +21,10 @@ type OnboardingCommandParts = {
   url: string | null;
   suffix: string;
 };
+type TopBannerDismissal = {
+  noticeId: string;
+  dismissedAt: number;
+};
 
 const ONBOARDING_COMMAND_URL_PATTERN = /https:\/\/\S+/u;
 const PUBLIC_SKILL_ORIGIN = 'https://mem9.ai';
@@ -29,6 +33,7 @@ const PUBLIC_SKILL_URLS = [
   'https://mem9.ai/beta/SKILL.md',
 ];
 const TRACKED_SKILL_PATHS = new Set(['/SKILL.md', '/beta/SKILL.md']);
+const TOP_BANNER_DISMISS_STORAGE_KEY = 'mem9.topBanner.dismissal';
 
 function getValue(dictionary: SiteDictionary, path: string): unknown {
   return path.split('.').reduce<unknown>((current, segment) => {
@@ -859,6 +864,57 @@ function initOnboardingVersionControls(): void {
   });
 
   applyOnboardingVersion('stable');
+}
+
+function initTopBannerDismissal(): void {
+  const banner = document.querySelector<HTMLElement>('[data-top-banner]');
+  if (!banner) {
+    return;
+  }
+
+  const dismissButton = banner.querySelector<HTMLButtonElement>('[data-top-banner-dismiss]');
+  const noticeId = banner.dataset.noticeId;
+  const ttlMS = Number(banner.dataset.dismissTtlMs);
+  if (!dismissButton || !noticeId || !Number.isFinite(ttlMS) || ttlMS <= 0) {
+    return;
+  }
+
+  try {
+    const stored = localStorage.getItem(TOP_BANNER_DISMISS_STORAGE_KEY);
+    const dismissal = stored ? JSON.parse(stored) as Partial<TopBannerDismissal> : null;
+    const ageMS = Date.now() - (dismissal?.dismissedAt ?? 0);
+    if (
+      dismissal?.noticeId === noticeId
+      && typeof dismissal.dismissedAt === 'number'
+      && ageMS >= 0
+      && ageMS < ttlMS
+    ) {
+      banner.hidden = true;
+      return;
+    }
+
+    if (stored) {
+      localStorage.removeItem(TOP_BANNER_DISMISS_STORAGE_KEY);
+    }
+  } catch {
+    // Ignore storage failures and keep the banner visible.
+  }
+
+  dismissButton.addEventListener('click', () => {
+    try {
+      localStorage.setItem(
+        TOP_BANNER_DISMISS_STORAGE_KEY,
+        JSON.stringify({
+          noticeId,
+          dismissedAt: Date.now(),
+        } satisfies TopBannerDismissal),
+      );
+    } catch {
+      // Ignore storage failures and still dismiss the banner for this page view.
+    }
+
+    banner.hidden = true;
+  });
 }
 
 function normalizeDocsTocQuery(value: string): string[] {
@@ -2224,6 +2280,7 @@ export function initSiteUI(): void {
   initSystemThemeListener();
   initCopyButton();
   initOnboardingVersionControls();
+  initTopBannerDismissal();
   setOpenMenu(null);
 
   if (isDocsPage()) {


### PR DESCRIPTION
## What Changed
- Homepage billing banner now includes a compact dismiss button.
- Dismissals are stored by notice id with a 24-hour TTL.
- Dismiss button labels are localized through the site copy layer.

## Why
- Users can clear the notice during a visit while future notice versions and expired dismissals surface again.
- The notice id makes future banner updates explicit.

## Review Path
1. Start with `site/src/components/TopBanner.astro` for the UI markup and notice metadata.
2. Check `site/src/scripts/site-ui.ts` for localStorage dismissal behavior.
3. Finish with `site/src/content/site.ts` for localized dismiss labels.

## Validation
- `git diff --check`
- `npm run build`
- `npx tsc --noEmit`
- Chrome smoke check at `http://127.0.0.1:4322/`: initial display, click dismiss, reload persistence, 25-hour expiry, and 390px mobile overflow.