### PR TITLE
feat(memory): persist Agent9 message provenance

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -72,12 +72,20 @@ A memory is a piece of knowledge with optional structure:
   key: "tikv/compaction-tuning",      // optional, for upsert lookup
   tags: ["tikv", "performance"],       // optional, for filtering
   source: "sj-claude-code",           // who wrote it
-  metadata: { severity: "high" },      // optional, arbitrary structured data
+  metadata: { severity: "high" },      // optional JSON; server mode reserves external_provenance
   embedding: [0.012, -0.034, ...],     // auto-generated if embedding provider configured
   version: 3,                          // auto-managed, for conflict detection
   score: 0.87                          // only in hybrid search responses, omitted otherwise
 }
 ```
+
+Metadata remains application-defined JSON in general. In Server Mode, the
+`external_provenance` object member is reserved for creation provenance. The
+server currently accepts only the exact `agent9/message-source@1` envelope on a
+message-ingest request with one fact-eligible user message, persists the
+sanitized envelope on each new fact revision, and prevents generic memory
+updates from replacing or removing it. Requests and existing memories without
+that reserved member retain the legacy metadata behavior.
 
 ### Space (Server Mode only)
 
@@ -453,7 +461,7 @@ CREATE TABLE IF NOT EXISTS space_tokens (
 |--------|------------|-------------|
 | `space_id` | Fixed value (derived from DB name) | Server-managed, maps to space |
 | `embedding` | Plugin generates (if configured) | Server generates (if configured) |
-| `metadata` | Full JSON support | Full JSON support |
+| `metadata` | Full JSON support | Full JSON support, with reserved creation-only `external_provenance` |
 | `version` | Auto-incremented on write | Atomic `version = version + 1` in SQL |
 
 The `memories` table is **identical** across modes. This makes Direct → Server migration

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2246,7 +2246,7 @@
       },
       "CreateImport": {
         "required": true,
-        "description": "Multipart upload for async file ingest. File size is limited to 50 MiB.",
+        "description": "Multipart upload for async file ingest. File size is limited to 50 MiB. The upload may return 202 before background processing; for file_type=memory, any memories[].metadata.external_provenance member is reserved and causes the import task to fail without writing that file.",
         "content": {
           "multipart/form-data": {
             "schema": {
@@ -3128,7 +3128,7 @@
             "description": "Optional session ID associated with session imports."
           }
         },
-        "description": "Multipart upload for async file ingest. File size is limited to 50 MiB. For JSON memory/session import files, include top-level appId or per-memory appId fields to assign imported rows to an application isolation id."
+        "description": "Multipart upload for async file ingest. File size is limited to 50 MiB. For JSON memory/session import files, include top-level appId or per-memory appId fields to assign imported rows to an application isolation id. The HTTP upload may return 202 before background validation; a memory import containing memories[].metadata.external_provenance fails as a task because the reserved envelope is accepted only through validated message ingest."
       },
       "MemoryListResponse": {
         "type": "object",
@@ -3420,7 +3420,7 @@
         }
       },
       "Metadata": {
-        "description": "Raw JSON metadata. The server accepts any valid JSON value. Generic update metadata cannot create, replace, or remove the creation-only external_provenance field; metadata updates to a provenance-bearing memory must therefore be objects.",
+        "description": "Raw JSON metadata. The server accepts any valid JSON value. Generic update metadata cannot create, replace, or remove the creation-only external_provenance field; metadata updates to a provenance-bearing memory must therefore be objects. New fact responses may contain the exact agent9/message-source@1 envelope, while historical values are returned as stored and consumers must treat unrecognized provenance shapes as opaque.",
         "nullable": true,
         "oneOf": [
           {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2988,7 +2988,7 @@
       },
       "CreateMemoryRequest": {
         "type": "object",
-        "description": "Provide either content or messages, not both. memory_type is only accepted for content requests. mode is only accepted for messages requests.",
+        "description": "Provide either content or messages, not both. memory_type is only accepted for content requests. mode is only accepted for messages requests. The reserved metadata.external_provenance envelope is optional, creation-only, and accepted only for a messages request containing exactly one fact-eligible user message; invalid reserved envelopes are rejected before asynchronous acceptance.",
         "properties": {
           "content": {
             "type": "string",
@@ -3014,7 +3014,7 @@
             }
           },
           "metadata": {
-            "$ref": "#/components/schemas/Metadata"
+            "$ref": "#/components/schemas/CreateMemoryMetadata"
           },
           "messages": {
             "type": "array",
@@ -3420,7 +3420,7 @@
         }
       },
       "Metadata": {
-        "description": "Raw JSON metadata. The server accepts any valid JSON value.",
+        "description": "Raw JSON metadata. The server accepts any valid JSON value. Generic update metadata cannot create, replace, or remove the creation-only external_provenance field; metadata updates to a provenance-bearing memory must therefore be objects.",
         "nullable": true,
         "oneOf": [
           {
@@ -3441,6 +3441,56 @@
             "type": "boolean"
           }
         ]
+      },
+      "CreateMemoryMetadata": {
+        "description": "Raw JSON metadata for memory creation. Object metadata may carry the optional reserved external_provenance envelope; all other object members remain application-defined.",
+        "nullable": true,
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "external_provenance": {
+                "$ref": "#/components/schemas/ExternalProvenance"
+              }
+            },
+            "additionalProperties": true
+          },
+          {
+            "type": "array",
+            "items": {}
+          },
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "ExternalProvenance": {
+        "type": "object",
+        "description": "Reserved creation provenance. This exact envelope is accepted only on message ingest with exactly one fact-eligible user message and is copied to every newly created memory revision.",
+        "required": [
+          "schema",
+          "source_message_id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "schema": {
+            "type": "string",
+            "enum": [
+              "agent9/message-source@1"
+            ]
+          },
+          "source_message_id": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64
+          }
+        }
       },
       "MemoryType": {
         "type": "string",

--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -137,7 +137,7 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 					return
 				}
 			}
-			result, err := targetSvc.ingest.ReconcilePhase2(ctx, nodeAuth.AgentName, req.AgentID, req.AppID, req.SessionID, factsForTarget)
+			result, err := targetSvc.ingest.ReconcilePhase2(ctx, nodeAuth.AgentName, req.AgentID, req.AppID, req.SessionID, factsForTarget, req.ExternalProvenance)
 			if err != nil {
 				if s.runtimeUsageEnabled() && lease != nil {
 					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -91,6 +91,11 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		s.handleError(r.Context(), w, &domain.ValidationError{Field: "memory_type", Message: "memory_type is only allowed with content, not messages"})
 		return
 	}
+	genericMetadata, externalProvenance, err := service.ParseExternalProvenance(req.Metadata, req.Messages)
+	if err != nil {
+		s.handleError(r.Context(), w, err)
+		return
+	}
 
 	if hasMessages {
 		messages := append([]service.IngestMessage(nil), req.Messages...)
@@ -101,7 +106,8 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			AppID:              appID,
 			Mode:               req.Mode,
 			DisableSessionSave: s.disableSessionSave || req.DisableSessionSave,
-			Metadata:           append(json.RawMessage(nil), req.Metadata...),
+			Metadata:           genericMetadata,
+			ExternalProvenance: externalProvenance,
 		}
 
 		if req.Sync {
@@ -244,7 +250,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tags := append([]string(nil), req.Tags...)
-	metadata := append(json.RawMessage(nil), req.Metadata...)
+	metadata := append(json.RawMessage(nil), genericMetadata...)
 	content := req.Content
 	explicitMemoryType := strings.TrimSpace(req.MemoryType)
 
@@ -605,7 +611,7 @@ func (s *Server) ingestMessages(ctx context.Context, auth *domain.AuthInfo, svc 
 			reconcileDuration = time.Since(reconcileStart)
 		}()
 		reconcileResult, reconcileErr = svc.ingest.ReconcilePhase2(
-			ctx, auth.AgentName, req.AgentID, req.AppID, req.SessionID, phase1.Facts)
+			ctx, auth.AgentName, req.AgentID, req.AppID, req.SessionID, phase1.Facts, req.ExternalProvenance)
 	}()
 
 	wg.Wait()
@@ -662,7 +668,7 @@ func (s *Server) createSmartContentWithRouting(ctx context.Context, chainAuth *d
 	if len(facts) == 0 {
 		return &service.IngestResult{Status: "complete"}, nil
 	}
-	result, err := svc.ingest.ReconcilePhase2(ctx, agentName, agentID, appID, sessionID, facts)
+	result, err := svc.ingest.ReconcilePhase2(ctx, agentName, agentID, appID, sessionID, facts, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1558,6 +1559,57 @@ func TestGetMemory_FallsBackToSessionRow(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), `"memory_type":"session"`) {
 		t.Fatalf("body = %s, want session memory type", rr.Body.String())
+	}
+}
+
+func TestGetMemory_ReturnsExternalProvenanceMetadataAsStored(t *testing.T) {
+	tests := []struct {
+		name     string
+		metadata json.RawMessage
+	}{
+		{
+			name:     "validated envelope",
+			metadata: json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_valid"},"generic":"kept"}`),
+		},
+		{
+			name:     "historical malformed envelope",
+			metadata: json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@2","source_message_id":331,"extra":"untrusted"},"generic":"kept"}`),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			memRepo := &testMemoryRepo{createCalls: []*domain.Memory{{
+				ID:         "mem-provenance",
+				Content:    "stored fact",
+				MemoryType: domain.TypeInsight,
+				Metadata:   tt.metadata,
+				State:      domain.StateActive,
+				Version:    1,
+			}}}
+			srv := newTestServer(memRepo, &testSessionRepo{})
+			req := withURLParam(makeRequest(t, http.MethodGet, "/memories/mem-provenance", nil), "id", "mem-provenance")
+			rr := httptest.NewRecorder()
+
+			srv.getMemory(rr, req)
+
+			if rr.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+			}
+			var response domain.Memory
+			if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			var got, want any
+			if err := json.Unmarshal(response.Metadata, &got); err != nil {
+				t.Fatalf("decode returned metadata: %v", err)
+			}
+			if err := json.Unmarshal(tt.metadata, &want); err != nil {
+				t.Fatalf("decode expected metadata: %v", err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("metadata = %#v, want stored %#v", got, want)
+			}
+		})
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -38,6 +38,7 @@ type testMemoryRepo struct {
 	bulkCreateCalls      int
 	bulkCreateHook       func(context.Context)
 	updateCalls          []*domain.Memory
+	vectorSearchResults  []domain.Memory
 	keywordSearchResults []domain.Memory
 	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordQuery     string
@@ -139,11 +140,11 @@ func (m *testMemoryRepo) BulkCreate(ctx context.Context, _ []*domain.Memory) err
 	return nil
 }
 func (m *testMemoryRepo) VectorSearch(context.Context, []float32, domain.MemoryFilter, int) ([]domain.Memory, error) {
-	return nil, nil
+	return append([]domain.Memory(nil), m.vectorSearchResults...), nil
 }
 
 func (m *testMemoryRepo) AutoVectorSearch(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
-	return nil, nil
+	return append([]domain.Memory(nil), m.vectorSearchResults...), nil
 }
 
 func (m *testMemoryRepo) KeywordSearch(ctx context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
@@ -848,8 +849,9 @@ func TestReconcileRoutedChainFactsRuntimeUsageUsesTargetSubjects(t *testing.T) {
 	}
 
 	result := srv.reconcileRoutedChainFacts(context.Background(), auth, service.IngestRequest{
-		AgentID:   "actor-agent",
-		SessionID: "session-a",
+		AgentID:            "actor-agent",
+		SessionID:          "session-a",
+		ExternalProvenance: &service.ExternalProvenance{Schema: service.ExternalProvenanceSchema, SourceMessageID: "message_routed"},
 	}, []service.ExtractedFact{
 		{Text: "mem9 uses PingCAP TiDB for this test", Tags: []string{"tech"}, RouteTargets: []string{"space-target-a", "space-target-b"}},
 	})
@@ -859,6 +861,14 @@ func TestReconcileRoutedChainFactsRuntimeUsageUsesTargetSubjects(t *testing.T) {
 	}
 	if len(targetARepo.createCalls) != 1 || len(targetBRepo.createCalls) != 1 {
 		t.Fatalf("target writes = %d/%d, want 1/1", len(targetARepo.createCalls), len(targetBRepo.createCalls))
+	}
+	for _, created := range []*domain.Memory{targetARepo.createCalls[0], targetBRepo.createCalls[0]} {
+		var metadata struct {
+			ExternalProvenance *service.ExternalProvenance `json:"external_provenance"`
+		}
+		if err := json.Unmarshal(created.Metadata, &metadata); err != nil || metadata.ExternalProvenance == nil || metadata.ExternalProvenance.SourceMessageID != "message_routed" {
+			t.Fatalf("routed metadata = %s, error = %v", created.Metadata, err)
+		}
 	}
 	if runtimeUsage.beforeCreateCalls != 2 || runtimeUsage.afterCreateSuccessCalls != 2 {
 		t.Fatalf("runtime create calls = before:%d success:%d, want 2/2", runtimeUsage.beforeCreateCalls, runtimeUsage.afterCreateSuccessCalls)
@@ -883,6 +893,85 @@ func TestReconcileRoutedChainFactsRuntimeUsageUsesTargetSubjects(t *testing.T) {
 	for _, createResult := range runtimeUsage.createResults {
 		if createResult.AgentName != "chain-agent" || createResult.ObjectsAffected != 1 || len(createResult.MemoryIDs) != 1 {
 			t.Fatalf("create result = %+v, want chain-agent/1 object/1 memory", createResult)
+		}
+	}
+}
+
+func TestReconcileRoutedChainFactsUpdateUsesCurrentExternalProvenance(t *testing.T) {
+	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{{"message": map[string]string{
+				"content": `{"memory":[{"id":"0","text":"Works at company Y","event":"UPDATE","old_memory":"Works at startup X"}]}`,
+			}}},
+		})
+	}))
+	defer mockLLM.Close()
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
+	oldMetadata := json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_old"}}`)
+	predecessor := domain.Memory{
+		ID:         "memory_old",
+		Content:    "Works at startup X",
+		MemoryType: domain.TypeInsight,
+		State:      domain.StateActive,
+		Metadata:   oldMetadata,
+	}
+	targetRepo := &testMemoryRepo{
+		createCalls:         []*domain.Memory{&predecessor},
+		vectorSearchResults: []domain.Memory{predecessor},
+	}
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	srv.svcCache.Store(tenantSvcKey("tenant-target-a-0x0"), resolvedSvc{
+		memory:  service.NewMemoryService(targetRepo, nil, nil, "", service.ModeSmart),
+		ingest:  service.NewIngestService(targetRepo, llmClient, nil, "auto-model", service.ModeSmart),
+		session: service.NewSessionService(&testSessionRepo{}, nil, ""),
+	})
+	auth := &domain.AuthInfo{
+		AgentName: "chain-agent",
+		Chain: &domain.ChainAuth{
+			ChainID: "chain-a",
+			Nodes: []domain.ChainAuthNode{
+				{
+					SpaceChainNode: domain.SpaceChainNode{TenantID: "tenant-source", ExternalSpaceID: "space-source", Position: 0},
+				},
+				{
+					SpaceChainNode: domain.SpaceChainNode{
+						TenantID:             "tenant-target-a",
+						ExternalSpaceID:      "space-target-a",
+						Position:             1,
+						RoutingPolicyEnabled: true,
+						RoutingPolicyPrompt:  "employment facts",
+					},
+				},
+			},
+		},
+	}
+
+	result := srv.reconcileRoutedChainFacts(context.Background(), auth, service.IngestRequest{
+		AgentID:            "actor-agent",
+		SessionID:          "session-a",
+		ExternalProvenance: &service.ExternalProvenance{Schema: service.ExternalProvenanceSchema, SourceMessageID: "message_current"},
+	}, []service.ExtractedFact{{
+		Text:         "Works at company Y",
+		RouteTargets: []string{"space-target-a"},
+	}})
+
+	if result.memoriesChanged != 1 || len(targetRepo.createCalls) != 2 {
+		t.Fatalf("result = %+v, create calls = %d, want one routed update", result, len(targetRepo.createCalls))
+	}
+	for _, check := range []struct {
+		name     string
+		metadata json.RawMessage
+		want     string
+	}{
+		{name: "successor", metadata: targetRepo.createCalls[1].Metadata, want: "message_current"},
+		{name: "predecessor", metadata: predecessor.Metadata, want: "message_old"},
+	} {
+		var decoded struct {
+			ExternalProvenance *service.ExternalProvenance `json:"external_provenance"`
+		}
+		if err := json.Unmarshal(check.metadata, &decoded); err != nil || decoded.ExternalProvenance == nil || decoded.ExternalProvenance.SourceMessageID != check.want {
+			t.Fatalf("%s metadata = %s, error = %v, want source %s", check.name, check.metadata, err, check.want)
 		}
 	}
 }
