### PR TITLE
fix: require explicit runtime usage provider id

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MNEMO_RUNTIME_USAGE_ENABLED` | No | `false` | Enable runtime usage quota gating and console metering for memory recall/write operations |
-| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | — | Runtime usage provider discriminator returned with object-shaped `providerData` in runtime-state responses. Set to `mem9-official` to enable official hosted provider notices and provider data |
+| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | — | Runtime usage provider discriminator returned with object-shaped `providerData` in runtime-state responses. Mem9 official hosted deployments set `mem9-official`; self-hosted deployments usually leave this empty or use their own provider id |
 | `MNEMO_RUNTIME_USAGE_BASE_URL` | Yes when enabled | — | Runtime usage service base URL. Must be `http` or `https`; query and fragment are rejected |
 | `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Yes when enabled | — | Bearer token for internal runtime usage service calls |
 | `MNEMO_RUNTIME_USAGE_TIMEOUT` | No | `3s` | Timeout for quota reservation and finalization requests |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MNEMO_RUNTIME_USAGE_ENABLED` | No | `false` | Enable runtime usage quota gating and console metering for memory recall/write operations |
-| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | `mem9-official` when runtime usage is enabled | Runtime usage provider discriminator returned with object-shaped `providerData` in runtime-state responses |
+| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | — | Runtime usage provider discriminator returned with object-shaped `providerData` in runtime-state responses. Set to `mem9-official` to enable official hosted provider notices and provider data |
 | `MNEMO_RUNTIME_USAGE_BASE_URL` | Yes when enabled | — | Runtime usage service base URL. Must be `http` or `https`; query and fragment are rejected |
 | `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Yes when enabled | — | Bearer token for internal runtime usage service calls |
 | `MNEMO_RUNTIME_USAGE_TIMEOUT` | No | `3s` | Timeout for quota reservation and finalization requests |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MNEMO_RUNTIME_USAGE_ENABLED` | No | `false` | Enable runtime usage quota gating and console metering for memory recall/write operations |
-| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | — | Runtime usage provider discriminator returned with object-shaped `providerData` in runtime-state responses. Mem9 official hosted deployments set `mem9-official`; self-hosted deployments usually leave this empty or use their own provider id |
+| `MNEMO_RUNTIME_USAGE_PROVIDER_ID` | No | — | Runtime usage provider discriminator returned in runtime-state responses. Mem9 official hosted deployments set `mem9-official`; self-hosted deployments usually leave this empty or use their own provider id. Upstream object-shaped `providerData` is returned independently and interpreted by consumers that recognize the provider id |
 | `MNEMO_RUNTIME_USAGE_BASE_URL` | Yes when enabled | — | Runtime usage service base URL. Must be `http` or `https`; query and fragment are rejected |
 | `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Yes when enabled | — | Bearer token for internal runtime usage service calls |
 | `MNEMO_RUNTIME_USAGE_TIMEOUT` | No | `3s` | Timeout for quota reservation and finalization requests |

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2749,7 +2749,7 @@
           },
           "providerId": {
             "type": "string",
-            "description": "Optional provider discriminator for providerData. Clients should interpret providerData only when they recognize this value.",
+            "description": "Optional provider discriminator. Clients can use this value to decide whether to interpret provider-specific providerData fields.",
             "minLength": 1,
             "maxLength": 128,
             "pattern": "^[A-Za-z][A-Za-z0-9_.-]{0,127}$",
@@ -2760,7 +2760,7 @@
           },
           "providerData": {
             "type": "object",
-            "description": "Optional hosted-provider details. Present only when providerId is also present. Plugins should ignore this object unless they explicitly recognize providerId.",
+            "description": "Optional upstream provider details. Returned independently of providerId; clients should interpret provider-specific fields only when they recognize providerId.",
             "additionalProperties": true
           }
         },

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -55,8 +55,9 @@ defaults only where required for a stable public shape, and returns configured
 
 `MNEMO_RUNTIME_USAGE_PROVIDER_ID` controls the public provider discriminator.
 When the env var is omitted, mem9-server uses an empty provider id and omits
