### PR TITLE
fix(server): classify runtime usage failures in logs

### DIFF
--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -140,7 +140,7 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 			result, err := targetSvc.ingest.ReconcilePhase2(ctx, nodeAuth.AgentName, req.AgentID, req.AppID, req.SessionID, factsForTarget, req.ExternalProvenance)
 			if err != nil {
 				if s.runtimeUsageEnabled() && lease != nil {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryCreateFailure(ctx, lease, err)
 				}
 				logger.WarnContext(ctx, "space chain routed reconcile failed",
 					"chain_id", auth.Chain.ChainID,
@@ -158,7 +158,7 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 			}
 			if result.Status == "failed" {
 				if s.runtimeUsageEnabled() && lease != nil {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, errors.New("routed reconcile failed"))
+					s.afterRuntimeUsageMemoryCreateFailure(ctx, lease, errors.New("routed reconcile failed"))
 				}
 				logger.WarnContext(ctx, "space chain routed reconcile returned failed",
 					"chain_id", auth.Chain.ChainID,
@@ -172,7 +172,7 @@ func (s *Server) reconcileRoutedChainFacts(ctx context.Context, auth *domain.Aut
 				return
 			}
 			if s.runtimeUsageEnabled() && lease != nil {
-				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				if err := withRuntimeUsagePostSuccessContext(ctx, func(ctx context.Context) error {
 					return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
 						MemoryIDs:       result.InsightIDs,
 						AgentName:       nodeAuth.AgentName,

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -120,12 +120,12 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				var err error
 				lease, err = s.runtimeUsage.BeforeMemoryCreate(syncCtx, subjectFromAuth(auth), 1)
 				if err != nil {
-					s.handleRuntimeUsageError(w, err)
+					s.handleRuntimeUsageError(syncCtx, w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 					return
 				}
 				defer func() {
 					if !finalized {
-						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+						s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, context.Canceled)
 					}
 				}()
 			}
@@ -133,7 +133,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			result, err := s.ingestMessages(syncCtx, auth, svc, ingestReq, chainAuth)
 			if err != nil {
 				if s.runtimeUsageEnabled() {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 					finalized = true
 				}
 				if isSyncIngestTimeout(syncCtx, err) {
@@ -147,7 +147,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if result != nil && result.Status == "failed" {
 				if s.runtimeUsageEnabled() {
 					err := errors.New("ingest reconciliation failed")
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 					finalized = true
 				}
 				respondError(w, http.StatusInternalServerError, "ingest reconciliation failed")
@@ -162,20 +162,15 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				if result != nil {
 					ids = result.InsightIDs
 				}
-				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 					return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
 						MemoryIDs:       ids,
 						AgentName:       auth.AgentName,
 						ObjectsAffected: written,
 					})
 				}); err != nil {
-					s.logger.Error("runtime usage sync ingest finalization failed",
-						"operation_id", lease.OperationID,
-						"tenant_id", auth.TenantID,
-						"cluster_id", auth.ClusterID,
-						"err", err)
 					finalized = true
-					s.handleRuntimeUsageError(w, err)
+					s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 					return
 				}
 				finalized = true
@@ -190,7 +185,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				var err error
 				lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
 				if err != nil {
-					s.handleRuntimeUsageError(w, err)
+					s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 					return
 				}
 			}
@@ -198,14 +193,14 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				result, err := s.ingestMessages(context.Background(), auth, svc, ingestReq, chainAuth)
 				if err != nil {
 					if s.runtimeUsageEnabled() {
-						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+						s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 					}
 					slog.Error("async ingest failed", "session", ingestReq.SessionID, "err", err)
 					return
 				}
 				if result != nil && result.Status == "failed" {
 					if s.runtimeUsageEnabled() {
-						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, errors.New("ingest reconciliation failed"))
+						s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, errors.New("ingest reconciliation failed"))
 					}
 					slog.Error("async ingest reconcile failed", "session", ingestReq.SessionID)
 					return
@@ -219,16 +214,14 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					if result != nil {
 						ids = result.InsightIDs
 					}
-					if err := s.runtimeUsage.AfterMemoryCreateSuccess(context.Background(), lease, runtimeusage.MemoryCreateResult{
-						MemoryIDs:       ids,
-						AgentName:       auth.AgentName,
-						ObjectsAffected: written,
+					if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
+						return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+							MemoryIDs:       ids,
+							AgentName:       auth.AgentName,
+							ObjectsAffected: written,
+						})
 					}); err != nil {
-						s.logger.Error("runtime usage async ingest finalization failed",
-							"operation_id", lease.OperationID,
-							"tenant_id", auth.TenantID,
-							"cluster_id", auth.ClusterID,
-							"err", err)
+						s.logRuntimeUsageError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
 						return
 					}
 				}
@@ -269,12 +262,12 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			var err error
 			lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
 			if err != nil {
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 				return
 			}
 			defer func() {
 				if !finalized {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, context.Canceled)
 				}
 			}()
 		}
@@ -282,7 +275,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		mem, written, err := svc.memory.CreatePinned(r.Context(), agentID, appID, content, tags, metadata)
 		if err != nil {
 			if s.runtimeUsageEnabled() {
-				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+				s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 				finalized = true
 			}
 			slog.Error("pinned memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
@@ -301,20 +294,15 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if memoryID != "" {
 				ids = []string{memoryID}
 			}
-			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 				return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
 					MemoryIDs:       ids,
 					AgentName:       auth.AgentName,
 					ObjectsAffected: int64(written),
 				})
 			}); err != nil {
-				s.logger.Error("runtime usage memory create finalization failed",
-					"operation_id", lease.OperationID,
-					"tenant_id", auth.TenantID,
-					"cluster_id", auth.ClusterID,
-					"err", err)
 				finalized = true
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 				return
 			}
 			finalized = true
