### PR TITLE
feat: cache runtime notice state lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for
 | `MNEMO_RUNTIME_USAGE_OPERATION_TTL` | No | `30m` | Parsed into server config, but currently not used to expire runtime usage outbox rows; changing it does not alter outbox lifetimes |
 | `MNEMO_RUNTIME_USAGE_FAIL_OPEN` | No | `false` | Allow operations when quota reservation fails with a retryable runtime usage service error. Quota denials and operation conflicts still fail closed |
 | `MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED` | No | same as `MNEMO_RUNTIME_USAGE_ENABLED` | Persist pending reservation and metering steps for retry. If explicitly set to `false` while runtime usage is enabled, `MNEMO_RUNTIME_USAGE_FAIL_OPEN` must be `true` |
+| `MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT` | No | `1s` | Timeout for best-effort runtime-state lookups used only by success response notices |
+| `MNEMO_RUNTIME_USAGE_NOTICE_CACHE_ENABLED` | No | `true` | Enable API-key-scoped caching for success response runtime-state notices |
+| `MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL` | No | `30s` | Fresh TTL for success response runtime-state notice cache entries |
+| `MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL` | No | `2m` | Maximum stale-cache age used for success notices when the state provider is unavailable |
 
 #### Security And Debugging
 

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -190,17 +190,21 @@ func main() {
 	}
 	runtimeUsageClient := runtimeusage.NewHTTPClient(cfg.RuntimeUsageBaseURL, cfg.RuntimeUsageInternalSecret, cfg.RuntimeUsageTimeout)
 	runtimeUsageManager := runtimeusage.NewManager(runtimeusage.Config{
-		Enabled:         cfg.RuntimeUsageEnabled,
-		ProviderID:      cfg.RuntimeUsageProviderID,
-		BaseURL:         cfg.RuntimeUsageBaseURL,
-		InternalSecret:  cfg.RuntimeUsageInternalSecret,
-		Timeout:         cfg.RuntimeUsageTimeout,
-		MeteringTimeout: cfg.RuntimeUsageMeteringTimeout,
-		ReservationTTL:  cfg.RuntimeUsageReservationTTL,
-		OperationTTL:    cfg.RuntimeUsageOperationTTL,
-		FailOpen:        cfg.RuntimeUsageFailOpen,
-		OutboxEnabled:   cfg.RuntimeUsageOutboxEnabled,
-		Outbox:          runtimeUsageStore,
+		Enabled:            cfg.RuntimeUsageEnabled,
+		ProviderID:         cfg.RuntimeUsageProviderID,
+		BaseURL:            cfg.RuntimeUsageBaseURL,
+		InternalSecret:     cfg.RuntimeUsageInternalSecret,
+		Timeout:            cfg.RuntimeUsageTimeout,
+		MeteringTimeout:    cfg.RuntimeUsageMeteringTimeout,
+		ReservationTTL:     cfg.RuntimeUsageReservationTTL,
+		OperationTTL:       cfg.RuntimeUsageOperationTTL,
+		FailOpen:           cfg.RuntimeUsageFailOpen,
+		OutboxEnabled:      cfg.RuntimeUsageOutboxEnabled,
+		NoticeTimeout:      cfg.RuntimeUsageNoticeTimeout,
+		NoticeCacheEnabled: cfg.RuntimeUsageNoticeCacheEnabled,
+		NoticeCacheTTL:     cfg.RuntimeUsageNoticeCacheTTL,
+		NoticeStaleTTL:     cfg.RuntimeUsageNoticeStaleTTL,
+		Outbox:             runtimeUsageStore,
 	}, runtimeUsageClient, runtimeUsageMetering, logger)
 	var runtimeUsageWorkerCancel context.CancelFunc
 	if cfg.RuntimeUsageEnabled && runtimeUsageStore != nil {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -74,16 +74,20 @@ type Config struct {
 
 	// RuntimeUsage enables commercial SaaS quota gating plus runtime usage
 	// service metering. Runtime usage metering uses RuntimeUsageBaseURL, not MeteringURL.
-	RuntimeUsageEnabled         bool
-	RuntimeUsageProviderID      string
-	RuntimeUsageBaseURL         string
-	RuntimeUsageInternalSecret  string `json:"-"`
-	RuntimeUsageTimeout         time.Duration
-	RuntimeUsageMeteringTimeout time.Duration
-	RuntimeUsageReservationTTL  time.Duration
-	RuntimeUsageOperationTTL    time.Duration
-	RuntimeUsageFailOpen        bool
-	RuntimeUsageOutboxEnabled   bool
+	RuntimeUsageEnabled            bool
+	RuntimeUsageProviderID         string
+	RuntimeUsageBaseURL            string
+	RuntimeUsageInternalSecret     string `json:"-"`
+	RuntimeUsageTimeout            time.Duration
+	RuntimeUsageMeteringTimeout    time.Duration
+	RuntimeUsageReservationTTL     time.Duration
+	RuntimeUsageOperationTTL       time.Duration
+	RuntimeUsageFailOpen           bool
+	RuntimeUsageOutboxEnabled      bool
+	RuntimeUsageNoticeTimeout      time.Duration
+	RuntimeUsageNoticeCacheEnabled bool
+	RuntimeUsageNoticeCacheTTL     time.Duration
+	RuntimeUsageNoticeStaleTTL     time.Duration
 
 	// DebugLLM enables logging of raw LLM response content, which may contain
 	// user data. Disabled by default. Enable only in dev/test environments via
@@ -212,6 +216,10 @@ func Load() (*Config, error) {
 		RuntimeUsageOperationTTL:         envDuration("MNEMO_RUNTIME_USAGE_OPERATION_TTL", 30*time.Minute),
 		RuntimeUsageFailOpen:             runtimeUsageFailOpen,
 		RuntimeUsageOutboxEnabled:        runtimeUsageOutboxEnabled,
+		RuntimeUsageNoticeTimeout:        envDuration("MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT", time.Second),
+		RuntimeUsageNoticeCacheEnabled:   envBool("MNEMO_RUNTIME_USAGE_NOTICE_CACHE_ENABLED", true),
+		RuntimeUsageNoticeCacheTTL:       envDuration("MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL", 30*time.Second),
+		RuntimeUsageNoticeStaleTTL:       envDuration("MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL", 2*time.Minute),
 		EncryptType:                      envOr("MNEMO_ENCRYPT_TYPE", "plain"),
 		EncryptKey:                       os.Getenv("MNEMO_ENCRYPT_KEY"),
 		DebugLLM:                         envBool("MNEMO_DEBUG_LLM", false),
@@ -250,6 +258,15 @@ func Load() (*Config, error) {
 	}
 	if cfg.ChainRecallStopScore < 0 || cfg.ChainRecallStopScore > 1 {
 		return nil, fmt.Errorf("MNEMO_CHAIN_RECALL_STOP_SCORE must be between 0 and 1")
+	}
+	if cfg.RuntimeUsageNoticeTimeout <= 0 {
+		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT must be positive")
+	}
+	if cfg.RuntimeUsageNoticeCacheTTL <= 0 {
+		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL must be positive")
+	}
+	if cfg.RuntimeUsageNoticeStaleTTL < 0 {
+		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL must not be negative")
 	}
 
 	return cfg, nil

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -222,6 +222,104 @@ func TestLoad_RuntimeUsageProviderID(t *testing.T) {
 	}
 }
 
+func TestLoad_RuntimeUsageNoticeConfigDefaults(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RuntimeUsageNoticeTimeout != time.Second {
+		t.Fatalf("RuntimeUsageNoticeTimeout = %v, want 1s", cfg.RuntimeUsageNoticeTimeout)
+	}
+	if !cfg.RuntimeUsageNoticeCacheEnabled {
+		t.Fatal("RuntimeUsageNoticeCacheEnabled = false, want true")
+	}
+	if cfg.RuntimeUsageNoticeCacheTTL != 30*time.Second {
+		t.Fatalf("RuntimeUsageNoticeCacheTTL = %v, want 30s", cfg.RuntimeUsageNoticeCacheTTL)
+	}
+	if cfg.RuntimeUsageNoticeStaleTTL != 2*time.Minute {
+		t.Fatalf("RuntimeUsageNoticeStaleTTL = %v, want 2m", cfg.RuntimeUsageNoticeStaleTTL)
+	}
+}
+
+func TestLoad_RuntimeUsageNoticeConfigOverrides(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+	t.Setenv("MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT", "1500ms")
+	t.Setenv("MNEMO_RUNTIME_USAGE_NOTICE_CACHE_ENABLED", "false")
+	t.Setenv("MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL", "45s")
+	t.Setenv("MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL", "3m")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RuntimeUsageNoticeTimeout != 1500*time.Millisecond {
+		t.Fatalf("RuntimeUsageNoticeTimeout = %v, want 1500ms", cfg.RuntimeUsageNoticeTimeout)
+	}
+	if cfg.RuntimeUsageNoticeCacheEnabled {
+		t.Fatal("RuntimeUsageNoticeCacheEnabled = true, want false")
+	}
+	if cfg.RuntimeUsageNoticeCacheTTL != 45*time.Second {
+		t.Fatalf("RuntimeUsageNoticeCacheTTL = %v, want 45s", cfg.RuntimeUsageNoticeCacheTTL)
+	}
+	if cfg.RuntimeUsageNoticeStaleTTL != 3*time.Minute {
+		t.Fatalf("RuntimeUsageNoticeStaleTTL = %v, want 3m", cfg.RuntimeUsageNoticeStaleTTL)
+	}
+}
+
+func TestLoad_RuntimeUsageNoticeConfigValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		envKey     string
+		envValue   string
+		wantSubstr string
+	}{
+		{
+			name:       "timeout must be positive",
+			envKey:     "MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT",
+			envValue:   "0",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT must be positive",
+		},
+		{
+			name:       "cache ttl must be positive",
+			envKey:     "MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL",
+			envValue:   "0",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL must be positive",
+		},
+		{
+			name:       "stale ttl must not be negative",
+			envKey:     "MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL",
+			envValue:   "-1s",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL must not be negative",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MNEMO_DSN", "test-dsn")
+			t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+			t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+			t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+			t.Setenv(tt.envKey, tt.envValue)
+
+			_, err := Load()
+			if err == nil {
+				t.Fatal("Load error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("Load error = %v, want %q", err, tt.wantSubstr)
+			}
+		})
+	}
+}
+
 func TestLoad_RuntimeUsageRequiresBaseURLAndSecret(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -447,6 +447,9 @@ func (m *captureRuntimeUsageManager) RuntimeState(_ context.Context, subject run
 	}
 	return runtimeusage.RuntimeUsageDisabledState(), nil
 }