-provider-specific `providerData`. Set the env var to `mem9-official` to enable
-official hosted provider notices and provider data.
+provider-specific `providerData`. Mem9 official hosted deployments set
+`mem9-official`; self-hosted deployments usually leave this empty or use their
+own provider id.
 
 ## Success Response Notices
 

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -208,7 +208,7 @@ response and uses this fallback.
 - Provider-unavailable fallback: hosted response shape used when state lookup
   fails.
 - Provider ID: public discriminator for interpreting provider-specific
-  `providerData`.
+  `providerData` fields when recognized by the consumer.
 - Success response notice: optional top-level `message` and `runtimeState`
   data attached to successful recall and ingest responses.
 - Displayable warning or action: a runtime state condition that should reach the

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -54,8 +54,9 @@ defaults only where required for a stable public shape, and returns configured
 `providerId` with object-shaped `providerData`.
 
 `MNEMO_RUNTIME_USAGE_PROVIDER_ID` controls the public provider discriminator.
-When runtime usage is enabled and the env var is omitted, mem9-server uses
-`mem9-official`.
+When the env var is omitted, mem9-server uses an empty provider id and omits
+provider-specific `providerData`. Set the env var to `mem9-official` to enable
+official hosted provider notices and provider data.
 
 ## Success Response Notices
 

--- a/docs/design/runtime-state-api.md
+++ b/docs/design/runtime-state-api.md
@@ -50,14 +50,16 @@ X-API-Key: <public mem9 API key subject>
 
 The response is mapped into the public runtime-state core. mem9-server keeps
 `mem9ApiKey.status` from local key/status resolution, fills missing provider
-defaults only where required for a stable public shape, and returns configured
-`providerId` with object-shaped `providerData`.
+defaults only where required for a stable public shape, returns the configured
+`providerId`, and preserves upstream object-shaped `providerData`.
 
 `MNEMO_RUNTIME_USAGE_PROVIDER_ID` controls the public provider discriminator.