@@ -332,12 +320,12 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			var err error
 			lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
 			if err != nil {
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 				return
 			}
 			defer func() {
 				if !finalized {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, context.Canceled)
 				}
 			}()
 		}
@@ -346,7 +334,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			result, err := s.createSmartContentWithRouting(r.Context(), chainAuth, svc, routingTargets, auth.AgentName, agentID, appID, req.SessionID, content, tags, metadata)
 			if err != nil {
 				if s.runtimeUsageEnabled() {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 					finalized = true
 				}
 				slog.Error("sync routed memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
@@ -356,7 +344,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if result != nil && result.Status == "failed" {
 				if s.runtimeUsageEnabled() {
 					err := errors.New("content reconciliation failed")
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 					finalized = true
 				}
 				respondError(w, http.StatusInternalServerError, "content reconciliation failed")
@@ -369,20 +357,15 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				ids = result.InsightIDs
 			}
 			if s.runtimeUsageEnabled() {
-				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 					return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
 						MemoryIDs:       ids,
 						AgentName:       auth.AgentName,
 						ObjectsAffected: written,
 					})
 				}); err != nil {
-					s.logger.Error("runtime usage sync routed memory create finalization failed",
-						"operation_id", lease.OperationID,
-						"tenant_id", auth.TenantID,
-						"cluster_id", auth.ClusterID,
-						"err", err)
 					finalized = true
-					s.handleRuntimeUsageError(w, err)
+					s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 					return
 				}
 				finalized = true
@@ -396,7 +379,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 		mem, written, err := svc.memory.Create(r.Context(), agentID, appID, content, tags, metadata)
 		if err != nil {
 			if s.runtimeUsageEnabled() {
-				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+				s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 				finalized = true
 			}
 			slog.Error("sync memory create failed", "agent", agentID, "actor", auth.AgentName, "err", err)
@@ -408,20 +391,15 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			if mem != nil && mem.ID != "" {
 				ids = []string{mem.ID}
 			}
-			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 				return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
 					MemoryIDs:       ids,
 					AgentName:       auth.AgentName,
 					ObjectsAffected: int64(written),
 				})
 			}); err != nil {
-				s.logger.Error("runtime usage sync memory create finalization failed",
-					"operation_id", lease.OperationID,
-					"tenant_id", auth.TenantID,
-					"cluster_id", auth.ClusterID,
-					"err", err)
 				finalized = true
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 				return
 			}
 			finalized = true
@@ -435,7 +413,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			var err error
 			lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
 			if err != nil {
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 				return
 			}
 		}
@@ -446,14 +424,14 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				result, err := s.createSmartContentWithRouting(context.Background(), chainAuth, svc, routingTargets, agentName, actorAgentID, appID, sessionID, content, tags, metadata)
 				if err != nil {
 					if s.runtimeUsageEnabled() {
-						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+						s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 					}
 					slog.Error("async routed memory create failed", "agent", actorAgentID, "actor", agentName, "err", err)
 					return
 				}
 				if result != nil && result.Status == "failed" {
 					if s.runtimeUsageEnabled() {
-						s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, errors.New("content reconciliation failed"))
+						s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, errors.New("content reconciliation failed"))
 					}
 					slog.Error("async routed memory reconcile failed", "agent", actorAgentID, "actor", agentName)
 					return
@@ -465,16 +443,14 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 					ids = result.InsightIDs
 				}
 				if s.runtimeUsageEnabled() {
-					if err := s.runtimeUsage.AfterMemoryCreateSuccess(context.Background(), lease, runtimeusage.MemoryCreateResult{
-						MemoryIDs:       ids,
-						AgentName:       auth.AgentName,
-						ObjectsAffected: written,
+					if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
+						return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+							MemoryIDs:       ids,
+							AgentName:       auth.AgentName,
+							ObjectsAffected: written,
+						})
 					}); err != nil {
-						s.logger.Error("runtime usage async routed memory create finalization failed",
-							"operation_id", lease.OperationID,
-							"tenant_id", auth.TenantID,
-							"cluster_id", auth.ClusterID,
-							"err", err)
+						s.logRuntimeUsageError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
 						return
 					}
 				}
@@ -485,7 +461,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 			mem, written, err := svc.memory.Create(context.Background(), actorAgentID, appID, content, tags, metadata)
 			if err != nil {
 				if s.runtimeUsageEnabled() {
-					s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 				}
 				slog.Error("async memory create failed", "agent", actorAgentID, "actor", agentName, "err", err)
 				return
@@ -500,16 +476,14 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 				if mem != nil && mem.ID != "" {
 					ids = []string{mem.ID}
 				}
-				if err := s.runtimeUsage.AfterMemoryCreateSuccess(context.Background(), lease, runtimeusage.MemoryCreateResult{
-					MemoryIDs:       ids,
-					AgentName:       auth.AgentName,
-					ObjectsAffected: int64(written),
+				if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
+					return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
+						MemoryIDs:       ids,
+						AgentName:       auth.AgentName,
+						ObjectsAffected: int64(written),
+					})
 				}); err != nil {
-					s.logger.Error("runtime usage async memory create finalization failed",
-						"operation_id", lease.OperationID,
-						"tenant_id", auth.TenantID,
-						"cluster_id", auth.ClusterID,
-						"err", err)
+					s.logRuntimeUsageError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
 					return
 				}
 			}
@@ -891,12 +865,12 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	if s.runtimeUsageEnabled() && recallSearch {
 		recallLease, err = s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
 		if err != nil {
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryRecallRequests))
 			return
 		}
 		defer func() {
 			if !recallFinalized {
-				s.runtimeUsage.AfterRecallFailure(context.Background(), recallLease, context.Canceled)
+				s.afterRuntimeUsageRecallFailure(r.Context(), recallLease, context.Canceled)
 			}
 		}()
 	}
