### PR TITLE
Add runtime notices to memory success responses

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -241,7 +241,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Memory"
+                  "$ref": "#/components/schemas/MemoryCreateResponse"
                 }
               }
             }
@@ -696,7 +696,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Memory"
+                  "$ref": "#/components/schemas/MemoryCreateResponse"
                 }
               }
             }
@@ -2965,6 +2965,13 @@
               "ok",
               "accepted"
             ]
+          },
+          "message": {
+            "type": "string",
+            "description": "Optional runtime-state usage notice for hosted mem9 clients."
+          },
+          "runtimeState": {
+            "$ref": "#/components/schemas/RuntimeStateResponse"
           }
         }
       },
@@ -3149,8 +3156,35 @@
           "offset": {
             "type": "integer",
             "minimum": 0
+          },
+          "message": {
+            "type": "string",
+            "description": "Optional runtime-state usage notice for hosted mem9 clients."
+          },
+          "runtimeState": {
+            "$ref": "#/components/schemas/RuntimeStateResponse"
           }
         }
+      },
+      "MemoryCreateResponse": {
+        "description": "Created memory with optional runtime-state usage notice fields.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Memory"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string",
+                "description": "Optional runtime-state usage notice for hosted mem9 clients."
+              },
+              "runtimeState": {
+                "$ref": "#/components/schemas/RuntimeStateResponse"
+              }
+            }
+          }
+        ]
       },
       "Memory": {
         "type": "object",

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -2,7 +2,7 @@
 title: mem9-server Runtime State API
 status: draft
 created: 2026-07-06
-last_updated: 2026-07-06
+last_updated: 2026-07-09
 ---
 
 ## Summary
@@ -56,6 +56,84 @@ defaults only where required for a stable public shape, and returns configured
 `MNEMO_RUNTIME_USAGE_PROVIDER_ID` controls the public provider discriminator.
 When runtime usage is enabled and the env var is omitted, mem9-server uses
 `mem9-official`.
+
+## Success Response Notices
+
+mem9-server also attaches advisory runtime-state notices to successful memory
+route responses for plugins that only read recall or ingest responses. This is
+an additive response extension for existing response bodies.
+
+### Trigger
+
+The notice path runs only when all conditions below are true:
+
+- Runtime usage is enabled.
+- The runtime usage provider id resolves to `mem9-official`.
+- The primary recall operation has succeeded, or the memory write request has
+  been accepted or completed.
+- The runtime state contains a displayable warning or action.
+
+Runtime-state lookup happens after the primary operation succeeds. Lookup
+failure omits the advisory fields and writes a warning log, while the successful
+recall or write response continues with its normal status code.
+
+### Response Shape
+
+Successful recall responses may include the optional top-level fields below:
+
+```text
+{
+  "memories": [...],
+  "total": 1,
+  "limit": 10,
+  "offset": 0,
+  "message": "mem9 recall has used 80% of included quota. Upgrade your plan to get more included usage.",
+  "runtimeState": RuntimeStateResponse
+}
+```
+
+Successful ingest responses may include the same optional fields on top-level
+status responses:
+
+```text
+{
+  "status": "accepted",
+  "message": "Mem9 needs account or billing attention. Open https://console.example.com/console/billing/plan to upgrade your plan.",
+  "runtimeState": RuntimeStateResponse
+}
+```
+
+Successful `201 Created` memory-object responses may include the same optional
+top-level `message` and `runtimeState` fields.
+
+`runtimeState` uses the same public response shape as
+`GET /v1alpha2/mem9s/runtime-state`. mem9-server returns it as-is after the
+provider-id guard.
+
+### Message Selection
+
+The `message` field is fixed English user-facing copy. The server returns at
+most one notice per response, using this template:
+
+```text
+<feature> <state>. <action>.
+```
+
+Priority order:
+
+1. Inactive API key.
+2. Blocking recommended action or gate result.
+3. Rate-limited gate result.
+4. Constrained usage mode, such as on-demand or post-quota usage.
+5. Exhausted or urgent budget.
+6. Warning budget.
+
+Example messages:
+
+- `This API key is inactive. Run mem9 setup again or create a new API key to keep memory access available.`
+- `Mem9 needs account or billing attention. Open https://console.example.com/console/billing/plan to upgrade your plan.`
+- `mem9 recall has used 80% of included quota. Upgrade your plan to get more included usage.`
+- `mem9 memory saving is using on-demand usage. Review billing settings in the mem9 console.`
 
 ## Provider-Disabled Fallback
 
@@ -127,3 +205,7 @@ response and uses this fallback.
   fails.
 - Provider ID: public discriminator for interpreting provider-specific
   `providerData`.
+- Success response notice: optional top-level `message` and `runtimeState`
+  data attached to successful recall and ingest responses.
+- Displayable warning or action: a runtime state condition that should reach the
+  user through a response notice.

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -177,7 +177,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			s.recordIngestMetering(auth, svc)
 			s.enqueueMemoryAddedIDWebhooks(syncCtx, auth, svc, writeChainSource, chainAuth, result)
 			go s.afterSuccessfulWrite(auth, svc, written)
-			respond(w, http.StatusOK, map[string]string{"status": "ok"})
+			respond(w, http.StatusOK, statusResponseWithRuntimeNotice("ok", s.runtimeResponseNotice(r.Context(), auth)))
 		} else {
 			var lease *runtimeusage.OperationLease
 			if s.runtimeUsageEnabled() {
@@ -229,7 +229,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				s.enqueueMemoryAddedIDWebhooks(context.Background(), auth, svc, writeChainSource, chainAuth, result)
 				s.afterSuccessfulIngest(auth, svc, written)
 			}(lease)
-			respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
+			respond(w, http.StatusAccepted, statusResponseWithRuntimeNotice("accepted", s.runtimeResponseNotice(r.Context(), auth)))
 		}
 		return
 	}
