### PR TITLE
Sync Claude marketplace version

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "mem9",
       "source": "./claude-plugin",
       "description": "Persistent cloud memory for Claude Code with automatic recall, transcript ingest, and on-demand setup, recall, and store skills.",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "homepage": "https://mem9.ai",
       "repository": "https://github.com/mem9-ai/mem9",
       "license": "Apache-2.0"


### PR DESCRIPTION
## What Changed
- Claude marketplace manifest now reports version `0.3.4`.

## Why
- The Claude plugin manifest already reports `0.3.4`, so marketplace metadata should match the plugin version.

## Review Path
1. Review `.claude-plugin/marketplace.json`.
2. Compare it with `claude-plugin/.claude-plugin/plugin.json`.

## Validation
- `node -e 'const fs=require("fs"); const marketplace=JSON.parse(fs.readFileSync(".claude-plugin/marketplace.json","utf8")); const plugin=JSON.parse(fs.readFileSync("claude-plugin/.claude-plugin/plugin.json","utf8")); if (marketplace.plugins[0].version !== plugin.version) { throw new Error(`${marketplace.plugins[0].version} != ${plugin.version}`); } console.log(`claude marketplace version ${marketplace.plugins[0].version}`);'`
- `git diff --check`