@@ -931,7 +905,7 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		if s.runtimeUsageEnabled() && recallLease != nil {
-			s.runtimeUsage.AfterRecallFailure(context.Background(), recallLease, err)
+			s.afterRuntimeUsageRecallFailure(r.Context(), recallLease, err)
 			recallFinalized = true
 		}
 		s.handleError(r.Context(), w, err)
@@ -955,20 +929,15 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if recallSearch {
 		if s.runtimeUsageEnabled() && recallLease != nil {
-			if finalizeErr := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			if finalizeErr := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 				return s.runtimeUsage.AfterRecallSuccess(ctx, recallLease, runtimeusage.RecallResult{
 					MemoryIDs: memoryIDs(memories),
 					AgentName: auth.AgentName,
 				})
 			}); finalizeErr != nil {
-				s.logger.Error("runtime usage recall finalization failed",
-					"operation_id", recallLease.OperationID,
-					"tenant_id", auth.TenantID,
-					"cluster_id", auth.ClusterID,
-					"err", finalizeErr)
 				recallFinalized = true
 				err = finalizeErr
-				s.handleRuntimeUsageError(w, finalizeErr)
+				s.handleRuntimeUsageError(r.Context(), w, finalizeErr, runtimeUsageFinalizeErrorDetails(recallLease))
 				return
 			}
 			recallFinalized = true
@@ -1285,19 +1254,19 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		if s.runtimeUsageEnabled() {
 			lease, err = s.runtimeUsage.BeforeMemoryUpdate(r.Context(), subjectFromAuth(target.nodeAuth))
 			if err != nil {
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(target.nodeAuth, runtimeusage.MeterMemoryWriteRequests))
 				return
 			}
 			defer func() {
 				if !finalized {
-					s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, context.Canceled)
+					s.afterRuntimeUsageMemoryUpdateFailure(r.Context(), lease, context.Canceled)
 				}
 			}()
 		}
 		mem, err := target.svc.memory.Update(r.Context(), auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
 		if err != nil {
 			if s.runtimeUsageEnabled() {
-				s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, err)
+				s.afterRuntimeUsageMemoryUpdateFailure(r.Context(), lease, err)
 				finalized = true
 			}
 			s.handleError(r.Context(), w, err)
@@ -1305,20 +1274,15 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		mem.ChainSource = target.source
 		if s.runtimeUsageEnabled() {
-			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 				return s.runtimeUsage.AfterMemoryUpdateSuccess(ctx, lease, runtimeusage.MemoryUpdateResult{
 					MemoryIDs:       []string{mem.ID},
 					AgentName:       target.nodeAuth.AgentName,
 					ObjectsAffected: 1,
 				})
 			}); err != nil {
-				s.logger.Error("runtime usage chain memory update finalization failed",
-					"operation_id", lease.OperationID,
-					"tenant_id", target.nodeAuth.TenantID,
-					"cluster_id", target.nodeAuth.ClusterID,
-					"err", err)
 				finalized = true
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 				return
 			}
 			finalized = true
@@ -1336,39 +1300,34 @@ func (s *Server) updateMemory(w http.ResponseWriter, r *http.Request) {
 		var err error
 		lease, err = s.runtimeUsage.BeforeMemoryUpdate(r.Context(), subjectFromAuth(auth))
 		if err != nil {
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 			return
 		}
 		defer func() {
 			if !finalized {
-				s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, context.Canceled)
+				s.afterRuntimeUsageMemoryUpdateFailure(r.Context(), lease, context.Canceled)
 			}
 		}()
 	}
 	mem, err := svc.memory.Update(r.Context(), auth.AgentName, id, req.Content, req.Tags, req.Metadata, ifMatch)
 	if err != nil {
 		if s.runtimeUsageEnabled() {
-			s.runtimeUsage.AfterMemoryUpdateFailure(context.Background(), lease, err)
+			s.afterRuntimeUsageMemoryUpdateFailure(r.Context(), lease, err)
 			finalized = true
 		}
 		s.handleError(r.Context(), w, err)
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+		if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 			return s.runtimeUsage.AfterMemoryUpdateSuccess(ctx, lease, runtimeusage.MemoryUpdateResult{
 				MemoryIDs:       []string{mem.ID},
 				AgentName:       auth.AgentName,
 				ObjectsAffected: 1,
 			})
 		}); err != nil {
-			s.logger.Error("runtime usage memory update finalization failed",
-				"operation_id", lease.OperationID,
-				"tenant_id", auth.TenantID,
-				"cluster_id", auth.ClusterID,
-				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 			return
 		}
 		finalized = true
@@ -1394,12 +1353,12 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		if s.runtimeUsageEnabled() {
 			lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(target.nodeAuth))
 			if err != nil {
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(target.nodeAuth, runtimeusage.MeterMemoryWriteRequests))
 				return
 			}
 			defer func() {
 				if !finalized {
-					s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+					s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, context.Canceled)
 				}
 			}()
 		}
@@ -1409,27 +1368,22 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		if err != nil {
 			if s.runtimeUsageEnabled() {
-				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+				s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, err)
 				finalized = true
 			}
 			s.handleError(r.Context(), w, err)
 			return
 		}
 		if s.runtimeUsageEnabled() {
-			if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+			if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 				return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
 					MemoryIDs:       []string{id},
 					AgentName:       target.nodeAuth.AgentName,
 					ObjectsAffected: deleted,
 				})
 			}); err != nil {
-				s.logger.Error("runtime usage chain memory delete finalization failed",
-					"operation_id", lease.OperationID,
-					"tenant_id", target.nodeAuth.TenantID,
-					"cluster_id", target.nodeAuth.ClusterID,
-					"err", err)
 				finalized = true
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 				return
 			}
 			finalized = true