@@ -315,7 +315,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		s.enqueueMemoryAddedWebhook(r.Context(), auth, writeChainSource, chainAuth, mem)
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
-		respond(w, http.StatusCreated, mem)
+		respond(w, http.StatusCreated, memoryResponseWithRuntimeNotice(mem, s.runtimeResponseNotice(r.Context(), auth)))
 		return
 	}
 
@@ -383,7 +383,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			}
 			s.enqueueMemoryAddedIDWebhooks(r.Context(), auth, svc, writeChainSource, chainAuth, result)
 			go s.afterSuccessfulWrite(auth, svc, written)
-			respond(w, http.StatusOK, map[string]string{"status": "ok"})
+			respond(w, http.StatusOK, statusResponseWithRuntimeNotice("ok", s.runtimeResponseNotice(r.Context(), auth)))
 			return
 		}
 		// s.persistContentSession(r.Context(), auth, svc, req.SessionID, agentID, content, metadata)
@@ -422,7 +422,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		s.enqueueMemoryAddedWebhook(r.Context(), auth, writeChainSource, chainAuth, mem)
 		go s.afterSuccessfulWrite(auth, svc, int64(written))
-		respond(w, http.StatusOK, map[string]string{"status": "ok"})
+		respond(w, http.StatusOK, statusResponseWithRuntimeNotice("ok", s.runtimeResponseNotice(r.Context(), auth)))
 	} else {
 		var lease *runtimeusage.OperationLease
 		if s.runtimeUsageEnabled() {
@@ -511,7 +511,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			s.afterSuccessfulWrite(auth, svc, int64(written))
 		}(auth, chainAuth, lease, auth.AgentName, agentID, appID, req.SessionID, content, tags, metadata, routingTargets)
 
-		respond(w, http.StatusAccepted, map[string]string{"status": "accepted"})
+		respond(w, http.StatusAccepted, statusResponseWithRuntimeNotice("accepted", s.runtimeResponseNotice(r.Context(), auth)))
 	}
 }
 
@@ -732,10 +732,12 @@ func mergeMetadata(base, incoming json.RawMessage) json.RawMessage {
 }
 
 type listResponse struct {
-	Memories []domain.Memory `json:"memories"`
-	Total    int             `json:"total"`
-	Limit    int             `json:"limit"`
-	Offset   int             `json:"offset"`
+	Memories     []domain.Memory            `json:"memories"`
+	Total        int                        `json:"total"`
+	Limit        int                        `json:"limit"`
+	Offset       int                        `json:"offset"`
+	Message      string                     `json:"message,omitempty"`
+	RuntimeState *runtimeusage.RuntimeState `json:"runtimeState,omitempty"`
 }
 
 type memoryRecallMetric struct {
@@ -966,11 +968,17 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		s.recordRecallMetering(auth)
 	}
 