@@ -1812,9 +1901,13 @@ func TestCreateMemory_SyncMessagesWithMetadataPreservesMetadata(t *testing.T) {
 		"messages": []map[string]string{
 			{"role": "user", "content": "This is a test with metadata"},
 		},
-		"metadata": map[string]string{
+		"metadata": map[string]any{
 			"source": "unit-test",
 			"key":    "val",
+			"external_provenance": map[string]string{
+				"schema":            "agent9/message-source@1",
+				"source_message_id": "message_handler_source",
+			},
 		},
 	}
 	req := makeRequest(t, http.MethodPost, "/memories", body)
@@ -1856,6 +1949,13 @@ func TestCreateMemory_SyncMessagesWithMetadataPreservesMetadata(t *testing.T) {
 	}
 	if keyVal != "val" {
 		t.Fatalf("updated metadata.key = %q, want val", keyVal)
+	}
+	var externalProvenance service.ExternalProvenance
+	if err := json.Unmarshal(updatedMeta["external_provenance"], &externalProvenance); err != nil {
+		t.Fatalf("updated external_provenance unmarshal error: %v", err)
+	}
+	if externalProvenance.Schema != service.ExternalProvenanceSchema || externalProvenance.SourceMessageID != "message_handler_source" {
+		t.Fatalf("updated external_provenance = %+v", externalProvenance)
 	}
 
 	// Verify mergeMetadata preserves existing keys.
@@ -2802,6 +2902,58 @@ func TestCreateMemory_AsyncMessages_Returns202(t *testing.T) {
 	}
 }
 
