### PR TITLE
Surface success response notices in plugins

### DIFF
--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Persistent cloud memory for Claude Code. Requires Node.js 18+, auto-initializes auth on startup, recalls memories on each user turn, and uploads structured conversation turns to mem9.",
   "author": {
     "name": "mem9-ai"

--- a/claude-plugin/hooks/common.sh
+++ b/claude-plugin/hooks/common.sh
@@ -105,6 +105,12 @@ mem9_auth_file() {
   printf '%s/auth.json\n' "${data_dir}"
 }
 
+mem9_notice_state_file() {
+  local data_dir
+  data_dir="$(mem9_plugin_data_dir)" || return 1
+  printf '%s/runtime-notices.json\n' "${data_dir}"
+}
+
 mem9_memory_base() {
   printf '%s\n' "${MEM9_API_URL%/}/v1alpha2/mem9s"
 }

--- a/claude-plugin/hooks/common.test.sh
+++ b/claude-plugin/hooks/common.test.sh
@@ -95,6 +95,47 @@ case "${inactive_notice}" in
     ;;
 esac
 
+notice_state_file="${TMP_DIR}/runtime-notices.json"
+formatter_notice="$(
+  printf '%s' '{"memories":[],"message":"mem9 recall has used 80% of included quota."}' \
+    | MEM9_NOTICE_SESSION_ID="claude-session" MEM9_NOTICE_STATE_FILE="${notice_state_file}" \
+      node "${SCRIPT_DIR}/lib/memories-formatter.mjs"
+)"
+case "${formatter_notice}" in
+  *"<mem9-status-warning>"*"mem9 recall has used 80% of included quota."*"Mention this mem9 notice to the user once."* ) ;;
+  *)
+    printf 'expected response message status warning, got: %s\n' "${formatter_notice}" >&2
+    exit 1
+    ;;
+esac
+
+formatter_duplicate="$(
+  printf '%s' '{"memories":[],"message":"mem9 recall has used 80% of included quota."}' \
+    | MEM9_NOTICE_SESSION_ID="claude-session" MEM9_NOTICE_STATE_FILE="${notice_state_file}" \
+      node "${SCRIPT_DIR}/lib/memories-formatter.mjs"
+)"
+if [[ -n "${formatter_duplicate}" ]]; then
+  printf 'expected duplicate response message to be suppressed, got: %s\n' "${formatter_duplicate}" >&2
+  exit 1
+fi
+
+stripped_context="$(
+  node --input-type=module -e 'import { pathToFileURL } from "node:url"; const { stripInjectedMemories } = await import(pathToFileURL(process.argv[2])); process.stdout.write(stripInjectedMemories("keep\n<mem9-status-warning>\nhidden\n</mem9-status-warning>\n<relevant-memories>\nmemory\n</relevant-memories>\n<memory-context>\nlegacy\n</memory-context>\nend"));' \
+    _ \
+    "${SCRIPT_DIR}/lib/transcript-parser.mjs"
+)"
+case "${stripped_context}" in
+  *hidden*|*memory*|*legacy* )
+    printf 'expected injected context to be stripped, got: %s\n' "${stripped_context}" >&2
+    exit 1
+    ;;
+  *keep*end* ) ;;
+  *)
+    printf 'expected original user content to remain, got: %s\n' "${stripped_context}" >&2
+    exit 1
+    ;;
+esac
+
 SESSION_ENV_FILE="${TMP_DIR}/session.env"
 session_output="$(
   printf '{"source":"startup"}' | env -u MEM9_API_KEY \