@@ -1449,12 +1403,12 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 		var err error
 		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth))
 		if err != nil {
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 			return
 		}
 		defer func() {
 			if !finalized {
-				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+				s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, context.Canceled)
 			}
 		}()
 	}
@@ -1468,27 +1422,22 @@ func (s *Server) deleteMemory(w http.ResponseWriter, r *http.Request) {
 	}
 	if err != nil {
 		if s.runtimeUsageEnabled() {
-			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+			s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, err)
 			finalized = true
 		}
 		s.handleError(r.Context(), w, err)
 		return
 	}
 	if s.runtimeUsageEnabled() {
-		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+		if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 			return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
 				MemoryIDs:       []string{id},
 				AgentName:       auth.AgentName,
 				ObjectsAffected: deleted,
 			})
 		}); err != nil {
-			s.logger.Error("runtime usage memory delete finalization failed",
-				"operation_id", lease.OperationID,
-				"tenant_id", auth.TenantID,
-				"cluster_id", auth.ClusterID,
-				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 			return
 		}
 		finalized = true
@@ -1517,7 +1466,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		groups, err := s.chainDeleteGroups(r.Context(), auth, req.IDs)
 		if err != nil {
 			if isRuntimeUsageError(err) {
-				s.handleRuntimeUsageError(w, err)
+				s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 			} else {
 				s.handleError(r.Context(), w, err)
 			}
@@ -1531,14 +1480,14 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 			if s.runtimeUsageEnabled() {
 				lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(group.target.nodeAuth))
 				if err != nil {
-					s.handleRuntimeUsageError(w, err)
+					s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(group.target.nodeAuth, runtimeusage.MeterMemoryWriteRequests))
 					return
 				}
 			}
 			groupDeleted, err := group.target.svc.memory.BulkDelete(r.Context(), group.ids, auth.AgentName)
 			if err != nil {
 				if s.runtimeUsageEnabled() {
-					s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+					s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, err)
 					finalized = true
 				}
 				s.handleError(r.Context(), w, err)
@@ -1547,7 +1496,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 			sessionDeleted, sessionErr := group.target.svc.session.BulkDelete(r.Context(), group.ids, auth.AgentName)
 			if sessionErr != nil && !errors.Is(sessionErr, domain.ErrNotSupported) {
 				if s.runtimeUsageEnabled() {
-					s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, sessionErr)
+					s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, sessionErr)
 					finalized = true
 				}
 				s.handleError(r.Context(), w, sessionErr)
@@ -1555,26 +1504,21 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 			}
 			groupDeleted += sessionDeleted
 			if s.runtimeUsageEnabled() {
-				if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+				if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 					return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
 						MemoryIDs:       append([]string(nil), group.ids...),
 						AgentName:       group.target.nodeAuth.AgentName,
 						ObjectsAffected: groupDeleted,
 					})
 				}); err != nil {
-					s.logger.Error("runtime usage chain batch delete finalization failed",
-						"operation_id", lease.OperationID,
-						"tenant_id", group.target.nodeAuth.TenantID,
-						"cluster_id", group.target.nodeAuth.ClusterID,
-						"err", err)
 					finalized = true
-					s.handleRuntimeUsageError(w, err)
+					s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 					return
 				}
 				finalized = true
 			}
 			if s.runtimeUsageEnabled() && !finalized {
-				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+				s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, context.Canceled)
 			}
 			if groupDeleted > 0 {
 				for _, id := range webhookDeleteIDs {
@@ -1603,19 +1547,19 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 		var err error
 		lease, err = s.runtimeUsage.BeforeMemoryDelete(r.Context(), subjectFromAuth(auth))
 		if err != nil {
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 			return
 		}
 		defer func() {
 			if !finalized {
-				s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, context.Canceled)
+				s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, context.Canceled)
 			}
 		}()
 	}
 	deleted, err := svc.memory.BulkDelete(r.Context(), deleteIDs, auth.AgentName)
 	if err != nil {
 		if s.runtimeUsageEnabled() {
-			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, err)
+			s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, err)
 			finalized = true
 		}
 		s.handleError(r.Context(), w, err)
