### PR TITLE
Modernize docs and add Markdown sharing

### DIFF
--- a/site/src/components/ApiReference.astro
+++ b/site/src/components/ApiReference.astro
@@ -8,6 +8,7 @@ import {
   type SiteLinkCopy,
 } from "../content/site";
 import { yourMemoryApiPage } from "../content/your-memory-api";
+import PageMarkdownAction from "./PageMarkdownAction.astro";
 
 function linkTarget(link: SiteLinkCopy): string | undefined {
   return link.external ? "_blank" : undefined;
@@ -83,7 +84,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                 <span>{copy.labels.sidebarTitle}</span>
                 <span class="api-toc-toggle-icon" aria-hidden="true"></span>
               </button>
-              <nav class="api-toc surface-card">
+              <nav class="api-toc">
                 <p class="api-toc-title">{copy.labels.sidebarTitle}</p>
                 <div class="api-product-tabs" role="tablist" aria-label={copy.labels.apiProduct}>
                   <button class="api-product-tab" type="button" role="tab" data-api-product-tab="web-console" aria-selected={catalogId === "web-console"}>{copy.labels.webConsole}</button>
@@ -161,6 +162,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                 <h1 class="api-title">{copy.title}</h1>
                 <p class="api-intro">{copy.intro}</p>
                 <p class="api-summary">{copy.summary}</p>
+                <PageMarkdownAction />
               </section>
 
               <section
@@ -173,7 +175,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                 </div>
                 <div class="api-auth-grid">
                   {copy.authCards.map((card) => (
-                    <article class="surface-card api-auth-card">
+                    <article class="api-auth-card">
                       <h3>{card.title}</h3>
                       <p>{card.body}</p>
                     </article>
@@ -190,7 +192,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                   <h2 class="api-section-title">{copy.quickstartTitle}</h2>
                   <p class="api-section-desc">{copy.quickstartDescription}</p>
                 </div>
-                <div class="api-quickstart surface-card">
+                <div class="api-quickstart">
                   <ol class="api-steps">
                     {copy.quickstartSteps.map((step) => (
                       <li>{step}</li>
@@ -221,7 +223,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                   <div class="api-endpoint-list">
                     {group.endpoints.map((endpoint, index) => (
                       <article
-                        class="surface-card api-endpoint-card"
+                        class="api-endpoint-card"
                         id={locale === DEFAULT_LOCALE ? endpointAnchor(group.id, endpoint, index) : undefined}
                         data-api-anchor={endpointAnchor(group.id, endpoint, index)}
                       >
@@ -353,7 +355,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                 </section>
               ))}
 
-              <section class="api-cta surface-card">
+              <section class="api-cta">
                 <div>
                   <p class="section-kicker">{copy.labels.next}</p>
                   <h2 class="api-section-title">{copy.ctaTitle}</h2>
@@ -464,7 +466,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
 <style>
   .api-page {
-    padding: 1.6rem 0 4.8rem;
+    padding: 2.2rem 0 4.8rem;
   }
 
   .api-copy[hidden] {
@@ -480,10 +482,22 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   }
 
   .api-hero {
+    position: relative;
     width: min(100%, 72rem);
     display: grid;
     gap: 0.8rem;
-    padding: 0 0 0.45rem;
+    padding: 0 0 2.8rem;
+  }
+
+  .api-hero > :global(.page-markdown-action) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: auto;
+  }
+
+  .api-hero > .section-kicker {
+    padding-right: 12rem;
   }
 
   .api-title {
@@ -508,8 +522,8 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   /* Two-column layout */
   .api-layout {
     display: grid;
-    grid-template-columns: minmax(17rem, 22rem) minmax(0, 1fr);
-    gap: clamp(2.4rem, 4vw, 4rem);
+    grid-template-columns: minmax(14rem, 16rem) minmax(0, 1fr);
+    gap: clamp(2rem, 4vw, 4rem);
     align-items: start;
   }
 
@@ -522,7 +536,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   }
 
   .api-toc {
-    padding: 0.95rem;
+    padding: 0 0.75rem 0 0;
     max-height: inherit;
     overflow-y: auto;
     overscroll-behavior: contain;
@@ -530,18 +544,32 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     -webkit-overflow-scrolling: touch;
   }
 
+  .api-toc::-webkit-scrollbar {
+    width: 0.25rem;
+  }
+
+  .api-toc::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+
+  .api-toc:hover::-webkit-scrollbar-thumb {
+    background: var(--button-active-border);
+  }
+
   .api-toc-title {
     font-family: var(--font-mono);
-    font-size: 0.75rem;
-    letter-spacing: 0.05em;
-    color: var(--accent);
-    margin-bottom: 0.9rem;
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+    color: var(--text-soft);
+    margin-bottom: 1rem;
   }
 
   .api-toc-search {
     display: grid;
     gap: 0.38rem;
-    margin-bottom: 0.85rem;
+    margin-bottom: 1.15rem;
   }
 
   .api-toc-search-label {
@@ -553,21 +581,21 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
   .api-toc-search input {
     width: 100%;
-    min-height: 2.2rem;
+    min-height: 2.35rem;
     border: 1px solid var(--border);
-    border-radius: 0.72rem;
-    background: var(--button-bg);
+    border-radius: 0.55rem;
+    background: transparent;
     color: var(--text);
     padding: 0.46rem 0.58rem;
     font: inherit;
     font-size: 0.82rem;
     outline: none;
-    box-shadow: var(--surface-inset);
+    box-shadow: none;
   }
 
   .api-toc-search input:focus {
     border-color: var(--accent);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent), var(--surface-inset);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
   }
 
   .api-toc-empty {
@@ -585,9 +613,9 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
   .api-toc-link {
     display: block;
-    padding: 0.42rem 0.6rem;
-    border-radius: 0.8rem;
-    border-left: 2px solid transparent;
+    padding: 0.48rem 0.55rem;
+    border-radius: 0.5rem;
+    border-left: 0;
     color: var(--text-dim);
     font-size: 0.88rem;
     line-height: 1.35;
@@ -603,7 +631,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   .api-toc-link.is-active {
     background: var(--button-active-bg);
     color: var(--text);
-    border-left-color: var(--accent);
+    font-weight: 650;
     opacity: 1;
   }
 
@@ -615,10 +643,9 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     display: block;
     width: 100%;
     min-width: 0;
-    padding: 0.42rem 0.6rem;
+    padding: 0.48rem 0.55rem;
     border: 0;
-    border-left: 2px solid transparent;
-    border-radius: 0.8rem;
+    border-radius: 0.5rem;
     text-align: left;
     background: transparent;
     color: var(--text-dim);
@@ -632,9 +659,9 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     list-style: none;
     display: grid;
     gap: 0.22rem;
-    margin: 0.24rem 0 0.1rem 0.72rem;
-    padding-left: 0.7rem;
-    border-left: 1px solid var(--border);
+    margin: 0.24rem 0 0.1rem 0.45rem;
+    padding-left: 0;
+    border-left: 0;
   }
 
   .api-toc-sublist[hidden] {
@@ -697,13 +724,15 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   /* Content area */
   .api-content {
     display: grid;
-    gap: 1.8rem;
+    gap: 0;
+    min-width: 0;
   }
 
   .api-section {
     display: grid;
     gap: 1rem;
-    padding: 0;
+    padding: 2.5rem 0 2.8rem;
+    border-top: 1px solid var(--border);
     scroll-margin-top: 6rem;
   }
 
@@ -719,22 +748,24 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   .api-auth-grid {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
+    gap: 0 2rem;
   }
 
   .api-auth-card,
   .api-quickstart,
   .api-endpoint-card,
   .api-cta {
-    padding: 1.3rem;
-    background: linear-gradient(180deg, var(--surface-elevated-start), var(--surface-elevated-end));
+    padding: 0;
+    background: transparent;
   }
 
   .api-auth-card {
     display: grid;
     gap: 0.55rem;
     align-content: start;
-    min-height: 10.5rem;
+    min-height: 0;
+    padding: 1rem 0;
+    border-top: 1px solid var(--border);
   }
 
   .api-auth-card h3 {
@@ -797,21 +828,16 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   }
 
   .api-field-title::before {
-    content: '';
-    width: 0.22rem;
-    height: 0.95rem;
-    border-radius: 999px;
-    background: var(--accent);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+    content: none;
   }
 
   .api-code {
     padding: 0.95rem 1rem;
-    border-radius: 0.95rem;
+    border-radius: 0.65rem;
     background: var(--bg-terminal);
     border: 1px solid var(--border);
     overflow-x: auto;
-    box-shadow: var(--surface-inset), var(--surface-shadow-soft);
+    box-shadow: none;
   }
 
   .api-code code {
@@ -824,25 +850,32 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
   .api-endpoint-list {
     display: grid;
-    gap: 1rem;
+    gap: 0;
   }
 
   .api-endpoint-card {
     display: grid;
     gap: 1.15rem;
+    padding: 1.75rem 0;
+    border-top: 1px solid var(--border);
+    border-radius: 0;
+    box-shadow: none;
     scroll-margin-top: 6rem;
+  }
+
+  .api-endpoint-card:first-child {
+    padding-top: 0.5rem;
+    border-top: 0;
   }
 
   .api-endpoint-head {
     display: grid;
     gap: 0.7rem;
-    padding: 0.95rem 1rem;
-    border: 1px solid var(--border);
-    border-radius: 0.9rem;
-    background:
-      linear-gradient(180deg, color-mix(in srgb, var(--button-active-bg) 72%, transparent), transparent),
-      var(--button-bg);
-    box-shadow: var(--surface-inset);
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
   }
 
   .api-endpoint-top {
@@ -882,16 +915,13 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     min-height: 2.28rem;
     padding: 0.48rem 0.86rem;
     border-radius: 0.55rem;
-    border-color: rgba(17, 17, 17, 0.9);
-    background: linear-gradient(180deg, #202020, #0f0f0f);
+    border-color: #111111;
+    background: #111111;
     color: #ffffff;
     font-weight: 750;
     font-size: 0.8rem;
     letter-spacing: 0;
-    box-shadow:
-      0 0 0 2px rgba(17, 17, 17, 0.07),
-      0 10px 22px rgba(17, 17, 17, 0.14),
-      var(--surface-inset);
+    box-shadow: none;
   }
 
   .api-test-button span {
@@ -908,8 +938,8 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   }
 
   .api-test-button:hover {
-    background: linear-gradient(180deg, #303030, #111111);
-    border-color: #111111;
+    background: #2b2b2b;
+    border-color: #2b2b2b;
   }
 
   .api-test-button:focus-visible {
@@ -918,18 +948,14 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   }
 
   :global(html[data-theme='dark']) .api-test-button {
-    border-color: rgba(255, 255, 255, 0.82);
-    background: linear-gradient(180deg, #ffffff, #e8e8e4);
+    border-color: #ffffff;
+    background: #ffffff;
     color: #111111;
-    box-shadow:
-      0 0 0 2px rgba(255, 255, 255, 0.12),
-      0 10px 22px rgba(255, 255, 255, 0.12),
-      var(--surface-inset);
   }
 
   :global(html[data-theme='dark']) .api-test-button:hover {
-    background: linear-gradient(180deg, #ffffff, #f4f4f1);
-    border-color: #ffffff;
+    border-color: #e8e8e4;
+    background: #e8e8e4;
   }
 
   :global(html[data-theme='dark']) .api-test-button:focus-visible {
@@ -949,13 +975,13 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     justify-content: center;
     min-width: 4.7rem;
     padding: 0.38rem 0.7rem;
-    border-radius: 999px;
+    border-radius: 0.45rem;
     font-family: var(--font-mono);
     font-size: 0.72rem;
     letter-spacing: 0.05em;
     border: 1px solid var(--button-active-border);
     color: var(--text);
-    box-shadow: var(--surface-inset);
+    box-shadow: none;
   }
 
   .api-method-get {
@@ -1030,7 +1056,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     font-size: 0.9rem;
     line-height: 1.35;
     word-break: break-word;
-    box-shadow: var(--surface-inset);
+    box-shadow: none;
   }
 
   .api-endpoint-summary {
@@ -1054,11 +1080,12 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   .api-field-block {
     display: grid;
     gap: 0.55rem;
-    padding: 0.95rem 1rem;
-    border: 1px solid var(--border);
-    border-radius: 0.9rem;
-    background: color-mix(in srgb, var(--button-bg) 70%, transparent);
-    box-shadow: var(--surface-inset);
+    padding: 1rem 0 0;
+    border: 0;
+    border-top: 1px solid var(--border);
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
   }
 
   .api-field-list {
@@ -1122,6 +1149,9 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     align-items: end;
     justify-content: space-between;
     gap: 1rem;
+    margin-top: 0.4rem;
+    padding: 2.5rem 0 0;
+    border-top: 1px solid var(--border);
   }
 
   .api-cta-links {
@@ -1134,12 +1164,19 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding: 0.72rem 1rem;
-    border-radius: 999px;
-    border: 1px solid var(--button-active-border);
-    background: var(--button-bg);
+    padding: 0.2rem 0;
+    border: 0;
+    border-bottom: 1px solid var(--border-strong);
+    border-radius: 0;
+    background: transparent;
     color: var(--text);
-    box-shadow: var(--surface-inset), var(--surface-shadow-soft);
+    box-shadow: none;
+    font-weight: 650;
+  }
+
+  .api-cta-link:hover {
+    border-bottom-color: var(--text);
+    opacity: 1;
   }
 
   .api-test-modal {
@@ -1627,9 +1664,9 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
       width: 100%;
       padding: 0.75rem 1rem;
       border: 1px solid var(--border);
-      border-radius: 1rem;
-      background: linear-gradient(180deg, var(--surface-gradient-start), var(--surface-gradient-end));
-      box-shadow: var(--surface-inset), var(--surface-shadow-soft);
+      border-radius: 0.7rem;
+      background: var(--bg-elevated);
+      box-shadow: none;
       color: var(--text);
       font-family: var(--font-mono);
       font-size: 0.8rem;
@@ -1659,8 +1696,9 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
     .api-toc {
       max-height: 0;
       overflow: hidden;
-      padding: 0 0.95rem;
+      padding: 0;
       margin-top: 0.5rem;
+      border-radius: 0.7rem;
       transition: max-height 0.3s ease, padding 0.3s ease;
     }
 
@@ -1668,6 +1706,8 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
       max-height: 80vh;
       overflow-y: auto;
       padding: 0.95rem;
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
     }
   }
 
@@ -1684,14 +1724,16 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
   @media (max-width: 720px) {
     .api-page {
-      padding-top: 1rem;
+      padding-top: 1.3rem;
     }
 
-    .api-auth-card,
-    .api-quickstart,
-    .api-endpoint-card,
-    .api-cta {
-      padding: 1rem;
+    .api-hero > :global(.page-markdown-action) {
+      position: static;
+      width: 100%;
+    }
+
+    .api-hero > .section-kicker {
+      padding-right: 0;
     }
 
     .api-code code {

--- a/site/src/components/ApiReference.astro
+++ b/site/src/components/ApiReference.astro
@@ -155,7 +155,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
               </nav>
             </aside>
 
-            <div class="api-content">
+            <div class="api-content" data-markdown-root data-markdown-lang={locale}>
               <section class="api-hero">
                 <p class="section-kicker">{copy.kicker}</p>
                 <h1 class="api-title">{copy.title}</h1>
@@ -227,7 +227,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                       >
                         <div class="api-endpoint-head">
                           <div class="api-endpoint-top">
-                            <div class="api-endpoint-route">
+                            <div class="api-endpoint-route" data-markdown-heading="3">
                               <span class={`api-method api-method-${endpoint.method.toLowerCase()}`}>
                                 {endpoint.method}
                               </span>
@@ -250,7 +250,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
                         <div class="api-endpoint-body">
                           {hasFields(endpoint.headers) && (
                             <section class="api-field-block">
-                              <h3 class="api-field-title">{copy.labels.headers}</h3>
+                              <h3 class="api-field-title" data-markdown-heading="4">{copy.labels.headers}</h3>
                               <dl class="api-field-list">
                                 {endpoint.headers.map((field) => (
                                   <div class="api-field-row">
@@ -267,7 +267,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
                           {hasFields(endpoint.queryParams) && (
                             <section class="api-field-block">
-                              <h3 class="api-field-title">{copy.labels.queryParams}</h3>
+                              <h3 class="api-field-title" data-markdown-heading="4">{copy.labels.queryParams}</h3>
                               <dl class="api-field-list">
                                 {endpoint.queryParams.map((field) => (
                                   <div class="api-field-row">
@@ -284,7 +284,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
                           {hasFields(endpoint.pathParams) && (
                             <section class="api-field-block">
-                              <h3 class="api-field-title">{copy.labels.pathParams}</h3>
+                              <h3 class="api-field-title" data-markdown-heading="4">{copy.labels.pathParams}</h3>
                               <dl class="api-field-list">
                                 {endpoint.pathParams.map((field) => (
                                   <div class="api-field-row">
@@ -301,7 +301,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
                           {hasFields(endpoint.bodyFields) && (
                             <section class="api-field-block">
-                              <h3 class="api-field-title">{copy.labels.body}</h3>
+                              <h3 class="api-field-title" data-markdown-heading="4">{copy.labels.body}</h3>
                               <dl class="api-field-list">
                                 {endpoint.bodyFields.map((field) => (
                                   <div class="api-field-row">
@@ -318,7 +318,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
                           {hasFields(endpoint.responseFields) && (
                             <section class="api-field-block">
-                              <h3 class="api-field-title">{copy.labels.response}</h3>
+                              <h3 class="api-field-title" data-markdown-heading="4">{copy.labels.response}</h3>
                               <dl class="api-field-list">
                                 {endpoint.responseFields.map((field) => (
                                   <div class="api-field-row">
@@ -335,7 +335,7 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
 
                           {endpoint.examples && endpoint.examples.length > 0 && (
                             <section class="api-field-block">
-                              <h3 class="api-field-title">{copy.labels.examples}</h3>
+                              <h3 class="api-field-title" data-markdown-heading="4">{copy.labels.examples}</h3>
                               <div class="api-code-grid">
                                 {endpoint.examples.map((example) => (
                                   <div class="api-example">

--- a/site/src/components/DocsArticlePage.astro
+++ b/site/src/components/DocsArticlePage.astro
@@ -1,6 +1,7 @@
 ---
 import { resolveDocsLocale, type DocsLink, type DocsLocale, type DocsPageCopy, type DocsSection, type DocsTable } from '../content/docs';
 import { DEFAULT_LOCALE } from '../content/site';
+import PageMarkdownAction from './PageMarkdownAction.astro';
 
 interface Props {
   copies: Record<DocsLocale, DocsPageCopy>;
@@ -72,7 +73,7 @@ function docsSectionSearchText(section: DocsSection): string {
                 <span>{copy.hero.tocTitle}</span>
                 <span class="docs-toc-toggle-icon" aria-hidden="true"></span>
               </button>
-              <div class:list={['docs-toc', source !== 'docs' && 'surface-card']}>
+              <div class="docs-toc">
                 <p class="docs-toc-title">{copy.hero.tocTitle}</p>
                 <label class="docs-toc-search">
                   <span class="docs-toc-search-label">{copy.search.label}</span>
@@ -122,13 +123,12 @@ function docsSectionSearchText(section: DocsSection): string {
             </aside>
 
             <div class="docs-content" data-markdown-root data-markdown-lang={locale}>
-              {source === 'docs' && (
-                <header class="docs-hero">
-                  <p class="docs-hero-eyebrow">{copy.hero.eyebrow}</p>
-                  <h1 class="docs-hero-title">{copy.hero.title}</h1>
-                  <p class="docs-hero-intro">{copy.hero.intro}</p>
-                </header>
-              )}
+              <header class="docs-hero">
+                <p class="docs-hero-eyebrow">{copy.hero.eyebrow}</p>
+                <h1 class="docs-hero-title">{copy.hero.title}</h1>
+                <p class="docs-hero-intro">{copy.hero.intro}</p>
+                <PageMarkdownAction />
+              </header>
 
               {copy.sections.map((section) => (
                 <article
@@ -179,7 +179,7 @@ function docsSectionSearchText(section: DocsSection): string {
                   ))}
 
                   {section.subsections?.map((subsection) => (
-                    <section class:list={['docs-subsection', source !== 'docs' && 'surface-card']}>
+                    <section class="docs-subsection">
                       <h3 class="docs-subsection-title">{subsection.title}</h3>
                       {subsection.paragraphs?.map((paragraph) => (
                         <p class="docs-paragraph" set:html={paragraph}></p>
@@ -640,12 +640,21 @@ function docsSectionSearchText(section: DocsSection): string {
   }
 
   .docs-hero {
+    position: relative;
     padding: 0.2rem 0 2.8rem;
     max-width: 52rem;
   }
 
+  .docs-hero > :global(.page-markdown-action) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: auto;
+  }
+
   .docs-hero-eyebrow {
     margin: 0 0 0.8rem;
+    padding-right: 12rem;
     color: var(--accent);
     font-family: var(--font-mono);
     font-size: 0.72rem;
@@ -668,33 +677,33 @@ function docsSectionSearchText(section: DocsSection): string {
     line-height: 1.75;
   }
 
-  .docs-page[data-docs-source='docs'] {
+  .docs-page {
     padding-top: 2.2rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-layout {
+  .docs-page .docs-layout {
     grid-template-columns: minmax(14rem, 16rem) minmax(0, 1fr);
     gap: clamp(2rem, 4vw, 4rem);
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc {
+  .docs-page .docs-toc {
     padding: 0 0.75rem 0 0;
     scrollbar-gutter: auto;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc::-webkit-scrollbar {
+  .docs-page .docs-toc::-webkit-scrollbar {
     width: 0.25rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc::-webkit-scrollbar-thumb {
+  .docs-page .docs-toc::-webkit-scrollbar-thumb {
     background: transparent;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc:hover::-webkit-scrollbar-thumb {
+  .docs-page .docs-toc:hover::-webkit-scrollbar-thumb {
     background: var(--button-active-border);
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-title {
+  .docs-page .docs-toc-title {
     margin-bottom: 1rem;
     color: var(--text-soft);
     font-size: 0.68rem;
@@ -703,43 +712,44 @@ function docsSectionSearchText(section: DocsSection): string {
     text-transform: uppercase;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-search {
+  .docs-page .docs-toc-search {
     margin-bottom: 1.15rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-search input {
+  .docs-page .docs-toc-search input {
     min-height: 2.35rem;
     border-radius: 0.55rem;
     background: transparent;
     box-shadow: none;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-group {
+  .docs-page .docs-toc-group {
     padding-top: 0.75rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-group-summary {
+  .docs-page .docs-toc-group-summary {
     padding: 0.3rem 0.55rem;
     border-radius: 0.5rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-link {
+  .docs-page .docs-toc-link {
     padding: 0.48rem 0.55rem;
     border-left: 0;
     border-radius: 0.5rem;
     transition: background-color 0.16s, color 0.16s;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-toc-link.is-active {
+  .docs-page .docs-toc-link.is-active {
     font-weight: 650;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-content {
+  .docs-page .docs-content {
     gap: 0;
     min-width: 0;
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .docs-page[data-docs-source='docs'] .docs-section {
+  .docs-page .docs-section {
     padding: 2.5rem 0 2.8rem;
     border: 0;
     border-top: 1px solid var(--border);
@@ -748,13 +758,13 @@ function docsSectionSearchText(section: DocsSection): string {
     box-shadow: none;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-section-head {
+  .docs-page .docs-section-head {
     margin-bottom: 1rem;
     padding-bottom: 0;
     border-bottom: 0;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-section-label {
+  .docs-page .docs-section-label {
     display: block;
     margin-bottom: 0.65rem;
     padding: 0;
@@ -765,34 +775,34 @@ function docsSectionSearchText(section: DocsSection): string {
     letter-spacing: 0.1em;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-section-title {
+  .docs-page .docs-section-title {
     margin-bottom: 0.55rem;
     font-size: clamp(1.65rem, 2.6vw, 2.2rem);
   }
 
-  .docs-page[data-docs-source='docs'] .docs-section-intro,
-  .docs-page[data-docs-source='docs'] .docs-paragraph,
-  .docs-page[data-docs-source='docs'] .docs-bullets {
+  .docs-page .docs-section-intro,
+  .docs-page .docs-paragraph,
+  .docs-page .docs-bullets {
     max-width: 52rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-subsection {
+  .docs-page .docs-subsection {
     margin-top: 1.75rem;
     padding: 1.75rem 0 0;
     border: 0;
     border-top: 1px solid var(--border);
   }
 
-  .docs-page[data-docs-source='docs'] .docs-subsection-title {
+  .docs-page .docs-subsection-title {
     font-size: 1.12rem;
     letter-spacing: -0.02em;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-link-row {
+  .docs-page .docs-link-row {
     gap: 1.25rem;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-inline-link {
+  .docs-page .docs-inline-link {
     padding: 0.2rem 0;
     border: 0;
     border-bottom: 1px solid var(--border-strong);
@@ -801,12 +811,12 @@ function docsSectionSearchText(section: DocsSection): string {
     font-weight: 650;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-inline-link:hover {
+  .docs-page .docs-inline-link:hover {
     border-bottom-color: var(--text);
     transform: none;
   }
 
-  .docs-page[data-docs-source='docs'] .docs-table-wrap {
+  .docs-page .docs-table-wrap {
     border-radius: 0.65rem;
     background: transparent;
     box-shadow: none;
@@ -931,27 +941,27 @@ function docsSectionSearchText(section: DocsSection): string {
       padding: 0.95rem;
     }
 
-    .docs-page[data-docs-source='docs'] {
+    .docs-page {
       padding-top: 1.3rem;
     }
 
-    .docs-page[data-docs-source='docs'] .docs-layout {
+    .docs-page .docs-layout {
       gap: 1.25rem;
       grid-template-columns: minmax(0, 1fr);
     }
 
-    .docs-page[data-docs-source='docs'] .docs-toc-toggle {
+    .docs-page .docs-toc-toggle {
       border-radius: 0.7rem;
       background: var(--bg-elevated);
       box-shadow: none;
     }
 
-    .docs-page[data-docs-source='docs'] .docs-toc {
+    .docs-page .docs-toc {
       padding: 0;
       border-radius: 0.7rem;
     }
 
-    .docs-page[data-docs-source='docs'] .docs-sidebar.is-toc-open .docs-toc {
+    .docs-page .docs-sidebar.is-toc-open .docs-toc {
       padding: 0.95rem;
       border: 1px solid var(--border);
       background: var(--bg-elevated);
@@ -976,15 +986,24 @@ function docsSectionSearchText(section: DocsSection): string {
       padding: 1rem;
     }
 
-    .docs-page[data-docs-source='docs'] .docs-hero {
+    .docs-page .docs-hero {
       padding: 0.25rem 0 2.2rem;
     }
 
-    .docs-page[data-docs-source='docs'] .docs-hero-title {
+    .docs-page .docs-hero > :global(.page-markdown-action) {
+      position: static;
+      width: 100%;
+    }
+
+    .docs-page .docs-hero-eyebrow {
+      padding-right: 0;
+    }
+
+    .docs-page .docs-hero-title {
       font-size: clamp(2.35rem, 13vw, 3.25rem);
     }
 
-    .docs-page[data-docs-source='docs'] .docs-section {
+    .docs-page .docs-section {
       padding: 2rem 0 2.25rem;
     }
 

--- a/site/src/components/DocsArticlePage.astro
+++ b/site/src/components/DocsArticlePage.astro
@@ -639,6 +639,179 @@ function docsSectionSearchText(section: DocsSection): string {
     flex-shrink: 0;
   }
 
+  .docs-hero {
+    padding: 0.2rem 0 2.8rem;
+    max-width: 52rem;
+  }
+
+  .docs-hero-eyebrow {
+    margin: 0 0 0.8rem;
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .docs-hero-title {
+    font-size: clamp(2.35rem, 5vw, 4.25rem);
+    letter-spacing: -0.055em;
+    line-height: 1.02;
+  }
+
+  .docs-hero-intro {
+    margin-top: 1.15rem;
+    max-width: 48rem;
+    color: var(--text-dim);
+    font-size: clamp(1rem, 1.6vw, 1.16rem);
+    line-height: 1.75;
+  }
+
+  .docs-page[data-docs-source='docs'] {
+    padding-top: 2.2rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-layout {
+    grid-template-columns: minmax(14rem, 16rem) minmax(0, 1fr);
+    gap: clamp(2rem, 4vw, 4rem);
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc {
+    padding: 0 0.75rem 0 0;
+    scrollbar-gutter: auto;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc::-webkit-scrollbar {
+    width: 0.25rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc:hover::-webkit-scrollbar-thumb {
+    background: var(--button-active-border);
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-title {
+    margin-bottom: 1rem;
+    color: var(--text-soft);
+    font-size: 0.68rem;
+    font-weight: 650;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-search {
+    margin-bottom: 1.15rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-search input {
+    min-height: 2.35rem;
+    border-radius: 0.55rem;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-group {
+    padding-top: 0.75rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-group-summary {
+    padding: 0.3rem 0.55rem;
+    border-radius: 0.5rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-link {
+    padding: 0.48rem 0.55rem;
+    border-left: 0;
+    border-radius: 0.5rem;
+    transition: background-color 0.16s, color 0.16s;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-toc-link.is-active {
+    font-weight: 650;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-content {
+    gap: 0;
+    min-width: 0;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-section {
+    padding: 2.5rem 0 2.8rem;
+    border: 0;
+    border-top: 1px solid var(--border);
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-section-head {
+    margin-bottom: 1rem;
+    padding-bottom: 0;
+    border-bottom: 0;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-section-label {
+    display: block;
+    margin-bottom: 0.65rem;
+    padding: 0;
+    background: transparent;
+    border-radius: 0;
+    font-size: 0.72rem;
+    font-weight: 650;
+    letter-spacing: 0.1em;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-section-title {
+    margin-bottom: 0.55rem;
+    font-size: clamp(1.65rem, 2.6vw, 2.2rem);
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-section-intro,
+  .docs-page[data-docs-source='docs'] .docs-paragraph,
+  .docs-page[data-docs-source='docs'] .docs-bullets {
+    max-width: 52rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-subsection {
+    margin-top: 1.75rem;
+    padding: 1.75rem 0 0;
+    border: 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-subsection-title {
+    font-size: 1.12rem;
+    letter-spacing: -0.02em;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-link-row {
+    gap: 1.25rem;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-inline-link {
+    padding: 0.2rem 0;
+    border: 0;
+    border-bottom: 1px solid var(--border-strong);
+    border-radius: 0;
+    background: transparent;
+    font-weight: 650;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-inline-link:hover {
+    border-bottom-color: var(--text);
+    transform: none;
+  }
+
+  .docs-page[data-docs-source='docs'] .docs-table-wrap {
+    border-radius: 0.65rem;
+    background: transparent;
+    box-shadow: none;
+  }
+
   /* Progress bar */
   .docs-progress-bar {
     position: fixed;
@@ -757,6 +930,32 @@ function docsSectionSearchText(section: DocsSection): string {
       overflow-y: auto;
       padding: 0.95rem;
     }
+
+    .docs-page[data-docs-source='docs'] {
+      padding-top: 1.3rem;
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-layout {
+      gap: 1.25rem;
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-toc-toggle {
+      border-radius: 0.7rem;
+      background: var(--bg-elevated);
+      box-shadow: none;
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-toc {
+      padding: 0;
+      border-radius: 0.7rem;
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-sidebar.is-toc-open .docs-toc {
+      padding: 0.95rem;
+      border: 1px solid var(--border);
+      background: var(--bg-elevated);
+    }
   }
 
   @media (max-width: 720px) {
@@ -775,6 +974,18 @@ function docsSectionSearchText(section: DocsSection): string {
 
     .docs-section {
       padding: 1rem;
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-hero {
+      padding: 0.25rem 0 2.2rem;
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-hero-title {
+      font-size: clamp(2.35rem, 13vw, 3.25rem);
+    }
+
+    .docs-page[data-docs-source='docs'] .docs-section {
+      padding: 2rem 0 2.25rem;
     }
 
     .docs-back-to-top {

--- a/site/src/components/DocsArticlePage.astro
+++ b/site/src/components/DocsArticlePage.astro
@@ -4,7 +4,7 @@ import { DEFAULT_LOCALE } from '../content/site';
 
 interface Props {
   copies: Record<DocsLocale, DocsPageCopy>;
-  source: string;
+  source: 'docs' | 'console';
 }
 
 const localeOrder: DocsLocale[] = ['zh', 'en', 'ja', 'ko', 'id', 'th'];
@@ -72,7 +72,7 @@ function docsSectionSearchText(section: DocsSection): string {
                 <span>{copy.hero.tocTitle}</span>
                 <span class="docs-toc-toggle-icon" aria-hidden="true"></span>
               </button>
-              <div class="docs-toc surface-card">
+              <div class:list={['docs-toc', source !== 'docs' && 'surface-card']}>
                 <p class="docs-toc-title">{copy.hero.tocTitle}</p>
                 <label class="docs-toc-search">
                   <span class="docs-toc-search-label">{copy.search.label}</span>
@@ -122,6 +122,14 @@ function docsSectionSearchText(section: DocsSection): string {
             </aside>
 
             <div class="docs-content">
+              {source === 'docs' && (
+                <header class="docs-hero">
+                  <p class="docs-hero-eyebrow">{copy.hero.eyebrow}</p>
+                  <h1 class="docs-hero-title">{copy.hero.title}</h1>
+                  <p class="docs-hero-intro">{copy.hero.intro}</p>
+                </header>
+              )}
+
               {copy.sections.map((section) => (
                 <article
                   class="docs-section"
@@ -171,7 +179,7 @@ function docsSectionSearchText(section: DocsSection): string {
                   ))}
 
                   {section.subsections?.map((subsection) => (
-                    <section class="docs-subsection surface-card">
+                    <section class:list={['docs-subsection', source !== 'docs' && 'surface-card']}>
                       <h3 class="docs-subsection-title">{subsection.title}</h3>
                       {subsection.paragraphs?.map((paragraph) => (
                         <p class="docs-paragraph" set:html={paragraph}></p>

--- a/site/src/components/DocsArticlePage.astro
+++ b/site/src/components/DocsArticlePage.astro
@@ -121,7 +121,7 @@ function docsSectionSearchText(section: DocsSection): string {
               </div>
             </aside>
 
-            <div class="docs-content">
+            <div class="docs-content" data-markdown-root data-markdown-lang={locale}>
               {source === 'docs' && (
                 <header class="docs-hero">
                   <p class="docs-hero-eyebrow">{copy.hero.eyebrow}</p>

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,6 +1,7 @@
 ---
 import { agentGuideTargets } from '../content/site';
 import type { SiteAriaCopy, SiteHeroCopy } from '../content/site';
+import PageMarkdownAction from './PageMarkdownAction.astro';
 
 interface Props {
   hero: SiteHeroCopy;
@@ -53,6 +54,8 @@ const onboardingCommandStable = splitOnboardingCommand(hero.onboardingCommandSta
         <p class="subtitle" data-i18n="hero.subtitle">
           {hero.subtitle}
         </p>
+
+        <PageMarkdownAction />
 
         <div class="cta-grid" data-onboarding-shell data-onboarding-version="stable">
           {showOnboardingVersionTabs && (

--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -6,7 +6,7 @@ import type {
   SiteNavCopy,
   SiteThemeOptionsCopy,
 } from '../content/site';
-import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
+import { siteCopy, siteLocales } from '../content/site';
 
 interface Props {
   nav: SiteNavCopy;
@@ -17,7 +17,6 @@ interface Props {
 }
 
 const { nav, aria, localeNames, themeOptions, currentPath = '/' } = Astro.props;
-const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
 const isActivePath = (path: string): boolean => currentPath === path;
 const localeToLang = (locale: SiteLocale): string => {
   if (locale === 'zh') {
@@ -200,29 +199,6 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
                 ))}
               </span>
             </a>
-            <div class="page-markdown-action" data-page-markdown-action role="none" hidden>
-              <div class="docs-menu-separator" role="separator"></div>
-              <button
-                type="button"
-                class="docs-menu-item page-markdown-copy"
-                role="menuitem"
-                data-page-markdown-copy
-                aria-label={pageTools.copyMarkdown}
-                title={pageTools.copyMarkdown}
-                data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown"
-              >
-                <svg class="page-markdown-icon page-markdown-icon-copy" viewBox="0 0 20 20" aria-hidden="true">
-                  <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z" />
-                  <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1" />
-                </svg>
-                <svg class="page-markdown-icon page-markdown-icon-check" viewBox="0 0 20 20" aria-hidden="true">
-                  <path d="m4.5 10.5 3.25 3.25 7.75-8" />
-                </svg>
-                <span data-page-markdown-label data-i18n="pageTools.copyMarkdown" aria-live="polite">
-                  {pageTools.copyMarkdown}
-                </span>
-              </button>
-            </div>
           </div>
         </div>
         <a
@@ -425,28 +401,6 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
                   ))}
                 </span>
               </a>
-              <div class="page-markdown-action" data-page-markdown-action role="none" hidden>
-                <button
-                  type="button"
-                  class="mobile-menu-item page-markdown-copy"
-                  role="menuitem"
-                  data-page-markdown-copy
-                  aria-label={pageTools.copyMarkdown}
-                  title={pageTools.copyMarkdown}
-                  data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown"
-                >
-                  <svg class="page-markdown-icon page-markdown-icon-copy" viewBox="0 0 20 20" aria-hidden="true">
-                    <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z" />
-                    <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1" />
-                  </svg>
-                  <svg class="page-markdown-icon page-markdown-icon-check" viewBox="0 0 20 20" aria-hidden="true">
-                    <path d="m4.5 10.5 3.25 3.25 7.75-8" />
-                  </svg>
-                  <span data-page-markdown-label data-i18n="pageTools.copyMarkdown" aria-live="polite">
-                    {pageTools.copyMarkdown}
-                  </span>
-                </button>
-              </div>
             </div>
 
             <div class="mobile-menu-section" role="presentation">
@@ -1019,55 +973,6 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
     border-color: var(--button-active-border);
     color: var(--text);
     opacity: 1;
-  }
-
-  .page-markdown-action[hidden] {
-    display: none;
-  }
-
-  .docs-menu-separator {
-    height: 1px;
-    margin: 0.35rem 0.75rem;
-    background: var(--border);
-  }
-
-  .page-markdown-copy {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    width: 100%;
-    background: transparent;
-    font: inherit;
-    text-align: left;
-    cursor: pointer;
-  }
-
-  .page-markdown-copy[aria-busy='true'] {
-    cursor: progress;
-    opacity: 0.7;
-  }
-
-  .page-markdown-icon {
-    width: 1rem;
-    height: 1rem;
-    flex: 0 0 auto;
-    fill: none;
-    stroke: currentColor;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    stroke-width: 1.5;
-  }
-
-  .page-markdown-icon-check {
-    display: none;
-  }
-
-  .page-markdown-copy.is-copied .page-markdown-icon-copy {
-    display: none;
-  }
-
-  .page-markdown-copy.is-copied .page-markdown-icon-check {
-    display: block;
   }
 
   /* Social links */

--- a/site/src/components/Navbar.astro
+++ b/site/src/components/Navbar.astro
@@ -6,7 +6,7 @@ import type {
   SiteNavCopy,
   SiteThemeOptionsCopy,
 } from '../content/site';
-import { siteCopy, siteLocales } from '../content/site';
+import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
 
 interface Props {
   nav: SiteNavCopy;
@@ -17,6 +17,7 @@ interface Props {
 }
 
 const { nav, aria, localeNames, themeOptions, currentPath = '/' } = Astro.props;
+const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
 const isActivePath = (path: string): boolean => currentPath === path;
 const localeToLang = (locale: SiteLocale): string => {
   if (locale === 'zh') {
@@ -199,6 +200,29 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
                 ))}
               </span>
             </a>
+            <div class="page-markdown-action" data-page-markdown-action role="none" hidden>
+              <div class="docs-menu-separator" role="separator"></div>
+              <button
+                type="button"
+                class="docs-menu-item page-markdown-copy"
+                role="menuitem"
+                data-page-markdown-copy
+                aria-label={pageTools.copyMarkdown}
+                title={pageTools.copyMarkdown}
+                data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown"
+              >
+                <svg class="page-markdown-icon page-markdown-icon-copy" viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z" />
+                  <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1" />
+                </svg>
+                <svg class="page-markdown-icon page-markdown-icon-check" viewBox="0 0 20 20" aria-hidden="true">
+                  <path d="m4.5 10.5 3.25 3.25 7.75-8" />
+                </svg>
+                <span data-page-markdown-label data-i18n="pageTools.copyMarkdown" aria-live="polite">
+                  {pageTools.copyMarkdown}
+                </span>
+              </button>
+            </div>
           </div>
         </div>
         <a
@@ -401,6 +425,28 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
                   ))}
                 </span>
               </a>
+              <div class="page-markdown-action" data-page-markdown-action role="none" hidden>
+                <button
+                  type="button"
+                  class="mobile-menu-item page-markdown-copy"
+                  role="menuitem"
+                  data-page-markdown-copy
+                  aria-label={pageTools.copyMarkdown}
+                  title={pageTools.copyMarkdown}
+                  data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown"
+                >
+                  <svg class="page-markdown-icon page-markdown-icon-copy" viewBox="0 0 20 20" aria-hidden="true">
+                    <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z" />
+                    <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1" />
+                  </svg>
+                  <svg class="page-markdown-icon page-markdown-icon-check" viewBox="0 0 20 20" aria-hidden="true">
+                    <path d="m4.5 10.5 3.25 3.25 7.75-8" />
+                  </svg>
+                  <span data-page-markdown-label data-i18n="pageTools.copyMarkdown" aria-live="polite">
+                    {pageTools.copyMarkdown}
+                  </span>
+                </button>
+              </div>
             </div>
 
             <div class="mobile-menu-section" role="presentation">
@@ -973,6 +1019,55 @@ const navLabels = (key: keyof SiteNavCopy): { locale: SiteLocale; lang: string; 
     border-color: var(--button-active-border);
     color: var(--text);
     opacity: 1;
+  }
+
+  .page-markdown-action[hidden] {
+    display: none;
+  }
+
+  .docs-menu-separator {
+    height: 1px;
+    margin: 0.35rem 0.75rem;
+    background: var(--border);
+  }
+
+  .page-markdown-copy {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    background: transparent;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .page-markdown-copy[aria-busy='true'] {
+    cursor: progress;
+    opacity: 0.7;
+  }
+
+  .page-markdown-icon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.5;
+  }
+
+  .page-markdown-icon-check {
+    display: none;
+  }
+
+  .page-markdown-copy.is-copied .page-markdown-icon-copy {
+    display: none;
+  }
+
+  .page-markdown-copy.is-copied .page-markdown-icon-check {
+    display: block;
   }
 
   /* Social links */

--- a/site/src/components/PageMarkdownAction.astro
+++ b/site/src/components/PageMarkdownAction.astro
@@ -1,0 +1,111 @@
+---
+import { DEFAULT_LOCALE, siteCopy } from '../content/site';
+
+const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
+---
+
+<div class="page-markdown-action" data-page-markdown-action data-markdown-exclude>
+  <button
+    type="button"
+    class="page-markdown-copy"
+    data-page-markdown-copy
+    aria-label={pageTools.copyMarkdown}
+    title={pageTools.copyMarkdown}
+    data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown"
+  >
+    <svg class="page-markdown-icon page-markdown-icon-copy" viewBox="0 0 20 20" aria-hidden="true">
+      <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z" />
+      <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1" />
+    </svg>
+    <svg class="page-markdown-icon page-markdown-icon-check" viewBox="0 0 20 20" aria-hidden="true">
+      <path d="m4.5 10.5 3.25 3.25 7.75-8" />
+    </svg>
+    <span data-page-markdown-label data-i18n="pageTools.copyMarkdown" aria-live="polite">
+      {pageTools.copyMarkdown}
+    </span>
+  </button>
+</div>
+
+<style>
+  .page-markdown-action {
+    display: flex;
+    justify-content: flex-end;
+    width: 100%;
+    margin-bottom: 0.3rem;
+  }
+
+  .page-markdown-action[hidden] {
+    display: none;
+  }
+
+  .page-markdown-copy {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 2.35rem;
+    padding: 0.5rem 0.72rem;
+    border: 1px solid var(--border);
+    border-radius: 0.55rem;
+    background: transparent;
+    color: var(--text-dim);
+    font: inherit;
+    font-size: 0.82rem;
+    font-weight: 650;
+    cursor: pointer;
+    transition: border-color 0.16s ease, color 0.16s ease, background-color 0.16s ease;
+  }
+
+  .page-markdown-copy:hover,
+  .page-markdown-copy:focus-visible {
+    border-color: var(--border-strong);
+    background: var(--button-active-bg);
+    color: var(--text);
+  }
+
+  .page-markdown-copy[aria-busy='true'] {
+    cursor: progress;
+    opacity: 0.7;
+  }
+
+  .page-markdown-icon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.5;
+  }
+
+  .page-markdown-icon-check {
+    display: none;
+  }
+
+  .page-markdown-copy.is-copied .page-markdown-icon-copy {
+    display: none;
+  }
+
+  .page-markdown-copy.is-copied .page-markdown-icon-check {
+    display: block;
+  }
+
+  .page-markdown-copy.is-error {
+    border-color: color-mix(in srgb, #d33 55%, var(--border));
+    color: #b42318;
+  }
+
+  :global(html[data-theme='dark']) .page-markdown-copy.is-error {
+    border-color: color-mix(in srgb, #ff8a80 60%, var(--border));
+    color: #ff8a80;
+  }
+
+  @media (max-width: 720px) {
+    .page-markdown-action {
+      justify-content: flex-start;
+      margin-top: 0.35rem;
+      margin-bottom: 0.5rem;
+    }
+  }
+</style>

--- a/site/src/components/PageMarkdownAction.astro
+++ b/site/src/components/PageMarkdownAction.astro
@@ -1,5 +1,5 @@
 ---
-import { DEFAULT_LOCALE, siteCopy } from '../content/site';
+import { DEFAULT_LOCALE, siteCopy } from "../content/site";
 
 const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
 ---
@@ -11,14 +11,14 @@ const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
     data-page-markdown-copy
     aria-label={pageTools.copyMarkdown}
     title={pageTools.copyMarkdown}
-    data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown"
-  >
+    data-i18n-attr="aria-label:pageTools.copyMarkdown;title:pageTools.copyMarkdown">
     <svg class="page-markdown-icon page-markdown-icon-copy" viewBox="0 0 20 20" aria-hidden="true">
-      <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z" />
-      <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1" />
+      <path d="M7.5 5.5h7a1.5 1.5 0 0 1 1.5 1.5v8a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 6 15V7a1.5 1.5 0 0 1 1.5-1.5Z"
+      ></path>
+      <path d="M13.5 5.5V5A1.5 1.5 0 0 0 12 3.5H5A1.5 1.5 0 0 0 3.5 5v8A1.5 1.5 0 0 0 5 14.5h1"></path>
     </svg>
     <svg class="page-markdown-icon page-markdown-icon-check" viewBox="0 0 20 20" aria-hidden="true">
-      <path d="m4.5 10.5 3.25 3.25 7.75-8" />
+      <path d="m4.5 10.5 3.25 3.25 7.75-8"></path>
     </svg>
     <span data-page-markdown-label data-i18n="pageTools.copyMarkdown" aria-live="polite">
       {pageTools.copyMarkdown}
@@ -29,9 +29,9 @@ const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
 <style>
   .page-markdown-action {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     width: 100%;
-    margin-bottom: 0.3rem;
+    margin-top: 1rem;
   }
 
   .page-markdown-action[hidden] {
@@ -53,7 +53,10 @@ const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
     font-size: 0.82rem;
     font-weight: 650;
     cursor: pointer;
-    transition: border-color 0.16s ease, color 0.16s ease, background-color 0.16s ease;
+    transition:
+      border-color 0.16s ease,
+      color 0.16s ease,
+      background-color 0.16s ease;
   }
 
   .page-markdown-copy:hover,
@@ -63,7 +66,7 @@ const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
     color: var(--text);
   }
 
-  .page-markdown-copy[aria-busy='true'] {
+  .page-markdown-copy[aria-busy="true"] {
     cursor: progress;
     opacity: 0.7;
   }
@@ -96,16 +99,8 @@ const pageTools = siteCopy[DEFAULT_LOCALE].pageTools;
     color: #b42318;
   }
 
-  :global(html[data-theme='dark']) .page-markdown-copy.is-error {
+  :global(html[data-theme="dark"]) .page-markdown-copy.is-error {
     border-color: color-mix(in srgb, #ff8a80 60%, var(--border));
     color: #ff8a80;
-  }
-
-  @media (max-width: 720px) {
-    .page-markdown-action {
-      justify-content: flex-start;
-      margin-top: 0.35rem;
-      margin-bottom: 0.5rem;
-    }
   }
 </style>

--- a/site/src/components/Pricing.astro
+++ b/site/src/components/Pricing.astro
@@ -21,7 +21,7 @@ function getPlanHref(tier: SiteBillingTier): string {
 ---
 
 <section id="billing" class="billing-section">
-  <div class="container billing-stack">
+  <div class="container billing-stack" data-markdown-root>
     <div class="section-head">
       <p class="section-kicker" data-i18n="billing.kicker">{billing.kicker}</p>
       <h2 class="section-title" data-i18n="billing.title">{billing.title}</h2>
@@ -90,6 +90,7 @@ function getPlanHref(tier: SiteBillingTier): string {
                   ) : tier.ctaAction === 'mailto' ? (
                     <button
                       type="button"
+                      data-markdown-include
                       class="cta-button"
                       data-contact-modal-trigger
                       data-billing-track
@@ -125,7 +126,7 @@ function getPlanHref(tier: SiteBillingTier): string {
       </table>
     </div>
 
-    <div class="pricing-mobile-list">
+    <div class="pricing-mobile-list" data-markdown-exclude>
       {billing.tiers.map((tier, tierIndex) => (
         <article class:list={['pricing-mobile-tier', 'surface-card', tier.highlighted && 'is-highlighted']}>
           <div class="mobile-tier-header">
@@ -173,6 +174,7 @@ function getPlanHref(tier: SiteBillingTier): string {
             ) : tier.ctaAction === 'mailto' ? (
               <button
                 type="button"
+                data-markdown-include
                 class="cta-button"
                 data-contact-modal-trigger
                 data-billing-track

--- a/site/src/components/Pricing.astro
+++ b/site/src/components/Pricing.astro
@@ -1,5 +1,6 @@
 ---
 import type { SiteBillingPageCopy, SiteBillingTier } from '../content/site';
+import PageMarkdownAction from './PageMarkdownAction.astro';
 
 interface Props {
   billing: SiteBillingPageCopy;
@@ -33,6 +34,7 @@ function getPlanHref(tier: SiteBillingTier): string {
           {billing.docsLinkLabel}
         </a>
       )}
+      <PageMarkdownAction />
     </div>
 
     <div class="pricing-table-wrap surface-card">

--- a/site/src/components/ReleaseNotes.astro
+++ b/site/src/components/ReleaseNotes.astro
@@ -11,7 +11,7 @@ import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
         data-release-notes-copy={locale}
         hidden={locale !== DEFAULT_LOCALE}
       >
-        <div class="container release-notes-shell">
+        <div class="container release-notes-shell" data-markdown-root data-markdown-lang={locale}>
           <div class="release-notes-hero">
             <header class="release-notes-header">
               <p class="section-kicker">{releaseNotes.kicker}</p>
@@ -33,7 +33,7 @@ import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
               </div>
             </header>
 
-            <div class="release-notes-art">
+            <div class="release-notes-art" data-markdown-exclude>
               <img
                 src="/release-notes-hero.jpg"
                 alt={releaseNotes.heroImageAlt}

--- a/site/src/components/ReleaseNotes.astro
+++ b/site/src/components/ReleaseNotes.astro
@@ -1,5 +1,6 @@
 ---
 import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
+import PageMarkdownAction from './PageMarkdownAction.astro';
 ---
 
 <section class="release-notes" data-release-notes-root data-release-notes-locale={DEFAULT_LOCALE}>
@@ -17,6 +18,7 @@ import { DEFAULT_LOCALE, siteCopy, siteLocales } from '../content/site';
               <p class="section-kicker">{releaseNotes.kicker}</p>
               <h1>{releaseNotes.title}</h1>
               <p>{releaseNotes.intro}</p>
+              <PageMarkdownAction />
               <div class="release-notes-star">
                 <span>{releaseNotes.starPrompt}</span>
                 <a href={releaseNotes.starHref} target="_blank" rel="noopener">

--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -428,6 +428,12 @@ export interface SiteCopyFeedback {
   copyFailed: string;
 }
 
+export interface SitePageToolsCopy {
+  copyMarkdown: string;
+  copiedMarkdown: string;
+  copyMarkdownFailed: string;
+}
+
 export interface SiteDictionary {
   meta: SiteMeta;
   nav: SiteNavCopy;
@@ -446,6 +452,7 @@ export interface SiteDictionary {
   aria: SiteAriaCopy;
   themeOptions: SiteThemeOptionsCopy;
   copyFeedback: SiteCopyFeedback;
+  pageTools: SitePageToolsCopy;
   localeNames: Record<SiteLocale, string>;
 }
 
@@ -6474,6 +6481,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       copied: 'Onboarding instructions copied.',
       copyFailed: 'Copy failed. Please copy the command manually.',
     },
+    pageTools: {
+      copyMarkdown: 'Copy as Markdown',
+      copiedMarkdown: 'Markdown copied',
+      copyMarkdownFailed: 'Copy failed. Please try again.',
+    },
     localeNames,
   },
   zh: {
@@ -6828,6 +6840,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     copyFeedback: {
       copied: '已复制接入说明。',
       copyFailed: '复制失败，请手动复制命令。',
+    },
+    pageTools: {
+      copyMarkdown: '复制为 Markdown',
+      copiedMarkdown: 'Markdown 已复制',
+      copyMarkdownFailed: '复制失败，请重试。',
     },
     localeNames,
   },
@@ -7188,6 +7205,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     copyFeedback: {
       copied: '已複製接入說明。',
       copyFailed: '複製失敗，請手動複製命令。',
+    },
+    pageTools: {
+      copyMarkdown: '複製為 Markdown',
+      copiedMarkdown: 'Markdown 已複製',
+      copyMarkdownFailed: '複製失敗，請重試。',
     },
     localeNames,
   },
@@ -7554,6 +7576,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       copied: '導入手順をコピーしました。',
       copyFailed: 'コピーに失敗しました。手動でコピーしてください。',
     },
+    pageTools: {
+      copyMarkdown: 'Markdown としてコピー',
+      copiedMarkdown: 'Markdown をコピーしました',
+      copyMarkdownFailed: 'コピーに失敗しました。もう一度お試しください。',
+    },
     localeNames,
   },
   ko: {
@@ -7915,6 +7942,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     copyFeedback: {
       copied: '온보딩 안내를 복사했습니다.',
       copyFailed: '복사에 실패했습니다. 직접 복사해 주세요.',
+    },
+    pageTools: {
+      copyMarkdown: 'Markdown으로 복사',
+      copiedMarkdown: 'Markdown을 복사했습니다',
+      copyMarkdownFailed: '복사에 실패했습니다. 다시 시도해 주세요.',
     },
     localeNames,
   },
@@ -8281,6 +8313,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
       copied: 'Instruksi onboarding disalin.',
       copyFailed: 'Gagal menyalin. Silakan salin manual.',
     },
+    pageTools: {
+      copyMarkdown: 'Salin sebagai Markdown',
+      copiedMarkdown: 'Markdown disalin',
+      copyMarkdownFailed: 'Gagal menyalin. Silakan coba lagi.',
+    },
     localeNames,
   },
   th: {
@@ -8645,6 +8682,11 @@ export const siteCopy: Record<SiteLocale, SiteDictionary> = {
     copyFeedback: {
       copied: 'คัดลอกคำแนะนำการตั้งค่าแล้ว',
       copyFailed: 'คัดลอกไม่สำเร็จ กรุณาคัดลอกด้วยตนเอง',
+    },
+    pageTools: {
+      copyMarkdown: 'คัดลอกเป็น Markdown',
+      copiedMarkdown: 'คัดลอก Markdown แล้ว',
+      copyMarkdownFailed: 'คัดลอกไม่สำเร็จ โปรดลองอีกครั้ง',
     },
     localeNames,
   },

--- a/site/src/layouts/Layout.astro
+++ b/site/src/layouts/Layout.astro
@@ -165,8 +165,10 @@ const modalCopy = siteCopy[locale].billing;
     <ContactModal billing={modalCopy} />
     <script>
       import { initSiteUI } from '../scripts/site-ui';
+      import { initPageMarkdownCopy } from '../scripts/page-markdown';
 
       initSiteUI();
+      initPageMarkdownCopy();
     </script>
   </body>
 </html>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -24,7 +24,7 @@ const copy = siteCopy[DEFAULT_LOCALE];
     themeOptions={copy.themeOptions}
     currentPath="/"
   />
-  <main>
+  <main data-markdown-root>
     <Hero hero={copy.hero} aria={copy.aria} />
     <Features features={copy.features} />
     <Benchmark benchmark={copy.benchmark} />

--- a/site/src/pages/llms.txt.ts
+++ b/site/src/pages/llms.txt.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from 'astro';
+
+export const prerender = true;
+
+const fallbackSiteUrl = 'https://mem9.ai';
+
+export const GET: APIRoute = ({ site }) => {
+  const siteUrl = site ?? new URL(fallbackSiteUrl);
+  const link = (label: string, path: string, description: string): string => (
+    `- [${label}](${new URL(path, siteUrl).toString()}): ${description}`
+  );
+  const llmsText = [
+    '# mem9',
+    '',
+    '> Shared, cloud-persistent memory infrastructure for AI agents and agentic applications.',
+    '',
+    'mem9 provides durable memory across sessions, machines, agents, and applications, with hybrid recall and a visual management console.',
+    '',
+    '## Documentation',
+    '',
+    link('Product overview', '/', 'Capabilities, supported agents, benchmarks, security, and common questions.'),
+    link('User guide', '/docs/', 'Setup, integrations, security, pricing, and operating guidance.'),
+    link('API reference', '/api/', 'REST API authentication, endpoints, schemas, and examples.'),
+    link('Console guide', '/console-docs/', 'Web console workflows for spaces, memory review, usage, billing, and settings.'),
+    link('OpenClaw memory guide', '/openclaw-memory/', 'Persistent memory setup and usage for OpenClaw.'),
+    '',
+    '## Agent resources',
+    '',
+    link('Agent skill', '/SKILL.md', 'Stable agent-readable installation and operating instructions.'),
+    link('Setup guide', '/SETUP.md', 'Detailed setup and reconnection steps.'),
+    link('Troubleshooting guide', '/TROUBLESHOOTING.md', 'Known setup and runtime recovery procedures.'),
+    link('Uninstall guide', '/UNINSTALL.md', 'Cleanup and removal instructions.'),
+    '',
+    '## Optional',
+    '',
+    link('Pricing', '/pricing/', 'Plans, included usage, and billing controls.'),
+    link('Release notes', '/release-notes/', 'Product changes and version history.'),
+    '- [Source code](https://github.com/mem9-ai/mem9): Core server, site, dashboard, CLI, and in-repo agent integrations.',
+    '',
+  ].join('\n');
+
+  return new Response(llmsText, {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+    },
+  });
+};

--- a/site/src/pages/openclaw-memory.astro
+++ b/site/src/pages/openclaw-memory.astro
@@ -2,6 +2,7 @@
 import Layout from "../layouts/Layout.astro";
 import Navbar from "../components/Navbar.astro";
 import Footer from "../components/Footer.astro";
+import PageMarkdownAction from "../components/PageMarkdownAction.astro";
 import { DEFAULT_LOCALE, siteCopy } from "../content/site";
 
 const copy = siteCopy[DEFAULT_LOCALE];
@@ -35,6 +36,8 @@ const meta = {
             How do I share memory across agents and reduce repeated context? mem9 is the plugin
             for that job.
           </p>
+
+          <PageMarkdownAction />
 
           <div class="cta-row">
             <a class="button primary" href="/SKILL.md" target="_blank">Open SKILL.md</a>

--- a/site/src/pages/openclaw-memory.astro
+++ b/site/src/pages/openclaw-memory.astro
@@ -20,7 +20,7 @@ const meta = {
     themeOptions={copy.themeOptions}
   />
 
-  <main class="landing">
+  <main class="landing" data-markdown-root data-markdown-lang="en">
     <section class="hero">
       <div class="container hero-shell">
         <div class="hero-copy">

--- a/site/src/scripts/clipboard.ts
+++ b/site/src/scripts/clipboard.ts
@@ -1,0 +1,52 @@
+export async function copyText(text: string): Promise<boolean> {
+  let clipboardCopy = false;
+  try {
+    if (navigator.clipboard?.writeText) {
+      clipboardCopy = await Promise.race([
+        navigator.clipboard.writeText(text).then(() => true, () => false),
+        new Promise<boolean>((resolve) => window.setTimeout(() => resolve(false), 1000)),
+      ]);
+    }
+  } catch {
+    clipboardCopy = false;
+  }
+
+  if (clipboardCopy) {
+    return true;
+  }
+
+  const activeElement = document.activeElement instanceof HTMLElement
+    ? document.activeElement
+    : null;
+  const selection = window.getSelection();
+  const ranges = selection
+    ? Array.from({ length: selection.rangeCount }, (_, index) => selection.getRangeAt(index).cloneRange())
+    : [];
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.left = '-9999px';
+  textarea.style.top = '0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  let copied = false;
+  try {
+    copied = document.execCommand('copy');
+  } catch {
+    copied = false;
+  }
+
+  document.body.removeChild(textarea);
+  activeElement?.focus({ preventScroll: true });
+
+  if (selection && ranges.length > 0) {
+    selection.removeAllRanges();
+    ranges.forEach((range) => selection.addRange(range));
+  }
+
+  return copied;
+}

--- a/site/src/scripts/page-markdown.ts
+++ b/site/src/scripts/page-markdown.ts
@@ -1,0 +1,385 @@
+import { DEFAULT_LOCALE, isSiteLocale, siteCopy, type SiteLocale } from '../content/site';
+import { copyText } from './clipboard';
+
+const excludedSelector = [
+  '[hidden]',
+  '[aria-hidden="true"]',
+  '[data-markdown-exclude]',
+  'button:not([data-markdown-include])',
+  'canvas',
+  'dialog',
+  'form',
+  'iframe',
+  'input',
+  'nav',
+  'script',
+  'select',
+  'style',
+  'svg',
+  'template',
+  'textarea',
+].join(',');
+
+const blockTags = new Set([
+  'ADDRESS',
+  'ARTICLE',
+  'ASIDE',
+  'BLOCKQUOTE',
+  'DETAILS',
+  'DIV',
+  'DL',
+  'FIGURE',
+  'FOOTER',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'HEADER',
+  'HR',
+  'MAIN',
+  'OL',
+  'P',
+  'PRE',
+  'SECTION',
+  'TABLE',
+  'UL',
+]);
+
+interface SerializerContext {
+  codeBlocks: string[];
+}
+
+type CopyState = 'copied' | 'error' | 'idle';
+
+function currentLocale(): SiteLocale {
+  const locale = document.documentElement.dataset.locale;
+  return isSiteLocale(locale) ? locale : DEFAULT_LOCALE;
+}
+
+function canonicalUrl(): string {
+  return document.querySelector<HTMLLinkElement>('link[rel="canonical"]')?.href
+    ?? window.location.href;
+}
+
+function absoluteUrl(value: string): string {
+  try {
+    return new URL(value, canonicalUrl()).toString();
+  } catch {
+    return value;
+  }
+}
+
+function escapeText(value: string): string {
+  return value.replace(/([\\*[\]])/g, '\\$1');
+}
+
+function inlineCode(value: string): string {
+  const longestFence = Math.max(0, ...Array.from(value.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(longestFence + 1);
+  const padded = /^\s|\s$|^`|`$/u.test(value) ? ` ${value} ` : value;
+  return `${fence}${padded}${fence}`;
+}
+
+function inlineNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return escapeText(node.textContent ?? '').replace(/\s+/gu, ' ');
+  }
+
+  if (!(node instanceof HTMLElement) || node.matches(excludedSelector)) {
+    return '';
+  }
+
+  const content = inlineChildren(node);
+
+  switch (node.tagName) {
+    case 'A': {
+      const rawHref = node instanceof HTMLAnchorElement ? node.getAttribute('href') ?? '' : '';
+      const href = rawHref ? absoluteUrl(rawHref) : '';
+      return href && content ? `[${content}](<${href.replaceAll('>', '%3E')}>)` : content;
+    }
+    case 'BR':
+      return '  \n';
+    case 'CODE':
+      return inlineCode(node.textContent ?? '');
+    case 'DEL':
+    case 'S':
+      return content ? `~~${content}~~` : '';
+    case 'EM':
+    case 'I':
+      return content ? `*${content}*` : '';
+    case 'IMG': {
+      const image = node as HTMLImageElement;
+      const rawSrc = image.getAttribute('src') ?? '';
+      const src = rawSrc ? absoluteUrl(rawSrc) : '';
+      return image.alt && src ? `![${escapeText(image.alt)}](<${src.replaceAll('>', '%3E')}>)` : '';
+    }
+    case 'STRONG':
+    case 'B':
+      return content ? `**${content}**` : '';
+    default:
+      return content;
+  }
+}
+
+function inlineChildren(element: HTMLElement): string {
+  return Array.from(element.childNodes)
+    .map(inlineNode)
+    .join('')
+    .replace(/[ \t]+/gu, ' ')
+    .trim();
+}
+
+function normalizeFragment(value: string): string {
+  return value
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n')
+    .replace(/\n{3,}/gu, '\n\n')
+    .trim();
+}
+
+function codeBlock(pre: HTMLElement, context: SerializerContext): string {
+  const code = pre.querySelector('code');
+  const value = (code?.textContent ?? pre.textContent ?? '').replace(/\n$/u, '');
+  const language = code?.className.match(/(?:^|\s)language-([\w-]+)/u)?.[1] ?? '';
+  const longestFence = Math.max(0, ...Array.from(value.matchAll(/`+/g), (match) => match[0].length));
+  const fence = '`'.repeat(Math.max(3, longestFence + 1));
+  const token = `@@MEM9_CODE_BLOCK_${context.codeBlocks.length}@@`;
+  context.codeBlocks.push(`${fence}${language}\n${value}\n${fence}`);
+  return token;
+}
+
+function tableMarkdown(table: HTMLTableElement): string {
+  const rows = Array.from(table.rows).map((row) => (
+    Array.from(row.cells).map((cell) => (
+      inlineChildren(cell)
+        .replaceAll('|', '\\|')
+        .replace(/\n+/gu, '<br>')
+    ))
+  ));
+
+  if (rows.length === 0) {
+    return '';
+  }
+
+  const columnCount = Math.max(...rows.map((row) => row.length));
+  const normalizeRow = (row: string[]): string[] => (
+    Array.from({ length: columnCount }, (_, index) => row[index] ?? '')
+  );
+  const header = normalizeRow(rows[0]);
+  const body = rows.slice(1).map(normalizeRow);
+  const caption = table.caption ? inlineChildren(table.caption) : '';
+  const markdown = [
+    `| ${header.join(' | ')} |`,
+    `| ${header.map(() => '---').join(' | ')} |`,
+    ...body.map((row) => `| ${row.join(' | ')} |`),
+  ].join('\n');
+
+  return caption ? `**${caption}**\n\n${markdown}` : markdown;
+}
+
+function listMarkdown(list: HTMLOListElement | HTMLUListElement, context: SerializerContext, depth = 0): string {
+  const ordered = list instanceof HTMLOListElement;
+  const start = ordered ? list.start : 1;
+  const items = Array.from(list.children).filter((child): child is HTMLLIElement => child.tagName === 'LI');
+
+  return items.map((item, index) => {
+    const nestedLists = Array.from(item.children).filter(
+      (child): child is HTMLOListElement | HTMLUListElement => child.tagName === 'OL' || child.tagName === 'UL',
+    );
+    const contentNodes = Array.from(item.childNodes)
+      .filter((child) => !(child instanceof HTMLElement && nestedLists.includes(child as HTMLOListElement | HTMLUListElement)));
+    const hasBlockContent = contentNodes.some(
+      (child) => child instanceof HTMLElement && blockTags.has(child.tagName),
+    );
+    const content = normalizeFragment(
+      hasBlockContent
+        ? contentNodes
+          .map((child) => blockNode(child, context))
+          .filter(Boolean)
+          .join('\n\n')
+        : contentNodes.map(inlineNode).join('').replace(/[ \t]+/gu, ' '),
+    );
+    const marker = ordered ? `${start + index}. ` : '- ';
+    const indent = '  '.repeat(depth);
+    const continuation = `${indent}${' '.repeat(marker.length)}`;
+    const line = `${indent}${marker}${content.replaceAll('\n', `\n${continuation}`)}`.trimEnd();
+    const nested = nestedLists.map((child) => listMarkdown(child, context, depth + 1)).join('\n');
+    return nested ? `${line}\n${nested}` : line;
+  }).join('\n');
+}
+
+function blockChildren(element: HTMLElement, context: SerializerContext): string {
+  return Array.from(element.childNodes)
+    .map((child) => blockNode(child, context))
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function blockNode(node: Node, context: SerializerContext): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return escapeText(node.textContent ?? '').replace(/\s+/gu, ' ').trim();
+  }
+
+  if (!(node instanceof HTMLElement) || node.matches(excludedSelector)) {
+    return '';
+  }
+
+  const markdownHeading = Number(node.dataset.markdownHeading);
+  if (Number.isInteger(markdownHeading) && markdownHeading >= 1 && markdownHeading <= 6) {
+    return `${'#'.repeat(markdownHeading)} ${inlineChildren(node)}`;
+  }
+
+  switch (node.tagName) {
+    case 'H1':
+    case 'H2':
+    case 'H3':
+    case 'H4':
+    case 'H5':
+    case 'H6':
+      return `${'#'.repeat(Number(node.tagName[1]))} ${inlineChildren(node)}`;
+    case 'P':
+    case 'FIGCAPTION':
+    case 'SUMMARY':
+      return inlineChildren(node);
+    case 'PRE':
+      return codeBlock(node, context);
+    case 'UL':
+    case 'OL':
+      return listMarkdown(node as HTMLOListElement | HTMLUListElement, context);
+    case 'TABLE':
+      return tableMarkdown(node as HTMLTableElement);
+    case 'BLOCKQUOTE':
+      return normalizeFragment(blockChildren(node, context))
+        .split('\n')
+        .map((line) => `> ${line}`.trimEnd())
+        .join('\n');
+    case 'DETAILS': {
+      const summary = Array.from(node.children).find((child) => child.tagName === 'SUMMARY');
+      const content = Array.from(node.childNodes)
+        .filter((child) => child !== summary)
+        .map((child) => blockNode(child, context))
+        .filter(Boolean)
+        .join('\n\n');
+      return [`### ${summary instanceof HTMLElement ? inlineChildren(summary) : ''}`, content]
+        .filter(Boolean)
+        .join('\n\n');
+    }
+    case 'DT':
+      return `**${inlineChildren(node)}**`;
+    case 'DD':
+      return blockChildren(node, context) || inlineChildren(node);
+    case 'HR':
+      return '---';
+    case 'A':
+    case 'B':
+    case 'CODE':
+    case 'DEL':
+    case 'EM':
+    case 'I':
+    case 'IMG':
+    case 'S':
+    case 'SPAN':
+    case 'STRONG':
+      return inlineNode(node);
+    case 'DIV':
+      if (Array.from(node.children).some((child) => blockTags.has(child.tagName))) {
+        return blockChildren(node, context);
+      }
+
+      if (
+        node.children.length > 1
+        && Array.from(node.childNodes).every(
+          (child) => child.nodeType !== Node.TEXT_NODE || child.textContent?.trim() === '',
+        )
+      ) {
+        return Array.from(node.children).map(inlineNode).filter(Boolean).join(' ');
+      }
+
+      return inlineChildren(node);
+    default:
+      return blockChildren(node, context) || inlineChildren(node);
+  }
+}
+
+function activeMarkdownRoot(): HTMLElement | null {
+  return Array.from(document.querySelectorAll<HTMLElement>('[data-markdown-root]'))
+    .find((root) => root.closest('[hidden], [aria-hidden="true"]') === null) ?? null;
+}
+
+export function serializePageMarkdown(root: HTMLElement): string {
+  const clone = root.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll<HTMLElement>(excludedSelector).forEach((element) => element.remove());
+
+  const context: SerializerContext = { codeBlocks: [] };
+  let content = normalizeFragment(blockNode(clone, context));
+  context.codeBlocks.forEach((block, index) => {
+    content = content.replace(`@@MEM9_CODE_BLOCK_${index}@@`, block);
+  });
+
+  if (!/^#\s/mu.test(content)) {
+    content = `# ${escapeText(document.title)}\n\n${content}`;
+  }
+
+  const canonical = canonicalUrl();
+  const language = root.dataset.markdownLang ?? document.documentElement.lang;
+  const source = `> Source: [${canonical}](<${canonical.replaceAll('>', '%3E')}>)\n> Language: ${language}`;
+  return `${source}\n\n${content.trim()}\n`;
+}
+
+function setButtonState(button: HTMLButtonElement, state: CopyState): void {
+  const dictionary = siteCopy[currentLocale()].pageTools;
+  const label = button.querySelector<HTMLElement>('[data-page-markdown-label]');
+  const text = state === 'copied'
+    ? dictionary.copiedMarkdown
+    : state === 'error'
+      ? dictionary.copyMarkdownFailed
+      : dictionary.copyMarkdown;
+
+  if (label) {
+    label.textContent = text;
+  }
+
+  button.classList.toggle('is-copied', state === 'copied');
+  button.classList.toggle('is-error', state === 'error');
+  button.setAttribute('aria-label', text);
+  button.setAttribute('title', text);
+}
+
+export function initPageMarkdownCopy(): void {
+  const actions = document.querySelectorAll<HTMLElement>('[data-page-markdown-action]');
+  const buttons = document.querySelectorAll<HTMLButtonElement>('[data-page-markdown-copy]');
+  const hasRoot = activeMarkdownRoot() !== null;
+
+  actions.forEach((action) => {
+    action.hidden = !hasRoot;
+  });
+
+  buttons.forEach((button) => {
+    let resetTimer = 0;
+    let copying = false;
+    button.addEventListener('click', async () => {
+      const root = activeMarkdownRoot();
+      if (!root || copying) {
+        return;
+      }
+
+      window.clearTimeout(resetTimer);
+      copying = true;
+      button.setAttribute('aria-busy', 'true');
+      let copied = false;
+      try {
+        copied = await copyText(serializePageMarkdown(root));
+      } catch {
+        copied = false;
+      } finally {
+        copying = false;
+        button.removeAttribute('aria-busy');
+      }
+      setButtonState(button, copied ? 'copied' : 'error');
+      resetTimer = window.setTimeout(() => setButtonState(button, 'idle'), copied ? 2200 : 3000);
+    });
+  });
+}

--- a/site/src/scripts/site-ui.ts
+++ b/site/src/scripts/site-ui.ts
@@ -12,6 +12,7 @@ import {
   type SiteResolvedTheme,
   type SiteThemePreference,
 } from '../content/site';
+import { copyText } from './clipboard';
 
 type MenuName = 'docs' | 'login' | 'language' | 'theme' | 'mobile';
 type DocsLocale = 'en' | 'zh' | 'ja' | 'ko' | 'id' | 'th';
@@ -423,6 +424,10 @@ function updateTranslations(dictionary: SiteDictionary): void {
     element.dataset.copyText = textFor(dictionary, copyKey);
   });
 
+  document.querySelectorAll<HTMLElement>('[data-page-markdown-copy]').forEach((button) => {
+    button.classList.remove('is-copied', 'is-error');
+  });
+
   document.querySelectorAll<HTMLButtonElement>('[data-set-locale]').forEach((button) => {
     const isActive = button.dataset.setLocale === document.documentElement.dataset.locale;
     button.classList.toggle('is-active', isActive);
@@ -692,31 +697,6 @@ function applyLocale(locale: SiteLocale): void {
   const feedback = document.querySelector<HTMLElement>('[data-copy-feedback]');
   if (feedback) {
     feedback.textContent = '';
-  }
-}
-
-async function copyText(text: string): Promise<boolean> {
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    const textarea = document.createElement('textarea');
-    textarea.value = text;
-    textarea.setAttribute('readonly', '');
-    textarea.style.position = 'absolute';
-    textarea.style.left = '-9999px';
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    let copied = false;
-    try {
-      copied = document.execCommand('copy');
-    } catch {
-      copied = false;
-    }
-
-    document.body.removeChild(textarea);
-    return copied;
   }
 }
 

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -225,14 +225,15 @@ section {
 .api-page .api-product-tabs {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.25rem;
+  gap: 0;
   width: 100%;
-  margin: 0 0 0.9rem;
-  padding: 0.25rem;
-  border: 1px solid var(--border);
-  border-radius: 0.78rem;
-  background: color-mix(in srgb, var(--button-bg) 82%, transparent);
-  box-shadow: var(--surface-inset);
+  margin: 0 0 1rem;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .api-page .api-product-tab {
@@ -244,9 +245,10 @@ section {
   min-width: 0;
   min-height: 2.25rem;
   margin: 0;
-  padding: 0.48rem 0.45rem;
-  border: 1px solid transparent;
-  border-radius: 0.58rem;
+  padding: 0.48rem 0.35rem;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
   background: transparent;
   box-shadow: none;
   color: var(--text-muted);
@@ -262,14 +264,14 @@ section {
 
 .api-page .api-product-tab:hover {
   color: var(--text);
-  background: color-mix(in srgb, var(--button-active-bg) 58%, transparent);
+  background: transparent;
 }
 
 .api-page .api-product-tab[aria-selected='true'] {
-  border-color: var(--border-strong);
-  background: var(--button-active-bg);
+  border-bottom-color: var(--text);
+  background: transparent;
   color: var(--text);
-  box-shadow: var(--surface-shadow-soft);
+  box-shadow: none;
 }
 
 .api-page .api-product-tab:focus-visible {


### PR DESCRIPTION
## What Changed
- Unifies `/docs`, `/console-docs`, and `/api` with a flat, modern documentation layout.
- Adds `/llms.txt` for agent discovery.
- Adds a visible **Copy as Markdown** action to every public page.

## Review Path
1. Compare the three Docs-menu destinations on desktop and mobile.
2. Use **Copy as Markdown** from a page hero and inspect the clipboard output.
3. Open `/llms.txt` and verify the documentation links.

## Validation
- `npm run build`
- `npm exec tsc -- --noEmit`
- Chrome desktop/mobile checks for `/docs`, `/console-docs`, and `/api`
- Clipboard verification for canonical URL, locale, headings, code, lists, and tables

## Screenshot

| Page | Before | After |
| --- | --- | --- |
| **Docs** | <img width="800" alt="Docs before" src="https://github.com/user-attachments/assets/885c18e7-a640-4920-be87-b7445df02d38" /> | <img width="800" alt="Docs after" src="https://github.com/user-attachments/assets/dbd21529-6b3d-46e5-9484-a4a700f645db" /> |
| **Console Docs** | <img width="800" alt="Console Docs before" src="https://github.com/user-attachments/assets/4292aa76-96f8-4546-b1bb-90616c351c26" /> | <img width="800" alt="Console Docs after" src="https://github.com/user-attachments/assets/c010d646-d698-416d-80df-51b5f1728b9b" /> |
| **API Reference** | <img width="800" alt="API Reference before" src="https://github.com/user-attachments/assets/ffb6cd40-ea0a-48f8-8f12-0889afab771b" /> | <img width="800" alt="API Reference after" src="https://github.com/user-attachments/assets/fa70b3df-3914-4840-9ebf-616143448610" /> |