--- a/claude-plugin/hooks/lib/memories-formatter.mjs
+++ b/claude-plugin/hooks/lib/memories-formatter.mjs
@@ -5,6 +5,12 @@ import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { formatRuntimeStateNotice } from "./runtime-state.mjs";
+import { claimRuntimeNotice } from "./runtime-notice-state.mjs";
+
+const STATUS_WARNING_START_TAG = "<mem9-status-warning>";
+const STATUS_WARNING_END_TAG = "</mem9-status-warning>";
+
 /**
  * @typedef {{
  *   id?: string,
@@ -24,6 +30,32 @@ function escapeForPrompt(text) {
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
     .replaceAll(">", "&gt;");
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeNoticeMessage(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {string} message
+ * @returns {string}
+ */
+export function formatStatusWarningBlock(message) {
+  const notice = normalizeNoticeMessage(message);
+  if (!notice) {
+    return "";
+  }
+
+  return [
+    STATUS_WARNING_START_TAG,
+    `Mem9 notice for the user: ${escapeForPrompt(notice)}`,
+    "Mention this mem9 notice to the user once.",
+    STATUS_WARNING_END_TAG,
+  ].join("\n");
 }
 
 /**
@@ -93,6 +125,14 @@ function parseMemories(raw) {
   }
 
   const parsed = JSON.parse(raw);
+  return extractMemories(parsed);
+}
+
+/**
+ * @param {unknown} parsed
+ * @returns {MemoryItem[]}
+ */
+export function extractMemories(parsed) {
   if (Array.isArray(parsed)) {
     return /** @type {MemoryItem[]} */ (parsed);
   }
@@ -103,10 +143,49 @@ function parseMemories(raw) {
 }
 
 /**
+ * @param {unknown} parsed
+ * @returns {string}
+ */
+export function responseMessage(parsed) {
+  if (!parsed || typeof parsed !== "object") {
+    return "";
+  }
+
+  const typed = /** @type {{message?: unknown, runtimeState?: unknown}} */ (parsed);
+  return normalizeNoticeMessage(typed.message)
+    || normalizeNoticeMessage(formatRuntimeStateNotice(typed.runtimeState));
+}
+
+/**
+ * @param {unknown} parsed
+ * @param {{maxItems?: number, maxContentLength?: number, stateFile?: string, sessionID?: string}} [options]
+ * @returns {string}
+ */
+export function formatResponseContext(parsed, options = {}) {
+  const memoriesBlock = formatMemoriesBlock(extractMemories(parsed), options);
+  const message = responseMessage(parsed);
+  const statusBlock = message && claimRuntimeNotice({
+    stateFile: options.stateFile,
+    sessionID: options.sessionID,
+    message,
+  })
+    ? formatStatusWarningBlock(message)
+    : "";
+
+  return [statusBlock, memoriesBlock].filter(Boolean).join("\n\n");
+}
+
+/**
  * @returns {number}
  */
 function main() {
-  const block = formatMemoriesBlock(parseMemories(readFileSync(0, "utf8")));
+  const raw = readFileSync(0, "utf8");
+  const block = raw.trim()
+    ? formatResponseContext(JSON.parse(raw), {
+      stateFile: process.env.MEM9_NOTICE_STATE_FILE,
+      sessionID: process.env.MEM9_NOTICE_SESSION_ID,
+    })
+    : formatMemoriesBlock(parseMemories(raw));
   if (block) {
     process.stdout.write(block);
   }

--- a/claude-plugin/hooks/lib/runtime-notice-state.mjs
+++ b/claude-plugin/hooks/lib/runtime-notice-state.mjs
@@ -1,0 +1,137 @@
+// @ts-check
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+const SCHEMA_VERSION = 1;
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_SESSIONS = 200;
+
+/**
+ * @param {string} message
+ * @returns {string}
+ */
+export function noticeHash(message) {
+  return `sha256:${createHash("sha256").update(message).digest("hex")}`;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function stringArray(value) {
+  return Array.isArray(value)
+    ? value.filter((item) => typeof item === "string")
+    : [];
+}
+
+/**
+ * @param {string} filePath
+ * @returns {{schemaVersion: number, sessions: Record<string, {seenMessages: string[], updatedAt: string}>}}
+ */
+function readState(filePath) {
+  if (!existsSync(filePath)) {
+    return { schemaVersion: SCHEMA_VERSION, sessions: {} };
+  }
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  const sessions = isRecord(parsed?.sessions) ? parsed.sessions : {};
+  /** @type {Record<string, {seenMessages: string[], updatedAt: string}>} */
+  const normalized = {};
+  for (const [sessionID, rawSession] of Object.entries(sessions)) {
+    if (!isRecord(rawSession)) {
+      continue;
+    }
+    normalized[sessionID] = {
+      seenMessages: stringArray(rawSession.seenMessages),
+      updatedAt: typeof rawSession.updatedAt === "string" ? rawSession.updatedAt : "",
+    };
+  }
+
+  return { schemaVersion: SCHEMA_VERSION, sessions: normalized };
+}
+
+/**
+ * @param {ReturnType<typeof readState>} state
+ * @param {Date} now
+ */
+function pruneState(state, now) {
+  const cutoff = now.getTime() - RETENTION_MS;
+  for (const [sessionID, session] of Object.entries(state.sessions)) {
+    const updated = Date.parse(session.updatedAt);
+    if (!Number.isFinite(updated) || updated < cutoff) {
+      delete state.sessions[sessionID];
+    }
+  }
+
+  const entries = Object.entries(state.sessions)
+    .sort((left, right) => Date.parse(right[1].updatedAt) - Date.parse(left[1].updatedAt));
+  for (const [sessionID] of entries.slice(MAX_SESSIONS)) {
+    delete state.sessions[sessionID];
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {ReturnType<typeof readState>} state
+ */
+function writeState(filePath, state) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tempPath, filePath);
+}
+
+/**
+ * Returns true when this message should be shown for the current hook run.
+ *
+ * @param {{stateFile?: string, sessionID?: string, message: string, now?: Date}} input
+ * @returns {boolean}
+ */
+export function claimRuntimeNotice(input) {
+  const message = String(input.message ?? "").trim();
+  const sessionID = String(input.sessionID ?? "").trim();
+  const stateFile = String(input.stateFile ?? "").trim();
+  if (!message) {
+    return false;
+  }
+  if (!sessionID || !stateFile) {
+    return true;
+  }
+
+  try {
+    const now = input.now ?? new Date();
+    const state = readState(stateFile);
+    pruneState(state, now);
+    const session = state.sessions[sessionID] ?? { seenMessages: [], updatedAt: "" };
+    if (session.seenMessages.includes(message)) {
+      session.updatedAt = now.toISOString();
+      state.sessions[sessionID] = session;
+      writeState(stateFile, state);
+      return false;
+    }
+
+    session.seenMessages.push(message);
+    session.updatedAt = now.toISOString();
+    state.sessions[sessionID] = session;
+    writeState(stateFile, state);
+    return true;
+  } catch {
+    return true;
+  }
+}

--- a/claude-plugin/hooks/lib/runtime-state.mjs
+++ b/claude-plugin/hooks/lib/runtime-state.mjs
@@ -2,6 +2,8 @@
 // runtime-state.mjs - Format mem9 runtime-state payloads for hooks.
 
 import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const WARNING_PERCENT = 80;
 const URGENT_PERCENT = 95;
@@ -103,7 +105,7 @@ function budgetNumbers(budget) {
   };
 }
 
-function formatRuntimeStateNotice(runtimeState) {
+export function formatRuntimeStateNotice(runtimeState) {
   if (!isRecord(runtimeState)) return "";
 
   const action = normalizeAction(runtimeState.recommendedAction);
@@ -226,7 +228,17 @@ function readPayload() {
   }
 }
 
-const notice = formatRuntimeStateNotice(readPayload());
-if (notice) {
-  process.stdout.write(notice);
+function main() {
+  const notice = formatRuntimeStateNotice(readPayload());
+  if (notice) {
+    process.stdout.write(notice);
+  }
+  return 0;
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  process.exitCode = main();
 }

--- a/claude-plugin/hooks/lib/transcript-parser.mjs
+++ b/claude-plugin/hooks/lib/transcript-parser.mjs
@@ -5,8 +5,11 @@ import path from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const START_TAG = "<relevant-memories>";
-const END_TAG = "</relevant-memories>";
+const INJECTED_BLOCK_TAGS = [
+  ["<relevant-memories>", "</relevant-memories>"],
+  ["<mem9-status-warning>", "</mem9-status-warning>"],
+  ["<memory-context>", "</memory-context>"],
+];
 
 /**
  * @typedef {{
@@ -29,14 +32,16 @@ const END_TAG = "</relevant-memories>";
  */
 export function stripInjectedMemories(text) {
   let result = text;
-  while (result.includes(START_TAG)) {
-    const start = result.indexOf(START_TAG);
-    const end = result.indexOf(END_TAG, start);
-    if (end === -1) {
-      result = result.slice(0, start);
-      break;
+  for (const [startTag, endTag] of INJECTED_BLOCK_TAGS) {
+    while (result.includes(startTag)) {
+      const start = result.indexOf(startTag);
+      const end = result.indexOf(endTag, start);
+      if (end === -1) {
+        result = result.slice(0, start);
+        break;
+      }
+      result = result.slice(0, start) + result.slice(end + endTag.length);
     }
-    result = result.slice(0, start) + result.slice(end + END_TAG.length);
   }
   return result.trim();
 }

--- a/claude-plugin/hooks/user-prompt-submit.sh
+++ b/claude-plugin/hooks/user-prompt-submit.sh
@@ -58,11 +58,22 @@ if [[ -z "${response}" ]]; then
 fi
 
 memories_count="$(printf '%s' "${response}" | node -e 'const fs=require("node:fs"); const raw=fs.readFileSync(0, "utf8"); const parsed=JSON.parse(raw); const memories=Array.isArray(parsed) ? parsed : Array.isArray(parsed.memories) ? parsed.memories : []; process.stdout.write(String(memories.length));' 2>/dev/null || printf '0')"
+message_stats="$(printf '%s' "${response}" | node --input-type=module -e 'import { createHash } from "node:crypto"; import { readFileSync } from "node:fs"; import { pathToFileURL } from "node:url"; const { responseMessage } = await import(pathToFileURL(process.argv[2])); const message=responseMessage(JSON.parse(readFileSync(0, "utf8"))); const hash=message ? `sha256:${createHash("sha256").update(message).digest("hex")}` : ""; process.stdout.write([message ? "true" : "false", String(message.length), hash].join("\t"));' _ "${SCRIPT_DIR}/lib/memories-formatter.mjs" 2>/dev/null || printf 'false\t0\t')"
+IFS=$'\t' read -r has_message message_length message_hash <<< "${message_stats}"
 mem9_debug "UserPromptSubmit" "recall_response" \
   "prompt_length" "${#prompt}" \
-  "memories_count" "${memories_count}"
+  "memories_count" "${memories_count}" \
+  "has_message" "${has_message}" \
+  "message_length" "${message_length}" \
+  "message_hash" "${message_hash}"
 
-context="$(printf '%s' "${response}" | node "${SCRIPT_DIR}/lib/memories-formatter.mjs" 2>/dev/null || true)"
+session_id="$(mem9_hook_get_string "${HOOK_INPUT}" "session_id")"
+notice_state_file="$(mem9_notice_state_file || true)"
+context="$(
+  printf '%s' "${response}" \
+    | MEM9_NOTICE_SESSION_ID="${session_id}" MEM9_NOTICE_STATE_FILE="${notice_state_file}" \
+      node "${SCRIPT_DIR}/lib/memories-formatter.mjs" 2>/dev/null || true
+)"
 if [[ -z "${context}" ]]; then
   mem9_debug "UserPromptSubmit" "recall_no_context" \
     "prompt_length" "${#prompt}" \

--- a/codex-plugin/.codex-plugin/plugin.json
+++ b/codex-plugin/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mem9",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Persistent memory for Codex. Run $mem9:setup once, then mem9 recalls before prompts and saves recent turns on stop.",
   "author": {
     "name": "mem9-ai"

--- a/codex-plugin/hooks/shared/format.mjs
+++ b/codex-plugin/hooks/shared/format.mjs
@@ -2,6 +2,8 @@
 
 const START_TAG = "<relevant-memories>";
 const END_TAG = "</relevant-memories>";
+const STATUS_WARNING_START_TAG = "<mem9-status-warning>";
+const STATUS_WARNING_END_TAG = "</mem9-status-warning>";
 
 /**
  * @typedef {{
@@ -24,20 +26,58 @@ function escapeForPrompt(text) {
 
 /**
  * @param {string | null | undefined} text
+ * @param {string} startTag
+ * @param {string} endTag
+ * @returns {string}
+ */
+function stripTaggedBlock(text, startTag, endTag) {
+  let next = String(text ?? "");
+
+  while (next.includes(startTag)) {
+    const start = next.indexOf(startTag);
+    const end = next.indexOf(endTag, start);
+    next = end === -1
+      ? next.slice(0, start)
+      : next.slice(0, start) + next.slice(end + endTag.length);
+  }
+
+  return next;
+}
+
+/**
+ * @param {string | null | undefined} text
  * @returns {string}
  */
 export function stripInjectedMemories(text) {
-  let next = String(text ?? "");
+  let next = stripTaggedBlock(text, START_TAG, END_TAG);
+  next = stripTaggedBlock(next, STATUS_WARNING_START_TAG, STATUS_WARNING_END_TAG);
+  return next.trim();
+}
 
-  while (next.includes(START_TAG)) {
-    const start = next.indexOf(START_TAG);
-    const end = next.indexOf(END_TAG, start);
-    next = end === -1
-      ? next.slice(0, start)
-      : next.slice(0, start) + next.slice(end + END_TAG.length);
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeNoticeMessage(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {string} message
+ * @returns {string}
+ */
+export function formatStatusWarningBlock(message) {
+  const notice = normalizeNoticeMessage(message);
+  if (!notice) {
+    return "";
   }
 
-  return next.trim();
+  return [
+    STATUS_WARNING_START_TAG,
+    `Mem9 notice for the user: ${escapeForPrompt(notice)}`,
+    "Mention this mem9 notice to the user once.",
+    STATUS_WARNING_END_TAG,
+  ].join("\n");
 }
 
 /**

--- a/codex-plugin/hooks/shared/runtime-notice-state.mjs
+++ b/codex-plugin/hooks/shared/runtime-notice-state.mjs
@@ -1,0 +1,137 @@
+// @ts-check
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+const SCHEMA_VERSION = 1;
+const RETENTION_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_SESSIONS = 200;
+
+/**
+ * @param {string} message
+ * @returns {string}
+ */
+export function noticeHash(message) {
+  return `sha256:${createHash("sha256").update(message).digest("hex")}`;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+function stringArray(value) {
+  return Array.isArray(value)
+    ? value.filter((item) => typeof item === "string")
+    : [];
+}
+
+/**
+ * @param {string} filePath
+ * @returns {{schemaVersion: number, sessions: Record<string, {seenMessages: string[], updatedAt: string}>}}
+ */
+function readState(filePath) {
+  if (!existsSync(filePath)) {
+    return { schemaVersion: SCHEMA_VERSION, sessions: {} };
+  }
+
+  const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  const sessions = isRecord(parsed?.sessions) ? parsed.sessions : {};
+  /** @type {Record<string, {seenMessages: string[], updatedAt: string}>} */
+  const normalized = {};
+  for (const [sessionID, rawSession] of Object.entries(sessions)) {
+    if (!isRecord(rawSession)) {
+      continue;
+    }
+    normalized[sessionID] = {
+      seenMessages: stringArray(rawSession.seenMessages),
+      updatedAt: typeof rawSession.updatedAt === "string" ? rawSession.updatedAt : "",
+    };
+  }
+
+  return { schemaVersion: SCHEMA_VERSION, sessions: normalized };
+}
+
+/**
+ * @param {ReturnType<typeof readState>} state
+ * @param {Date} now
+ */
+function pruneState(state, now) {
+  const cutoff = now.getTime() - RETENTION_MS;
+  for (const [sessionID, session] of Object.entries(state.sessions)) {
+    const updated = Date.parse(session.updatedAt);
+    if (!Number.isFinite(updated) || updated < cutoff) {
+      delete state.sessions[sessionID];
+    }
+  }
+
+  const entries = Object.entries(state.sessions)
+    .sort((left, right) => Date.parse(right[1].updatedAt) - Date.parse(left[1].updatedAt));
+  for (const [sessionID] of entries.slice(MAX_SESSIONS)) {
+    delete state.sessions[sessionID];
+  }
+}
+
+/**
+ * @param {string} filePath
+ * @param {ReturnType<typeof readState>} state
+ */
+function writeState(filePath, state) {
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(tempPath, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tempPath, filePath);
+}
+
+/**
+ * Returns true when this message should be shown for the current hook run.
+ *
+ * @param {{stateFile?: string, sessionID?: string, message: string, now?: Date}} input
+ * @returns {boolean}
+ */
+export function claimRuntimeNotice(input) {
+  const message = String(input.message ?? "").trim();
+  const sessionID = String(input.sessionID ?? "").trim();
+  const stateFile = String(input.stateFile ?? "").trim();
+  if (!message) {
+    return false;
+  }
+  if (!sessionID || !stateFile) {
+    return true;
+  }
+
+  try {
+    const now = input.now ?? new Date();
+    const state = readState(stateFile);
+    pruneState(state, now);
+    const session = state.sessions[sessionID] ?? { seenMessages: [], updatedAt: "" };
+    if (session.seenMessages.includes(message)) {
+      session.updatedAt = now.toISOString();
+      state.sessions[sessionID] = session;
+      writeState(stateFile, state);
+      return false;
+    }
+
+    session.seenMessages.push(message);
+    session.updatedAt = now.toISOString();
+    state.sessions[sessionID] = session;
+    writeState(stateFile, state);
+    return true;
+  } catch {
+    return true;
+  }
+}

--- a/codex-plugin/hooks/user-prompt-submit.mjs
+++ b/codex-plugin/hooks/user-prompt-submit.mjs
@@ -1,13 +1,25 @@
 // @ts-check
 
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 
 import { loadRuntimeStateFromDisk } from "../lib/config.mjs";
 import { appendDebugError, appendDebugLog } from "./shared/debug.mjs";
-import { formatMemoriesBlock, hookAdditionalContext, stripInjectedMemories } from "./shared/format.mjs";
+import {
+  formatMemoriesBlock,
+  formatStatusWarningBlock,
+  hookAdditionalContext,
+  normalizeNoticeMessage,
+  stripInjectedMemories,
+} from "./shared/format.mjs";
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../lib/http.mjs";
 import { formatRuntimeQuotaNotice, parseRuntimeQuotaDenied } from "../lib/quota-error.mjs";
+import { formatRuntimeStateNotice } from "../lib/runtime-state.mjs";
+import {
+  claimRuntimeNotice,
+  noticeHash,
+} from "./shared/runtime-notice-state.mjs";
 
 const RECALL_LIMIT = 10;
 
@@ -66,11 +78,36 @@ export function extractMemories(payload) {
 }
 
 /**
+ * @param {unknown} payload
+ * @returns {{message: string, source: "success-response" | "runtime-state"} | null}
+ */
+export function extractResponseNotice(payload) {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const typedPayload = /** @type {{message?: unknown, runtimeState?: unknown}} */ (payload);
+  const responseMessage = normalizeNoticeMessage(typedPayload.message);
+  if (responseMessage) {
+    return { message: responseMessage, source: "success-response" };
+  }
+
+  const runtimeStateNotice = normalizeNoticeMessage(
+    formatRuntimeStateNotice(typedPayload.runtimeState),
+  );
+  return runtimeStateNotice
+    ? { message: runtimeStateNotice, source: "runtime-state" }
+    : null;
+}
+
+/**
  * @param {{
  *   prompt?: string,
  *   runtime: RecallRuntime,
  *   search: (url: string, options: {timeoutMs: number}) => Promise<unknown>,
  *   debug?: (stage: string, fields?: Record<string, string | number | boolean | null | undefined>) => void,
+ *   sessionID?: string,
+ *   noticeStateFile?: string,
  * }} input
  * @returns {Promise<string>}
  */
@@ -127,21 +164,37 @@ export async function runUserPromptSubmit(input) {
     );
   }
   const memories = extractMemories(result).slice(0, RECALL_LIMIT);
+  const notice = extractResponseNotice(result);
+  const shouldShowNotice = notice
+    ? claimRuntimeNotice({
+      stateFile: input.noticeStateFile,
+      sessionID: input.sessionID,
+      message: notice.message,
+    })
+    : false;
   debug("recall_response", {
     memoryCount: memories.length,
+    hasMessage: Boolean(notice),
+    messageLength: notice ? notice.message.length : 0,
+    messageHash: notice ? noticeHash(notice.message) : "",
+    messageSource: notice?.source ?? "",
   });
   const block = formatMemoriesBlock(memories);
+  const statusBlock = shouldShowNotice && notice
+    ? formatStatusWarningBlock(notice.message)
+    : "";
+  const context = [statusBlock, block].filter(Boolean).join("\n\n");
 
-  if (!block) {
+  if (!context) {
     debug("recall_no_context");
     return "";
   }
 
   debug("context_injected", {
     memoryCount: memories.length,
-    blockChars: block.length,
+    blockChars: context.length,
   });
-  return hookAdditionalContext("UserPromptSubmit", block);
+  return hookAdditionalContext("UserPromptSubmit", context);
 }
 
 /**
@@ -160,6 +213,10 @@ export async function main() {
   const prompt =
     stdin && typeof stdin === "object" && typeof stdin.prompt === "string"
       ? stdin.prompt
+      : "";
+  const sessionID =
+    stdin && typeof stdin === "object" && typeof stdin.session_id === "string"
+      ? stdin.session_id
       : "";
   const state = loadRuntimeStateFromDisk({ cwd });
   debugContext = {
@@ -204,6 +261,8 @@ export async function main() {
   return runUserPromptSubmit({
     prompt,
     runtime: state.runtime,
+    sessionID,
+    noticeStateFile: path.join(state.codexHome, "mem9", "runtime-notices.json"),
     debug(stage, fields) {
       appendDebugLog({
         hook: "UserPromptSubmit",

--- a/codex-plugin/package.json
+++ b/codex-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/codex-plugin",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Persistent memory for Codex with setup-driven hooks, prompt recall, and stop-time save.",
   "type": "module",
   "license": "Apache-2.0",

--- a/codex-plugin/skills/recall/scripts/recall.mjs
+++ b/codex-plugin/skills/recall/scripts/recall.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../../../lib/http.mjs";
 import { runtimeQuotaDeniedSummary } from "../../../lib/quota-error.mjs";
+import { formatRuntimeStateNotice } from "../../../lib/runtime-state.mjs";
 import { loadReadyRuntimeState } from "../../../lib/skill-runtime.mjs";
 
 const DEFAULT_LIMIT = 10;
@@ -135,6 +136,16 @@ export function normalizeMemorySummary(memory) {
   };
 }
 
+export function responseMessage(payload) {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+  if (typeof payload.message === "string" && payload.message.trim()) {
+    return payload.message.trim();
+  }
+  return formatRuntimeStateNotice(payload.runtimeState).trim();
+}
+
 function readStdinText() {
   return readFileSync(0, "utf8");
 }
@@ -202,6 +213,16 @@ export async function runRecall(argv = process.argv.slice(2), options = {}) {
     .slice(0, args.limit)
     .map(normalizeMemorySummary)
     .filter((memory) => memory.content);
+  /** @type {{
+   *   status: string,
+   *   profileId: string,
+   *   configSource: string,
+   *   query: string,
+   *   memoryCount: number,
+   *   memories: Array<ReturnType<typeof normalizeMemorySummary>>,
+   *   message?: string,
+   * }}
+   */
   const summary = {
     status: "ok",
     profileId: state.runtime.profileId,
@@ -210,6 +231,10 @@ export async function runRecall(argv = process.argv.slice(2), options = {}) {
     memoryCount: memories.length,
     memories,
   };
+  const message = responseMessage(payload);
+  if (message) {
+    summary.message = message;
+  }
   const stdout = options.stdout ?? process.stdout;
   stdout?.write?.(`${JSON.stringify(summary)}\n`);
   return summary;

--- a/codex-plugin/skills/store/scripts/store.mjs
+++ b/codex-plugin/skills/store/scripts/store.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 import { buildMem9Url, mem9FetchJson, mem9Headers } from "../../../lib/http.mjs";
 import { runtimeQuotaDeniedSummary } from "../../../lib/quota-error.mjs";
+import { formatRuntimeStateNotice } from "../../../lib/runtime-state.mjs";
 import { loadReadyRuntimeState } from "../../../lib/skill-runtime.mjs";
 
 function normalizeString(value) {
@@ -85,6 +86,16 @@ function readStdinText() {
   return readFileSync(0, "utf8");
 }
 
+export function responseMessage(payload) {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+  if (typeof payload.message === "string" && payload.message.trim()) {
+    return payload.message.trim();
+  }
+  return formatRuntimeStateNotice(payload.runtimeState).trim();
+}
+
 export async function runStore(argv = process.argv.slice(2), options = {}) {
   const args = Array.isArray(argv) ? parseArgs(argv) : argv;
   const content = normalizeString(args.content)
@@ -112,8 +123,9 @@ export async function runStore(argv = process.argv.slice(2), options = {}) {
     env: options.env,
   });
   const fetchJson = options.fetchJson ?? mem9FetchJson;
+  let payload;
   try {
-    await fetchJson(
+    payload = await fetchJson(
       buildMem9Url(state.runtime.baseUrl, "v1alpha2/mem9s/memories").toString(),
       {
         method: "POST",
@@ -142,12 +154,24 @@ export async function runStore(argv = process.argv.slice(2), options = {}) {
     return summary;
   }
 
+  /** @type {{
+   *   status: string,
+   *   profileId: string,
+   *   configSource: string,
+   *   contentChars: number,
+   *   message?: string,
+   * }}
+   */
   const summary = {
     status: "ok",
     profileId: state.runtime.profileId,
     configSource: state.configSource,
     contentChars: content.length,
   };
+  const message = responseMessage(payload);
+  if (message) {
+    summary.message = message;
+  }
   const stdout = options.stdout ?? process.stdout;
   stdout?.write?.(`${JSON.stringify(summary)}\n`);
   return summary;

--- a/codex-plugin/tests/recall.test.mjs
+++ b/codex-plugin/tests/recall.test.mjs
@@ -96,6 +96,7 @@ test("runRecall calls mem9 with the current runtime and prints a safe summary", 
           request.url = url;
           request.options = options;
           return {
+            message: "mem9 recall has used 80% of included quota.",
             memories: [
               {
                 id: "m1",
@@ -133,6 +134,7 @@ test("runRecall calls mem9 with the current runtime and prints a safe summary", 
     assert.equal(result.profileId, "work");
     assert.equal(result.configSource, "project");
     assert.equal(result.memoryCount, 1);
+    assert.equal(result.message, "mem9 recall has used 80% of included quota.");
     assert.deepEqual(result.memories, [
       {
         id: "m1",

--- a/codex-plugin/tests/store.test.mjs
+++ b/codex-plugin/tests/store.test.mjs
@@ -75,7 +75,7 @@ test("runStore posts a synchronous memory create and prints a safe summary", asy
         ) => {
           request.url = url;
           request.options = options;
-          return { status: "ok" };
+          return { status: "ok", message: "mem9 memory saving has used 80% of included quota." };
         },
         stdout: {
           write(/** @type {string} */ chunk) {
@@ -103,6 +103,7 @@ test("runStore posts a synchronous memory create and prints a safe summary", asy
     assert.equal(result.profileId, "default");
     assert.equal(result.configSource, "global");
     assert.equal(result.contentChars, "The user prefers concise release notes.".length);
+    assert.equal(result.message, "mem9 memory saving has used 80% of included quota.");
     assert.deepEqual(JSON.parse(stdoutText), result);
     assert.equal(stdoutText.includes("key-save"), false);
     assert.equal(stdoutText.includes("The user prefers concise release notes."), false);

--- a/codex-plugin/tests/user-prompt-submit.test.mjs
+++ b/codex-plugin/tests/user-prompt-submit.test.mjs
@@ -12,6 +12,7 @@ import test from "node:test";
 import {
   buildRecallUrl,
   extractMemories,
+  extractResponseNotice,
   runUserPromptSubmit,
 } from "../hooks/user-prompt-submit.mjs";
 import { Mem9HttpError } from "../lib/http.mjs";
@@ -209,6 +210,42 @@ test("extractMemories accepts both server response shapes", () => {
   assert.deepEqual(extractMemories(null), []);
 });
 
+test("extractResponseNotice prefers success response message", () => {
+  assert.deepEqual(
+    extractResponseNotice({
+      message: "mem9 recall has used 80% of included quota.",
+      runtimeState: {
+        mem9ApiKey: { status: "active" },
+        meters: [],
+      },
+    }),
+    {
+      message: "mem9 recall has used 80% of included quota.",
+      source: "success-response",
+    },
+  );
+});
+
+test("extractResponseNotice falls back to runtimeState", () => {
+  const notice = extractResponseNotice({
+    runtimeState: {
+      mem9ApiKey: { status: "active" },
+      meters: [{
+        meter: "memory_recall_requests",
+        budgets: [{
+          type: "includedQuota",
+          state: "warning",
+          usage: { percent: 82, remaining: 18 },
+          capacity: { type: "limited", value: 100 },
+        }],
+      }],
+    },
+  });
+
+  assert.equal(notice?.source, "runtime-state");
+  assert.match(notice?.message ?? "", /mem9 recall is at 82% of its included quota/);
+});
+
 test("user prompt submit recalls memories with the search timeout bucket", async () => {
   /** @type {string | null} */
   let requestedUrl = null;
@@ -253,6 +290,74 @@ test("user prompt submit recalls memories with the search timeout bucket", async
     debugEvents.map((event) => event.stage),
     ["recall_request", "recall_response", "context_injected"],
   );
+});
+
+test("user prompt submit injects success response message without memories", async () => {
+  /** @type {Array<{stage: string, fields: Record<string, unknown> | undefined}>} */
+  const debugEvents = [];
+
+  const output = await runUserPromptSubmit({
+    prompt: "remember my preference",
+    sessionID: "session-message-1",
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
+    },
+    async search() {
+      return {
+        memories: [],
+        message: "mem9 recall has used 80% of included quota.",
+      };
+    },
+    debug(stage, fields) {
+      debugEvents.push({ stage, fields });
+    },
+  });
+
+  const parsed = JSON.parse(output);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /<mem9-status-warning>/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Mem9 notice for the user: mem9 recall has used 80%/);
+  assert.match(parsed.hookSpecificOutput.additionalContext, /Mention this mem9 notice to the user once/);
+  assert.doesNotMatch(parsed.hookSpecificOutput.additionalContext, /<relevant-memories>/);
+  assert.deepEqual(debugEvents.at(1)?.fields, {
+    memoryCount: 0,
+    hasMessage: true,
+    messageLength: 43,
+    messageHash: "sha256:2365c7aac0acad4c5300a420722fec83ac8ae4012e34c7694500334f9b4de1d6",
+    messageSource: "success-response",
+  });
+});
+
+test("user prompt submit deduplicates success response message by session", async () => {
+  const tempRoot = createTempRoot("runtime-notice-state");
+  const noticeStateFile = path.join(tempRoot, "codex-home", "mem9", "runtime-notices.json");
+  const input = {
+    prompt: "remember my preference",
+    sessionID: "session-message-1",
+    noticeStateFile,
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
+    },
+    async search() {
+      return {
+        memories: [],
+        message: "mem9 recall has used 80% of included quota.",
+      };
+    },
+  };
+
+  const firstOutput = await runUserPromptSubmit(input);
+  const secondOutput = await runUserPromptSubmit(input);
+
+  assert.match(firstOutput, /mem9 recall has used 80%/);
+  assert.equal(secondOutput, "");
 });
 
 test("user prompt submit renders runtime quota denial action", async () => {
@@ -535,6 +640,27 @@ test("user prompt submit skips empty queries after stripping injected memories",
   assert.equal(called, false);
   assert.equal(output, "");
   assert.equal(debugEvents[0]?.stage, "prompt_empty");
+});
+
+test("user prompt submit strips injected status warnings before recall", async () => {
+  let called = false;
+  const output = await runUserPromptSubmit({
+    prompt: "<mem9-status-warning>\nMem9 notice for the user: old\n</mem9-status-warning>",
+    runtime: {
+      baseUrl: "https://api.mem9.ai",
+      apiKey: "key-1",
+      agentId: "codex",
+      searchTimeoutMs: 15_000,
+      recallMinPromptLength: 5,
+    },
+    async search() {
+      called = true;
+      return { memories: [] };
+    },
+  });
+
+  assert.equal(called, false);
+  assert.equal(output, "");
 });
 
 test("user prompt submit skips recall when the stripped query is shorter than the configured minimum", async () => {

--- a/openclaw-plugin/hooks.ts
+++ b/openclaw-plugin/hooks.ts
@@ -14,7 +14,7 @@
 import { isPendingProvisionError, type MemoryBackend } from "./backend.js";
 import { formatRuntimeQuotaNotice } from "./quota-error.js";
 import { formatRuntimeStateNotice } from "./runtime-state.js";
-import type { Memory, IngestMessage } from "./types.js";
+import type { Memory, IngestMessage, SearchResult } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -149,21 +149,50 @@ function formatMemoriesBlock(memories: Memory[]): string {
   ].join("\n");
 }
 
+function normalizeNoticeMessage(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function formatStatusWarningBlock(message: string): string {
+  const notice = normalizeNoticeMessage(message);
+  if (!notice) return "";
+
+  return [
+    "<mem9-status-warning>",
+    `Mem9 notice for the user: ${escapeForPrompt(notice)}`,
+    "Mention this mem9 notice to the user once.",
+    "</mem9-status-warning>",
+  ].join("\n");
+}
+
+function responseNotice(result: SearchResult): string {
+  return normalizeNoticeMessage(result.message)
+    || normalizeNoticeMessage(formatRuntimeStateNotice(result.runtimeState));
+}
+
 // ---------------------------------------------------------------------------
 // Context stripping (prevent re-ingesting injected memories)
 // ---------------------------------------------------------------------------
 
 function stripInjectedContext(content: string): string {
   let s = content;
-  for (;;) {
-    const start = s.indexOf("<relevant-memories>");
-    if (start === -1) break;
-    const end = s.indexOf("</relevant-memories>");
-    if (end === -1) {
-      s = s.slice(0, start);
-      break;
+  const tagPairs = [
+    ["<relevant-memories>", "</relevant-memories>"],
+    ["<mem9-status-warning>", "</mem9-status-warning>"],
+    ["<memory-context>", "</memory-context>"],
+  ] as const;
+
+  for (const [startTag, endTag] of tagPairs) {
+    for (;;) {
+      const start = s.indexOf(startTag);
+      if (start === -1) break;
+      const end = s.indexOf(endTag, start);
+      if (end === -1) {
+        s = s.slice(0, start);
+        break;
+      }
+      s = s.slice(0, start) + s.slice(end + endTag.length);
     }
-    s = s.slice(0, start) + s.slice(end + "</relevant-memories>".length);
   }
   return s.trim();
 }
@@ -217,6 +246,16 @@ export function registerHooks(
   const maxIngestBytes = options?.maxIngestBytes ?? DEFAULT_MAX_INGEST_BYTES;
   let loggedMissingConversationAccess = false;
   let runtimeStateNoticeShown = false;
+  const seenNoticeMessages = new Set<string>();
+
+  function consumeNoticeMessage(message: string): string {
+    const notice = normalizeNoticeMessage(message);
+    if (!notice || seenNoticeMessages.has(notice)) {
+      return "";
+    }
+    seenNoticeMessages.add(notice);
+    return notice;
+  }
 
   // --------------------------------------------------------------------------
   // before_prompt_build — inject relevant memories into every LLM call
@@ -247,18 +286,20 @@ export function registerHooks(
           return;
         }
 
-        let runtimeStateNotice = "";
-        if (!runtimeStateNoticeShown) {
+        const result = await backend.search({ q: recallQuery, limit: MAX_INJECT });
+        const memories = result.data ?? [];
+        const resultNotice = responseNotice(result);
+        let runtimeStateNotice = consumeNoticeMessage(resultNotice);
+        if (!resultNotice && !runtimeStateNoticeShown) {
           runtimeStateNoticeShown = true;
           try {
-            runtimeStateNotice = formatRuntimeStateNotice(await backend.runtimeState());
+            runtimeStateNotice = consumeNoticeMessage(
+              formatRuntimeStateNotice(await backend.runtimeState()),
+            );
           } catch {
             runtimeStateNotice = "";
           }
         }
-
-        const result = await backend.search({ q: recallQuery, limit: MAX_INJECT });
-        const memories = result.data ?? [];
         if (options?.debug) {
           logger.info(
             `[mem9][debug] before_prompt_build recall search limit=${MAX_INJECT} results=${memories.length}`,
@@ -267,16 +308,17 @@ export function registerHooks(
 
         if (memories.length === 0) {
           return runtimeStateNotice
-            ? { prependContext: runtimeStateNotice }
+            ? { prependContext: formatStatusWarningBlock(runtimeStateNotice) }
             : undefined;
         }
 
         logger.info(`[mem9] Injecting ${memories.length} memories into prompt context`);
         const memoriesBlock = formatMemoriesBlock(memories);
+        const statusBlock = formatStatusWarningBlock(runtimeStateNotice);
 
         return {
-          prependContext: runtimeStateNotice
-            ? `${runtimeStateNotice}\n\n${memoriesBlock}`
+          prependContext: statusBlock
+            ? `${statusBlock}\n\n${memoriesBlock}`
             : memoriesBlock,
         };
       } catch (err) {

--- a/openclaw-plugin/index.test.ts
+++ b/openclaw-plugin/index.test.ts
@@ -307,6 +307,59 @@ test("before_prompt_build forwards the prompt as q during recall search", async 
   }
 });
 
+test("before_prompt_build injects success response message without memories once", async () => {
+  const originalFetch = globalThis.fetch;
+  const apiUrl = uniqueApiUrl("before-prompt-message");
+  let runtimeStateRequests = 0;
+
+  globalThis.fetch = async (input, init) => {
+    const requestURL = String(input);
+    assert.equal(init?.method, "GET");
+
+    if (requestURL.endsWith("/v1alpha2/mem9s/runtime-state")) {
+      runtimeStateRequests += 1;
+      return new Response(JSON.stringify({ mem9ApiKey: { status: "active" }, meters: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        memories: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        message: "mem9 recall has used 80% of included quota.",
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const api = createStubApi({
+      apiUrl,
+      apiKey: "space-before-prompt-message",
+    });
+    mnemoPlugin.register(api);
+
+    const beforePromptBuild = api.getHook("before_prompt_build");
+    const firstResult = await beforePromptBuild({ prompt: "remember alpha" }) as { prependContext?: string } | undefined;
+    const secondResult = await beforePromptBuild({ prompt: "remember beta" }) as { prependContext?: string } | undefined;
+
+    assert.match(firstResult?.prependContext ?? "", /<mem9-status-warning>/);
+    assert.match(firstResult?.prependContext ?? "", /mem9 recall has used 80% of included quota\./);
+    assert.match(firstResult?.prependContext ?? "", /Mention this mem9 notice to the user once\./);
+    assert.equal(secondResult, undefined);
+    assert.equal(runtimeStateRequests, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("before_prompt_build returns runtime quota denial action context", async () => {
   const originalFetch = globalThis.fetch;
   const apiUrl = uniqueApiUrl("before-prompt-quota");
@@ -909,6 +962,56 @@ test("background save quota handling logs a terse status", async () => {
       2,
     );
     assert.equal(infoLogs.some((line) => line.includes("In your reply")), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("agent_end strips injected status warning before ingest", async () => {
+  const originalFetch = globalThis.fetch;
+  const ingestBodies: Record<string, unknown>[] = [];
+
+  globalThis.fetch = async (input, init) => {
+    assert.equal(String(input).includes("/v1alpha2/mem9s/memories"), true);
+    assert.equal(init?.method, "POST");
+    ingestBodies.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+    return new Response(JSON.stringify({ status: "accepted" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const api = createStubApi({
+      apiUrl: uniqueApiUrl("agent-end-strip-status-warning"),
+      apiKey: "space-agent-end-strip",
+    });
+    mnemoPlugin.register(api);
+
+    await api.getHook("agent_end")({
+      success: true,
+      sessionId: "session-strip",
+      messages: [
+        {
+          role: "user",
+          content: [
+            "keep this preference",
+            "<mem9-status-warning>",
+            "Mem9 notice for the user: hidden",
+            "</mem9-status-warning>",
+            "<memory-context>",
+            "legacy hidden",
+            "</memory-context>",
+          ].join("\n"),
+        },
+      ],
+    });
+
+    const messages = ingestBodies[0]?.messages as Array<{ content: string }> | undefined;
+    assert.ok(messages);
+    assert.equal(messages?.[0]?.content.includes("keep this preference"), true);
+    assert.equal(messages?.[0]?.content.includes("Mem9 notice for the user"), false);
+    assert.equal(messages?.[0]?.content.includes("legacy hidden"), false);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/mem9",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "OpenClaw shared memory plugin — cloud-persistent memory with hybrid vector + keyword search via mnemo-server",
   "type": "module",
   "license": "Apache-2.0",

--- a/openclaw-plugin/server-backend.ts
+++ b/openclaw-plugin/server-backend.ts
@@ -138,6 +138,8 @@ export class ServerBackend implements MemoryBackend {
       total: number;
       limit: number;
       offset: number;
+      message?: string;
+      runtimeState?: unknown;
     }>(
       "GET",
       `${this.memoryPath("/memories")}${qs ? "?" + qs : ""}`,
@@ -149,6 +151,8 @@ export class ServerBackend implements MemoryBackend {
       total: raw.total,
       limit: raw.limit,
       offset: raw.offset,
+      ...(typeof raw.message === "string" ? { message: raw.message } : {}),
+      ...(raw.runtimeState !== undefined ? { runtimeState: raw.runtimeState } : {}),
     };
   }
 

--- a/openclaw-plugin/types.ts
+++ b/openclaw-plugin/types.ts
@@ -48,6 +48,8 @@ export interface SearchResult {
   total: number;
   limit: number;
   offset: number;
+  message?: string;
+  runtimeState?: unknown;
 }
 
 export interface CreateMemoryInput {
@@ -91,6 +93,8 @@ export interface IngestResult {
   insight_ids?: string[];
   warnings?: number;
   error?: string;
+  message?: string;
+  runtimeState?: unknown;
 }
 
 export type StoreResult = Memory | IngestResult;

--- a/opencode-plugin/package.json
+++ b/opencode-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mem9/opencode",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "OpenCode memory plugin — cloud-persistent AI agent memory with hybrid vector + keyword search via mem9",
   "type": "module",
   "main": "src/index.ts",

--- a/opencode-plugin/src/server/backend.ts
+++ b/opencode-plugin/src/server/backend.ts
@@ -22,6 +22,8 @@ export interface IngestInput {
 export interface IngestResult {
   status: string;
   memories_changed?: number;
+  message?: string;
+  runtimeState?: unknown;
 }
 
 /**

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -31,6 +31,7 @@ interface SessionState {
   pendingIngestFingerprint: string | null;
   agentID: string;
   runtimeStateNoticeShown: boolean;
+  pendingRuntimeStateNotice: string | null;
   seenNoticeMessages: Set<string>;
   updatedAt: number;
 }
@@ -176,6 +177,7 @@ function ensureSessionState(
     pendingIngestFingerprint: null,
     agentID: fallbackAgentID,
     runtimeStateNoticeShown: false,
+    pendingRuntimeStateNotice: null,
     seenNoticeMessages: new Set<string>(),
     updatedAt: now,
   };
@@ -346,16 +348,7 @@ export function buildHooks(
       if (!notice) {
         return;
       }
-      options.noticeLogger?.(notice);
-
-      latestUserMessage.parts.push({
-        id: `prt_mem9_runtime_state_${latestUserMessage.info.id}`,
-        sessionID: latestUserMessage.info.sessionID,
-        messageID: latestUserMessage.info.id,
-        type: "text",
-        text: runtimeStateNoticeText(notice),
-        metadata: { source: "mem9-runtime-state" },
-      } as MessagesTransformOutput["messages"][number]["parts"][number]);
+      state.pendingRuntimeStateNotice = notice;
     },
     event: async (input) => {
       if (input.event.type !== "session.idle") {
@@ -415,7 +408,10 @@ export function buildHooks(
           limit: MAX_RECALL_RESULTS,
         });
         const result = await backend.search({ q: query, limit: MAX_RECALL_RESULTS });
-        const notice = consumeNoticeMessage(state, responseMessage(result));
+        const responseNotice = consumeNoticeMessage(state, responseMessage(result));
+        const pendingNotice = state.pendingRuntimeStateNotice;
+        state.pendingRuntimeStateNotice = null;
+        const notice = responseNotice || pendingNotice || "";
         if (notice) {
           options.noticeLogger?.(notice);
         }

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -39,6 +39,7 @@ export interface BuildHooksOptions {
   agentID?: string;
   debugLogger?: DebugLogger;
   loadSessionTranscript?: SessionTranscriptLoader;
+  noticeLogger?: (notice: string) => void;
 }
 
 function runInBackground(task: Promise<unknown>): void {
@@ -345,6 +346,7 @@ export function buildHooks(
       if (!notice) {
         return;
       }
+      options.noticeLogger?.(notice);
 
       latestUserMessage.parts.push({
         id: `prt_mem9_runtime_state_${latestUserMessage.info.id}`,
@@ -414,6 +416,9 @@ export function buildHooks(
         });
         const result = await backend.search({ q: query, limit: MAX_RECALL_RESULTS });
         const notice = consumeNoticeMessage(state, responseMessage(result));
+        if (notice) {
+          options.noticeLogger?.(notice);
+        }
         const block = formatRecallBlock(result.memories);
         const statusBlock = runtimeStateNoticeText(notice);
         const context = [statusBlock, block].filter(Boolean).join("\n\n");

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -98,7 +98,7 @@ function runtimeStateNoticeText(notice: string): string {
   return [
     "<mem9-status-warning>",
     `Mem9 notice for the user: ${escapeForPrompt(message)}`,
-    "Mention this mem9 notice to the user once.",
+    `Start the next response with: Mem9 notice: ${escapeForPrompt(message)}`,
     "</mem9-status-warning>",
   ].join("\n");
 }

--- a/opencode-plugin/src/server/hooks.ts
+++ b/opencode-plugin/src/server/hooks.ts
@@ -6,6 +6,7 @@ import { submitMessagesForIngest } from "./ingest/submit.ts";
 import { formatRuntimeQuotaNotice, parseRuntimeQuotaDenied } from "./quota-error.ts";
 import { formatRecallBlock } from "./recall/format.ts";
 import { buildRecallQuery } from "./recall/query.ts";
+import { normalizeNoticeMessage, responseMessage } from "./response-message.ts";
 import { formatRuntimeStateNotice } from "./runtime-state.ts";
 import type { SessionTranscriptLoader } from "./session-transcript.ts";
 
@@ -30,6 +31,7 @@ interface SessionState {
   pendingIngestFingerprint: string | null;
   agentID: string;
   runtimeStateNoticeShown: boolean;
+  seenNoticeMessages: Set<string>;
   updatedAt: number;
 }
 
@@ -80,12 +82,35 @@ function findLatestUserMessage(
   return null;
 }
 
+function escapeForPrompt(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
 function runtimeStateNoticeText(notice: string): string {
+  const message = normalizeNoticeMessage(notice);
+  if (!message) {
+    return "";
+  }
+
   return [
     "<mem9-status-warning>",
-    notice,
+    `Mem9 notice for the user: ${escapeForPrompt(message)}`,
+    "Mention this mem9 notice to the user once.",
     "</mem9-status-warning>",
   ].join("\n");
+}
+
+function consumeNoticeMessage(state: SessionState, message: string): string {
+  const notice = normalizeNoticeMessage(message);
+  if (!notice || state.seenNoticeMessages.has(notice)) {
+    return "";
+  }
+
+  state.seenNoticeMessages.add(notice);
+  return notice;
 }
 
 async function consumeRuntimeStateNotice(
@@ -98,7 +123,7 @@ async function consumeRuntimeStateNotice(
   state.runtimeStateNoticeShown = true;
 
   try {
-    return formatRuntimeStateNotice(await backend.runtimeState());
+    return consumeNoticeMessage(state, formatRuntimeStateNotice(await backend.runtimeState()));
   } catch {
     // Runtime-state warmup is advisory and must stay fail-soft.
     return "";
@@ -150,6 +175,7 @@ function ensureSessionState(
     pendingIngestFingerprint: null,
     agentID: fallbackAgentID,
     runtimeStateNoticeShown: false,
+    seenNoticeMessages: new Set<string>(),
     updatedAt: now,
   };
   cache.set(sessionID, state);
@@ -387,14 +413,19 @@ export function buildHooks(
           limit: MAX_RECALL_RESULTS,
         });
         const result = await backend.search({ q: query, limit: MAX_RECALL_RESULTS });
+        const notice = consumeNoticeMessage(state, responseMessage(result));
         const block = formatRecallBlock(result.memories);
+        const statusBlock = runtimeStateNoticeText(notice);
+        const context = [statusBlock, block].filter(Boolean).join("\n\n");
         await options.debugLogger?.("recall.result", {
           sessionID: input.sessionID,
           memoryCount: result.memories.length,
-          injected: Boolean(block),
+          injected: Boolean(context),
+          hasMessage: Boolean(notice),
+          messageLength: notice.length,
         });
-        if (block) {
-          output.system.push(block);
+        if (context) {
+          output.system.push(context);
         }
       } catch (error) {
         const quotaDenied = parseRuntimeQuotaDenied(error);

--- a/opencode-plugin/src/server/index.ts
+++ b/opencode-plugin/src/server/index.ts
@@ -64,6 +64,9 @@ const mem9Plugin: Plugin = async (input) => {
     agentID: "opencode",
     debugLogger,
     loadSessionTranscript: createSessionTranscriptLoader(input.client),
+    noticeLogger: (notice) => {
+      console.info(`Mem9 notice: ${notice}`);
+    },
   });
 };
 

--- a/opencode-plugin/src/server/ingest/select.ts
+++ b/opencode-plugin/src/server/ingest/select.ts
@@ -2,12 +2,14 @@ import type { IngestMessage } from "../backend.ts";
 
 const RELEVANT_MEMORIES_BLOCK_RE = /<relevant-memories>[\s\S]*?(<\/relevant-memories>|$)/g;
 const MEM9_STATUS_WARNING_BLOCK_RE = /<mem9-status-warning>[\s\S]*?(<\/mem9-status-warning>|$)/g;
+const MEMORY_CONTEXT_BLOCK_RE = /<memory-context>[\s\S]*?(<\/memory-context>|$)/g;
 const MAX_INGEST_MESSAGES = 12;
 
 function cleanMessageContent(content: string): string {
   return content
     .replace(RELEVANT_MEMORIES_BLOCK_RE, "")
     .replace(MEM9_STATUS_WARNING_BLOCK_RE, "")
+    .replace(MEMORY_CONTEXT_BLOCK_RE, "")
     .trim();
 }
 

--- a/opencode-plugin/src/server/response-message.ts
+++ b/opencode-plugin/src/server/response-message.ts
@@ -1,0 +1,20 @@
+import { formatRuntimeStateNotice } from "./runtime-state.ts";
+
+export function normalizeNoticeMessage(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export function responseMessage(payload: unknown): string {
+  if (!payload || typeof payload !== "object") {
+    return "";
+  }
+
+  const typed = payload as { message?: unknown; runtimeState?: unknown };
+  return normalizeNoticeMessage(typed.message)
+    || normalizeNoticeMessage(formatRuntimeStateNotice(typed.runtimeState));
+}
+
+export function responseMessageFields(payload: unknown): { message?: string } {
+  const message = responseMessage(payload);
+  return message ? { message } : {};
+}

--- a/opencode-plugin/src/server/server-backend.ts
+++ b/opencode-plugin/src/server/server-backend.ts
@@ -120,6 +120,8 @@ export class ServerBackend implements MemoryBackend {
       total: number;
       limit: number;
       offset: number;
+      message?: string;
+      runtimeState?: unknown;
     }>(
       "GET",
       `${this.memoryPath("/memories")}${qs ? "?" + qs : ""}`,
@@ -132,6 +134,8 @@ export class ServerBackend implements MemoryBackend {
       total: raw.total,
       limit: raw.limit,
       offset: raw.offset,
+      ...(typeof raw.message === "string" ? { message: raw.message } : {}),
+      ...(raw.runtimeState !== undefined ? { runtimeState: raw.runtimeState } : {}),
     };
   }
 

--- a/opencode-plugin/src/server/tools.ts
+++ b/opencode-plugin/src/server/tools.ts
@@ -6,6 +6,7 @@ import type {
   SearchInput,
 } from "../shared/types.ts";
 import { toolErrorPayload } from "./quota-error.ts";
+import { responseMessageFields } from "./response-message.ts";
 
 function jsonToolError(error: unknown): string {
   return JSON.stringify(toolErrorPayload(error));
@@ -48,7 +49,11 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
             metadata: args.metadata as Record<string, unknown> | undefined,
           };
           const result = await backend.store(input);
-          return JSON.stringify({ ok: true, data: result });
+          return JSON.stringify({
+            ok: true,
+            data: result,
+            ...responseMessageFields(result),
+          });
         } catch (err) {
           return jsonToolError(err);
         }
@@ -97,7 +102,12 @@ export function buildTools(backend: MemoryBackend): Record<string, ReturnType<ty
             memory_type: args.memory_type,
           };
           const result = await backend.search(input);
-          return JSON.stringify({ ok: true, ...result });
+          const { runtimeState: _runtimeState, message: _message, ...searchResult } = result;
+          return JSON.stringify({
+            ok: true,
+            ...searchResult,
+            ...responseMessageFields(result),
+          });
         } catch (err) {
           return jsonToolError(err);
         }

--- a/opencode-plugin/src/shared/types.ts
+++ b/opencode-plugin/src/shared/types.ts
@@ -46,6 +46,8 @@ export interface SearchResult {
   total: number;
   limit: number;
   offset: number;
+  message?: string;
+  runtimeState?: unknown;
 }
 
 export interface CreateMemoryInput {
@@ -71,4 +73,7 @@ export interface SearchInput {
   memory_type?: string;
 }
 
-export type StoreResult = Memory;
+export type StoreResult = Memory & {
+  message?: string;
+  runtimeState?: unknown;
+};

--- a/opencode-plugin/tests/ingest.test.ts
+++ b/opencode-plugin/tests/ingest.test.ts
@@ -159,6 +159,10 @@ test("selectMessagesForIngest strips injected memory blocks and keeps the latest
 Mem9 API key is inactive.
 </mem9-status-warning>
 
+<memory-context>
+Legacy injected context.
+</memory-context>
+
 Keep this request.
 `,
     },

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -340,15 +340,24 @@ test("buildHooks captures the latest non-synthetic text parts and injects releva
 
 test("buildHooks injects success response message without memories once per session", async () => {
   const debugEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  let runtimeStateCalls = 0;
   const notices: string[] = [];
   const hooks = buildHooks(
-    createBackend(async (input) => ({
-      memories: [],
-      total: 0,
-      limit: input.limit ?? 0,
-      offset: input.offset ?? 0,
-      message: "mem9 recall has used 80% of included quota.",
-    })),
+    createBackend(
+      async (input) => ({
+        memories: [],
+        total: 0,
+        limit: input.limit ?? 0,
+        offset: input.offset ?? 0,
+        message: "mem9 recall has used 80% of included quota.",
+      }),
+      async () => {
+        runtimeStateCalls += 1;
+        return {
+          mem9ApiKey: { status: "inactive" },
+        };
+      },
+    ),
     {
       debugLogger: async (event, payload = {}) => {
         debugEvents.push({ event, payload });
@@ -360,13 +369,22 @@ test("buildHooks injects success response message without memories once per sess
   );
 
   const onChatMessage = hooks["chat.message"];
+  const onMessagesTransform = hooks["experimental.chat.messages.transform"];
   const onSystemTransform = hooks["experimental.chat.system.transform"];
   assert.ok(onChatMessage);
+  assert.ok(onMessagesTransform);
   assert.ok(onSystemTransform);
 
   await onChatMessage(
     createChatMessageInput("session-response-message"),
     createChatMessageOutput([textPart("Find relevant project context.")]),
+  );
+  await onMessagesTransform(
+    {},
+    createMessagesTransformOutput(
+      "session-response-message",
+      [textPart("Find relevant project context.")],
+    ),
   );
 
   const firstOutput = createSystemTransformOutput(["Existing system"]);
@@ -389,6 +407,8 @@ test("buildHooks injects success response message without memories once per sess
   );
   assert.deepEqual(secondOutput.system, ["Existing system"]);
   assert.deepEqual(notices, ["mem9 recall has used 80% of included quota."]);
+  assert.equal(runtimeStateCalls, 1);
+  assert.doesNotMatch(firstOutput.system[1] ?? "", /Mem9 API key is inactive/);
   assert.equal(debugEvents[2]?.payload.hasMessage, true);
   assert.equal(debugEvents[2]?.payload.messageLength, 43);
 });
@@ -686,7 +706,7 @@ test("buildHooks renders runtime quota denial action in recall context", async (
   );
 });
 
-test("buildHooks appends runtime-state notice to latest user message once per session", async () => {
+test("buildHooks uses pending runtime-state notice as recall fallback once per session", async () => {
   let runtimeStateCalls = 0;
   let searchCalls = 0;
   const notices: string[] = [];
@@ -729,39 +749,38 @@ test("buildHooks appends runtime-state notice to latest user message once per se
   );
 
   const onMessagesTransform = hooks["experimental.chat.messages.transform"];
+  const onSystemTransform = hooks["experimental.chat.system.transform"];
   assert.ok(onMessagesTransform);
+  assert.ok(onSystemTransform);
 
   const firstOutput = createMessagesTransformOutput(
     "session-runtime-state",
     [textPart("Find relevant project context.")],
   );
   await onMessagesTransform({}, firstOutput);
+  const firstSystemOutput = createSystemTransformOutput(["Existing system"]);
+  await onSystemTransform(createSystemTransformInput("session-runtime-state"), firstSystemOutput);
 
   const secondOutput = createMessagesTransformOutput(
     "session-runtime-state",
     [textPart("Check again.")],
   );
   await onMessagesTransform({}, secondOutput);
-
-  const injectedPart = firstOutput.messages[0]?.parts.find(
-    (part) => part.type === "text" && part.text.includes("<mem9-status-warning>"),
-  );
+  const secondSystemOutput = createSystemTransformOutput(["Existing system"]);
+  await onSystemTransform(createSystemTransformInput("session-runtime-state"), secondSystemOutput);
 
   assert.equal(runtimeStateCalls, 1);
-  assert.equal(searchCalls, 0);
+  assert.equal(searchCalls, 2);
   assert.equal(notices.length, 1);
   assert.match(notices[0] ?? "", /mem9 recall is at 82% of its included quota/);
-  assert.ok(injectedPart);
-  assert.match(
-    injectedPart.type === "text" ? injectedPart.text : "",
-    /mem9 recall is at 82% of its included quota/,
-  );
+  assert.match(firstSystemOutput.system[1] ?? "", /mem9 recall is at 82% of its included quota/);
   assert.equal(
-    secondOutput.messages[0]?.parts.some(
+    firstOutput.messages[0]?.parts.some(
       (part) => part.type === "text" && part.text.includes("<mem9-status-warning>"),
     ),
     false,
   );
+  assert.deepEqual(secondSystemOutput.system, ["Existing system"]);
 });
 
 test("formatRuntimeQuotaNotice renders spending limit guidance", () => {

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -340,6 +340,7 @@ test("buildHooks captures the latest non-synthetic text parts and injects releva
 
 test("buildHooks injects success response message without memories once per session", async () => {
   const debugEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const notices: string[] = [];
   const hooks = buildHooks(
     createBackend(async (input) => ({
       memories: [],
@@ -351,6 +352,9 @@ test("buildHooks injects success response message without memories once per sess
     {
       debugLogger: async (event, payload = {}) => {
         debugEvents.push({ event, payload });
+      },
+      noticeLogger: (notice) => {
+        notices.push(notice);
       },
     },
   );
@@ -384,6 +388,7 @@ test("buildHooks injects success response message without memories once per sess
     /Start the next response with: Mem9 notice: mem9 recall has used 80% of included quota\./,
   );
   assert.deepEqual(secondOutput.system, ["Existing system"]);
+  assert.deepEqual(notices, ["mem9 recall has used 80% of included quota."]);
   assert.equal(debugEvents[2]?.payload.hasMessage, true);
   assert.equal(debugEvents[2]?.payload.messageLength, 43);
 });
@@ -684,6 +689,7 @@ test("buildHooks renders runtime quota denial action in recall context", async (
 test("buildHooks appends runtime-state notice to latest user message once per session", async () => {
   let runtimeStateCalls = 0;
   let searchCalls = 0;
+  const notices: string[] = [];
   const hooks = buildHooks(
     createBackend(
       async (input) => {
@@ -715,6 +721,11 @@ test("buildHooks appends runtime-state notice to latest user message once per se
         };
       },
     ),
+    {
+      noticeLogger: (notice) => {
+        notices.push(notice);
+      },
+    },
   );
 
   const onMessagesTransform = hooks["experimental.chat.messages.transform"];
@@ -738,6 +749,8 @@ test("buildHooks appends runtime-state notice to latest user message once per se
 
   assert.equal(runtimeStateCalls, 1);
   assert.equal(searchCalls, 0);
+  assert.equal(notices.length, 1);
+  assert.match(notices[0] ?? "", /mem9 recall is at 82% of its included quota/);
   assert.ok(injectedPart);
   assert.match(
     injectedPart.type === "text" ? injectedPart.text : "",

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -338,6 +338,53 @@ test("buildHooks captures the latest non-synthetic text parts and injects releva
   assert.equal(debugEvents[3]?.payload.injected, true);
 });
 
+test("buildHooks injects success response message without memories once per session", async () => {
+  const debugEvents: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const hooks = buildHooks(
+    createBackend(async (input) => ({
+      memories: [],
+      total: 0,
+      limit: input.limit ?? 0,
+      offset: input.offset ?? 0,
+      message: "mem9 recall has used 80% of included quota.",
+    })),
+    {
+      debugLogger: async (event, payload = {}) => {
+        debugEvents.push({ event, payload });
+      },
+    },
+  );
+
+  const onChatMessage = hooks["chat.message"];
+  const onSystemTransform = hooks["experimental.chat.system.transform"];
+  assert.ok(onChatMessage);
+  assert.ok(onSystemTransform);
+
+  await onChatMessage(
+    createChatMessageInput("session-response-message"),
+    createChatMessageOutput([textPart("Find relevant project context.")]),
+  );
+
+  const firstOutput = createSystemTransformOutput(["Existing system"]);
+  await onSystemTransform(createSystemTransformInput("session-response-message"), firstOutput);
+
+  await onChatMessage(
+    createChatMessageInput("session-response-message"),
+    createChatMessageOutput([textPart("Find relevant project context again.")]),
+  );
+
+  const secondOutput = createSystemTransformOutput(["Existing system"]);
+  await onSystemTransform(createSystemTransformInput("session-response-message"), secondOutput);
+
+  assert.equal(firstOutput.system.length, 2);
+  assert.match(firstOutput.system[1] ?? "", /<mem9-status-warning>/);
+  assert.match(firstOutput.system[1] ?? "", /mem9 recall has used 80% of included quota\./);
+  assert.match(firstOutput.system[1] ?? "", /Mention this mem9 notice to the user once\./);
+  assert.deepEqual(secondOutput.system, ["Existing system"]);
+  assert.equal(debugEvents[2]?.payload.hasMessage, true);
+  assert.equal(debugEvents[2]?.payload.messageLength, 43);
+});
+
 test("buildHooks preserves the latest recall prompt across compaction", async () => {
   const queries: SearchInput[] = [];
   const hooks = buildHooks(

--- a/opencode-plugin/tests/recall.test.ts
+++ b/opencode-plugin/tests/recall.test.ts
@@ -379,7 +379,10 @@ test("buildHooks injects success response message without memories once per sess
   assert.equal(firstOutput.system.length, 2);
   assert.match(firstOutput.system[1] ?? "", /<mem9-status-warning>/);
   assert.match(firstOutput.system[1] ?? "", /mem9 recall has used 80% of included quota\./);
-  assert.match(firstOutput.system[1] ?? "", /Mention this mem9 notice to the user once\./);
+  assert.match(
+    firstOutput.system[1] ?? "",
+    /Start the next response with: Mem9 notice: mem9 recall has used 80% of included quota\./,
+  );
   assert.deepEqual(secondOutput.system, ["Existing system"]);
   assert.equal(debugEvents[2]?.payload.hasMessage, true);
   assert.equal(debugEvents[2]?.payload.messageLength, 43);

--- a/opencode-plugin/tests/server-backend.test.ts
+++ b/opencode-plugin/tests/server-backend.test.ts
@@ -73,6 +73,36 @@ test("ServerBackend uses X-API-Key and v1alpha2 paths", async () => {
   }
 });
 
+test("ServerBackend preserves search success response message", async () => {
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async () => {
+    return new Response(
+      JSON.stringify({
+        memories: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        message: "mem9 recall has used 80% of included quota.",
+        runtimeState: { mem9ApiKey: { status: "active" } },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const backend = new ServerBackend("https://api.mem9.ai", "mk_demo", "opencode");
+    const result = await backend.search({ q: "hello" });
+    assert.equal(result.message, "mem9 recall has used 80% of included quota.");
+    assert.deepEqual(result.runtimeState, { mem9ApiKey: { status: "active" } });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("ServerBackend fetches runtime-state through the public v1alpha2 path", async () => {
   const originalFetch = globalThis.fetch;
   let requestURL = "";

--- a/opencode-plugin/tests/tools.test.ts
+++ b/opencode-plugin/tests/tools.test.ts
@@ -63,6 +63,62 @@ function createBackend(): MemoryBackend {
   };
 }
 
+function createSuccessBackend(): MemoryBackend {
+  return {
+    async store(_input: CreateMemoryInput): Promise<StoreResult> {
+      return {
+        id: "memory-1",
+        content: "saved",
+        created_at: "2026-04-21T00:00:00.000Z",
+        updated_at: "2026-04-21T00:00:00.000Z",
+        message: "mem9 memory saving has used 80% of included quota.",
+      };
+    },
+    async search(_input: SearchInput): Promise<SearchResult> {
+      return {
+        memories: [],
+        total: 0,
+        limit: 10,
+        offset: 0,
+        runtimeState: {
+          mem9ApiKey: { status: "active" },
+          meters: [
+            {
+              meter: "memory_recall_requests",
+              budgets: [
+                {
+                  type: "includedQuota",
+                  state: "warning",
+                  usage: { percent: 82, remaining: 18 },
+                  capacity: { type: "limited", value: 100 },
+                },
+              ],
+            },
+          ],
+        },
+      };
+    },
+    async get(_id: string): Promise<Memory | null> {
+      return null;
+    },
+    async update(_id: string, _input: UpdateMemoryInput): Promise<Memory | null> {
+      return null;
+    },
+    async remove(_id: string): Promise<boolean> {
+      return false;
+    },
+    async listRecent(_limit: number): Promise<Memory[]> {
+      return [];
+    },
+    async ingest(_input: IngestInput): Promise<IngestResult> {
+      return { status: "ok" };
+    },
+    async runtimeState(): Promise<unknown> {
+      return null;
+    },
+  };
+}
+
 test("memory tools return structured runtime quota denial payloads", async () => {
   const tools = buildTools(createBackend()) as unknown as Record<
     string,
@@ -81,4 +137,23 @@ test("memory tools return structured runtime quota denial payloads", async () =>
     type: "openUrl",
     url: "https://console.mem9.ai/console/billing/plan",
   });
+});
+
+test("memory tools expose success response message at top level", async () => {
+  const tools = buildTools(createSuccessBackend()) as unknown as Record<
+    string,
+    { execute(args: Record<string, unknown>, context?: unknown): Promise<unknown> }
+  >;
+
+  const searchOutput = await tools.memory_search.execute({ q: "theme" });
+  const storeOutput = await tools.memory_store.execute({ content: "saved" });
+
+  const searchParsed = JSON.parse(searchOutput as string);
+  const storeParsed = JSON.parse(storeOutput as string);
+
+  assert.equal(searchParsed.ok, true);
+  assert.equal(searchParsed.runtimeState, undefined);
+  assert.match(searchParsed.message, /mem9 recall is at 82% of its included quota/);
+  assert.equal(storeParsed.ok, true);
+  assert.equal(storeParsed.message, "mem9 memory saving has used 80% of included quota.");
 });


### PR DESCRIPTION
## What Changed
- Surface success response `message` and `runtimeState` notices across Claude, Codex, OpenClaw, and OpenCode plugins.
- Inject a one-time `<mem9-status-warning>` context block and strip injected notice blocks before automatic ingest.
- Expose top-level tool `message` fields where plugin tools return recall/store results.
- Print consumed OpenCode notices once so users still receive backend messages when the model output skips injected system context.
- Prefer OpenCode recall response messages over pending runtime-state fallback notices when both are available.
- Bump plugin patch versions: Claude `0.3.4`, Codex `0.2.6`, OpenClaw `0.4.15`, OpenCode `0.1.6`.

## Review Path
- Start with `codex-plugin/hooks/user-prompt-submit.mjs` and `claude-plugin/hooks/lib/memories-formatter.mjs`.
- Then review the OpenClaw/OpenCode hook and tool adapters.
- Finish with plugin manifest/package version files.

## Validation
- `pnpm --dir codex-plugin test && pnpm --dir codex-plugin typecheck`
- `bash -n claude-plugin/hooks/common.sh claude-plugin/hooks/session-start.sh claude-plugin/hooks/user-prompt-submit.sh claude-plugin/hooks/stop.sh claude-plugin/hooks/pre-compact.sh claude-plugin/hooks/session-end.sh && for file in claude-plugin/hooks/lib/*.mjs; do node --check "$file" || exit 1; done && bash claude-plugin/hooks/common.test.sh`
- `cd openclaw-plugin && npm test && npm run typecheck`
- `cd opencode-plugin && pnpm test && pnpm run typecheck`
- `git diff --check`
- mem9-tester core E2E success: https://github.com/mem9-ai/mem9-tester/actions/runs/29010509637
- E2E artifact confirmed User-Agent values: `claude-code/0.3.4`, `codex/0.2.6`, `opencode/0.1.6`; local OpenClaw helper confirmed `openclaw/0.4.15`.