@@ -1624,7 +1568,7 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	sessionDeleted, sessionErr := svc.session.BulkDelete(r.Context(), deleteIDs, auth.AgentName)
 	if sessionErr != nil && !errors.Is(sessionErr, domain.ErrNotSupported) {
 		if s.runtimeUsageEnabled() {
-			s.runtimeUsage.AfterMemoryDeleteFailure(context.Background(), lease, sessionErr)
+			s.afterRuntimeUsageMemoryDeleteFailure(r.Context(), lease, sessionErr)
 			finalized = true
 		}
 		s.handleError(r.Context(), w, sessionErr)
@@ -1632,20 +1576,15 @@ func (s *Server) batchDeleteMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	deleted += sessionDeleted
 	if s.runtimeUsageEnabled() {
-		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+		if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 			return s.runtimeUsage.AfterMemoryDeleteSuccess(ctx, lease, runtimeusage.MemoryDeleteResult{
 				MemoryIDs:       append([]string(nil), deleteIDs...),
 				AgentName:       auth.AgentName,
 				ObjectsAffected: deleted,
 			})
 		}); err != nil {
-			s.logger.Error("runtime usage batch delete finalization failed",
-				"operation_id", lease.OperationID,
-				"tenant_id", auth.TenantID,
-				"cluster_id", auth.ClusterID,
-				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 			return
 		}
 		finalized = true
@@ -1722,19 +1661,19 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 		var err error
 		lease, err = s.runtimeUsage.BeforeMemoryCreate(r.Context(), subjectFromAuth(auth), 1)
 		if err != nil {
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryWriteRequests))
 			return
 		}
 		defer func() {
 			if !finalized {
-				s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, context.Canceled)
+				s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, context.Canceled)
 			}
 		}()
 	}
 	memories, err := svc.memory.BulkCreate(r.Context(), auth.AgentName, req.Memories)
 	if err != nil {
 		if s.runtimeUsageEnabled() {
-			s.runtimeUsage.AfterMemoryCreateFailure(context.Background(), lease, err)
+			s.afterRuntimeUsageMemoryCreateFailure(r.Context(), lease, err)
 			finalized = true
 		}
 		s.handleError(r.Context(), w, err)
@@ -1742,20 +1681,15 @@ func (s *Server) bulkCreateMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	applyChainSource(memories, writeChainSource)
 	if s.runtimeUsageEnabled() {
-		if err := withRuntimeUsagePostSuccessContext(func(ctx context.Context) error {
+		if err := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
 			return s.runtimeUsage.AfterMemoryCreateSuccess(ctx, lease, runtimeusage.MemoryCreateResult{
 				MemoryIDs:       memoryIDs(memories),
 				AgentName:       auth.AgentName,
 				ObjectsAffected: int64(len(memories)),
 			})
 		}); err != nil {
-			s.logger.Error("runtime usage bulk create finalization failed",
-				"operation_id", lease.OperationID,
-				"tenant_id", auth.TenantID,
-				"cluster_id", auth.ClusterID,
-				"err", err)
 			finalized = true
-			s.handleRuntimeUsageError(w, err)
+			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageFinalizeErrorDetails(lease))
 			return
 		}
 		finalized = true

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -221,7 +221,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 							ObjectsAffected: written,
 						})
 					}); err != nil {
-						s.logRuntimeUsageError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
+						s.logRuntimeUsageBackgroundFinalizeError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
 						return
 					}
 				}
@@ -450,7 +450,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 							ObjectsAffected: written,
 						})
 					}); err != nil {
-						s.logRuntimeUsageError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
+						s.logRuntimeUsageBackgroundFinalizeError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
 						return
 					}
 				}
@@ -483,7 +483,7 @@ func (s *Server) createMemory(w http.ResponseWriter, r *http.Request) {
 						ObjectsAffected: int64(written),
 					})
 				}); err != nil {
-					s.logRuntimeUsageError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
+					s.logRuntimeUsageBackgroundFinalizeError(r.Context(), err, runtimeUsageFinalizeErrorDetails(lease))
 					return
 				}
 			}

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -13,9 +14,18 @@ import (
 )
 
 const (
-	runtimeUsagePostSuccessTimeout  = 10 * time.Second
+	runtimeUsagePostRequestTimeout  = 10 * time.Second
 	runtimeQuotaPublicErrorCategory = "runtime_quota_denied"
+	runtimeUsageStageReserve        = "reserve"
+	runtimeUsageStageFinalize       = "finalize"
 )
+
+type runtimeUsageErrorDetails struct {
+	stage       string
+	clusterID   string
+	meter       string
+	operationID string
+}
 
 func (s *Server) runtimeUsageEnabled() bool {
 	return s != nil && s.runtimeUsage != nil && s.runtimeUsage.Enabled()
@@ -31,11 +41,45 @@ func memoryIDs(memories []domain.Memory) []string {
 	return ids
 }
 
-func withRuntimeUsagePostSuccessContext(run func(context.Context) error) error {
+func withRuntimeUsagePostSuccessContext(parent context.Context, run func(context.Context) error) error {
 	// Post-success finalization must survive request cancellation after tenant writes commit.
-	ctx, cancel := context.WithTimeout(context.Background(), runtimeUsagePostSuccessTimeout)
+	ctx, cancel := runtimeUsagePostRequestContext(parent)
 	defer cancel()
 	return run(ctx)
+}
+
+func withRuntimeUsagePostFailureContext(parent context.Context, run func(context.Context)) {
+	ctx, cancel := runtimeUsagePostRequestContext(parent)
+	defer cancel()
+	run(ctx)
+}
+
+func (s *Server) afterRuntimeUsageRecallFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
+	withRuntimeUsagePostFailureContext(parent, func(ctx context.Context) {
+		s.runtimeUsage.AfterRecallFailure(ctx, lease, cause)
+	})
+}
+
+func (s *Server) afterRuntimeUsageMemoryCreateFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
+	withRuntimeUsagePostFailureContext(parent, func(ctx context.Context) {
+		s.runtimeUsage.AfterMemoryCreateFailure(ctx, lease, cause)
+	})
+}
+
+func (s *Server) afterRuntimeUsageMemoryUpdateFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
+	withRuntimeUsagePostFailureContext(parent, func(ctx context.Context) {
+		s.runtimeUsage.AfterMemoryUpdateFailure(ctx, lease, cause)
+	})
+}
+
+func (s *Server) afterRuntimeUsageMemoryDeleteFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
+	withRuntimeUsagePostFailureContext(parent, func(ctx context.Context) {
+		s.runtimeUsage.AfterMemoryDeleteFailure(ctx, lease, cause)
+	})
+}
+
+func runtimeUsagePostRequestContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), runtimeUsagePostRequestTimeout)
 }
 
 func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
@@ -57,7 +101,33 @@ func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
 	}
 }
 