+func TestCreateMemory_AsyncMessagesValidatesExternalProvenanceBeforeAcceptance(t *testing.T) {
+	validEnvelope := func(sourceMessageID string) map[string]any {
+		return map[string]any{
+			"external_provenance": map[string]any{
+				"schema":            "agent9/message-source@1",
+				"source_message_id": sourceMessageID,
+			},
+		}
+	}
+	defaultMessages := []map[string]string{
+		{"role": "user", "content": "hello"},
+		{"role": "assistant", "content": "hi"},
+	}
+	tests := []struct {
+		name       string
+		messages   []map[string]string
+		content    string
+		metadata   any
+		wantStatus int
+	}{
+		{name: "legacy metadata", messages: defaultMessages, metadata: map[string]any{"source": "legacy"}, wantStatus: http.StatusAccepted},
+		{name: "exact envelope", messages: defaultMessages, metadata: validEnvelope(strings.Repeat("🙂", 64)), wantStatus: http.StatusAccepted},
+		{name: "opaque id is not normalized", messages: defaultMessages, metadata: validEnvelope(" Message-ID "), wantStatus: http.StatusAccepted},
+		{name: "unknown schema", messages: defaultMessages, metadata: map[string]any{"external_provenance": map[string]any{"schema": "agent9/message-source@2", "source_message_id": "message_user"}}, wantStatus: http.StatusBadRequest},
+		{name: "missing member", messages: defaultMessages, metadata: map[string]any{"external_provenance": map[string]any{"schema": "agent9/message-source@1"}}, wantStatus: http.StatusBadRequest},
+		{name: "unexpected member", messages: defaultMessages, metadata: map[string]any{"external_provenance": map[string]any{"schema": "agent9/message-source@1", "source_message_id": "message_user", "session_id": "untrusted"}}, wantStatus: http.StatusBadRequest},
+		{name: "empty id", messages: defaultMessages, metadata: validEnvelope(""), wantStatus: http.StatusBadRequest},
+		{name: "over-limit id", messages: defaultMessages, metadata: validEnvelope(strings.Repeat("x", 65)), wantStatus: http.StatusBadRequest},
+		{name: "multiple user messages", messages: []map[string]string{{"role": "user", "content": "one"}, {"role": "assistant", "content": "context"}, {"role": "user", "content": "two"}}, metadata: validEnvelope("message_user"), wantStatus: http.StatusBadRequest},
+		{name: "content request", content: "hello", metadata: validEnvelope("message_user"), wantStatus: http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+			req := makeRequest(t, http.MethodPost, "/memories", map[string]any{
+				"messages":   tt.messages,
+				"content":    tt.content,
+				"session_id": "test-session",
+				"metadata":   tt.metadata,
+			})
+			rr := httptest.NewRecorder()
+
+			srv.createMemory(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d: %s", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+		})
+	}
+}
+
 func TestCreateMemory_AsyncMessages_DisableSessionSaveSkipsRawSession(t *testing.T) {
 	llmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -3391,6 +3543,101 @@ func TestUpdateMemory_RuntimeUsageRecordsUpdate(t *testing.T) {
 	}
 	if runtimeUsage.updateResults[0].ObjectsAffected != 1 {
 		t.Fatalf("objects affected = %d, want 1", runtimeUsage.updateResults[0].ObjectsAffected)
+	}
+}
+
+func TestUpdateMemory_GenericMetadataCannotOverwriteExternalProvenance(t *testing.T) {
+	originalMetadata, err := json.Marshal(map[string]any{
+		"external_provenance": map[string]any{
+			"schema":            service.ExternalProvenanceSchema,
+			"source_message_id": "message_original",
+		},
+		"old": "value",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	memRepo := &testMemoryRepo{createCalls: []*domain.Memory{{
+		ID:       "mem-1",
+		Content:  "old",
+		Version:  1,
+		Metadata: originalMetadata,
+	}}}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+
+	body := map[string]any{
+		"metadata": map[string]any{
+			"external_provenance": map[string]any{
+				"schema":            service.ExternalProvenanceSchema,
+				"source_message_id": "message_attacker",
+			},
+			"generic": "updated",
+		},
+	}
+	req := withURLParam(makeTenantRequest(t, http.MethodPatch, "/memories/mem-1", body), "id", "mem-1")
+	rr := httptest.NewRecorder()
+
+	srv.updateMemory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if len(memRepo.updateCalls) != 1 {
+		t.Fatalf("update calls = %d, want 1", len(memRepo.updateCalls))
+	}
+	var metadata map[string]json.RawMessage
+	if err := json.Unmarshal(memRepo.updateCalls[0].Metadata, &metadata); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	var provenance service.ExternalProvenance
+	if err := json.Unmarshal(metadata["external_provenance"], &provenance); err != nil {
+		t.Fatalf("unmarshal external_provenance: %v", err)
+	}
+	if provenance.SourceMessageID != "message_original" {
+		t.Fatalf("source_message_id = %q, want message_original", provenance.SourceMessageID)
+	}
+	var generic string
+	if err := json.Unmarshal(metadata["generic"], &generic); err != nil || generic != "updated" {
+		t.Fatalf("generic metadata = %q (%v), want updated", generic, err)
+	}
+}
+
+func TestUpdateMemory_ProvenanceBearingMetadataRejectsNonObjectReplacement(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		metadata any
+	}{
+		{name: "null", metadata: nil},
+		{name: "string", metadata: "replacement"},
+		{name: "array", metadata: []any{"replacement"}},
+		{name: "number", metadata: 42},
+		{name: "boolean", metadata: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			originalMetadata := json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_original"},"old":"value"}`)
+			memRepo := &testMemoryRepo{createCalls: []*domain.Memory{{
+				ID:       "mem-1",
+				Content:  "old",
+				Version:  1,
+				Metadata: originalMetadata,
+			}}}
+			srv := newTestServer(memRepo, &testSessionRepo{})
+			req := withURLParam(
+				makeTenantRequest(t, http.MethodPatch, "/memories/mem-1", map[string]any{"metadata": tt.metadata}),
+				"id",
+				"mem-1",
+			)
+			rr := httptest.NewRecorder()
+
+			srv.updateMemory(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+			}
+			if len(memRepo.updateCalls) != 0 {
+				t.Fatalf("update calls = %d, want 0", len(memRepo.updateCalls))
+			}
+		})
 	}
 }
 

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -219,6 +219,55 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	}
 }
 