+	notice := runtimeResponseNotice{}
+	if recallSearch {
+		notice = s.runtimeResponseNotice(r.Context(), auth)
+	}
 	respond(w, http.StatusOK, listResponse{
-		Memories: memories,
-		Total:    total,
-		Limit:    limit,
-		Offset:   offset,
+		Memories:     memories,
+		Total:        total,
+		Limit:        limit,
+		Offset:       offset,
+		Message:      notice.Message,
+		RuntimeState: runtimeNoticeState(notice),
 	})
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -413,6 +413,11 @@ type captureRuntimeUsageManager struct {
 	beforeDeleteCalls        int
 	afterDeleteSuccessCalls  int
 	enabled                  bool
+	providerID               string
+	runtimeState             runtimeusage.RuntimeState
+	runtimeStateErr          error
+	runtimeStateCalls        int
+	runtimeStateSubjects     []runtimeusage.Subject
 	afterCreateSuccessErr    error
 	beforeCreateErrByTenant  map[string]error
 	beforeRecallSubjects     []runtimeusage.Subject
@@ -427,8 +432,19 @@ type captureRuntimeUsageManager struct {
 	deleteResults            []runtimeusage.MemoryDeleteResult
 }
 
-func (m *captureRuntimeUsageManager) Enabled() bool { return m.enabled }
-func (m *captureRuntimeUsageManager) RuntimeState(context.Context, runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+func (m *captureRuntimeUsageManager) Enabled() bool      { return m.enabled }
+func (m *captureRuntimeUsageManager) ProviderID() string { return m.providerID }
+func (m *captureRuntimeUsageManager) RuntimeState(_ context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runtimeStateCalls++
+	m.runtimeStateSubjects = append(m.runtimeStateSubjects, subject)
+	if m.runtimeStateErr != nil {
+		return runtimeusage.RuntimeState{}, m.runtimeStateErr
+	}
+	if len(m.runtimeState.Meters) > 0 || m.runtimeState.Mem9APIKey.Status != "" || m.runtimeState.RecommendedAction != nil {
+		return m.runtimeState, nil
+	}
 	return runtimeusage.RuntimeUsageDisabledState(), nil
 }
 func (m *captureRuntimeUsageManager) BeforeRecall(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
@@ -493,6 +509,40 @@ func (m *captureRuntimeUsageManager) AfterMemoryDeleteSuccess(_ context.Context,
 	return nil
 }
 func (m *captureRuntimeUsageManager) AfterMemoryDeleteFailure(context.Context, *runtimeusage.OperationLease, error) {
+}
+
+func runtimeNoticeTestState(meter string) runtimeusage.RuntimeState {
+	percent := 82.0
+	remaining := int64(18)
+	capacity := int64(100)
+	return runtimeusage.RuntimeState{
+		Mem9APIKey: runtimeusage.RuntimeStateAPIKey{Status: runtimeusage.RuntimeAPIKeyStatusActive},
+		ProviderID: runtimeNoticeProviderID,
+		Meters: []runtimeusage.RuntimeStateMeter{{
+			Meter: meter,
+			Budgets: []runtimeusage.RuntimeStatusBudget{{
+				Type:  "includedQuota",
+				State: "warning",
+				Measure: runtimeusage.RuntimeStatusMeasure{
+					Kind:     runtimeusage.RuntimeMeasureKindCount,
+					Quantity: "request",
+					Scale:    1,
+				},
+				Period: runtimeusage.RuntimeStatusPeriod{
+					Type: "calendarMonth",
+				},
+				Capacity: runtimeusage.RuntimeStatusCapacity{
+					Type:  "limited",
+					Value: &capacity,
+				},
+				Usage: &runtimeusage.RuntimeStatusUsage{
+					Used:      nil,
+					Remaining: &remaining,
+					Percent:   &percent,
+				},
+			}},
+		}},
+	}
 }
 
 type handlerActivityTenantRepo struct {
@@ -1878,6 +1928,52 @@ func TestCreateMemory_RuntimeUsageAllowsPinnedKnownDelta(t *testing.T) {
 	}
 }
 
+func TestCreateMemory_RuntimeUsageNoticeAddsTopLevelFieldsToCreatedMemory(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled:      true,
+		providerID:   runtimeNoticeProviderID,
+		runtimeState: runtimeNoticeTestState(runtimeusage.MeterMemoryWriteRequests),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	body := map[string]any{
+		"content":     "test memory content",
+		"memory_type": "pinned",
+	}
+	req := makeTenantRequest(t, http.MethodPost, "/memories", body)
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ID           string                     `json:"id"`
+		Message      string                     `json:"message"`
+		RuntimeState *runtimeusage.RuntimeState `json:"runtimeState"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID == "" {
+		t.Fatal("id is empty")
+	}
+	if !strings.Contains(resp.Message, "mem9 memory saving has used 82% of included quota") {
+		t.Fatalf("message = %q, want memory saving quota warning", resp.Message)
+	}
+	if resp.RuntimeState == nil || resp.RuntimeState.ProviderID != runtimeNoticeProviderID {
+		t.Fatalf("runtimeState = %+v, want provider id", resp.RuntimeState)
+	}
+	if runtimeUsage.runtimeStateCalls != 1 {
+		t.Fatalf("RuntimeState calls = %d, want 1", runtimeUsage.runtimeStateCalls)
+	}
+	if len(runtimeUsage.runtimeStateSubjects) != 1 || runtimeUsage.runtimeStateSubjects[0].APIKeySubject != "tenant-a" {
+		t.Fatalf("runtime state subjects = %+v, want tenant-a subject", runtimeUsage.runtimeStateSubjects)
+	}
+}
+
 func TestCreateMemory_RuntimeUsageFinalizationFailureFailsClosed(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{
@@ -2733,6 +2829,84 @@ func TestListMemories_RuntimeUsageRecallFinalizationIgnoresRequestCancellation(t
 	}
 	if len(runtimeUsage.recallSuccessContextErrs) != 1 || runtimeUsage.recallSuccessContextErrs[0] != nil {
 		t.Fatalf("recall finalization context errors = %+v, want [<nil>]", runtimeUsage.recallSuccessContextErrs)
+	}
+}
+
+func TestListMemories_RuntimeUsageNoticeAddsTopLevelFields(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{ID: "m1", Content: `"Under Armour"`, MemoryType: domain.TypePinned, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled:      true,
+		providerID:   runtimeNoticeProviderID,
+		runtimeState: runtimeNoticeTestState(runtimeusage.MeterMemoryRecallRequests),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	req := makeTenantRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&memory_type=pinned&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(resp.Message, "mem9 recall has used 82% of included quota") {
+		t.Fatalf("message = %q, want recall quota warning", resp.Message)
+	}
+	if resp.RuntimeState == nil || resp.RuntimeState.ProviderID != runtimeNoticeProviderID {
+		t.Fatalf("runtimeState = %+v, want provider id", resp.RuntimeState)
+	}
+	if runtimeUsage.runtimeStateCalls != 1 {
+		t.Fatalf("RuntimeState calls = %d, want 1", runtimeUsage.runtimeStateCalls)
+	}
+	if len(runtimeUsage.runtimeStateSubjects) != 1 || runtimeUsage.runtimeStateSubjects[0].APIKeySubject != "tenant-a" {
+		t.Fatalf("runtime state subjects = %+v, want tenant-a subject", runtimeUsage.runtimeStateSubjects)
+	}
+}
+
+func TestListMemories_RuntimeUsageNoticeSkipsUnofficialProvider(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return []domain.Memory{
+				{ID: "m1", Content: `"Under Armour"`, MemoryType: domain.TypePinned, UpdatedAt: now, State: domain.StateActive},
+			}, nil
+		},
+	}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled:      true,
+		providerID:   "provider-x",
+		runtimeState: runtimeNoticeTestState(runtimeusage.MeterMemoryRecallRequests),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+
+	req := makeTenantRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&memory_type=pinned&limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Message != "" || resp.RuntimeState != nil {
+		t.Fatalf("notice = message:%q state:%+v, want omitted", resp.Message, resp.RuntimeState)
+	}
+	if runtimeUsage.runtimeStateCalls != 0 {
+		t.Fatalf("RuntimeState calls = %d, want 0", runtimeUsage.runtimeStateCalls)
 	}
 }
 

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -281,6 +281,39 @@ func TestOpenAPIRuntimeStateContract(t *testing.T) {
 	}
 }
 
+func TestOpenAPISuccessRuntimeNoticeFields(t *testing.T) {
+	openapi := loadOpenAPI(t)
+	components := objectValue(t, openapi, "components")
+	schemas := objectValue(t, components, "schemas")
+
+	status := objectValue(t, schemas, "StatusResponse")
+	assertRuntimeNoticeProperties(t, objectValue(t, status, "properties"))
+
+	list := objectValue(t, schemas, "MemoryListResponse")
+	assertRuntimeNoticeProperties(t, objectValue(t, list, "properties"))
+
+	created := objectValue(t, schemas, "MemoryCreateResponse")
+	allOf := objectSlice(t, created["allOf"])
+	if !containsRef(allOf, "#/components/schemas/Memory") {
+		t.Fatalf("MemoryCreateResponse should extend Memory: %#v", allOf)
+	}
+	if len(allOf) < 2 {
+		t.Fatalf("MemoryCreateResponse allOf = %#v, want notice extension", allOf)
+	}
+	assertRuntimeNoticeProperties(t, objectValue(t, allOf[1], "properties"))
+
+	for _, path := range []string{"/v1alpha1/mem9s/{tenantID}/memories", "/v1alpha2/mem9s/memories"} {
+		postResponses := operationResponses(t, openapi, path, "post")
+		createdResponse := objectValue(t, postResponses, "201")
+		content := objectValue(t, createdResponse, "content")
+		jsonContent := objectValue(t, content, "application/json")
+		schema := objectValue(t, jsonContent, "schema")
+		if schema["$ref"] != "#/components/schemas/MemoryCreateResponse" {
+			t.Fatalf("%s 201 schema ref = %#v, want MemoryCreateResponse", path, schema["$ref"])
+		}
+	}
+}
+
 func loadOpenAPI(t *testing.T) map[string]any {
 	t.Helper()
 	path := filepath.Join("..", "..", "..", "docs", "api", "openapi.json")
@@ -385,6 +418,18 @@ func containsRef(values []map[string]any, target string) bool {
 		}
 	}
 	return false
+}
+
+func assertRuntimeNoticeProperties(t *testing.T, properties map[string]any) {
+	t.Helper()
+	message := objectValue(t, properties, "message")
+	if message["type"] != "string" {
+		t.Fatalf("message.type = %#v, want string", message["type"])
+	}
+	runtimeState := objectValue(t, properties, "runtimeState")
+	if runtimeState["$ref"] != "#/components/schemas/RuntimeStateResponse" {
+		t.Fatalf("runtimeState ref = %#v, want RuntimeStateResponse", runtimeState["$ref"])
+	}
 }
 
 func allOfHasDetailsRef(values []map[string]any, target string) bool {

--- a/server/internal/handler/runtime_notice.go
+++ b/server/internal/handler/runtime_notice.go
@@ -1,0 +1,381 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
+)
+
+const (
+	runtimeNoticeProviderID     = "mem9-official"
+	runtimeNoticeWarningPercent = 80
+	runtimeNoticeUrgentPercent  = 95
+)
+
+type runtimeResponseNotice struct {
+	Message      string
+	RuntimeState runtimeusage.RuntimeState
+}
+
+type runtimeStatusResponse struct {
+	Status       string                     `json:"status"`
+	Message      string                     `json:"message,omitempty"`
+	RuntimeState *runtimeusage.RuntimeState `json:"runtimeState,omitempty"`
+}
+
+type memoryRuntimeResponse struct {
+	*domain.Memory
+	Message      string                     `json:"message,omitempty"`
+	RuntimeState *runtimeusage.RuntimeState `json:"runtimeState,omitempty"`
+}
+
+type runtimeNoticeCandidate struct {
+	priority int
+	message  string
+}
+
+func (s *Server) runtimeResponseNotice(ctx context.Context, auth *domain.AuthInfo) runtimeResponseNotice {
+	if !s.runtimeUsageEnabled() || strings.TrimSpace(s.runtimeUsage.ProviderID()) != runtimeNoticeProviderID {
+		return runtimeResponseNotice{}
+	}
+	state, err := s.runtimeUsage.RuntimeState(ctx, subjectFromAuth(auth))
+	if err != nil {
+		logger := s.logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.WarnContext(ctx, "runtime state response notice omitted",
+			"tenant_id", authTenantID(auth),
+			"cluster_id", authClusterID(auth),
+			"err", err,
+		)
+		return runtimeResponseNotice{}
+	}
+	message := runtimeStateNoticeMessage(state)
+	if message == "" {
+		return runtimeResponseNotice{}
+	}
+	return runtimeResponseNotice{
+		Message:      message,
+		RuntimeState: state,
+	}
+}
+
+func statusResponseWithRuntimeNotice(status string, notice runtimeResponseNotice) runtimeStatusResponse {
+	return runtimeStatusResponse{
+		Status:       status,
+		Message:      notice.Message,
+		RuntimeState: runtimeNoticeState(notice),
+	}
+}
+
+func memoryResponseWithRuntimeNotice(memory *domain.Memory, notice runtimeResponseNotice) any {
+	if notice.Message == "" {
+		return memory
+	}
+	return memoryRuntimeResponse{
+		Memory:       memory,
+		Message:      notice.Message,
+		RuntimeState: runtimeNoticeState(notice),
+	}
+}
+
+func runtimeNoticeState(notice runtimeResponseNotice) *runtimeusage.RuntimeState {
+	if notice.Message == "" {
+		return nil
+	}
+	return &notice.RuntimeState
+}
+
+func runtimeStateNoticeMessage(state runtimeusage.RuntimeState) string {
+	action := state.RecommendedAction
+	candidates := make([]runtimeNoticeCandidate, 0)
+
+	if strings.TrimSpace(state.Mem9APIKey.Status) == runtimeusage.RuntimeAPIKeyStatusInactive {
+		candidates = append(candidates, runtimeNoticeCandidate{
+			priority: 65,
+			message: runtimeNoticeSentence(
+				"This API key is inactive.",
+				action,
+				"Run mem9 setup again or create a new API key to keep memory access available.",
+			),
+		})
+	}
+
+	if runtimeNoticeActionDisplayable(action) {
+		candidates = append(candidates, runtimeNoticeCandidate{
+			priority: runtimeNoticeActionPriority(action),
+			message: runtimeNoticeSentence(
+				"Mem9 needs account or billing attention.",
+				action,
+				"Open the mem9 console to resolve the account or billing state.",
+			),
+		})
+	}
+
+	for _, meter := range state.Meters {
+		feature := runtimeNoticeMeterLabel(meter.Meter)
+		gate := meter.QuotaGateResult
+		outcome := runtimeNoticeString(gate["outcome"])
+		mode := runtimeNoticeString(gate["mode"])
+
+		switch outcome {
+		case "blocked":
+			candidates = append(candidates, runtimeNoticeCandidate{
+				priority: 60,
+				message: runtimeNoticeSentence(
+					fmt.Sprintf("%s is blocked by runtime quota.", feature),
+					action,
+					"Open the mem9 console to resolve the account or billing state.",
+				),
+			})
+		case "rateLimited":
+			candidates = append(candidates, runtimeNoticeCandidate{
+				priority: 55,
+				message: runtimeNoticeSentence(
+					fmt.Sprintf("%s has reached its temporary runtime rate limit.", feature),
+					action,
+					"Retry later or upgrade your plan to get more included usage.",
+				),
+			})
+		}
+
+		switch mode {
+		case "onDemand":
+			candidates = append(candidates, runtimeNoticeCandidate{
+				priority: 40,
+				message: runtimeNoticeSentence(
+					fmt.Sprintf("%s is using on-demand usage.", feature),
+					action,
+					"Review billing settings in the mem9 console.",
+				),
+			})
+		case "postQuota":
+			candidates = append(candidates, runtimeNoticeCandidate{
+				priority: 40,
+				message: runtimeNoticeSentence(
+					fmt.Sprintf("%s is using the post-quota request lane.", feature),
+					action,
+					"Upgrade your plan to get more included usage.",
+				),
+			})
+		}
+
+		for _, budget := range meter.Budgets {
+			candidates = append(candidates, runtimeNoticeBudgetCandidates(feature, budget, action)...)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return ""
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].priority > candidates[j].priority
+	})
+	return candidates[0].message
+}
+
+func runtimeNoticeBudgetCandidates(feature string, budget runtimeusage.RuntimeStatusBudget, action *runtimeusage.RuntimeRecommendedAction) []runtimeNoticeCandidate {
+	state := strings.TrimSpace(budget.State)
+	numbers := runtimeNoticeBudgetNumbers(budget)
+	switch {
+	case state == "exhausted":
+		return []runtimeNoticeCandidate{{
+			priority: 45,
+			message: runtimeNoticeSentence(
+				fmt.Sprintf("%s has exhausted its %s.", feature, runtimeNoticeBudgetLabel(budget.Type)),
+				action,
+				runtimeNoticeBudgetFallbackAction(budget.Type),
+			),
+		}}
+	case runtimeNoticeBudgetUrgent(numbers):
+		return []runtimeNoticeCandidate{{
+			priority: 35,
+			message: runtimeNoticeSentence(
+				runtimeNoticeBudgetUsageDetail(feature, budget, numbers, true),
+				action,
+				runtimeNoticeBudgetFallbackAction(budget.Type),
+			),
+		}}
+	case state == "warning" || (numbers.percent != nil && *numbers.percent >= runtimeNoticeWarningPercent):
+		return []runtimeNoticeCandidate{{
+			priority: 25,
+			message: runtimeNoticeSentence(
+				runtimeNoticeBudgetUsageDetail(feature, budget, numbers, false),
+				action,
+				runtimeNoticeBudgetFallbackAction(budget.Type),
+			),
+		}}
+	default:
+		return nil
+	}
+}
+
+type runtimeNoticeBudgetUsage struct {
+	percent   *float64
+	remaining *int64
+	capacity  *int64
+}
+
+func runtimeNoticeBudgetNumbers(budget runtimeusage.RuntimeStatusBudget) runtimeNoticeBudgetUsage {
+	var numbers runtimeNoticeBudgetUsage
+	if budget.Usage != nil {
+		numbers.percent = budget.Usage.Percent
+		numbers.remaining = budget.Usage.Remaining
+	}
+	if budget.Capacity.Type == "limited" && budget.Capacity.Value != nil && *budget.Capacity.Value > 0 {
+		numbers.capacity = budget.Capacity.Value
+	}
+	return numbers
+}
+
+func runtimeNoticeBudgetUrgent(numbers runtimeNoticeBudgetUsage) bool {
+	if numbers.percent != nil && *numbers.percent >= runtimeNoticeUrgentPercent {
+		return true
+	}
+	if numbers.remaining == nil || numbers.capacity == nil {
+		return false
+	}
+	threshold := (*numbers.capacity * 2) / 100
+	if threshold < 5 {
+		threshold = 5
+	}
+	return *numbers.remaining <= threshold
+}
+
+func runtimeNoticeBudgetUsageDetail(feature string, budget runtimeusage.RuntimeStatusBudget, numbers runtimeNoticeBudgetUsage, preferRemaining bool) string {
+	label := runtimeNoticeBudgetLabel(budget.Type)
+	if preferRemaining && budget.Type == "includedQuota" && numbers.remaining != nil {
+		return fmt.Sprintf("%s has %s included requests remaining.", feature, strconv.FormatInt(*numbers.remaining, 10))
+	}
+	if numbers.percent != nil {
+		return fmt.Sprintf("%s has used %s%% of %s.", feature, runtimeNoticeCompactFloat(*numbers.percent), label)
+	}
+	if numbers.remaining != nil {
+		return fmt.Sprintf("%s has %s units remaining in its %s.", feature, strconv.FormatInt(*numbers.remaining, 10), label)
+	}
+	return fmt.Sprintf("%s is nearing its %s.", feature, label)
+}
+
+func runtimeNoticeSentence(detail string, action *runtimeusage.RuntimeRecommendedAction, fallbackAction string) string {
+	return strings.TrimSpace(detail) + " " + runtimeNoticeActionSentence(action, fallbackAction)
+}
+
+func runtimeNoticeActionSentence(action *runtimeusage.RuntimeRecommendedAction, fallback string) string {
+	if action == nil {
+		return fallback
+	}
+	url := strings.TrimSpace(action.URL)
+	code := strings.TrimSpace(action.ProviderActionCode)
+	if url != "" {
+		switch code {
+		case "claimApiKey":
+			return fmt.Sprintf("Open %s to claim this API key.", url)
+		case "upgradePlan":
+			return fmt.Sprintf("Open %s to upgrade your plan.", url)
+		case "enableOnDemand":
+			return fmt.Sprintf("Open %s to enable billing or on-demand usage.", url)
+		case "increaseSpendingLimit":
+			return fmt.Sprintf("Open %s to increase your spending limit.", url)
+		case "resolveAccountState":
+			return fmt.Sprintf("Open %s to resolve your mem9 account state.", url)
+		default:
+			return fmt.Sprintf("Open %s to resolve this in the mem9 console.", url)
+		}
+	}
+	switch code {
+	case "claimApiKey":
+		return "Open the mem9 console to claim this API key."
+	case "upgradePlan":
+		return "Upgrade your plan to get more included usage."
+	case "enableOnDemand":
+		return "Enable billing or on-demand usage in the mem9 console."
+	case "increaseSpendingLimit":
+		return "Increase your spending limit in the mem9 console."
+	case "resolveAccountState":
+		return "Open the mem9 console to resolve your account state."
+	}
+	return fallback
+}
+
+func runtimeNoticeActionDisplayable(action *runtimeusage.RuntimeRecommendedAction) bool {
+	if action == nil {
+		return false
+	}
+	return strings.TrimSpace(action.URL) != "" ||
+		strings.TrimSpace(action.ProviderActionCode) != "" ||
+		strings.TrimSpace(action.Severity) == "blocking" ||
+		strings.TrimSpace(action.Severity) == "warning"
+}
+
+func runtimeNoticeActionPriority(action *runtimeusage.RuntimeRecommendedAction) int {
+	if action != nil && strings.TrimSpace(action.Severity) == "blocking" {
+		return 50
+	}
+	return 20
+}
+
+func runtimeNoticeMeterLabel(meter string) string {
+	switch strings.TrimSpace(meter) {
+	case runtimeusage.MeterMemoryRecallRequests:
+		return "mem9 recall"
+	case runtimeusage.MeterMemoryWriteRequests:
+		return "mem9 memory saving"
+	default:
+		return "mem9 memory"
+	}
+}
+
+func runtimeNoticeBudgetLabel(budgetType string) string {
+	switch strings.TrimSpace(budgetType) {
+	case "includedQuota":
+		return "included quota"
+	case "spendingLimit":
+		return "spending limit"
+	case "credits":
+		return "credit balance"
+	default:
+		return "runtime quota"
+	}
+}
+
+func runtimeNoticeBudgetFallbackAction(budgetType string) string {
+	switch strings.TrimSpace(budgetType) {
+	case "spendingLimit", "credits":
+		return "Review billing settings in the mem9 console."
+	default:
+		return "Upgrade your plan to get more included usage."
+	}
+}
+
+func runtimeNoticeString(value any) string {
+	text, _ := value.(string)
+	return strings.TrimSpace(text)
+}
+
+func runtimeNoticeCompactFloat(value float64) string {
+	if value == float64(int64(value)) {
+		return strconv.FormatInt(int64(value), 10)
+	}
+	return strconv.FormatFloat(value, 'f', 1, 64)
+}
+
+func authTenantID(auth *domain.AuthInfo) string {
+	if auth == nil {
+		return ""
+	}
+	return auth.TenantID
+}
+
+func authClusterID(auth *domain.AuthInfo) string {
+	if auth == nil {
+		return ""
+	}
+	return auth.ClusterID
+}

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -42,6 +42,9 @@ func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *
 type noopManager struct{}
 
 func (noopManager) Enabled() bool { return false }
+func (noopManager) ProviderID() string {
+	return ""
+}
 func (noopManager) RuntimeState(_ context.Context, subject Subject) (RuntimeState, error) {
 	return RuntimeUsageDisabledState(subject.APIKeyStatus), nil
 }
@@ -76,6 +79,10 @@ func (noopManager) AfterMemoryDeleteFailure(context.Context, *OperationLease, er
 
 func (m *manager) Enabled() bool { return true }
 
+func (m *manager) ProviderID() string {
+	return strings.TrimSpace(m.cfg.ProviderID)
+}
+
 func (m *manager) RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error) {
 	state, err := m.client.RuntimeState(ctx, subject)
 	if err != nil {
@@ -91,7 +98,7 @@ func (m *manager) RuntimeState(ctx context.Context, subject Subject) (RuntimeSta
 		state.Mem9APIKey.Status = subject.APIKeyStatus
 	}
 	if len(state.ProviderData) > 0 {
-		providerID := strings.TrimSpace(m.cfg.ProviderID)
+		providerID := m.ProviderID()
 		if providerID == "" {
 			state.ProviderData = nil
 		} else {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -331,6 +331,7 @@ type OutboxStore interface {
 
 type Manager interface {
 	Enabled() bool
+	ProviderID() string
 	RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error)
 	BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error)
 	AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error


### PR DESCRIPTION
## What Changed
- Memory recall success responses can include optional runtime-state guidance.
- Memory ingest success responses can include optional message and runtimeState fields, including 201 created memory responses.
- OpenAPI documents the additive success response fields and contract tests pin the schema.

## Why
- Older plugins may only inspect recall and ingest responses, so hosted usage warnings need a compatible response-body path.
- Runtime-state lookup is scoped to the mem9-official provider and omitted on lookup failure to preserve primary API availability.

## Review Path
1. Start with server/internal/handler/runtime_notice.go for message selection and provider guard behavior.
2. Check server/internal/handler/memory.go for recall and ingest response integration.
3. Review docs/design/runtime-state-api.md and docs/api/openapi.json for the documented contract.
4. Finish with server/internal/handler/memory_test.go and server/internal/handler/openapi_contract_test.go.

## Validation
- cd server && go test ./...
- git diff --check upstream/main...HEAD