-func (s *Server) handleRuntimeUsageError(w http.ResponseWriter, err error) {
+func runtimeUsageReserveErrorDetails(auth *domain.AuthInfo, meter string) runtimeUsageErrorDetails {
+	return runtimeUsageErrorDetails{
+		stage:     runtimeUsageStageReserve,
+		clusterID: subjectFromAuth(auth).ClusterID,
+		meter:     meter,
+	}
+}
+
+func runtimeUsageFinalizeErrorDetails(lease *runtimeusage.OperationLease) runtimeUsageErrorDetails {
+	details := runtimeUsageErrorDetails{stage: runtimeUsageStageFinalize}
+	if lease == nil {
+		return details
+	}
+	details.clusterID = lease.Subject.ClusterID
+	details.meter = lease.Meter
+	details.operationID = lease.OperationID
+	return details
+}
+
+func (s *Server) handleRuntimeUsageError(
+	ctx context.Context,
+	w http.ResponseWriter,
+	err error,
+	details runtimeUsageErrorDetails,
+) {
+	s.logRuntimeUsageError(ctx, err, details)
+
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
 		status := denied.Status()
@@ -76,6 +146,50 @@ func (s *Server) handleRuntimeUsageError(w http.ResponseWriter, err error) {
 		return
 	}
 	respondError(w, status, "runtime usage unavailable")
+}
+
+func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details runtimeUsageErrorDetails) {
+	errorClass, status, retryable := classifyRuntimeUsageError(err)
+	attrs := []any{
+		"error_class", errorClass,
+		"error_source", "runtime_usage",
+		"stage", details.stage,
+		"http_status", status,
+		"retryable", retryable,
+		"err", err,
+	}
+	if details.clusterID != "" {
+		attrs = append(attrs, "cluster_id", details.clusterID)
+	}
+	if details.meter != "" {
+		attrs = append(attrs, "meter", details.meter)
+	}
+	if details.operationID != "" {
+		attrs = append(attrs, "operation_id", details.operationID)
+	}
+
+	logger := s.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	level := slog.LevelError
+	if errorClass == "quota_denied" {
+		level = slog.LevelWarn
+	}
+	logger.Log(ctx, level, "runtime usage request failed", attrs...)
+}
+
+func classifyRuntimeUsageError(err error) (string, int, bool) {
+	status := runtimeusage.HTTPStatus(err)
+	var denied *runtimeusage.QuotaDeniedError
+	if errors.As(err, &denied) {
+		return "quota_denied", status, status == http.StatusTooManyRequests
+	}
+	var conflict *runtimeusage.ConflictError
+	if errors.As(err, &conflict) {
+		return "conflict", status, true
+	}
+	return "unavailable", status, true
 }
 
 func isRuntimeUsageError(err error) bool {

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -18,6 +18,8 @@ const (
 	runtimeQuotaPublicErrorCategory = "runtime_quota_denied"
 	runtimeUsageStageReserve        = "reserve"
 	runtimeUsageStageFinalize       = "finalize"
+	runtimeUsageRoleClientResponse  = "client_response"
+	runtimeUsageRoleBackground      = "background_finalize"
 )
 
 type runtimeUsageErrorDetails struct {
@@ -126,7 +128,7 @@ func (s *Server) handleRuntimeUsageError(
 	err error,
 	details runtimeUsageErrorDetails,
 ) {
-	s.logRuntimeUsageError(ctx, err, details)
+	s.logRuntimeUsageError(ctx, err, details, runtimeUsageRoleClientResponse)
 
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
@@ -148,13 +150,24 @@ func (s *Server) handleRuntimeUsageError(
 	respondError(w, status, "runtime usage unavailable")
 }
 
-func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details runtimeUsageErrorDetails) {
+func (s *Server) logRuntimeUsageBackgroundFinalizeError(ctx context.Context, err error, details runtimeUsageErrorDetails) {
+	s.logRuntimeUsageError(ctx, err, details, runtimeUsageRoleBackground)
+}
+
+func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details runtimeUsageErrorDetails, errorRole string) {
 	errorClass, status, retryable := classifyRuntimeUsageError(err)
+	statusField := "http_status"
+	message := "runtime usage request failed"
+	if errorRole == runtimeUsageRoleBackground {
+		statusField = "mapped_status"
+		message = "runtime usage background finalization failed"
+	}
 	attrs := []any{
 		"error_class", errorClass,
 		"error_source", "runtime_usage",
+		"error_role", errorRole,
 		"stage", details.stage,
-		"http_status", status,
+		statusField, status,
 		"retryable", retryable,
 		"err", err,
 	}
@@ -176,7 +189,7 @@ func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details ru
 	if errorClass == "quota_denied" {
 		level = slog.LevelWarn
 	}
-	logger.Log(ctx, level, "runtime usage request failed", attrs...)
+	logger.Log(ctx, level, message, attrs...)
 }
 
 func classifyRuntimeUsageError(err error) (string, int, bool) {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -338,8 +338,12 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			assertRuntimeUsageLogField(t, entry, "request_id", "request-runtime-usage")
 			assertRuntimeUsageLogField(t, entry, "error_class", tt.wantClass)
 			assertRuntimeUsageLogField(t, entry, "error_source", "runtime_usage")
+			assertRuntimeUsageLogField(t, entry, "error_role", runtimeUsageRoleClientResponse)
 			assertRuntimeUsageLogField(t, entry, "stage", tt.wantStage)
 			assertRuntimeUsageLogField(t, entry, "http_status", float64(tt.wantStatus))
+			if _, ok := entry["mapped_status"]; ok {
+				t.Fatalf("mapped_status = %v, want field omitted", entry["mapped_status"])
+			}
 			assertRuntimeUsageLogField(t, entry, "retryable", tt.wantRetryable)
 			assertRuntimeUsageLogField(t, entry, "cluster_id", tt.wantClusterID)
 			assertRuntimeUsageLogField(t, entry, "meter", tt.wantMeter)
@@ -354,6 +358,38 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 				t.Fatal("API key subject leaked into runtime usage log")
 			}
 		})