-When the env var is omitted, mem9-server uses an empty provider id and omits
-provider-specific `providerData`. Mem9 official hosted deployments set
-`mem9-official`; self-hosted deployments usually leave this empty or use their
-own provider id.
+When the env var is omitted, mem9-server uses an empty provider id. Upstream
+`providerData` and `recommendedAction` remain part of the explicit runtime-state
+response contract. Mem9 official hosted deployments set `mem9-official`;
+self-hosted deployments usually leave this empty or use their own provider id.
+Plugins and API consumers should interpret provider-specific `providerData`
+fields only for provider ids they recognize, such as `mem9-official`.
 
 ## Success Response Notices
 

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -159,7 +159,7 @@ func Load() (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		runtimeUsageProviderID = strings.TrimSpace(envOr("MNEMO_RUNTIME_USAGE_PROVIDER_ID", "mem9-official"))
+		runtimeUsageProviderID = strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_PROVIDER_ID"))
 		if strings.TrimSpace(os.Getenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET")) == "" {
 			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET is required when MNEMO_RUNTIME_USAGE_ENABLED=true")
 		}

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -177,8 +177,8 @@ func TestLoad_RuntimeUsageConfig(t *testing.T) {
 	if !cfg.RuntimeUsageEnabled {
 		t.Fatal("RuntimeUsageEnabled = false, want true")
 	}
-	if cfg.RuntimeUsageProviderID != "mem9-official" {
-		t.Fatalf("RuntimeUsageProviderID = %q, want mem9-official", cfg.RuntimeUsageProviderID)
+	if cfg.RuntimeUsageProviderID != "" {
+		t.Fatalf("RuntimeUsageProviderID = %q, want empty default", cfg.RuntimeUsageProviderID)
 	}
 	if cfg.RuntimeUsageBaseURL != "https://runtime-usage.example.com/internal" {
 		t.Fatalf("RuntimeUsageBaseURL = %q", cfg.RuntimeUsageBaseURL)

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -246,8 +246,10 @@ func TestOpenAPIRuntimeStateContract(t *testing.T) {
 	}
 	providerData := objectValue(t, stateProperties, "providerData")
 	providerDataDescription, _ := providerData["description"].(string)
-	if !strings.Contains(providerDataDescription, "providerId") {
-		t.Fatalf("RuntimeStateResponse.providerData description should require providerId pairing: %q", providerDataDescription)
+	for _, want := range []string{"independently of providerId", "recognize providerId"} {
+		if !strings.Contains(providerDataDescription, want) {
+			t.Fatalf("RuntimeStateResponse.providerData description missing %q: %q", want, providerDataDescription)
+		}
 	}
 	meters := objectValue(t, stateProperties, "meters")
 	if meters["minItems"] != float64(2) {

--- a/server/internal/handler/runtime_state_test.go
+++ b/server/internal/handler/runtime_state_test.go
@@ -128,6 +128,60 @@ func TestGetRuntimeStateCallsProviderWhenEnabled(t *testing.T) {
 	assertRuntimeStateMeter(t, state, runtimeusage.MeterMemoryRecallRequests, runtimeusage.RuntimeBudgetTypeNotMetered, runtimeusage.RuntimeBudgetStateUnlimited)
 }
 
+func TestGetRuntimeStateKeepsProviderDataWithoutConfiguredProviderID(t *testing.T) {
+	client := &runtimeStateQuotaClient{state: runtimeusage.RuntimeState{
+		Mem9APIKey:   runtimeusage.RuntimeStateAPIKey{Status: runtimeusage.RuntimeAPIKeyStatusUnknown},
+		ProviderID:   "mem9-official",
+		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
+		RecommendedAction: &runtimeusage.RuntimeRecommendedAction{
+			Type:               "openUrl",
+			ProviderActionCode: "upgradePlan",
+			Severity:           "warning",
+			URL:                "https://example.com/provider/billing/plan",
+		},
+		Meters: []runtimeusage.RuntimeStateMeter{{
+			Meter: runtimeusage.MeterMemoryRecallRequests,
+			Budgets: []runtimeusage.RuntimeStatusBudget{{
+				Type:     runtimeusage.RuntimeBudgetTypeNotMetered,
+				State:    runtimeusage.RuntimeBudgetStateUnlimited,
+				Measure:  runtimeusage.RuntimeStatusMeasure{Kind: runtimeusage.RuntimeMeasureKindCount, Quantity: "request", Scale: 1},
+				Period:   runtimeusage.RuntimeStatusPeriod{Type: runtimeusage.RuntimePeriodTypeNone},
+				Capacity: runtimeusage.RuntimeStatusCapacity{Type: runtimeusage.RuntimeCapacityTypeUnlimited},
+			}},
+		}},
+	}}
+	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())
+	router := runtimeStateRouter(t, manager, &domain.Tenant{
+		ID:        "tenant-a",
+		ClusterID: "cluster-a",
+		Status:    domain.TenantActive,
+	}, nil, nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/runtime-state", nil)
+	req.Header.Set("X-API-Key", "mem9_test")
+	router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("Unmarshal body: %v", err)
+	}
+	if _, ok := body["providerId"]; ok {
+		t.Fatalf("providerId should be omitted when provider id is not configured: %s", rec.Body.String())
+	}
+	providerData, ok := body["providerData"].(map[string]any)
+	if !ok || providerData["bindingState"] != "claimed" {
+		t.Fatalf("providerData = %#v, want upstream provider data", body["providerData"])
+	}
+	action, ok := body["recommendedAction"].(map[string]any)
+	if !ok || action["providerActionCode"] != "upgradePlan" {
+		t.Fatalf("recommendedAction = %#v, want upstream action", body["recommendedAction"])
+	}
+}
+
 func TestGetRuntimeStateFallsBackWithLocalStatusWhenProviderUnavailable(t *testing.T) {
 	client := &runtimeStateQuotaClient{err: errors.New("provider timeout")}
 	manager := runtimeusage.NewManager(runtimeusage.Config{Enabled: true}, client, nil, slog.Default())

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -124,13 +124,10 @@ func (m *manager) runtimeStateProvider(ctx context.Context, subject Subject) (Ru
 		return RuntimeState{}, &UnavailableError{Err: err}
 	}
 	state.SetProviderDefaults()
-	if len(state.ProviderData) > 0 {
-		providerID := m.ProviderID()
-		if providerID == "" {
-			state.ProviderData = nil
-		} else {
-			state.ProviderID = providerID
-		}
+	providerID := m.ProviderID()
+	state.ProviderID = providerID
+	if providerID == "" {
+		state.ProviderData = nil
 	}
 	return state, nil
 }

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -126,9 +126,6 @@ func (m *manager) runtimeStateProvider(ctx context.Context, subject Subject) (Ru
 	state.SetProviderDefaults()
 	providerID := m.ProviderID()
 	state.ProviderID = providerID
-	if providerID == "" {
-		state.ProviderData = nil
-	}
 	return state, nil
 }
 

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -180,11 +180,17 @@ func TestManagerRuntimeStateUsesProvider(t *testing.T) {
 	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
 }
 
-func TestManagerRuntimeStateClearsProviderFieldsWithoutConfiguredProvider(t *testing.T) {
+func TestManagerRuntimeStateKeepsProviderDataWithoutConfiguredProvider(t *testing.T) {
 	quota := &fakeQuotaClient{state: RuntimeState{
 		Mem9APIKey:   RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
 		ProviderID:   "mem9-official",
 		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
+		RecommendedAction: &RuntimeRecommendedAction{
+			Type:               "openUrl",
+			ProviderActionCode: "upgradePlan",
+			Severity:           "warning",
+			URL:                "https://example.com/provider/billing/plan",
+		},
 		Meters: []RuntimeStateMeter{{
 			Meter: MeterMemoryRecallRequests,
 			Budgets: []RuntimeStatusBudget{{
@@ -205,8 +211,11 @@ func TestManagerRuntimeStateClearsProviderFieldsWithoutConfiguredProvider(t *tes
 	if state.ProviderID != "" {
 		t.Fatalf("ProviderID = %q, want empty when provider is not configured", state.ProviderID)
 	}
-	if len(state.ProviderData) != 0 {
-		t.Fatalf("ProviderData = %s, want omitted when provider is not configured", state.ProviderData)
+	if string(state.ProviderData) != `{"bindingState":"claimed"}` {
+		t.Fatalf("ProviderData = %s, want upstream provider data when provider is not configured", state.ProviderData)
+	}
+	if state.RecommendedAction == nil || state.RecommendedAction.ProviderActionCode != "upgradePlan" {
+		t.Fatalf("RecommendedAction = %+v, want preserved when provider is not configured", state.RecommendedAction)
 	}
 }
 

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -180,6 +180,36 @@ func TestManagerRuntimeStateUsesProvider(t *testing.T) {
 	assertFallbackMeter(t, state, MeterMemoryRecallRequests, RuntimeBudgetTypeNotMetered, RuntimeBudgetStateUnlimited)
 }
 
+func TestManagerRuntimeStateClearsProviderFieldsWithoutConfiguredProvider(t *testing.T) {
+	quota := &fakeQuotaClient{state: RuntimeState{
+		Mem9APIKey:   RuntimeStateAPIKey{Status: RuntimeAPIKeyStatusUnknown},
+		ProviderID:   "mem9-official",
+		ProviderData: json.RawMessage(`{"bindingState":"claimed"}`),
+		Meters: []RuntimeStateMeter{{
+			Meter: MeterMemoryRecallRequests,
+			Budgets: []RuntimeStatusBudget{{
+				Type:     RuntimeBudgetTypeNotMetered,
+				State:    RuntimeBudgetStateUnlimited,
+				Measure:  RuntimeStatusMeasure{Kind: RuntimeMeasureKindCount, Quantity: "request", Scale: 1},
+				Period:   RuntimeStatusPeriod{Type: RuntimePeriodTypeNone},
+				Capacity: RuntimeStatusCapacity{Type: RuntimeCapacityTypeUnlimited},
+			}},
+		}},
+	}}
+	manager := NewManager(Config{Enabled: true}, quota, nil, nil)
+
+	state, err := manager.RuntimeState(context.Background(), Subject{APIKeySubject: "mem9_test"})
+	if err != nil {
+		t.Fatalf("RuntimeState: %v", err)
+	}
+	if state.ProviderID != "" {
+		t.Fatalf("ProviderID = %q, want empty when provider is not configured", state.ProviderID)
+	}
+	if len(state.ProviderData) != 0 {
+		t.Fatalf("ProviderData = %s, want omitted when provider is not configured", state.ProviderData)
+	}
+}
+
 func TestManagerRuntimeStateFallsBackWhenProviderUnavailable(t *testing.T) {
 	quota := &fakeQuotaClient{stateErr: &UnavailableError{Err: errString("timeout")}}
 	manager := NewManager(Config{Enabled: true}, quota, nil, nil)


### PR DESCRIPTION
## Summary

Changes `MNEMO_RUNTIME_USAGE_PROVIDER_ID` from an implicit `mem9-official` default to an empty default when runtime usage is enabled.

This makes provider identity explicit. Mem9 official hosted prod already sets `MNEMO_RUNTIME_USAGE_PROVIDER_ID=mem9-official`, while self-hosted deployments default to no provider-specific identity and can use their own provider id when they want consumers to recognize provider-specific data.

## Design Intent

- Keep runtime usage quota gating, reservation finalization, console metering, and outbox behavior unchanged.
- Use `MNEMO_RUNTIME_USAGE_PROVIDER_ID=mem9-official` for Mem9 official hosted deployments.
- Let self-hosted runtime usage deployments enable quota enforcement while leaving provider identity empty by default.
- Preserve explicit runtime-state `providerData` and `recommendedAction` behavior independent of provider id.
- Keep provider-specific interpretation at the consumer boundary: plugins read `providerData` fields only for provider ids they recognize.

## What Changed

- Changed the config default for `MNEMO_RUNTIME_USAGE_PROVIDER_ID` from `mem9-official` to empty.
- Made the configured provider id authoritative over upstream runtime-state provider ids.
- Cleared upstream `providerId` from public runtime-state responses when provider id is not configured.
- Updated config tests so runtime usage enabled without provider id expects an empty default.
- Added runtime usage manager coverage for upstream `providerData` and `recommendedAction` being preserved under the empty default.
- Added runtime-state handler coverage for public JSON preserving upstream `providerData` while omitting `providerId`.
- Kept explicit provider id override coverage.
- Updated README, runtime-state design docs, and OpenAPI contract docs to describe the empty default and Mem9 official hosted `mem9-official` provider id.

## Compatibility

Mem9 official hosted environments should set `MNEMO_RUNTIME_USAGE_PROVIDER_ID=mem9-official` explicitly. Self-hosted environments can leave it empty for generic provider identity, or set their own provider id when they own provider-specific data interpretation.

## Validation

- `go test -count=1 ./internal/config`
- `go test -count=1 ./internal/runtimeusage ./internal/handler -run 'Test(ManagerRuntimeState|ListMemories_RuntimeUsageNotice|CreateMemory_RuntimeUsageNotice|GetRuntimeState)'`
- `make vet`
- `make test`
- `git diff --check`