+func (m *captureRuntimeUsageManager) RuntimeStateForNotice(ctx context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+	return m.RuntimeState(ctx, subject)
+}
 func (m *captureRuntimeUsageManager) BeforeRecall(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeRecallCalls++
 	m.beforeRecallSubjects = append(m.beforeRecallSubjects, subject)

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -418,6 +418,8 @@ type captureRuntimeUsageManager struct {
 	runtimeStateErr          error
 	runtimeStateCalls        int
 	runtimeStateSubjects     []runtimeusage.Subject
+	noticeStateCalls         int
+	noticeStateSubjects      []runtimeusage.Subject
 	afterCreateSuccessErr    error
 	beforeCreateErrByTenant  map[string]error
 	beforeRecallSubjects     []runtimeusage.Subject
@@ -447,8 +449,18 @@ func (m *captureRuntimeUsageManager) RuntimeState(_ context.Context, subject run
 	}
 	return runtimeusage.RuntimeUsageDisabledState(), nil
 }
-func (m *captureRuntimeUsageManager) RuntimeStateForNotice(ctx context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
-	return m.RuntimeState(ctx, subject)
+func (m *captureRuntimeUsageManager) RuntimeStateForNotice(_ context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.noticeStateCalls++
+	m.noticeStateSubjects = append(m.noticeStateSubjects, subject)
+	if m.runtimeStateErr != nil {
+		return runtimeusage.RuntimeState{}, m.runtimeStateErr
+	}
+	if len(m.runtimeState.Meters) > 0 || m.runtimeState.Mem9APIKey.Status != "" || m.runtimeState.RecommendedAction != nil {
+		return m.runtimeState, nil
+	}
+	return runtimeusage.RuntimeUsageDisabledState(), nil
 }
 func (m *captureRuntimeUsageManager) BeforeRecall(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeRecallCalls++
@@ -1969,11 +1981,14 @@ func TestCreateMemory_RuntimeUsageNoticeAddsTopLevelFieldsToCreatedMemory(t *tes
 	if resp.RuntimeState == nil || resp.RuntimeState.ProviderID != runtimeNoticeProviderID {
 		t.Fatalf("runtimeState = %+v, want provider id", resp.RuntimeState)
 	}
-	if runtimeUsage.runtimeStateCalls != 1 {
-		t.Fatalf("RuntimeState calls = %d, want 1", runtimeUsage.runtimeStateCalls)
+	if runtimeUsage.runtimeStateCalls != 0 {
+		t.Fatalf("RuntimeState calls = %d, want 0", runtimeUsage.runtimeStateCalls)
 	}
-	if len(runtimeUsage.runtimeStateSubjects) != 1 || runtimeUsage.runtimeStateSubjects[0].APIKeySubject != "tenant-a" {
-		t.Fatalf("runtime state subjects = %+v, want tenant-a subject", runtimeUsage.runtimeStateSubjects)
+	if runtimeUsage.noticeStateCalls != 1 {
+		t.Fatalf("RuntimeStateForNotice calls = %d, want 1", runtimeUsage.noticeStateCalls)
+	}
+	if len(runtimeUsage.noticeStateSubjects) != 1 || runtimeUsage.noticeStateSubjects[0].APIKeySubject != "tenant-a" {
+		t.Fatalf("notice state subjects = %+v, want tenant-a subject", runtimeUsage.noticeStateSubjects)
 	}
 }
 
@@ -2869,11 +2884,14 @@ func TestListMemories_RuntimeUsageNoticeAddsTopLevelFields(t *testing.T) {
 	if resp.RuntimeState == nil || resp.RuntimeState.ProviderID != runtimeNoticeProviderID {
 		t.Fatalf("runtimeState = %+v, want provider id", resp.RuntimeState)
 	}
-	if runtimeUsage.runtimeStateCalls != 1 {
-		t.Fatalf("RuntimeState calls = %d, want 1", runtimeUsage.runtimeStateCalls)
+	if runtimeUsage.runtimeStateCalls != 0 {
+		t.Fatalf("RuntimeState calls = %d, want 0", runtimeUsage.runtimeStateCalls)
 	}
-	if len(runtimeUsage.runtimeStateSubjects) != 1 || runtimeUsage.runtimeStateSubjects[0].APIKeySubject != "tenant-a" {
-		t.Fatalf("runtime state subjects = %+v, want tenant-a subject", runtimeUsage.runtimeStateSubjects)
+	if runtimeUsage.noticeStateCalls != 1 {
+		t.Fatalf("RuntimeStateForNotice calls = %d, want 1", runtimeUsage.noticeStateCalls)
+	}
+	if len(runtimeUsage.noticeStateSubjects) != 1 || runtimeUsage.noticeStateSubjects[0].APIKeySubject != "tenant-a" {
+		t.Fatalf("notice state subjects = %+v, want tenant-a subject", runtimeUsage.noticeStateSubjects)
 	}
 }
 
@@ -2910,6 +2928,9 @@ func TestListMemories_RuntimeUsageNoticeSkipsUnofficialProvider(t *testing.T) {
 	}
 	if runtimeUsage.runtimeStateCalls != 0 {
 		t.Fatalf("RuntimeState calls = %d, want 0", runtimeUsage.runtimeStateCalls)
+	}
+	if runtimeUsage.noticeStateCalls != 0 {
+		t.Fatalf("RuntimeStateForNotice calls = %d, want 0", runtimeUsage.noticeStateCalls)
 	}
 }
 

--- a/server/internal/handler/runtime_notice.go
+++ b/server/internal/handler/runtime_notice.go
@@ -44,7 +44,7 @@ func (s *Server) runtimeResponseNotice(ctx context.Context, auth *domain.AuthInf
 	if !s.runtimeUsageEnabled() || strings.TrimSpace(s.runtimeUsage.ProviderID()) != runtimeNoticeProviderID {
 		return runtimeResponseNotice{}
 	}
-	state, err := s.runtimeUsage.RuntimeState(ctx, subjectFromAuth(auth))
+	state, err := s.runtimeUsage.RuntimeStateForNotice(ctx, subjectFromAuth(auth))
 	if err != nil {
 		logger := s.logger
 		if logger == nil {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -20,6 +20,8 @@ type manager struct {
 	outbox   OutboxStore
 	logger   *slog.Logger
 	now      func() time.Time
+
+	noticeState *noticeStateCache
 }
 
 func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *slog.Logger) Manager {
@@ -29,7 +31,7 @@ func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *
 	if !cfg.Enabled {
 		return noopManager{}
 	}
-	return &manager{
+	manager := &manager{
 		cfg:      cfg,
 		client:   client,
 		metering: writer,
@@ -37,6 +39,8 @@ func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *
 		logger:   logger,
 		now:      time.Now,
 	}
+	manager.noticeState = newNoticeStateCache(cfg, manager.runtimeStateProvider)
+	return manager
 }
 
 type noopManager struct{}
@@ -46,6 +50,9 @@ func (noopManager) ProviderID() string {
 	return ""
 }
 func (noopManager) RuntimeState(_ context.Context, subject Subject) (RuntimeState, error) {
+	return RuntimeUsageDisabledState(subject.APIKeyStatus), nil
+}
+func (noopManager) RuntimeStateForNotice(_ context.Context, subject Subject) (RuntimeState, error) {
 	return RuntimeUsageDisabledState(subject.APIKeyStatus), nil
 }
 func (noopManager) BeforeRecall(context.Context, Subject) (*OperationLease, error) {
@@ -84,7 +91,7 @@ func (m *manager) ProviderID() string {
 }
 
 func (m *manager) RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error) {
-	state, err := m.client.RuntimeState(ctx, subject)
+	state, err := m.runtimeStateProvider(ctx, subject)
 	if err != nil {
 		m.logger.WarnContext(ctx, "runtime usage state provider unavailable",
 			"tenant_id", subject.TenantID,
@@ -93,10 +100,30 @@ func (m *manager) RuntimeState(ctx context.Context, subject Subject) (RuntimeSta
 		)
 		return RuntimeStateProviderUnavailable(subject.APIKeyStatus), nil
 	}
-	state.SetProviderDefaults()
-	if subject.APIKeyStatus != "" {
-		state.Mem9APIKey.Status = subject.APIKeyStatus
+	applySubjectStatus(&state, subject.APIKeyStatus)
+	return state, nil
+}
+
+func (m *manager) RuntimeStateForNotice(ctx context.Context, subject Subject) (RuntimeState, error) {
+	if m.noticeState == nil {
+		state, err := m.runtimeStateProvider(ctx, subject)
+		if err != nil {
+			return RuntimeState{}, err
+		}
+		return cloneRuntimeStateForSubject(state, subject), nil
 	}
+	return m.noticeState.runtimeState(ctx, subject)
+}
+
+func (m *manager) runtimeStateProvider(ctx context.Context, subject Subject) (RuntimeState, error) {
+	state, err := m.client.RuntimeState(ctx, subject)
+	if err != nil {
+		return RuntimeState{}, err
+	}
+	if err := state.NormalizeProviderData(); err != nil {
+		return RuntimeState{}, &UnavailableError{Err: err}
+	}
+	state.SetProviderDefaults()
 	if len(state.ProviderData) > 0 {
 		providerID := m.ProviderID()
 		if providerID == "" {

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -2,13 +2,20 @@ package runtimeusage
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/qiffang/mnemos/server/internal/metering"
 )
 
 type fakeQuotaClient struct {
+	mu               sync.Mutex
 	reserveOps       []Operation
 	finalized        []string
 	finalizeSubjects []Subject
@@ -16,11 +23,14 @@ type fakeQuotaClient struct {
 	stateSubjects    []Subject
 	err              error
 	stateErr         error
+	stateDelay       time.Duration
 	reserveErr       error
 	finalizeErr      error
 }
 
 func (c *fakeQuotaClient) RuntimeState(_ context.Context, subject Subject) (RuntimeState, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.stateSubjects = append(c.stateSubjects, subject)
 	if c.stateErr != nil {
 		return RuntimeState{}, c.stateErr
@@ -28,10 +38,15 @@ func (c *fakeQuotaClient) RuntimeState(_ context.Context, subject Subject) (Runt
 	if c.err != nil {
 		return RuntimeState{}, c.err
 	}
+	if c.stateDelay > 0 {
+		time.Sleep(c.stateDelay)
+	}
 	return c.state, nil
 }
 
 func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID string, op Operation) (*Reservation, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.reserveErr != nil {
 		return nil, c.reserveErr
 	}
@@ -43,6 +58,8 @@ func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID stri
 }
 
 func (c *fakeQuotaClient) FinalizeReservation(_ context.Context, subject Subject, operationID string, status string, reason string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.finalizeErr != nil {
 		return c.finalizeErr
 	}
@@ -176,6 +193,448 @@ func TestManagerRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
 	}
 	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeProviderManaged, RuntimeBudgetStateProviderManaged)
 	assertFallbackMeter(t, state, MeterMemoryWriteRequests, RuntimeBudgetTypeProviderManaged, RuntimeBudgetStateProviderManaged)
+}
+
+func TestNoticeStateCacheKeyUsesKeyedDigest(t *testing.T) {
+	cache := &noticeStateCache{key: []byte("fixed-test-hmac-key")}
+	got := cache.cacheKey("raw-api-key")
+	again := cache.cacheKey("raw-api-key")
+	other := cache.cacheKey("other-api-key")
+	plain := sha256.Sum256([]byte("raw-api-key"))
+
+	if got != again {
+		t.Fatalf("cacheKey not deterministic: %q != %q", got, again)
+	}
+	if got == other {
+		t.Fatalf("cacheKey should differ for different subjects")
+	}
+	if len(got) != sha256.Size*2 {
+		t.Fatalf("cacheKey length = %d, want %d", len(got), sha256.Size*2)
+	}
+	if strings.Contains(got, "raw-api-key") {
+		t.Fatalf("cacheKey contains raw subject: %q", got)
+	}
+	if got == hex.EncodeToString(plain[:]) {
+		t.Fatalf("cacheKey equals plain sha256(subject); want keyed digest")
+	}
+}
+
+func TestManagerRuntimeStateForNoticeCachesByDigestKey(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil).(*manager)
+
+	subject := Subject{APIKeySubject: "raw-api-key"}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("RuntimeStateForNotice first: %v", err)
+	}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("RuntimeStateForNotice second: %v", err)
+	}
+	if len(quota.stateSubjects) != 1 {
+		t.Fatalf("runtime state calls = %d, want 1", len(quota.stateSubjects))
+	}
+	for key := range manager.noticeState.entries {
+		if strings.Contains(key, "raw-api-key") {
+			t.Fatalf("cache key contains raw subject: %q", key)
+		}
+	}
+}
+
+func TestManagerRuntimeStateForNoticeSeparatesSubjects(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil)
+
+	if _, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a"}); err != nil {
+		t.Fatalf("key-a: %v", err)
+	}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-b"}); err != nil {
+		t.Fatalf("key-b: %v", err)
+	}
+	if len(quota.stateSubjects) != 2 {
+		t.Fatalf("runtime state calls = %d, want 2", len(quota.stateSubjects))
+	}
+}
+
+func TestManagerRuntimeStateForNoticeSkipsCacheWithoutSubject(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil).(*manager)
+
+	if _, err := manager.RuntimeStateForNotice(context.Background(), Subject{}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), Subject{}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if len(quota.stateSubjects) != 2 {
+		t.Fatalf("runtime state calls = %d, want 2", len(quota.stateSubjects))
+	}
+	if len(manager.noticeState.entries) != 0 {
+		t.Fatalf("entries = %+v, want no cache entries", manager.noticeState.entries)
+	}
+}
+
+func TestManagerRuntimeStateForNoticeSingleflightCoalescesMisses(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82), stateDelay: 10 * time.Millisecond}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a"})
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("RuntimeStateForNotice error: %v", err)
+		}
+	}
+	if len(quota.stateSubjects) != 1 {
+		t.Fatalf("runtime state calls = %d, want 1", len(quota.stateSubjects))
+	}
+}
+
+func TestManagerRuntimeStateForNoticeUsesStaleOnProviderError(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil).(*manager)
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	manager.noticeState.now = func() time.Time { return now }
+
+	subject := Subject{APIKeySubject: "key-a"}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	quota.stateErr = errors.New("provider down")
+	now = now.Add(45 * time.Second)
+	state, err := manager.RuntimeStateForNotice(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("stale: %v", err)
+	}
+	if got := *state.Meters[0].Budgets[0].Usage.Percent; got != 82 {
+		t.Fatalf("percent = %v, want 82", got)
+	}
+}
+
+func TestManagerRuntimeStateForNoticeExpiresStaleEntries(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil).(*manager)
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	manager.noticeState.now = func() time.Time { return now }
+
+	subject := Subject{APIKeySubject: "key-a"}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	quota.stateErr = errors.New("provider down")
+	now = now.Add(3 * time.Minute)
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err == nil {
+		t.Fatal("RuntimeStateForNotice error = nil, want provider error after stale TTL")
+	}
+	if len(manager.noticeState.entries) != 0 {
+		t.Fatalf("entries = %+v, want expired entry pruned", manager.noticeState.entries)
+	}
+}
+
+func TestManagerRuntimeStateForNoticeRevalidatesExpiredFreshEntry(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil).(*manager)
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	manager.noticeState.now = func() time.Time { return now }
+
+	subject := Subject{APIKeySubject: "key-a"}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	quota.state = runtimeNoticeStateWithPercent(91)
+	now = now.Add(45 * time.Second)
+	state, err := manager.RuntimeStateForNotice(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("revalidate: %v", err)
+	}
+	if got := *state.Meters[0].Budgets[0].Usage.Percent; got != 91 {
+		t.Fatalf("percent = %v, want 91", got)
+	}
+	if len(quota.stateSubjects) != 2 {
+		t.Fatalf("runtime state calls = %d, want 2", len(quota.stateSubjects))
+	}
+	state, err = manager.RuntimeStateForNotice(context.Background(), subject)
+	if err != nil {
+		t.Fatalf("cached revalidated state: %v", err)
+	}
+	if got := *state.Meters[0].Budgets[0].Usage.Percent; got != 91 {
+		t.Fatalf("cached percent = %v, want 91", got)
+	}
+	if len(quota.stateSubjects) != 2 {
+		t.Fatalf("runtime state calls after cache hit = %d, want 2", len(quota.stateSubjects))
+	}
+}
+
+func TestManagerRuntimeStateForNoticeRejectsInvalidProviderData(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	quota.state.ProviderData = json.RawMessage(`["unexpected"]`)
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil).(*manager)
+
+	subject := Subject{APIKeySubject: "key-a"}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err == nil {
+		t.Fatal("RuntimeStateForNotice error = nil, want provider data error")
+	}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err == nil {
+		t.Fatal("RuntimeStateForNotice second error = nil, want provider data error")
+	}
+	if len(quota.stateSubjects) != 2 {
+		t.Fatalf("runtime state calls = %d, want 2 because invalid state is not cached", len(quota.stateSubjects))
+	}
+	if len(manager.noticeState.entries) != 0 {
+		t.Fatalf("entries = %+v, want no cache entry", manager.noticeState.entries)
+	}
+}
+
+func TestManagerRuntimeStateForNoticeDeepClonesCachedState(t *testing.T) {
+	startAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	endAt := startAt.Add(time.Hour)
+	capacity := int64(100)
+	used := int64(18)
+	remaining := int64(82)
+	percent := float64(82)
+	quota := &fakeQuotaClient{state: RuntimeState{
+		Mem9APIKey:   RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
+		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
+		RecommendedAction: &RuntimeRecommendedAction{
+			Type:               "provider",
+			ProviderActionCode: "upgradePlan",
+			Severity:           "warning",
+			URL:                "https://console.example.com",
+		},
+		Meters: []RuntimeStateMeter{{
+			Meter: MeterMemoryRecallRequests,
+			QuotaGateResult: map[string]any{
+				"outcome": "allowed",
+				"mode":    "included",
+				"details": map[string]any{"bucket": "included"},
+			},
+			Budgets: []RuntimeStatusBudget{{
+				Type:     RuntimeBudgetTypeProviderManaged,
+				State:    RuntimeBudgetStateProviderManaged,
+				Measure:  RuntimeStatusMeasure{Kind: RuntimeMeasureKindCount, Quantity: "request", Scale: 1},
+				Period:   RuntimeStatusPeriod{Type: "fixed", StartAt: &startAt, EndAt: &endAt},
+				Capacity: RuntimeStatusCapacity{Type: "fixed", Value: &capacity},
+				Usage:    &RuntimeStatusUsage{Used: &used, Remaining: &remaining, Percent: &percent},
+			}},
+		}},
+	}}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil)
+
+	first, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a"})
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	first.ProviderData[0] = '['
+	first.RecommendedAction.Type = "mutated"
+	first.Meters[0].Meter = "mutated"
+	first.Meters[0].QuotaGateResult["outcome"] = "mutated"
+	first.Meters[0].QuotaGateResult["details"].(map[string]any)["bucket"] = "mutated"
+	first.Meters[0].Budgets[0].Type = "mutated"
+	*first.Meters[0].Budgets[0].Period.StartAt = startAt.Add(24 * time.Hour)
+	*first.Meters[0].Budgets[0].Period.EndAt = endAt.Add(24 * time.Hour)
+	*first.Meters[0].Budgets[0].Capacity.Value = 999
+	*first.Meters[0].Budgets[0].Usage.Used = 999
+	*first.Meters[0].Budgets[0].Usage.Remaining = 999
+	*first.Meters[0].Budgets[0].Usage.Percent = 1
+
+	second, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a"})
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if string(second.ProviderData) != `{"bindingState":"claimed"}` {
+		t.Fatalf("ProviderData = %s, want original", second.ProviderData)
+	}
+	if second.RecommendedAction.Type != "provider" {
+		t.Fatalf("RecommendedAction.Type = %q, want provider", second.RecommendedAction.Type)
+	}
+	if second.Meters[0].Meter != MeterMemoryRecallRequests {
+		t.Fatalf("Meter = %q, want recall meter", second.Meters[0].Meter)
+	}
+	if second.Meters[0].QuotaGateResult["outcome"] != "allowed" {
+		t.Fatalf("quota outcome = %v, want allowed", second.Meters[0].QuotaGateResult["outcome"])
+	}
+	if second.Meters[0].QuotaGateResult["details"].(map[string]any)["bucket"] != "included" {
+		t.Fatalf("quota details = %v, want included", second.Meters[0].QuotaGateResult["details"])
+	}
+	if second.Meters[0].Budgets[0].Type != RuntimeBudgetTypeProviderManaged {
+		t.Fatalf("Budget.Type = %q, want provider managed", second.Meters[0].Budgets[0].Type)
+	}
+	if !second.Meters[0].Budgets[0].Period.StartAt.Equal(startAt) || !second.Meters[0].Budgets[0].Period.EndAt.Equal(endAt) {
+		t.Fatalf("period mutated: %+v", second.Meters[0].Budgets[0].Period)
+	}
+	if got := *second.Meters[0].Budgets[0].Capacity.Value; got != 100 {
+		t.Fatalf("capacity = %d, want 100", got)
+	}
+	if got := *second.Meters[0].Budgets[0].Usage.Used; got != 18 {
+		t.Fatalf("used = %d, want 18", got)
+	}
+	if got := *second.Meters[0].Budgets[0].Usage.Remaining; got != 82 {
+		t.Fatalf("remaining = %d, want 82", got)
+	}
+	if got := *second.Meters[0].Budgets[0].Usage.Percent; got != 82 {
+		t.Fatalf("percent = %v, want 82", got)
+	}
+}
+
+func TestManagerRuntimeStateForNoticeStatusOverlayDoesNotMutateCache(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: true,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil)
+
+	active, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a", APIKeyStatus: RuntimeAPIKeyStatusActive})
+	if err != nil {
+		t.Fatalf("active: %v", err)
+	}
+	inactive, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a", APIKeyStatus: RuntimeAPIKeyStatusInactive})
+	if err != nil {
+		t.Fatalf("inactive: %v", err)
+	}
+	unknown, err := manager.RuntimeStateForNotice(context.Background(), Subject{APIKeySubject: "key-a"})
+	if err != nil {
+		t.Fatalf("unknown: %v", err)
+	}
+	if active.Mem9APIKey.Status != RuntimeAPIKeyStatusActive {
+		t.Fatalf("active status = %q", active.Mem9APIKey.Status)
+	}
+	if inactive.Mem9APIKey.Status != RuntimeAPIKeyStatusInactive {
+		t.Fatalf("inactive status = %q", inactive.Mem9APIKey.Status)
+	}
+	if unknown.Mem9APIKey.Status != RuntimeAPIKeyStatusUnknown {
+		t.Fatalf("cached status = %q, want provider unknown", unknown.Mem9APIKey.Status)
+	}
+	if len(quota.stateSubjects) != 1 {
+		t.Fatalf("runtime state calls = %d, want 1", len(quota.stateSubjects))
+	}
+}
+
+func TestManagerRuntimeStateForNoticeCacheDisabledFetchesEachRequest(t *testing.T) {
+	quota := &fakeQuotaClient{state: runtimeNoticeStateWithPercent(82)}
+	manager := NewManager(Config{
+		Enabled:            true,
+		ProviderID:         "mem9-official",
+		InternalSecret:     "secret-value",
+		NoticeTimeout:      time.Second,
+		NoticeCacheEnabled: false,
+		NoticeCacheTTL:     30 * time.Second,
+		NoticeStaleTTL:     2 * time.Minute,
+	}, quota, nil, nil)
+
+	subject := Subject{APIKeySubject: "key-a"}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if _, err := manager.RuntimeStateForNotice(context.Background(), subject); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if len(quota.stateSubjects) != 2 {
+		t.Fatalf("runtime state calls = %d, want 2", len(quota.stateSubjects))
+	}
+}
+
+func runtimeNoticeStateWithPercent(percent float64) RuntimeState {
+	return RuntimeState{
+		Mem9APIKey: RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
+		Meters: []RuntimeStateMeter{{
+			Meter: MeterMemoryRecallRequests,
+			Budgets: []RuntimeStatusBudget{{
+				Type:     RuntimeBudgetTypeProviderManaged,
+				State:    RuntimeBudgetStateProviderManaged,
+				Measure:  RuntimeStatusMeasure{Kind: RuntimeMeasureKindCount, Quantity: "request", Scale: 1},
+				Period:   RuntimeStatusPeriod{Type: RuntimePeriodTypeProviderManaged},
+				Capacity: RuntimeStatusCapacity{Type: RuntimeCapacityTypeProviderManaged},
+				Usage:    &RuntimeStatusUsage{Percent: &percent},
+			}},
+		}},
+		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
+	}
 }
 
 func TestManagerRecallCommitsBeforeMetering(t *testing.T) {

--- a/server/internal/runtimeusage/notice_state.go
+++ b/server/internal/runtimeusage/notice_state.go
@@ -1,0 +1,298 @@
+package runtimeusage
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type noticeStateCache struct {
+	enabled  bool
+	timeout  time.Duration
+	ttl      time.Duration
+	staleTTL time.Duration
+	key      []byte
+	now      func() time.Time
+	fetch    func(context.Context, Subject) (RuntimeState, error)
+
+	entries map[string]noticeStateEntry
+	group   singleflight.Group
+	mu      sync.Mutex
+}
+
+type noticeStateEntry struct {
+	state     RuntimeState
+	fetchedAt time.Time
+}
+
+func newNoticeStateCache(cfg Config, fetch func(context.Context, Subject) (RuntimeState, error)) *noticeStateCache {
+	timeout := cfg.NoticeTimeout
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	ttl := cfg.NoticeCacheTTL
+	if ttl <= 0 {
+		ttl = 30 * time.Second
+	}
+	staleTTL := cfg.NoticeStaleTTL
+	if staleTTL < 0 {
+		staleTTL = 0
+	}
+	return &noticeStateCache{
+		enabled:  cfg.NoticeCacheEnabled,
+		timeout:  timeout,
+		ttl:      ttl,
+		staleTTL: staleTTL,
+		key:      noticeDigestKey(cfg),
+		now:      time.Now,
+		fetch:    fetch,
+		entries:  make(map[string]noticeStateEntry),
+	}
+}
+
+func noticeDigestKey(cfg Config) []byte {
+	if cfg.InternalSecret != "" {
+		sum := sha256.Sum256([]byte(cfg.InternalSecret))
+		return sum[:]
+	}
+	key := make([]byte, sha256.Size)
+	if _, err := rand.Read(key); err == nil {
+		return key
+	}
+	sum := sha256.Sum256([]byte(time.Now().UTC().String()))
+	return sum[:]
+}
+
+func (c *noticeStateCache) runtimeState(ctx context.Context, subject Subject) (RuntimeState, error) {
+	if c == nil {
+		return RuntimeState{}, nil
+	}
+	if !c.enabled || subject.APIKeySubject == "" {
+		state, err := c.fetchWithTimeout(ctx, subject)
+		if err != nil {
+			return RuntimeState{}, err
+		}
+		return cloneRuntimeStateForSubject(state, subject), nil
+	}
+
+	now := c.now()
+	key := c.cacheKey(subject.APIKeySubject)
+	if state, ok := c.fresh(key, now); ok {
+		return cloneRuntimeStateForSubject(state, subject), nil
+	}
+
+	result, err, _ := c.group.Do(key, func() (any, error) {
+		now := c.now()
+		if state, ok := c.fresh(key, now); ok {
+			return state, nil
+		}
+		state, fetchErr := c.fetchWithTimeout(ctx, subject)
+		if fetchErr == nil {
+			c.store(key, state, c.now())
+			return state, nil
+		}
+		if state, ok := c.stale(key, now); ok {
+			return state, nil
+		}
+		c.pruneExpired(now)
+		return RuntimeState{}, fetchErr
+	})
+	if err != nil {
+		return RuntimeState{}, err
+	}
+	state, ok := result.(RuntimeState)
+	if !ok {
+		return RuntimeState{}, nil
+	}
+	return cloneRuntimeStateForSubject(state, subject), nil
+}
+
+func (c *noticeStateCache) fetchWithTimeout(ctx context.Context, subject Subject) (RuntimeState, error) {
+	timeout := c.timeout
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	fetchCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return c.fetch(fetchCtx, subject)
+}
+
+func (c *noticeStateCache) cacheKey(subject string) string {
+	mac := hmac.New(sha256.New, c.key)
+	_, _ = mac.Write([]byte(subject))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (c *noticeStateCache) fresh(key string, now time.Time) (RuntimeState, bool) {
+	entry, ok := c.load(key)
+	if !ok {
+		return RuntimeState{}, false
+	}
+	if now.Sub(entry.fetchedAt) <= c.ttl {
+		return entry.state, true
+	}
+	return RuntimeState{}, false
+}
+
+func (c *noticeStateCache) stale(key string, now time.Time) (RuntimeState, bool) {
+	entry, ok := c.load(key)
+	if !ok {
+		return RuntimeState{}, false
+	}
+	if now.Sub(entry.fetchedAt) <= c.ttl+c.staleTTL {
+		return entry.state, true
+	}
+	c.delete(key)
+	return RuntimeState{}, false
+}
+
+func (c *noticeStateCache) load(key string) (noticeStateEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	return entry, ok
+}
+
+func (c *noticeStateCache) store(key string, state RuntimeState, fetchedAt time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneExpiredLocked(fetchedAt)
+	c.entries[key] = noticeStateEntry{state: cloneRuntimeState(state), fetchedAt: fetchedAt}
+}
+
+func (c *noticeStateCache) delete(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, key)
+}
+
+func (c *noticeStateCache) pruneExpired(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pruneExpiredLocked(now)
+}
+
+func (c *noticeStateCache) pruneExpiredLocked(now time.Time) {
+	maxAge := c.ttl + c.staleTTL
+	for key, entry := range c.entries {
+		if now.Sub(entry.fetchedAt) > maxAge {
+			delete(c.entries, key)
+		}
+	}
+}
+
+func cloneRuntimeStateForSubject(state RuntimeState, subject Subject) RuntimeState {
+	out := cloneRuntimeState(state)
+	applySubjectStatus(&out, subject.APIKeyStatus)
+	return out
+}
+
+func cloneRuntimeState(state RuntimeState) RuntimeState {
+	out := state
+	out.ProviderData = append([]byte(nil), state.ProviderData...)
+	if state.RecommendedAction != nil {
+		action := *state.RecommendedAction
+		out.RecommendedAction = &action
+	}
+	out.Meters = make([]RuntimeStateMeter, len(state.Meters))
+	for i := range state.Meters {
+		out.Meters[i] = cloneRuntimeStateMeter(state.Meters[i])
+	}
+	return out
+}
+
+func cloneRuntimeStateMeter(meter RuntimeStateMeter) RuntimeStateMeter {
+	out := meter
+	if meter.QuotaGateResult != nil {
+		out.QuotaGateResult = cloneRuntimeAnyMap(meter.QuotaGateResult)
+	}
+	out.Budgets = make([]RuntimeStatusBudget, len(meter.Budgets))
+	for i := range meter.Budgets {
+		out.Budgets[i] = cloneRuntimeStatusBudget(meter.Budgets[i])
+	}
+	return out
+}
+
+func cloneRuntimeStatusBudget(budget RuntimeStatusBudget) RuntimeStatusBudget {
+	out := budget
+	out.Period.StartAt = cloneTimePtr(budget.Period.StartAt)
+	out.Period.EndAt = cloneTimePtr(budget.Period.EndAt)
+	out.Capacity.Value = cloneInt64Ptr(budget.Capacity.Value)
+	if budget.Usage != nil {
+		usage := *budget.Usage
+		usage.Used = cloneInt64Ptr(budget.Usage.Used)
+		usage.Remaining = cloneInt64Ptr(budget.Usage.Remaining)
+		usage.Percent = cloneFloat64Ptr(budget.Usage.Percent)
+		out.Usage = &usage
+	}
+	return out
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneInt64Ptr(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneFloat64Ptr(value *float64) *float64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneRuntimeAnyMap(in map[string]any) map[string]any {
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = cloneRuntimeAny(value)
+	}
+	return out
+}
+
+func cloneRuntimeAnySlice(in []any) []any {
+	out := make([]any, len(in))
+	for i, value := range in {
+		out[i] = cloneRuntimeAny(value)
+	}
+	return out
+}
+
+func cloneRuntimeAny(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneRuntimeAnyMap(typed)
+	case []any:
+		return cloneRuntimeAnySlice(typed)
+	case json.RawMessage:
+		return append(json.RawMessage(nil), typed...)
+	case []byte:
+		return append([]byte(nil), typed...)
+	default:
+		return typed
+	}
+}
+
+func applySubjectStatus(state *RuntimeState, status string) {
+	switch status {
+	case RuntimeAPIKeyStatusActive, RuntimeAPIKeyStatusInactive, RuntimeAPIKeyStatusUnknown:
+		state.Mem9APIKey.Status = status
+	}
+}

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -62,17 +62,21 @@ const (
 )
 
 type Config struct {
-	Enabled         bool
-	ProviderID      string
-	BaseURL         string
-	InternalSecret  string
-	Timeout         time.Duration
-	MeteringTimeout time.Duration
-	ReservationTTL  time.Duration
-	OperationTTL    time.Duration
-	FailOpen        bool
-	OutboxEnabled   bool
-	Outbox          OutboxStore
+	Enabled            bool
+	ProviderID         string
+	BaseURL            string
+	InternalSecret     string
+	Timeout            time.Duration
+	MeteringTimeout    time.Duration
+	ReservationTTL     time.Duration
+	OperationTTL       time.Duration
+	FailOpen           bool
+	OutboxEnabled      bool
+	NoticeTimeout      time.Duration
+	NoticeCacheEnabled bool
+	NoticeCacheTTL     time.Duration
+	NoticeStaleTTL     time.Duration
+	Outbox             OutboxStore
 }
 
 type Subject struct {

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -337,6 +337,7 @@ type Manager interface {
 	Enabled() bool
 	ProviderID() string
 	RuntimeState(ctx context.Context, subject Subject) (RuntimeState, error)
+	RuntimeStateForNotice(ctx context.Context, subject Subject) (RuntimeState, error)
 	BeforeRecall(ctx context.Context, subject Subject) (*OperationLease, error)
 	AfterRecallSuccess(ctx context.Context, lease *OperationLease, result RecallResult) error
 	AfterRecallFailure(ctx context.Context, lease *OperationLease, cause error)


### PR DESCRIPTION
## Summary

Adds a notice-only runtime state timeout and cache for successful response notices from the official mem9 runtime usage provider.

This keeps advisory `message` / `runtimeState` fields available while reducing repeated upstream `GET /api/internal/mem9-api-key/state` calls for the same API key subject.

Closes #395

## Design Intent

- Keep runtime notices advisory and best-effort. Quota enforcement stays on reservation/finalization, so notice lookup failures or timeouts omit optional response fields instead of failing successful memory APIs.
- Bound upstream load and response latency for high-QPS success paths. The default fresh TTL means the same API key subject makes at most one notice state lookup per server pod per 30s window.
- Preserve explicit runtime-state semantics. `/v1alpha2/mem9s/runtime-state` continues to return real-time state through the existing `RuntimeState` path.
- Keep cached state isolated and safe to reuse. Cache keys use a keyed digest of `APIKeySubject`, cached provider state is deep-cloned before returning, and request-local API key status is applied outside the cached value.

```mermaid
flowchart TD
    A[Successful memory API response] --> B{Runtime usage enabled and provider is mem9-official?}
    B -- guard skips --> C[Return response without notice fields]
    B -- guard passes --> D[RuntimeStateForNotice]
    D --> E{Fresh cache entry for APIKeySubject?}
    E -- hit --> F[Clone cached provider state]
    E -- miss --> G[Singleflight upstream state lookup with notice timeout]
    G -- success --> H[Normalize provider state and refresh cache]
    G -- error --> I{Valid stale entry?}
    I -- available --> F
    I -- expired or absent --> C
    H --> F
    F --> J[Apply request-local API key status]
    J --> K{Notice message generated?}
    K -- present --> L[Attach message and runtimeState]
    K -- empty --> C
    M[Explicit /runtime-state API] --> N[Existing RuntimeState path]
```

## What Changed

- Added runtime notice config defaults and env docs:
  - `MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT=1s`
  - `MNEMO_RUNTIME_USAGE_NOTICE_CACHE_ENABLED=true`
  - `MNEMO_RUNTIME_USAGE_NOTICE_CACHE_TTL=30s`
  - `MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL=2m`
- Added `runtimeusage.Manager.RuntimeStateForNotice` for success notice lookups.
- Added an API-key-subject scoped in-memory cache with:
  - keyed HMAC-SHA256 cache keys
  - singleflight for concurrent same-key misses
  - fresh TTL and stale-on-provider-error behavior
  - deep-cloned runtime state returns
  - request-local API key status overlay outside the cached value
- Switched `runtimeResponseNotice()` to use the notice-specific state reader.
- Kept explicit `/v1alpha2/mem9s/runtime-state` on the existing `RuntimeState` path.

## Behavior

- Official provider (`mem9-official`) success notices use the new timeout and cache.
- Custom providers continue to skip success notice state lookups.
- Provider failures or notice timeouts omit optional notice fields unless a valid stale cache entry is available.
- Quota reservation, finalization, metering, outbox behavior, and runtime access decisions are unchanged.

## Validation

- `go test -count=1 ./internal/config ./internal/runtimeusage ./internal/handler`
- `make vet`
- `make test`
- `git diff --check`
- Verified this PR does not include changes under `docs/superpowers`, `.tmp/superpowers`, or `server/.tmp`; `.tmp/superpowers` and `server/.tmp` are ignored.