+	}
+}
+
+func TestLogRuntimeUsageBackgroundFinalizeError(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+	server := &Server{logger: logger}
+	ctx := reqid.NewContext(context.Background(), "request-background-finalize")
+	details := runtimeUsageFinalizeErrorDetails(&runtimeusage.OperationLease{
+		OperationID: "operation-background",
+		Subject:     runtimeusage.Subject{ClusterID: "cluster-background"},
+		Meter:       runtimeusage.MeterMemoryWriteRequests,
+	})
+
+	server.logRuntimeUsageBackgroundFinalizeError(ctx, &runtimeusage.UnavailableError{Err: errors.New("provider timeout")}, details)
+
+	entry := decodeSingleRuntimeUsageLog(t, &logBuf)
+	assertRuntimeUsageLogField(t, entry, "msg", "runtime usage background finalization failed")
+	assertRuntimeUsageLogField(t, entry, "request_id", "request-background-finalize")
+	assertRuntimeUsageLogField(t, entry, "error_class", "unavailable")
+	assertRuntimeUsageLogField(t, entry, "error_source", "runtime_usage")
+	assertRuntimeUsageLogField(t, entry, "error_role", runtimeUsageRoleBackground)
+	assertRuntimeUsageLogField(t, entry, "stage", runtimeUsageStageFinalize)
+	assertRuntimeUsageLogField(t, entry, "mapped_status", float64(http.StatusServiceUnavailable))
+	assertRuntimeUsageLogField(t, entry, "retryable", true)
+	assertRuntimeUsageLogField(t, entry, "cluster_id", "cluster-background")
+	assertRuntimeUsageLogField(t, entry, "meter", runtimeusage.MeterMemoryWriteRequests)
+	assertRuntimeUsageLogField(t, entry, "operation_id", "operation-background")
+	if _, ok := entry["http_status"]; ok {
+		t.Fatalf("http_status = %v, want field omitted", entry["http_status"])
 	}
 }
 

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -1,11 +1,18 @@
 package handler
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/reqid"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
@@ -209,37 +216,189 @@ func TestNormalizeRuntimeQuotaErrorBodyUsesStatusMessageFallbackWithDetails(t *t
 	}
 }
 
-func TestHandleRuntimeUsageErrorReturnsPostQuotaRateLimit(t *testing.T) {
-	recorder := httptest.NewRecorder()
-	server := &Server{}
-	server.handleRuntimeUsageError(recorder, &runtimeusage.QuotaDeniedError{
-		StatusCode: http.StatusTooManyRequests,
-		RetryAfter: "20",
-		Body: []byte(`{
-			"code":"post_quota_rate_limited",
-			"message":"Post-quota rate limit exceeded.",
-			"details":{
-				"meter":"memory_recall_requests"
-			}
-		}`),
-	})
+func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
+	t.Parallel()
 
-	if recorder.Code != http.StatusTooManyRequests {
-		t.Fatalf("status = %d, want 429", recorder.Code)
+	tests := []struct {
+		name           string
+		err            error
+		details        runtimeUsageErrorDetails
+		wantStatus     int
+		wantClass      string
+		wantRetryable  bool
+		wantStage      string
+		wantClusterID  string
+		wantMeter      string
+		wantOperation  string
+		wantMessage    string
+		wantRetryAfter string
+	}{
+		{
+			name: "quota rate limit during reserve",
+			err: &runtimeusage.QuotaDeniedError{
+				StatusCode: http.StatusTooManyRequests,
+				RetryAfter: "20",
+				Body: []byte(`{
+					"code":"post_quota_rate_limited",
+					"message":"Post-quota rate limit exceeded.",
+					"details":{"meter":"memory_recall_requests"}
+				}`),
+			},
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID:     "cluster-reserve",
+				APIKeySubject: "secret-api-key-subject",
+			}, runtimeusage.MeterMemoryRecallRequests),
+			wantStatus:     http.StatusTooManyRequests,
+			wantClass:      "quota_denied",
+			wantRetryable:  true,
+			wantStage:      runtimeUsageStageReserve,
+			wantClusterID:  "cluster-reserve",
+			wantMeter:      runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:    "Post-quota rate limit exceeded.",
+			wantRetryAfter: "20",
+		},
+		{
+			name: "quota denied during reserve",
+			err:  &runtimeusage.QuotaDeniedError{StatusCode: http.StatusPaymentRequired},
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-denied",
+			}, runtimeusage.MeterMemoryWriteRequests),
+			wantStatus:    http.StatusPaymentRequired,
+			wantClass:     "quota_denied",
+			wantRetryable: false,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-denied",
+			wantMeter:     runtimeusage.MeterMemoryWriteRequests,
+			wantMessage:   "Runtime access is blocked.",
+		},
+		{
+			name: "provider unavailable during finalize",
+			err:  &runtimeusage.UnavailableError{Err: errors.New("provider timeout")},
+			details: runtimeUsageFinalizeErrorDetails(&runtimeusage.OperationLease{
+				OperationID: "operation-unavailable",
+				Subject: runtimeusage.Subject{
+					ClusterID:     "cluster-finalize",
+					APIKeySubject: "secret-api-key-subject",
+				},
+				Meter: runtimeusage.MeterMemoryWriteRequests,
+			}),
+			wantStatus:    http.StatusServiceUnavailable,
+			wantClass:     "unavailable",
+			wantRetryable: true,
+			wantStage:     runtimeUsageStageFinalize,
+			wantClusterID: "cluster-finalize",
+			wantMeter:     runtimeusage.MeterMemoryWriteRequests,
+			wantOperation: "operation-unavailable",
+			wantMessage:   "runtime usage unavailable",
+		},
+		{
+			name: "operation conflict during finalize",
+			err:  &runtimeusage.ConflictError{StatusCode: http.StatusConflict},
+			details: runtimeUsageFinalizeErrorDetails(&runtimeusage.OperationLease{
+				OperationID: "operation-conflict",
+				Subject:     runtimeusage.Subject{ClusterID: "cluster-conflict"},
+				Meter:       runtimeusage.MeterMemoryWriteRequests,
+			}),
+			wantStatus:    http.StatusBadGateway,
+			wantClass:     "conflict",
+			wantRetryable: true,
+			wantStage:     runtimeUsageStageFinalize,
+			wantClusterID: "cluster-conflict",
+			wantMeter:     runtimeusage.MeterMemoryWriteRequests,
+			wantOperation: "operation-conflict",
+			wantMessage:   "runtime usage conflict",
+		},
 	}