+func TestOpenAPIExternalProvenanceContract(t *testing.T) {
+	openapi := loadOpenAPI(t)
+	components := objectValue(t, openapi, "components")
+	schemas := objectValue(t, components, "schemas")
+
+	create := objectValue(t, schemas, "CreateMemoryRequest")
+	createProperties := objectValue(t, create, "properties")
+	metadata := objectValue(t, createProperties, "metadata")
+	if got, want := metadata["$ref"], "#/components/schemas/CreateMemoryMetadata"; got != want {
+		t.Fatalf("CreateMemoryRequest.metadata ref = %#v, want %s", got, want)
+	}
+
+	createMetadata := objectValue(t, schemas, "CreateMemoryMetadata")
+	objectAlternatives := objectSlice(t, createMetadata["oneOf"])
+	if len(objectAlternatives) == 0 {
+		t.Fatal("CreateMemoryMetadata.oneOf should contain an object alternative")
+	}
+	metadataObject := objectAlternatives[0]
+	metadataProperties := objectValue(t, metadataObject, "properties")
+	reserved := objectValue(t, metadataProperties, "external_provenance")
+	if got, want := reserved["$ref"], "#/components/schemas/ExternalProvenance"; got != want {
+		t.Fatalf("external_provenance ref = %#v, want %s", got, want)
+	}
+
+	provenance := objectValue(t, schemas, "ExternalProvenance")
+	if got, ok := provenance["additionalProperties"].(bool); !ok || got {
+		t.Fatalf("ExternalProvenance.additionalProperties = %#v, want false", provenance["additionalProperties"])
+	}
+	for _, field := range []string{"schema", "source_message_id"} {
+		if !containsString(stringSlice(t, provenance["required"]), field) {
+			t.Fatalf("ExternalProvenance.required missing %q", field)
+		}
+	}
+	provenanceProperties := objectValue(t, provenance, "properties")
+	schema := objectValue(t, provenanceProperties, "schema")
+	if got, want := stringSlice(t, schema["enum"]), []string{"agent9/message-source@1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("ExternalProvenance.schema enum = %#v, want %#v", got, want)
+	}
+	sourceMessageID := objectValue(t, provenanceProperties, "source_message_id")
+	if sourceMessageID["minLength"] != float64(1) || sourceMessageID["maxLength"] != float64(64) {
+		t.Fatalf("source_message_id bounds = %#v/%#v, want 1/64", sourceMessageID["minLength"], sourceMessageID["maxLength"])
+	}
+	updateMetadata := objectValue(t, schemas, "Metadata")
+	description, _ := updateMetadata["description"].(string)
+	if !strings.Contains(description, "metadata updates to a provenance-bearing memory must therefore be objects") {
+		t.Fatalf("Metadata.description does not document the conditional object requirement: %q", description)
+	}
+}
+
 func TestOpenAPIRuntimeStateContract(t *testing.T) {
 	openapi := loadOpenAPI(t)
 	responses := operationResponses(t, openapi, "/v1alpha2/mem9s/runtime-state", "get")

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -261,10 +261,36 @@ func TestOpenAPIExternalProvenanceContract(t *testing.T) {
 	if sourceMessageID["minLength"] != float64(1) || sourceMessageID["maxLength"] != float64(64) {
 		t.Fatalf("source_message_id bounds = %#v/%#v, want 1/64", sourceMessageID["minLength"], sourceMessageID["maxLength"])
 	}
-	updateMetadata := objectValue(t, schemas, "Metadata")
-	description, _ := updateMetadata["description"].(string)
+	memory := objectValue(t, schemas, "Memory")
+	memoryProperties := objectValue(t, memory, "properties")
+	returnedMetadata := objectValue(t, memoryProperties, "metadata")
+	if got, want := returnedMetadata["$ref"], "#/components/schemas/Metadata"; got != want {
+		t.Fatalf("Memory.metadata ref = %#v, want permissive %s", got, want)
+	}
+	genericMetadata := objectValue(t, schemas, "Metadata")
+	genericAlternatives := objectSlice(t, genericMetadata["oneOf"])
+	if len(genericAlternatives) == 0 || genericAlternatives[0]["additionalProperties"] != true {
+		t.Fatalf("Metadata object response must remain permissive: %#v", genericAlternatives)
+	}
+	description, _ := genericMetadata["description"].(string)
 	if !strings.Contains(description, "metadata updates to a provenance-bearing memory must therefore be objects") {
 		t.Fatalf("Metadata.description does not document the conditional object requirement: %q", description)
+	}
+	if !strings.Contains(description, "historical values are returned as stored") || !strings.Contains(description, "unrecognized provenance shapes as opaque") {
+		t.Fatalf("Metadata.description does not document permissive historical responses: %q", description)
+	}
+	requestBodies := objectValue(t, components, "requestBodies")
+	createImport := objectValue(t, requestBodies, "CreateImport")
+	importDescription, _ := createImport["description"].(string)
+	createImportRequest := objectValue(t, schemas, "CreateImportRequest")
+	importSchemaDescription, _ := createImportRequest["description"].(string)
+	for location, text := range map[string]string{
+		"CreateImport":        importDescription,
+		"CreateImportRequest": importSchemaDescription,
+	} {
+		if !strings.Contains(text, "external_provenance") || !strings.Contains(text, "202") || !strings.Contains(text, "task") {
+			t.Fatalf("%s does not document asynchronous reserved-key rejection: %q", location, text)
+		}
 	}
 }
 

--- a/server/internal/service/external_provenance.go
+++ b/server/internal/service/external_provenance.go
@@ -1,0 +1,151 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+const (
+	ExternalProvenanceSchema   = "agent9/message-source@1"
+	MaxExternalSourceMessageID = 64
+	externalProvenanceKey      = "external_provenance"
+)
+
+// ExternalProvenance is the validated reserved metadata carried into fact creation.
+type ExternalProvenance struct {
+	Schema          string `json:"schema"`
+	SourceMessageID string `json:"source_message_id"`
+}
+
+// SetExternalProvenanceMetadata replaces stale reserved provenance on a newly created fact revision.
+func SetExternalProvenanceMetadata(existing json.RawMessage, provenance *ExternalProvenance) json.RawMessage {
+	var payload map[string]json.RawMessage
+	hadExternalProvenance := false
+	if len(existing) > 0 {
+		if err := json.Unmarshal(existing, &payload); err != nil || payload == nil {
+			if provenance == nil {
+				return append(json.RawMessage(nil), existing...)
+			}
+			payload = map[string]json.RawMessage{}
+		}
+	}
+	if payload == nil {
+		payload = map[string]json.RawMessage{}
+	}
+	_, hadExternalProvenance = payload[externalProvenanceKey]
+	delete(payload, "external_provenance")
+	if provenance != nil {
+		raw, err := json.Marshal(provenance)
+		if err == nil {
+			payload["external_provenance"] = raw
+		}
+	}
+	if len(payload) == 0 {
+		if provenance == nil && !hadExternalProvenance && len(existing) > 0 {
+			return append(json.RawMessage(nil), existing...)
+		}
+		return nil
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return existing
+	}
+	return raw
+}
+
+// preserveExternalProvenanceMetadata keeps the reserved creation provenance immutable under the
+// generic memory update API. Generic object metadata may still be replaced as before, but its
+// external_provenance member is ignored: an existing member is copied exactly and a new member is
+// removed. A provenance-bearing object cannot be replaced by a non-object while retaining the
+// reserved member, so that conditional shape is rejected explicitly rather than silently ignored.
+func preserveExternalProvenanceMetadata(current, update json.RawMessage) (json.RawMessage, error) {
+	if update == nil {
+		return nil, nil
+	}
+
+	var currentObject map[string]json.RawMessage
+	_ = json.Unmarshal(current, &currentObject)
+	currentProvenance, hasCurrentProvenance := currentObject[externalProvenanceKey]
+
+	var updateObject map[string]json.RawMessage
+	if err := json.Unmarshal(update, &updateObject); err != nil || updateObject == nil {
+		if hasCurrentProvenance {
+			return nil, &domain.ValidationError{
+				Field:   "metadata",
+				Message: "must be an object when the memory has external_provenance",
+			}
+		}
+		return update, nil
+	}
+
+	delete(updateObject, externalProvenanceKey)
+	if hasCurrentProvenance {
+		updateObject[externalProvenanceKey] = currentProvenance
+	}
+	encoded, err := json.Marshal(updateObject)
+	if err != nil {
+		return update, nil
+	}
+	return encoded, nil
+}
+
+// ParseExternalProvenance validates and removes the reserved key from generic request metadata.
+func ParseExternalProvenance(metadata json.RawMessage, messages []IngestMessage) (json.RawMessage, *ExternalProvenance, error) {
+	trimmed := strings.TrimSpace(string(metadata))
+	if trimmed == "" || !strings.HasPrefix(trimmed, "{") {
+		return append(json.RawMessage(nil), metadata...), nil, nil
+	}
+
+	var metadataObject map[string]json.RawMessage
+	if err := json.Unmarshal(metadata, &metadataObject); err != nil {
+		return append(json.RawMessage(nil), metadata...), nil, nil
+	}
+	rawEnvelope, present := metadataObject["external_provenance"]
+	if !present {
+		return append(json.RawMessage(nil), metadata...), nil, nil
+	}
+
+	invalid := func(message string) (json.RawMessage, *ExternalProvenance, error) {
+		return nil, nil, &domain.ValidationError{Field: "metadata.external_provenance", Message: message}
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(rawEnvelope, &envelope); err != nil || len(envelope) != 2 {
+		return invalid("must contain exactly schema and source_message_id")
+	}
+	rawSchema, hasSchema := envelope["schema"]
+	rawSourceMessageID, hasSourceMessageID := envelope["source_message_id"]
+	if !hasSchema || !hasSourceMessageID {
+		return invalid("must contain exactly schema and source_message_id")
+	}
+	var schema string
+	var sourceMessageID string
+	if err := json.Unmarshal(rawSchema, &schema); err != nil || schema != ExternalProvenanceSchema {
+		return invalid("schema must be agent9/message-source@1")
+	}
+	if err := json.Unmarshal(rawSourceMessageID, &sourceMessageID); err != nil || sourceMessageID == "" || utf8.RuneCountInString(sourceMessageID) > MaxExternalSourceMessageID {
+		return invalid("source_message_id must be a non-empty string of at most 64 characters")
+	}
+
+	factEligibleUsers := 0
+	for _, message := range messages {
+		if strings.EqualFold(strings.TrimSpace(message.Role), "user") && strings.TrimSpace(stripMemoryTags(message.Content)) != "" {
+			factEligibleUsers++
+		}
+	}
+	if factEligibleUsers != 1 {
+		return invalid("requires exactly one fact-eligible user message")
+	}
+
+	delete(metadataObject, "external_provenance")
+	var genericMetadata json.RawMessage
+	if len(metadataObject) > 0 {
+		genericMetadata, _ = json.Marshal(metadataObject)
+	}
+	return genericMetadata, &ExternalProvenance{
+		Schema:          schema,
+		SourceMessageID: sourceMessageID,
+	}, nil
+}

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -71,13 +71,14 @@ var (
 
 // IngestRequest is the input for the ingest pipeline.
 type IngestRequest struct {
-	Messages           []IngestMessage `json:"messages"`
-	SessionID          string          `json:"session_id"`
-	AgentID            string          `json:"agent_id"`
-	AppID              string          `json:"appId,omitempty"`
-	Mode               IngestMode      `json:"mode"`
-	DisableSessionSave bool            `json:"disableSessionSave,omitempty"`
-	Metadata           json.RawMessage `json:"metadata,omitempty"`
+	Messages           []IngestMessage     `json:"messages"`
+	SessionID          string              `json:"session_id"`
+	AgentID            string              `json:"agent_id"`
+	AppID              string              `json:"appId,omitempty"`
+	Mode               IngestMode          `json:"mode"`
+	DisableSessionSave bool                `json:"disableSessionSave,omitempty"`
+	Metadata           json.RawMessage     `json:"metadata,omitempty"`
+	ExternalProvenance *ExternalProvenance `json:"-"`
 }
 
 // IngestMessage represents a single conversation message.
@@ -171,7 +172,7 @@ func (s *IngestService) Ingest(ctx context.Context, agentName string, req Ingest
 	// Cap conversation size to avoid blowing LLM token limits.
 	formatted = truncateRunes(formatted, maxExtractionConversationRunes)
 
-	changes, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted)
+	changes, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted, req.ExternalProvenance)
 	if err != nil {
 		slog.Error("insight extraction failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
@@ -504,7 +505,7 @@ func (s *IngestService) ExtractPhase1WithRouting(ctx context.Context, messages [
 
 // ReconcilePhase2 runs reconciliation of extracted facts against existing memories.
 // Equivalent to the existing reconcile() pipeline, now exported for use by the handler.
-func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) (*IngestResult, error) {
+func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact, externalProvenance *ExternalProvenance) (*IngestResult, error) {
 	facts = filterLongTermFacts(facts)
 	if len(facts) == 0 {
 		return &IngestResult{Status: "complete"}, nil
@@ -514,7 +515,7 @@ func (s *IngestService) ReconcilePhase2(ctx context.Context, agentName, agentID,
 		slog.Warn("ReconcilePhase2: truncating facts", "count", len(facts), "max", maxFacts)
 		facts = facts[:maxFacts]
 	}
-	changes, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, facts)
+	changes, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, facts, externalProvenance)
 	if err != nil {
 		slog.Error("ReconcilePhase2: reconciliation failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
@@ -587,7 +588,7 @@ func (s *IngestService) ReconcileContent(ctx context.Context, agentName, agentID
 		}, nil
 	}
 
-	changes, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, allFacts)
+	changes, warnings, err := s.reconcile(ctx, agentName, agentID, appID, sessionID, allFacts, nil)
 	totalWarnings += warnings
 	if err != nil {
 		slog.Error("reconcile content: batched reconciliation failed", "err", err)
@@ -655,7 +656,7 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 		AppID:      req.AppID,
 		SessionID:  req.SessionID,
 		Embedding:  embedding,
-		Metadata:   req.Metadata,
+		Metadata:   SetExternalProvenanceMetadata(req.Metadata, req.ExternalProvenance),
 		State:      domain.StateActive,
 		Version:    1,
 		UpdatedBy:  agentName,
@@ -678,7 +679,7 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 }
 
 // extractAndReconcile runs Phase 1a (extraction) + Phase 2 (reconciliation).
-func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string) ([]MemoryChange, int, error) {
+func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string, externalProvenance *ExternalProvenance) ([]MemoryChange, int, error) {
 	const maxFacts = 50 // Cap extracted facts to bound reconciliation prompt size
 
 	// Phase 1a: Extract facts only — no message_tags needed here (smart-ingest / raw-ingest path).
@@ -698,7 +699,7 @@ func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agen
 	}
 
 	// Phase 2: Reconcile each fact against existing memories.
-	return s.reconcile(ctx, agentName, agentID, appID, sessionID, facts)
+	return s.reconcile(ctx, agentName, agentID, appID, sessionID, facts, externalProvenance)
 }
 
 // normalizeParsedFacts converts []ExtractedFact from a successful parse into a
@@ -1183,7 +1184,7 @@ user content is non-durable, while still returning message_tags for every messag
 // all facts and all retrieved memories to the LLM in a single call for batch
 // decision-making. This gives the LLM a complete view of both the new facts and
 // the existing knowledge base, enabling better ADD/UPDATE/DELETE/NOOP decisions.
-func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]MemoryChange, int, error) {
+func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact, externalProvenance *ExternalProvenance) ([]MemoryChange, int, error) {
 	start := time.Now()
 	var (
 		applyActionsDuration   time.Duration
@@ -1238,7 +1239,7 @@ func (s *IngestService) reconcile(ctx context.Context, agentName, agentID, appID
 
 	if len(existingMemories) == 0 {
 		applyActionsStart := time.Now()
-		changes, warningCount, err := s.addAllFacts(ctx, agentName, agentID, appID, sessionID, facts)
+		changes, warningCount, err := s.addAllFacts(ctx, agentName, agentID, appID, sessionID, facts, externalProvenance)
 		applyActionsDuration = time.Since(applyActionsStart)
 		warnings = warningCount
 		if err != nil {
@@ -1428,7 +1429,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 				sessionID,
 				normalizedText,
 				event.Tags,
-				SetSourceProvenanceMetadata(MergeTemporalMetadata(nil, temporal), sourceSeqs, sourceTurns),
+				SetExternalProvenanceMetadata(SetSourceProvenanceMetadata(MergeTemporalMetadata(nil, temporal), sourceSeqs, sourceTurns), externalProvenance),
 			)
 			if addErr != nil {
 				slog.Warn("failed to add insight", "err", addErr)
@@ -1459,7 +1460,7 @@ Analyze the new facts and determine whether each should be added, updated, or de
 			}
 			sourceSeqs := sourceSeqsForReconcileText(event.Text, facts)
 			sourceTurns := sourceTurnsForReconcileText(event.Text, facts)
-			metadata := SetSourceProvenanceMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs, sourceTurns)
+			metadata := SetExternalProvenanceMetadata(SetSourceProvenanceMetadata(MergeTemporalMetadata(existingMemories[intID].Metadata, temporal), sourceSeqs, sourceTurns), externalProvenance)
 			if existingMemories[intID].MemoryType == domain.TypePinned {
 				slog.Warn("skipping UPDATE for pinned memory — treating as ADD", "id", realID)
 				newID, addErr := s.addInsight(ctx, agentName, agentID, appID, sessionID, normalizedText, effectiveTags, metadata)
@@ -1714,11 +1715,11 @@ func (s *IngestService) searchExistingMemoriesForFact(
 
 // addAllFacts adds all facts as new insights when no existing memories are
 // found (i.e., all facts are guaranteed new). Called only when gatherExistingMemories returns empty.
-func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact) ([]MemoryChange, int, error) {
+func (s *IngestService) addAllFacts(ctx context.Context, agentName, agentID, appID, sessionID string, facts []ExtractedFact, externalProvenance *ExternalProvenance) ([]MemoryChange, int, error) {
 	var changes []MemoryChange
 	var warnings int
 	for _, fact := range facts {
-		id, err := s.addInsight(ctx, agentName, agentID, appID, sessionID, fact.Text, fact.Tags, metadataForExtractedFact(fact))
+		id, err := s.addInsight(ctx, agentName, agentID, appID, sessionID, fact.Text, fact.Tags, SetExternalProvenanceMetadata(metadataForExtractedFact(fact), externalProvenance))
 		if err != nil {
 			slog.Warn("failed to add fact", "err", err, "fact_len", len(fact.Text))
 			warnings++

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -56,6 +56,19 @@ type setStateCall struct {
 	State domain.MemoryState
 }
 
+func requireExternalSourceMessageID(t *testing.T, metadata json.RawMessage, want string) {
+	t.Helper()
+	var decoded struct {
+		ExternalProvenance *ExternalProvenance `json:"external_provenance"`
+	}
+	if err := json.Unmarshal(metadata, &decoded); err != nil {
+		t.Fatalf("metadata unmarshal error = %v: %s", err, metadata)
+	}
+	if decoded.ExternalProvenance == nil || decoded.ExternalProvenance.Schema != ExternalProvenanceSchema || decoded.ExternalProvenance.SourceMessageID != want {
+		t.Fatalf("external_provenance = %+v, want schema=%s source=%s", decoded.ExternalProvenance, ExternalProvenanceSchema, want)
+	}
+}
+
 func (m *memoryRepoMock) Create(ctx context.Context, mem *domain.Memory) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -591,7 +604,7 @@ func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
 
 	_, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "", "sess-1", []ExtractedFact{
 		{Text: "Jon lost his job, which motivated him to start a dance studio", Tags: []string{"work"}, SourceSeqs: []int{4, 2, 4}},
-	})
+	}, &ExternalProvenance{Schema: ExternalProvenanceSchema, SourceMessageID: "message_user"})
 	if err != nil {
 		t.Fatalf("ReconcilePhase2() error = %v", err)
 	}
@@ -599,8 +612,9 @@ func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
 		t.Fatalf("expected 1 created memory, got %d", len(memRepo.createCalls))
 	}
 	var metadata struct {
-		SourceSeqs  []int                `json:"source_seqs"`
-		SourceTurns []sourceTurnMetadata `json:"source_turns"`
+		SourceSeqs         []int                `json:"source_seqs"`
+		SourceTurns        []sourceTurnMetadata `json:"source_turns"`
+		ExternalProvenance *ExternalProvenance  `json:"external_provenance"`
 	}
 	if err := json.Unmarshal(memRepo.createCalls[0].Metadata, &metadata); err != nil {
 		t.Fatalf("metadata unmarshal error = %v", err)
@@ -610,6 +624,9 @@ func TestReconcilePhase2PersistsSourceSeqMetadata(t *testing.T) {
 	}
 	if len(metadata.SourceTurns) != 0 {
 		t.Fatalf("source_turns should be empty when facts did not provide turn payloads, got %+v", metadata.SourceTurns)
+	}
+	if metadata.ExternalProvenance == nil || metadata.ExternalProvenance.SourceMessageID != "message_user" {
+		t.Fatalf("external_provenance = %+v, want message_user", metadata.ExternalProvenance)
 	}
 }
 
@@ -629,7 +646,7 @@ func TestReconcilePhase2AddPersistsSourceTurnMetadata(t *testing.T) {
 				{Seq: 2, Content: "[date:1 January 2023] [speaker:Gina] You should open your own studio."},
 			},
 		},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("ReconcilePhase2() error = %v", err)
 	}
@@ -664,6 +681,40 @@ func TestSetSourceSeqMetadataClearsStaleSourceSeqs(t *testing.T) {
 	}
 	if _, ok := decoded["temporal"]; !ok {
 		t.Fatalf("temporal metadata should be preserved: %s", metadata)
+	}
+}
+
+func TestSetExternalProvenanceMetadataPreservesLegacyNonObjectWithoutProvenance(t *testing.T) {
+	legacy := json.RawMessage(`"legacy-metadata"`)
+
+	if got := SetExternalProvenanceMetadata(legacy, nil); string(got) != string(legacy) {
+		t.Fatalf("metadata = %s, want unchanged %s", got, legacy)
+	}
+}
+
+func TestSetExternalProvenanceMetadataPreservesLegacyEmptyObject(t *testing.T) {
+	legacy := json.RawMessage(`{}`)
+
+	if got := SetExternalProvenanceMetadata(legacy, nil); string(got) != string(legacy) {
+		t.Fatalf("metadata = %s, want unchanged %s", got, legacy)
+	}
+}
+
+func TestPreserveExternalProvenanceMetadataKeepsLegacyNonObjectUpdateBehavior(t *testing.T) {
+	for _, update := range []json.RawMessage{
+		json.RawMessage(`null`),
+		json.RawMessage(`"replacement"`),
+		json.RawMessage(`["replacement"]`),
+		json.RawMessage(`42`),
+		json.RawMessage(`true`),
+	} {
+		got, err := preserveExternalProvenanceMetadata(json.RawMessage(`{"old":"value"}`), update)
+		if err != nil {
+			t.Fatalf("update %s returned error: %v", update, err)
+		}
+		if string(got) != string(update) {
+			t.Fatalf("metadata = %s, want replacement %s", got, update)
+		}
 	}
 }
 
@@ -1304,7 +1355,7 @@ func TestReconcilePhase2FiltersNonLongTermFactsBeforeWrite(t *testing.T) {
 	res, err := svc.ReconcilePhase2(context.Background(), "agent-1", "agent-1", "", "sess-1", []ExtractedFact{
 		{Text: "Is working out now"},
 		{Text: "Temporary workspace is /home/ec2-user/clawd-workspace/"},
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("ReconcilePhase2() error = %v", err)
 	}
@@ -1416,9 +1467,10 @@ func TestReconcileAddSetsTagsOnMemory(t *testing.T) {
 	svc := NewIngestService(memRepo, llmClient, nil, "auto-model", ModeSmart)
 
 	_, err := svc.Ingest(context.Background(), "agent-1", IngestRequest{
-		Mode:      ModeSmart,
-		SessionID: "sess-add",
-		AgentID:   "agent-1",
+		Mode:               ModeSmart,
+		SessionID:          "sess-add",
+		AgentID:            "agent-1",
+		ExternalProvenance: &ExternalProvenance{Schema: ExternalProvenanceSchema, SourceMessageID: "message_add"},
 		Messages: []IngestMessage{
 			{Role: "user", Content: "I use Go 1.22"},
 			{Role: "assistant", Content: "Noted."},
@@ -1434,6 +1486,7 @@ func TestReconcileAddSetsTagsOnMemory(t *testing.T) {
 	if len(got) != 2 || got[0] != "tech" || got[1] != "work" {
 		t.Fatalf("expected tags [tech work], got %v", got)
 	}
+	requireExternalSourceMessageID(t, memRepo.createCalls[0].Metadata, "message_add")
 }
 
 func TestReconcileUpdateSetsTagsOnMemory(t *testing.T) {
@@ -1458,15 +1511,16 @@ func TestReconcileUpdateSetsTagsOnMemory(t *testing.T) {
 	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
 	memRepo := &memoryRepoMock{
 		vectorResults: []domain.Memory{
-			{ID: "mem-startup", Content: "Works at startup X", MemoryType: domain.TypeInsight, State: domain.StateActive},
+			{ID: "mem-startup", Content: "Works at startup X", MemoryType: domain.TypeInsight, State: domain.StateActive, Metadata: json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_old"},"kept":"yes"}`)},
 		},
 	}
 	svc := NewIngestService(memRepo, llmClient, nil, "auto-model", ModeSmart)
 
 	_, err := svc.Ingest(context.Background(), "agent-1", IngestRequest{
-		Mode:      ModeSmart,
-		SessionID: "sess-update",
-		AgentID:   "agent-1",
+		Mode:               ModeSmart,
+		SessionID:          "sess-update",
+		AgentID:            "agent-1",
+		ExternalProvenance: &ExternalProvenance{Schema: ExternalProvenanceSchema, SourceMessageID: "message_update"},
 		Messages: []IngestMessage{
 			{Role: "user", Content: "I now work at company Y"},
 			{Role: "assistant", Content: "Noted."},
@@ -1482,6 +1536,8 @@ func TestReconcileUpdateSetsTagsOnMemory(t *testing.T) {
 	if len(got) != 1 || got[0] != "work" {
 		t.Fatalf("expected tags [work], got %v", got)
 	}
+	requireExternalSourceMessageID(t, memRepo.createCalls[0].Metadata, "message_update")
+	requireExternalSourceMessageID(t, memRepo.vectorResults[0].Metadata, "message_old")
 }
 
 func TestReconcileUpdateTagsOmitted(t *testing.T) {
@@ -1659,15 +1715,16 @@ func TestReconcilePinnedFallbackCarriesTags(t *testing.T) {
 	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
 	memRepo := &memoryRepoMock{
 		vectorResults: []domain.Memory{
-			{ID: "pinned-1", Content: "Uses Python", MemoryType: domain.TypePinned, State: domain.StateActive},
+			{ID: "pinned-1", Content: "Uses Python", MemoryType: domain.TypePinned, State: domain.StateActive, Metadata: json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_pinned_old"}}`)},
 		},
 	}
 	svc := NewIngestService(memRepo, llmClient, nil, "auto-model", ModeSmart)
 
 	_, err := svc.Ingest(context.Background(), "agent-1", IngestRequest{
-		Mode:      ModeSmart,
-		SessionID: "sess-pinned",
-		AgentID:   "agent-1",
+		Mode:               ModeSmart,
+		SessionID:          "sess-pinned",
+		AgentID:            "agent-1",
+		ExternalProvenance: &ExternalProvenance{Schema: ExternalProvenanceSchema, SourceMessageID: "message_pinned_new"},
 		Messages: []IngestMessage{
 			{Role: "user", Content: "I use Go 1.22"},
 			{Role: "assistant", Content: "Noted."},
@@ -1683,6 +1740,8 @@ func TestReconcilePinnedFallbackCarriesTags(t *testing.T) {
 	if len(got) != 1 || got[0] != "tech" {
 		t.Fatalf("expected tags [tech], got %v", got)
 	}
+	requireExternalSourceMessageID(t, memRepo.createCalls[0].Metadata, "message_pinned_new")
+	requireExternalSourceMessageID(t, memRepo.vectorResults[0].Metadata, "message_pinned_old")
 }
 
 func TestIngestDoesNotReconcileWhenExtractionReturnsNoFacts(t *testing.T) {
@@ -2439,16 +2498,17 @@ func TestReconcileDeleteErrNotFoundIsNotWarning(t *testing.T) {
 	memRepo := &memoryRepoMock{
 		setStateErr: domain.ErrNotFound,
 		vectorResults: []domain.Memory{
-			{ID: "mem-123", Content: "user prefers dark mode", MemoryType: domain.TypeInsight, State: domain.StateActive},
+			{ID: "mem-123", Content: "user prefers dark mode", MemoryType: domain.TypeInsight, State: domain.StateActive, Metadata: json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_delete_old"}}`)},
 		},
 	}
 
 	svc := NewIngestService(memRepo, llmClient, nil, "auto-model", ModeSmart)
 
 	res, err := svc.Ingest(context.Background(), "agent-1", IngestRequest{
-		Mode:      ModeSmart,
-		SessionID: "sess-1",
-		AgentID:   "agent-1",
+		Mode:               ModeSmart,
+		SessionID:          "sess-1",
+		AgentID:            "agent-1",
+		ExternalProvenance: &ExternalProvenance{Schema: ExternalProvenanceSchema, SourceMessageID: "message_delete_new"},
 		Messages: []IngestMessage{
 			{Role: "user", Content: "I prefer dark mode"},
 			{Role: "assistant", Content: "Noted, dark mode preference saved."},
@@ -2476,6 +2536,10 @@ func TestReconcileDeleteErrNotFoundIsNotWarning(t *testing.T) {
 	if memRepo.setStateCalls[0].State != domain.StateDeleted {
 		t.Fatalf("expected StateDeleted, got %q", memRepo.setStateCalls[0].State)
 	}
+	if len(memRepo.createCalls) != 0 {
+		t.Fatalf("DELETE created %d facts, want 0", len(memRepo.createCalls))
+	}
+	requireExternalSourceMessageID(t, memRepo.vectorResults[0].Metadata, "message_delete_old")
 }
 
 // TestReconcileDeleteRealErrorCountsAsWarning verifies that a real database error
@@ -3088,6 +3152,7 @@ func TestReconcileOmitsAgeForZeroTimestamp(t *testing.T) {
 				Content:    "Prefers light mode",
 				MemoryType: domain.TypeInsight,
 				State:      domain.StateActive,
+				Metadata:   json.RawMessage(`{"external_provenance":{"schema":"agent9/message-source@1","source_message_id":"message_noop_old"}}`),
 				// UpdatedAt is zero value
 			},
 		},
@@ -3096,9 +3161,10 @@ func TestReconcileOmitsAgeForZeroTimestamp(t *testing.T) {
 	svc := NewIngestService(memRepo, llmClient, nil, "auto-model", ModeSmart)
 
 	_, err := svc.Ingest(context.Background(), "agent-1", IngestRequest{
-		Mode:      ModeSmart,
-		SessionID: "sess-noage",
-		AgentID:   "agent-1",
+		Mode:               ModeSmart,
+		SessionID:          "sess-noage",
+		AgentID:            "agent-1",
+		ExternalProvenance: &ExternalProvenance{Schema: ExternalProvenanceSchema, SourceMessageID: "message_noop_new"},
 		Messages: []IngestMessage{
 			{Role: "user", Content: "I prefer dark mode"},
 			{Role: "assistant", Content: "Noted."},
@@ -3125,6 +3191,10 @@ func TestReconcileOmitsAgeForZeroTimestamp(t *testing.T) {
 	} else {
 		t.Fatal("could not find 'Current memory contents:' marker in reconciliation body")
 	}
+	if len(memRepo.createCalls) != 0 || len(memRepo.setStateCalls) != 0 {
+		t.Fatalf("NOOP mutated facts: creates=%d states=%d", len(memRepo.createCalls), len(memRepo.setStateCalls))
+	}
+	requireExternalSourceMessageID(t, memRepo.vectorResults[0].Metadata, "message_noop_old")
 }
 
 func TestReconcileAcceptsEmptyChangeList(t *testing.T) {

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -1032,7 +1032,11 @@ func (s *MemoryService) Update(ctx context.Context, agentName, id, content strin
 		current.Tags = tags
 	}
 	if metadata != nil {
-		current.Metadata = metadata
+		preservedMetadata, err := preserveExternalProvenanceMetadata(current.Metadata, metadata)
+		if err != nil {
+			return nil, err
+		}
+		current.Metadata = preservedMetadata
 	}
 	current.UpdatedBy = agentName
 

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -380,9 +380,9 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 						return w.failTask(ctx, task, fmt.Errorf("validate memory app_id: %w", err), logger)
 					}
 				}
-				metadata, err := marshalMetadata(entry.Metadata)
+				metadata, err := marshalImportedMemoryMetadata(entry.Metadata)
 				if err != nil {
-					return w.failTask(ctx, task, fmt.Errorf("marshal memory metadata: %w", err), logger)
+					return w.failTask(ctx, task, fmt.Errorf("validate memories[%d] metadata: %w", i+j, err), logger)
 				}
 				memType := domain.TypeInsight
 				if entry.MemoryType != "" {
@@ -530,7 +530,13 @@ func (w *UploadWorker) cleanupFile(task domain.UploadTask, logger *slog.Logger) 
 	}
 }
 
-func marshalMetadata(metadata map[string]any) (json.RawMessage, error) {
+// marshalImportedMemoryMetadata keeps the reserved external provenance envelope exclusive to
+// validated message ingest. A generic memory import has no source message against which the
+// envelope can be validated, so any occurrence of the reserved key must fail the task.
+func marshalImportedMemoryMetadata(metadata map[string]any) (json.RawMessage, error) {
+	if err := validateImportedMemoryMetadata(metadata); err != nil {
+		return nil, err
+	}
 	if metadata == nil {
 		return nil, nil
 	}
@@ -541,6 +547,16 @@ func marshalMetadata(metadata map[string]any) (json.RawMessage, error) {
 	return json.RawMessage(b), nil
 }
 
+func validateImportedMemoryMetadata(metadata map[string]any) error {
+	if _, present := metadata[externalProvenanceKey]; present {
+		return &domain.ValidationError{
+			Field:   "metadata.external_provenance",
+			Message: "is reserved for validated message ingest",
+		}
+	}
+	return nil
+}
+
 // parseMemoryFile parses upload data as a MemoryFile.
 // It accepts two formats:
 //   - JSON: {"agent_id":"...","memories":[{"content":"..."},...]}
@@ -548,6 +564,14 @@ func marshalMetadata(metadata map[string]any) (json.RawMessage, error) {
 func parseMemoryFile(data []byte, fallbackAgentID string) (MemoryFile, error) {
 	var file MemoryFile
 	if err := json.Unmarshal(data, &file); err == nil && len(file.Memories) > 0 {
+		// Validate the whole import before the worker starts batching writes. Keeping this
+		// check here prevents a reserved envelope in a later batch from leaving a partially
+		// imported file behind; the per-entry write-path check remains defense in depth.
+		for i, entry := range file.Memories {
+			if err := validateImportedMemoryMetadata(entry.Metadata); err != nil {
+				return MemoryFile{}, fmt.Errorf("validate memories[%d] metadata: %w", i, err)
+			}
+		}
 		if file.AgentID == "" {
 			file.AgentID = fallbackAgentID
 		}

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -82,9 +84,9 @@ func TestChunkMessages(t *testing.T) {
 	}
 }
 
-func TestMarshalMetadata(t *testing.T) {
+func TestMarshalImportedMemoryMetadata(t *testing.T) {
 	t.Run("nil metadata", func(t *testing.T) {
-		raw, err := marshalMetadata(nil)
+		raw, err := marshalImportedMemoryMetadata(nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -95,7 +97,7 @@ func TestMarshalMetadata(t *testing.T) {
 
 	t.Run("non-nil metadata", func(t *testing.T) {
 		m := map[string]any{"key": "value", "num": 42.0}
-		raw, err := marshalMetadata(m)
+		raw, err := marshalImportedMemoryMetadata(m)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -108,6 +110,37 @@ func TestMarshalMetadata(t *testing.T) {
 			t.Errorf("unexpected empty result: %s", s)
 		}
 	})
+
+	for _, tt := range []struct {
+		name     string
+		reserved any
+	}{
+		{
+			name: "valid reserved envelope",
+			reserved: map[string]any{
+				"schema":            ExternalProvenanceSchema,
+				"source_message_id": "message_imported",
+			},
+		},
+		{name: "malformed reserved envelope", reserved: "untrusted"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := marshalImportedMemoryMetadata(map[string]any{
+				"external_provenance": tt.reserved,
+				"generic":             "preserved",
+			})
+			if err == nil {
+				t.Fatal("expected reserved external_provenance to be rejected")
+			}
+			var validationErr *domain.ValidationError
+			if !errors.As(err, &validationErr) {
+				t.Fatalf("error = %T, want ValidationError", err)
+			}
+			if validationErr.Field != "metadata.external_provenance" {
+				t.Fatalf("field = %q, want metadata.external_provenance", validationErr.Field)
+			}
+		})
+	}
 }
 
 func TestNormalizeUploadAppID(t *testing.T) {
@@ -355,6 +388,39 @@ func TestParseMemoryFile(t *testing.T) {
 				t.Errorf("content = %q, want %q", file.Memories[0].Content, tt.wantContent)
 			}
 		})
+	}
+}
+
+func TestParseMemoryFileRejectsReservedExternalProvenanceBeforeImport(t *testing.T) {
+	entries := make([]MemoryFileEntry, uploadMemoryBatchSize+1)
+	for i := range entries {
+		entries[i].Content = "safe imported memory"
+	}
+	entries[uploadMemoryBatchSize].Metadata = map[string]any{
+		"external_provenance": map[string]any{
+			"schema":            ExternalProvenanceSchema,
+			"source_message_id": "message_imported",
+		},
+	}
+	payload, marshalErr := json.Marshal(MemoryFile{AgentID: "agent-a", Memories: entries})
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+
+	_, err := parseMemoryFile(payload, "fallback-agent")
+	if err == nil {
+		t.Fatal("expected memory import with reserved external_provenance to fail")
+	}
+	wantPath := fmt.Sprintf("memories[%d]", uploadMemoryBatchSize)
+	if !strings.Contains(err.Error(), wantPath) {
+		t.Fatalf("error = %q, want indexed path %s", err, wantPath)
+	}
+	var validationErr *domain.ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error = %T, want ValidationError", err)
+	}
+	if validationErr.Field != "metadata.external_provenance" {
+		t.Fatalf("field = %q, want metadata.external_provenance", validationErr.Field)
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate the optional `agent9/message-source@1` request envelope before asynchronous acceptance
- persist sanitized provenance at fact creation across cold/reconcile/routed ADD, UPDATE replacement, and pinned fallback paths
- preserve predecessor provenance, keep NOOP/DELETE immutable, and protect the reserved key from generic metadata patches
- document the public contract and cover validation plus lifecycle behavior with handler/service tests

## Coordination

- Implements the Mem9 half of [mem9-ai/agent9#331](https://github.com/mem9-ai/agent9/issues/331).
- Mandatory real-stack gate evidence was posted before this PR: [integration evidence](https://github.com/mem9-ai/agent9/issues/331#issuecomment-4980963505).
- Companion Agent9 PR: [mem9-ai/agent9#336](https://github.com/mem9-ai/agent9/pull/336).

## Verification

- `make test`
- `make build`
- `make vet`
- real modified Mem9 + Agent9 + TiDB ADD/UPDATE/recall integration from the linked gate evidence
