### PR TITLE
Structure TiDB search dependency errors

### DIFF
--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -455,7 +455,7 @@ func (r *MemoryRepo) BulkCreate(ctx context.Context, memories []*domain.Memory) 
 
 // VectorSearch performs ANN search using cosine distance.
 // VEC_COSINE_DISTANCE must appear identically in SELECT and ORDER BY for TiDB VECTOR INDEX usage.
-func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) (_ []domain.Memory, resultErr error) {
 	vecStr := vecToString(queryVec)
 	if vecStr == nil {
 		return nil, nil
@@ -485,6 +485,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 		return nil, fmt.Errorf("vector search: %w", err)
 	}
 	defer rows.Close()
+	defer logSearchResultError(ctx, "vector search failed", "memory", "vector", r.clusterID, start, &resultErr)
 
 	var memories []domain.Memory
 	for rows.Next() {
@@ -501,7 +502,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 	return memories, nil
 }
 
-func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f domain.MemoryFilter, limit int) (_ []domain.Memory, resultErr error) {
 	conds, args := r.buildFilterConds(f)
 	conds = append(conds, "embedding IS NOT NULL")
 
@@ -525,6 +526,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 		return nil, fmt.Errorf("auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
+	defer logSearchResultError(ctx, "auto vector search failed", "memory", "auto_vector", r.clusterID, start, &resultErr)
 
 	var memories []domain.Memory
 	for rows.Next() {
@@ -542,7 +544,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 }
 
 // KeywordSearch performs substring search on content.
-func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) (_ []domain.Memory, resultErr error) {
 	conds, args := r.buildFilterConds(f)
 	if query != "" {
 		conds = append(conds, "content LIKE CONCAT('%', ?, '%')")
@@ -560,6 +562,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 	defer rows.Close()
+	defer logSearchResultError(ctx, "keyword search failed", "memory", "keyword", r.clusterID, start, &resultErr)
 
 	var memories []domain.Memory
 	for rows.Next() {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -481,7 +481,7 @@ func (r *MemoryRepo) VectorSearch(ctx context.Context, queryVec []float32, f dom
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
-		slog.ErrorContext(ctx, "vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "vector search failed", "memory", "vector", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("vector search: %w", err)
 	}
 	defer rows.Close()
@@ -521,7 +521,7 @@ func (r *MemoryRepo) AutoVectorSearch(ctx context.Context, queryText string, f d
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, query, fullArgs...)
 	if err != nil {
-		slog.ErrorContext(ctx, "auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "auto vector search failed", "memory", "auto_vector", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -556,7 +556,7 @@ func (r *MemoryRepo) KeywordSearch(ctx context.Context, query string, f domain.M
 	start := time.Now()
 	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		slog.ErrorContext(ctx, "keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "keyword search failed", "memory", "keyword", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("keyword search: %w", err)
 	}
 	defer rows.Close()
@@ -597,7 +597,7 @@ func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.Memor
 	start := time.Now()
 	memories, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
 	if err != nil {
-		slog.ErrorContext(ctx, "fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "fts search failed", "memory", "fts", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	slog.DebugContext(ctx, "fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))

--- a/server/internal/repository/tidb/search_logging.go
+++ b/server/internal/repository/tidb/search_logging.go
@@ -5,11 +5,16 @@ import (
 	"database/sql"
 	"errors"
 	"log/slog"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+)
+
+var searchInferenceStatusPattern = regexp.MustCompile(
+	`(?i)\btidb cloud inference:\s*(?:status code|status|http status|http)\s*:?\s*([1-5][0-9]{2})\b`,
 )
 
 const (
@@ -100,7 +105,7 @@ func classifySearchError(err error) searchErrorDetails {
 		message = strings.ToLower(mysqlErr.Message)
 	}
 	if strings.Contains(message, "memory limit") && strings.Contains(message, "exceeded") &&
-		(strings.Contains(message, "tiflashexception") || strings.Contains(message, "[flash:")) {
+		(strings.Contains(message, "tiflash") || strings.Contains(message, "[flash:")) {
 		details.class = searchErrorClassTiFlashMemoryLimit
 		details.source = searchErrorSourceTiFlash
 		details.retryable = true
@@ -129,15 +134,10 @@ func classifySearchError(err error) searchErrorDetails {
 }
 
 func inferenceStatus(message string) int {
-	const marker = "tidb cloud inference: status code "
-	index := strings.Index(message, marker)
-	if index < 0 {
+	match := searchInferenceStatusPattern.FindStringSubmatch(message)
+	if len(match) != 2 {
 		return 0
 	}
-	value := message[index+len(marker):]
-	if fields := strings.Fields(value); len(fields) > 0 {
-		status, _ := strconv.Atoi(strings.Trim(fields[0], ",.;:"))
-		return status
-	}
-	return 0
+	status, _ := strconv.Atoi(match[1])
+	return status
 }

--- a/server/internal/repository/tidb/search_logging.go
+++ b/server/internal/repository/tidb/search_logging.go
@@ -1,0 +1,132 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+const (
+	searchErrorClassDatabaseClosed       = "database_closed"
+	searchErrorClassDatabaseError        = "database_error"
+	searchErrorClassInferenceHTTPError   = "inference_http_error"
+	searchErrorClassInferenceUpstream5xx = "inference_upstream_5xx"
+	searchErrorClassOperationCanceled    = "operation_canceled"
+	searchErrorClassContextCanceled      = "context_canceled"
+	searchErrorClassContextDeadline      = "context_deadline_exceeded"
+	searchErrorClassTiFlashMemoryLimit   = "tiflash_memory_limit"
+
+	searchErrorSourceInference      = "inference"
+	searchErrorSourceRequest        = "request_context"
+	searchErrorSourceTenantDatabase = "tenant_database"
+	searchErrorSourceTiFlash        = "tiflash"
+)
+
+type searchErrorDetails struct {
+	class          string
+	source         string
+	retryable      bool
+	dbErrorCode    int
+	upstreamStatus int
+}
+
+func logSearchError(ctx context.Context, message, resource, queryType, clusterID string, duration time.Duration, err error) {
+	slog.LogAttrs(ctx, slog.LevelError, message, searchErrorLogAttrs(resource, queryType, clusterID, duration, err)...)
+}
+
+func searchErrorLogAttrs(resource, queryType, clusterID string, duration time.Duration, err error) []slog.Attr {
+	details := classifySearchError(err)
+	attrs := []slog.Attr{
+		slog.String("cluster_id", clusterID),
+		slog.String("resource", resource),
+		slog.String("query_type", queryType),
+		slog.String("error_role", "dependency_attempt"),
+		slog.String("error_class", details.class),
+		slog.String("error_source", details.source),
+		slog.Bool("retryable", details.retryable),
+		slog.Int64("duration_ms", duration.Milliseconds()),
+	}
+	if details.dbErrorCode != 0 {
+		attrs = append(attrs, slog.Int("db_error_code", details.dbErrorCode))
+	}
+	if details.upstreamStatus != 0 {
+		attrs = append(attrs, slog.Int("upstream_status", details.upstreamStatus))
+	}
+	return append(attrs, slog.Any("err", err))
+}
+
+func classifySearchError(err error) searchErrorDetails {
+	details := searchErrorDetails{
+		class:  searchErrorClassDatabaseError,
+		source: searchErrorSourceTenantDatabase,
+	}
+	if errors.Is(err, context.Canceled) {
+		details.class = searchErrorClassContextCanceled
+		details.source = searchErrorSourceRequest
+		return details
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		details.class = searchErrorClassContextDeadline
+		details.source = searchErrorSourceRequest
+		details.retryable = true
+		return details
+	}
+	if errors.Is(err, sql.ErrConnDone) {
+		details.class = searchErrorClassDatabaseClosed
+		details.retryable = true
+		return details
+	}
+
+	message := strings.ToLower(err.Error())
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		details.dbErrorCode = int(mysqlErr.Number)
+		message = strings.ToLower(mysqlErr.Message)
+	}
+	if strings.Contains(message, "tiflashexception") && strings.Contains(message, "memory limit") {
+		details.class = searchErrorClassTiFlashMemoryLimit
+		details.source = searchErrorSourceTiFlash
+		details.retryable = true
+		return details
+	}
+	if status := inferenceStatus(message); status != 0 {
+		details.class = searchErrorClassInferenceHTTPError
+		if status >= 500 && status < 600 {
+			details.class = searchErrorClassInferenceUpstream5xx
+		}
+		details.source = searchErrorSourceInference
+		details.retryable = status == 429 || status >= 500 && status < 600
+		details.upstreamStatus = status
+		return details
+	}
+	if strings.Contains(message, "database is closed") {
+		details.class = searchErrorClassDatabaseClosed
+		details.retryable = true
+		return details
+	}
+	if strings.Contains(message, "operation was canceled") {
+		details.class = searchErrorClassOperationCanceled
+		return details
+	}
+	return details
+}
+
+func inferenceStatus(message string) int {
+	const marker = "tidb cloud inference: status code "
+	index := strings.Index(message, marker)
+	if index < 0 {
+		return 0
+	}
+	value := message[index+len(marker):]
+	if fields := strings.Fields(value); len(fields) > 0 {
+		status, _ := strconv.Atoi(strings.Trim(fields[0], ",.;:"))
+		return status
+	}
+	return 0
+}

--- a/server/internal/repository/tidb/search_logging.go
+++ b/server/internal/repository/tidb/search_logging.go
@@ -39,6 +39,17 @@ func logSearchError(ctx context.Context, message, resource, queryType, clusterID
 	slog.LogAttrs(ctx, slog.LevelError, message, searchErrorLogAttrs(resource, queryType, clusterID, duration, err)...)
 }
 
+func logSearchResultError(
+	ctx context.Context,
+	message, resource, queryType, clusterID string,
+	start time.Time,
+	resultErr *error,
+) {
+	if *resultErr != nil {
+		logSearchError(ctx, message, resource, queryType, clusterID, time.Since(start), *resultErr)
+	}
+}
+
 func searchErrorLogAttrs(resource, queryType, clusterID string, duration time.Duration, err error) []slog.Attr {
 	details := classifySearchError(err)
 	attrs := []slog.Attr{
@@ -88,7 +99,8 @@ func classifySearchError(err error) searchErrorDetails {
 		details.dbErrorCode = int(mysqlErr.Number)
 		message = strings.ToLower(mysqlErr.Message)
 	}
-	if strings.Contains(message, "tiflashexception") && strings.Contains(message, "memory limit") {
+	if strings.Contains(message, "memory limit") && strings.Contains(message, "exceeded") &&
+		(strings.Contains(message, "tiflashexception") || strings.Contains(message, "[flash:")) {
 		details.class = searchErrorClassTiFlashMemoryLimit
 		details.source = searchErrorSourceTiFlash
 		details.retryable = true

--- a/server/internal/repository/tidb/search_logging.go
+++ b/server/internal/repository/tidb/search_logging.go
@@ -17,7 +17,6 @@ const (
 	searchErrorClassDatabaseError        = "database_error"
 	searchErrorClassInferenceHTTPError   = "inference_http_error"
 	searchErrorClassInferenceUpstream5xx = "inference_upstream_5xx"
-	searchErrorClassOperationCanceled    = "operation_canceled"
 	searchErrorClassContextCanceled      = "context_canceled"
 	searchErrorClassContextDeadline      = "context_deadline_exceeded"
 	searchErrorClassTiFlashMemoryLimit   = "tiflash_memory_limit"
@@ -111,7 +110,7 @@ func classifySearchError(err error) searchErrorDetails {
 		return details
 	}
 	if strings.Contains(message, "operation was canceled") {
-		details.class = searchErrorClassOperationCanceled
+		details.retryable = true
 		return details
 	}
 	return details

--- a/server/internal/repository/tidb/search_logging_test.go
+++ b/server/internal/repository/tidb/search_logging_test.go
@@ -1,8 +1,11 @@
 package tidb
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -10,6 +13,8 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
 func TestClassifySearchError(t *testing.T) {
@@ -29,6 +34,15 @@ func TestClassifySearchError(t *testing.T) {
 				source:      searchErrorSourceTiFlash,
 				retryable:   true,
 				dbErrorCode: 1105,
+			},
+		},
+		{
+			name: "TiFlash flash error",
+			err:  errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]"),
+			want: searchErrorDetails{
+				class:     searchErrorClassTiFlashMemoryLimit,
+				source:    searchErrorSourceTiFlash,
+				retryable: true,
 			},
 		},
 		{
@@ -143,6 +157,90 @@ func TestSearchErrorLogAttrs(t *testing.T) {
 		t.Fatalf("err = %v, want %v", got, err)
 	}
 }
+
+func TestSearchMethodsLogRowIterationErrors(t *testing.T) {
+	previousLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	tests := []struct {
+		name      string
+		columns   []string
+		resource  string
+		queryType string
+		run       func(*sql.DB) error
+	}{
+		{
+			name:      "memory keyword search",
+			columns:   memorySearchColumns(),
+			resource:  "memory",
+			queryType: "keyword",
+			run: func(db *sql.DB) error {
+				repo := NewMemoryRepo(db, "", false, "cluster-row-error")
+				_, err := repo.KeywordSearch(context.Background(), "", domain.MemoryFilter{}, 1)
+				return err
+			},
+		},
+		{
+			name:      "session keyword search",
+			columns:   sessionColumns(),
+			resource:  "session",
+			queryType: "keyword",
+			run: func(db *sql.DB) error {
+				repo := NewSessionRepo(db, "", false, "cluster-row-error")
+				_, err := repo.KeywordSearch(context.Background(), "", domain.MemoryFilter{}, 1)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rowErr := &mysql.MySQLError{
+				Number:  1105,
+				Message: "TiDB Cloud Inference: status code 503",
+			}
+			db := newScriptedTestDB(t, []*queryExpectation{{
+				wantArgs: []any{1},
+				rows: &searchFailingRows{
+					columns: tt.columns,
+					err:     rowErr,
+				},
+			}})
+			defer db.Close()
+
+			var logBuf bytes.Buffer
+			slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+			if err := tt.run(db); !errors.Is(err, rowErr) {
+				t.Fatalf("search error = %v, want %v", err, rowErr)
+			}
+
+			var entry map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(logBuf.Bytes()), &entry); err != nil {
+				t.Fatalf("decode search log: %v; log = %s", err, logBuf.String())
+			}
+			if got := entry["resource"]; got != tt.resource {
+				t.Fatalf("resource = %v, want %q", got, tt.resource)
+			}
+			if got := entry["query_type"]; got != tt.queryType {
+				t.Fatalf("query_type = %v, want %q", got, tt.queryType)
+			}
+			if got := entry["error_class"]; got != searchErrorClassInferenceUpstream5xx {
+				t.Fatalf("error_class = %v, want %q", got, searchErrorClassInferenceUpstream5xx)
+			}
+		})
+	}
+}
+
+type searchFailingRows struct {
+	columns []string
+	err     error
+}
+
+func (r *searchFailingRows) Columns() []string { return r.columns }
+
+func (r *searchFailingRows) Close() error { return nil }
+
+func (r *searchFailingRows) Next([]driver.Value) error { return r.err }
 
 func attrsByKey(attrs []slog.Attr) map[string]slog.Value {
 	result := make(map[string]slog.Value, len(attrs))

--- a/server/internal/repository/tidb/search_logging_test.go
+++ b/server/internal/repository/tidb/search_logging_test.go
@@ -1,0 +1,174 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+func TestClassifySearchError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want searchErrorDetails
+	}{
+		{
+			name: "TiFlash memory limit",
+			err: &mysql.MySQLError{
+				Number:  1105,
+				Message: "TiFlashException: Memory limit exceeded for query",
+			},
+			want: searchErrorDetails{
+				class:       searchErrorClassTiFlashMemoryLimit,
+				source:      searchErrorSourceTiFlash,
+				retryable:   true,
+				dbErrorCode: 1105,
+			},
+		},
+		{
+			name: "inference service error",
+			err: fmt.Errorf("auto vector search: %w", &mysql.MySQLError{
+				Number:  1105,
+				Message: "TiDB Cloud Inference: status code 503, service unavailable",
+			}),
+			want: searchErrorDetails{
+				class:          searchErrorClassInferenceUpstream5xx,
+				source:         searchErrorSourceInference,
+				retryable:      true,
+				dbErrorCode:    1105,
+				upstreamStatus: 503,
+			},
+		},
+		{
+			name: "inference request error",
+			err:  errors.New("TiDB Cloud Inference: status code 429: rate limited"),
+			want: searchErrorDetails{
+				class:          searchErrorClassInferenceHTTPError,
+				source:         searchErrorSourceInference,
+				retryable:      true,
+				upstreamStatus: 429,
+			},
+		},
+		{
+			name: "request canceled",
+			err:  fmt.Errorf("query: %w", context.Canceled),
+			want: searchErrorDetails{
+				class:  searchErrorClassContextCanceled,
+				source: searchErrorSourceRequest,
+			},
+		},
+		{
+			name: "request deadline",
+			err:  fmt.Errorf("query: %w", context.DeadlineExceeded),
+			want: searchErrorDetails{
+				class:     searchErrorClassContextDeadline,
+				source:    searchErrorSourceRequest,
+				retryable: true,
+			},
+		},
+		{
+			name: "connection closed",
+			err:  fmt.Errorf("query: %w", sql.ErrConnDone),
+			want: searchErrorDetails{
+				class:     searchErrorClassDatabaseClosed,
+				source:    searchErrorSourceTenantDatabase,
+				retryable: true,
+			},
+		},
+		{
+			name: "database closed",
+			err:  errors.New("sql: database is closed"),
+			want: searchErrorDetails{
+				class:     searchErrorClassDatabaseClosed,
+				source:    searchErrorSourceTenantDatabase,
+				retryable: true,
+			},
+		},
+		{
+			name: "operation canceled",
+			err:  errors.New("read tcp: operation was canceled"),
+			want: searchErrorDetails{
+				class:  searchErrorClassOperationCanceled,
+				source: searchErrorSourceTenantDatabase,
+			},
+		},
+		{
+			name: "database query failure",
+			err:  &mysql.MySQLError{Number: 1064, Message: "syntax error"},
+			want: searchErrorDetails{
+				class:       searchErrorClassDatabaseError,
+				source:      searchErrorSourceTenantDatabase,
+				dbErrorCode: 1064,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifySearchError(tt.err)
+			if got != tt.want {
+				t.Fatalf("classifySearchError() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSearchErrorLogAttrs(t *testing.T) {
+	err := &mysql.MySQLError{
+		Number:  1105,
+		Message: "TiDB Cloud Inference: status code 503, service unavailable",
+	}
+	attrs := attrsByKey(searchErrorLogAttrs("memory", "auto_vector", "cluster-1", 1250*time.Millisecond, err))
+
+	assertStringAttr(t, attrs, "cluster_id", "cluster-1")
+	assertStringAttr(t, attrs, "resource", "memory")
+	assertStringAttr(t, attrs, "query_type", "auto_vector")
+	assertStringAttr(t, attrs, "error_role", "dependency_attempt")
+	assertStringAttr(t, attrs, "error_class", searchErrorClassInferenceUpstream5xx)
+	assertStringAttr(t, attrs, "error_source", searchErrorSourceInference)
+	if got := attrs["retryable"].Bool(); !got {
+		t.Fatal("retryable = false, want true")
+	}
+	assertIntAttr(t, attrs, "duration_ms", 1250)
+	assertIntAttr(t, attrs, "db_error_code", 1105)
+	assertIntAttr(t, attrs, "upstream_status", 503)
+	if got := attrs["err"].Any(); got != err {
+		t.Fatalf("err = %v, want %v", got, err)
+	}
+}
+
+func attrsByKey(attrs []slog.Attr) map[string]slog.Value {
+	result := make(map[string]slog.Value, len(attrs))
+	for _, attr := range attrs {
+		result[attr.Key] = attr.Value
+	}
+	return result
+}
+
+func assertStringAttr(t *testing.T, attrs map[string]slog.Value, key, want string) {
+	t.Helper()
+	value, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if got := value.String(); got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func assertIntAttr(t *testing.T, attrs map[string]slog.Value, key string, want int64) {
+	t.Helper()
+	value, ok := attrs[key]
+	if !ok {
+		t.Fatalf("attribute %q missing", key)
+	}
+	if got := value.Int64(); got != want {
+		t.Fatalf("%s = %d, want %d", key, got, want)
+	}
+}

--- a/server/internal/repository/tidb/search_logging_test.go
+++ b/server/internal/repository/tidb/search_logging_test.go
@@ -60,6 +60,16 @@ func TestClassifySearchError(t *testing.T) {
 			},
 		},
 		{
+			name: "inference HTTP status error",
+			err:  errors.New("TiDB Cloud Inference: HTTP status 504"),
+			want: searchErrorDetails{
+				class:          searchErrorClassInferenceUpstream5xx,
+				source:         searchErrorSourceInference,
+				retryable:      true,
+				upstreamStatus: 504,
+			},
+		},
+		{
 			name: "inference request error",
 			err:  errors.New("TiDB Cloud Inference: status code 429: rate limited"),
 			want: searchErrorDetails{

--- a/server/internal/repository/tidb/search_logging_test.go
+++ b/server/internal/repository/tidb/search_logging_test.go
@@ -22,7 +22,7 @@ func TestClassifySearchError(t *testing.T) {
 			name: "TiFlash memory limit",
 			err: &mysql.MySQLError{
 				Number:  1105,
-				Message: "TiFlashException: Memory limit exceeded for query",
+				Message: "TiFlashException: Memory limit (total) exceeded",
 			},
 			want: searchErrorDetails{
 				class:       searchErrorClassTiFlashMemoryLimit,
@@ -92,10 +92,11 @@ func TestClassifySearchError(t *testing.T) {
 		},
 		{
 			name: "operation canceled",
-			err:  errors.New("read tcp: operation was canceled"),
+			err:  errors.New("dial tcp 192.0.2.1:4000: operation was canceled"),
 			want: searchErrorDetails{
-				class:  searchErrorClassOperationCanceled,
-				source: searchErrorSourceTenantDatabase,
+				class:     searchErrorClassDatabaseError,
+				source:    searchErrorSourceTenantDatabase,
+				retryable: true,
 			},
 		},
 		{

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -338,7 +338,7 @@ func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f doma
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, domain.ErrAutoVectorSearchSkipped
 		}
-		slog.ErrorContext(ctx, "sessions auto vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "sessions auto vector search failed", "session", "auto_vector", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("sessions auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
@@ -378,7 +378,7 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
-		slog.ErrorContext(ctx, "sessions vector search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "sessions vector search failed", "session", "vector", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("sessions vector search: %w", err)
 	}
 	defer rows.Close()
@@ -397,7 +397,7 @@ func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.Memo
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
-		slog.ErrorContext(ctx, "sessions fts search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "sessions fts search failed", "session", "fts", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("sessions fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	slog.DebugContext(ctx, "sessions fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
@@ -554,7 +554,7 @@ func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
 		}
-		slog.ErrorContext(ctx, "sessions keyword search failed", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "err", err)
+		logSearchError(ctx, "sessions keyword search failed", "session", "keyword", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("sessions keyword search: %w", err)
 	}
 	defer rows.Close()

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -315,7 +315,7 @@ func sessionListOrderBy(f domain.MemoryFilter) string {
 	return column + " " + direction + ", id " + direction
 }
 
-func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) (_ []domain.Memory, resultErr error) {
 	conds, args := r.buildSessionFilterConds(f)
 	conds = append(conds, "embedding IS NOT NULL")
 	where := strings.Join(conds, " AND ")
@@ -342,6 +342,7 @@ func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f doma
 		return nil, fmt.Errorf("sessions auto vector search: cluster_id=%s: %w", r.clusterID, err)
 	}
 	defer rows.Close()
+	defer logSearchResultError(ctx, "sessions auto vector search failed", "session", "auto_vector", r.clusterID, start, &resultErr)
 	memories, err := scanSessionRowsWithDistance(rows)
 	if err != nil {
 		return nil, err
@@ -350,7 +351,7 @@ func (r *SessionRepo) AutoVectorSearch(ctx context.Context, query string, f doma
 	return memories, nil
 }
 
-func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f domain.MemoryFilter, limit int) (_ []domain.Memory, resultErr error) {
 	vecStr := vecToString(queryVec)
 	if vecStr == nil {
 		return nil, nil
@@ -382,6 +383,7 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 		return nil, fmt.Errorf("sessions vector search: %w", err)
 	}
 	defer rows.Close()
+	defer logSearchResultError(ctx, "sessions vector search failed", "session", "vector", r.clusterID, start, &resultErr)
 	memories, err := scanSessionRowsWithDistance(rows)
 	if err != nil {
 		return nil, err
@@ -533,7 +535,7 @@ func (r *SessionRepo) fetchFilteredFTSSessions(ctx context.Context, candidates [
 	return ordered, nil
 }
 
-func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) (_ []domain.Memory, resultErr error) {
 	conds, args := r.buildSessionFilterConds(f)
 	if query != "" {
 		conds = append(conds, "content LIKE CONCAT('%', ?, '%')")
@@ -558,6 +560,7 @@ func (r *SessionRepo) KeywordSearch(ctx context.Context, query string, f domain.
 		return nil, fmt.Errorf("sessions keyword search: %w", err)
 	}
 	defer rows.Close()
+	defer logSearchResultError(ctx, "sessions keyword search failed", "session", "keyword", r.clusterID, start, &resultErr)
 	memories, err := scanSessionRows(rows)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## What Changed
- Add stable dependency-error fields to all memory and session search failures.
- Classify TiFlash memory pressure, TiDB Cloud Inference status failures, request cancellation, closed tenant databases, and generic database errors.
- Preserve raw errors and existing response behavior.

## Why
- The production 5xx investigation currently depends on regular expressions over free-form error text.
- Structured fields make Clinic aggregation and request-level root-cause correlation reliable.

## Review Path
1. `server/internal/repository/tidb/search_logging.go`
2. Search call sites in `memory.go` and `sessions.go`
3. `search_logging_test.go`

## Validation
- `cd server && go test -race -count=1 ./internal/repository/tidb/`
- `cd server && go vet ./...`
- `git diff --check upstream/main...HEAD`