-	if got := recorder.Header().Get("Retry-After"); got != "20" {
-		t.Fatalf("Retry-After = %q, want 20", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logBuf bytes.Buffer
+			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+			server := &Server{logger: logger}
+			recorder := httptest.NewRecorder()
+			ctx := reqid.NewContext(context.Background(), "request-runtime-usage")
+
+			server.handleRuntimeUsageError(ctx, recorder, tt.err, tt.details)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if got := recorder.Header().Get("Retry-After"); got != tt.wantRetryAfter {
+				t.Fatalf("Retry-After = %q, want %q", got, tt.wantRetryAfter)
+			}
+			body := decodeRuntimeQuotaErrorBody(t, recorder.Body.Bytes())
+			if body["error"] != tt.wantMessage {
+				t.Fatalf("response error = %v, want %q", body["error"], tt.wantMessage)
+			}
+
+			entry := decodeSingleRuntimeUsageLog(t, &logBuf)
+			assertRuntimeUsageLogField(t, entry, "msg", "runtime usage request failed")
+			assertRuntimeUsageLogField(t, entry, "request_id", "request-runtime-usage")
+			assertRuntimeUsageLogField(t, entry, "error_class", tt.wantClass)
+			assertRuntimeUsageLogField(t, entry, "error_source", "runtime_usage")
+			assertRuntimeUsageLogField(t, entry, "stage", tt.wantStage)
+			assertRuntimeUsageLogField(t, entry, "http_status", float64(tt.wantStatus))
+			assertRuntimeUsageLogField(t, entry, "retryable", tt.wantRetryable)
+			assertRuntimeUsageLogField(t, entry, "cluster_id", tt.wantClusterID)
+			assertRuntimeUsageLogField(t, entry, "meter", tt.wantMeter)
+			if tt.wantOperation == "" {
+				if _, ok := entry["operation_id"]; ok {
+					t.Fatalf("operation_id = %v, want field omitted", entry["operation_id"])
+				}
+			} else {
+				assertRuntimeUsageLogField(t, entry, "operation_id", tt.wantOperation)
+			}
+			if bytes.Contains(logBuf.Bytes(), []byte("secret-api-key-subject")) {
+				t.Fatal("API key subject leaked into runtime usage log")
+			}
+		})
 	}
-	got := decodeRuntimeQuotaErrorBody(t, recorder.Body.Bytes())
-	if got["error"] != "Post-quota rate limit exceeded." {
-		t.Fatalf("unexpected envelope: %#v", got)
+}
+
+func TestRuntimeUsagePostRequestContextPreservesValuesAndBoundsLifetime(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithCancel(reqid.NewContext(context.Background(), "request-detached"))
+	cancelParent()
+
+	ctx, cancel := runtimeUsagePostRequestContext(parent)
+	defer cancel()
+
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("detached context error = %v, want nil", err)
 	}
-	if quotaErrorCategory(t, got) != "runtime_quota_denied" {
-		t.Fatalf("details.errorCategory should include stable runtime quota category: %#v", got)
+	if got := reqid.FromContext(ctx); got != "request-detached" {
+		t.Fatalf("request_id = %q, want request-detached", got)
 	}
-	runtimeQuota := runtimeQuotaDetails(t, got)
-	if runtimeQuota["meter"] != "memory_recall_requests" {
-		t.Fatalf("unexpected runtime quota details: %#v", runtimeQuota)
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("detached context deadline is missing")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 || remaining > runtimeUsagePostRequestTimeout {
+		t.Fatalf("detached context remaining timeout = %s", remaining)
+	}
+}
+
+func decodeSingleRuntimeUsageLog(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))
+	if len(lines) != 1 {
+		t.Fatalf("log entry count = %d, want 1: %s", len(lines), buf.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(lines[0], &entry); err != nil {
+		t.Fatalf("decode runtime usage log: %v", err)
+	}
+	return entry
+}
+
+func assertRuntimeUsageLogField(t *testing.T, entry map[string]any, field string, want any) {
+	t.Helper()
+	if got := entry[field]; got != want {
+		t.Fatalf("%s = %v, want %v; log = %#v", field, got, want, entry)
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Emit request-correlated structured runtime-usage errors with stable class, source, stage, retryability, cluster, meter, and operation fields.
- Mark synchronous client failures as `error_role=client_response` with `http_status`.
- Mark post-202 background finalization failures as `error_role=background_finalize` with `mapped_status`, keeping them out of real 5xx counts.
- Preserve request-scoped values while allowing cleanup and finalization to outlive cancellation within a 10-second bound.
- Keep existing 402, 429, 502, and 503 response behavior unchanged.

## Review Path

1. Classification, log roles, and detached context helpers in `server/internal/handler/runtime_usage.go`.
2. Reserve and finalize metadata at call sites in `memory.go` and `chain_runtime.go`.
3. Response, redaction, classification, role, and context tests in `runtime_usage_test.go`.

## Validation

- `cd server && go test -race -count=1 ./internal/handler/`
- `cd server && go test -count=1 ./...`
- `cd server && go vet ./...`
- `git diff --check upstream/main...HEAD`
