### PR TITLE
Fix Markdown copy action placement

### DIFF
--- a/site/src/components/ApiReference.astro
+++ b/site/src/components/ApiReference.astro
@@ -482,22 +482,10 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   }
 
   .api-hero {
-    position: relative;
     width: min(100%, 72rem);
     display: grid;
     gap: 0.8rem;
     padding: 0 0 2.8rem;
-  }
-
-  .api-hero > :global(.page-markdown-action) {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: auto;
-  }
-
-  .api-hero > .section-kicker {
-    padding-right: 12rem;
   }
 
   .api-title {
@@ -1725,15 +1713,6 @@ const defaultApiLabels = siteCopy[DEFAULT_LOCALE].apiPage.labels;
   @media (max-width: 720px) {
     .api-page {
       padding-top: 1.3rem;
-    }
-
-    .api-hero > :global(.page-markdown-action) {
-      position: static;
-      width: 100%;
-    }
-
-    .api-hero > .section-kicker {
-      padding-right: 0;
     }
 
     .api-code code {

--- a/site/src/components/DocsArticlePage.astro
+++ b/site/src/components/DocsArticlePage.astro
@@ -640,21 +640,12 @@ function docsSectionSearchText(section: DocsSection): string {
   }
 
   .docs-hero {
-    position: relative;
     padding: 0.2rem 0 2.8rem;
     max-width: 52rem;
   }
 
-  .docs-hero > :global(.page-markdown-action) {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: auto;
-  }
-
   .docs-hero-eyebrow {
     margin: 0 0 0.8rem;
-    padding-right: 12rem;
     color: var(--accent);
     font-family: var(--font-mono);
     font-size: 0.72rem;
@@ -988,15 +979,6 @@ function docsSectionSearchText(section: DocsSection): string {
 
     .docs-page .docs-hero {
       padding: 0.25rem 0 2.2rem;
-    }
-
-    .docs-page .docs-hero > :global(.page-markdown-action) {
-      position: static;
-      width: 100%;
-    }
-
-    .docs-page .docs-hero-eyebrow {
-      padding-right: 0;
     }
 
     .docs-page .docs-hero-title {


### PR DESCRIPTION
## What Changed
- Restores **Copy as Markdown** below the page introduction on Docs, Console Docs, and API Reference.
- Removes the Hero positioning rules that overrode the shared left-aligned action.

## Why
- The desktop Hero overrides from #398 pulled the action to the top-right after its shared component moved into normal content flow.

## Review Path
1. Review the Docs Hero cleanup in `site/src/components/DocsArticlePage.astro`.
2. Review the matching API Hero cleanup in `site/src/components/ApiReference.astro`.
3. Confirm `PageMarkdownAction.astro` remains the single source for alignment and spacing.

## Validation
- `npm run build`
- `npm exec tsc -- --noEmit`
- Static assertion confirms no Hero absolute positioning remains
- Chrome checks on `/docs`, `/console-docs`, and `/api`
- Chrome check at 390px mobile width