### PR TITLE
fix(server): classify final internal error logs

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -331,7 +331,21 @@ func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err err
 	case errors.Is(err, domain.ErrSchemaIncompatible):
 		respondError(w, http.StatusConflict, err.Error())
 	default:
-		s.logger.Error("internal error", "err", err, "request_id", reqid.FromContext(ctx))
+		classification := classifyInternalError(err)
+		attrs := []slog.Attr{
+			slog.String("error_role", "final"),
+			slog.String("error_class", classification.class),
+			slog.String("error_source", classification.source),
+			slog.Bool("retryable", classification.retryable),
+			slog.Any("err", err),
+		}
+		if classification.dbErrorCode != 0 {
+			attrs = append(attrs, slog.Uint64("db_error_code", uint64(classification.dbErrorCode)))
+		}
+		if classification.upstreamStatus != 0 {
+			attrs = append(attrs, slog.Int("upstream_status", classification.upstreamStatus))
+		}
+		s.logger.LogAttrs(ctx, slog.LevelError, "internal error", attrs...)
 		respondError(w, http.StatusInternalServerError, "internal server error")
 	}
 }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -345,6 +345,9 @@ func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err err
 		if classification.upstreamStatus != 0 {
 			attrs = append(attrs, slog.Int("upstream_status", classification.upstreamStatus))
 		}
+		if auth := middleware.AuthFromContext(ctx); auth != nil && auth.ClusterID != "" {
+			attrs = append(attrs, slog.String("cluster_id", auth.ClusterID))
+		}
 		s.logger.LogAttrs(ctx, slog.LevelError, "internal error", attrs...)
 		respondError(w, http.StatusInternalServerError, "internal server error")
 	}

--- a/server/internal/handler/internal_error.go
+++ b/server/internal/handler/internal_error.go
@@ -37,17 +37,31 @@ func classifyInternalError(err error) internalErrorClassification {
 		classification.dbErrorCode = dbErr.Number
 	}
 
-	var upstreamErr *llm.HTTPStatusError
-	isInferenceError := errors.As(err, &upstreamErr)
-	if isInferenceError {
-		classification.upstreamStatus = upstreamErr.Code
-	} else if status, ok := tidbCloudInferenceStatus(err); ok {
-		isInferenceError = true
-		classification.upstreamStatus = status
+	var llmErr *llm.HTTPStatusError
+	isLLMError := errors.As(err, &llmErr)
+	if isLLMError {
+		classification.upstreamStatus = llmErr.Code
+	}
+
+	isInferenceError := false
+	if !isLLMError {
+		if status, ok := tidbCloudInferenceStatus(err); ok {
+			isInferenceError = true
+			classification.upstreamStatus = status
+		}
 	}
 	message := strings.ToLower(err.Error())
 
 	switch {
+	case isLLMError && classification.upstreamStatus >= http.StatusInternalServerError &&
+		classification.upstreamStatus < 600:
+		classification.class = "llm_upstream_5xx"
+		classification.source = "llm_provider"
+		classification.retryable = true
+	case isLLMError:
+		classification.class = "llm_http_error"
+		classification.source = "llm_provider"
+		classification.retryable = classification.upstreamStatus == http.StatusTooManyRequests
 	case isTiFlashMemoryLimit(message):
 		classification.class = "tiflash_memory_limit"
 		classification.source = "tiflash"

--- a/server/internal/handler/internal_error.go
+++ b/server/internal/handler/internal_error.go
@@ -1,0 +1,98 @@
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/qiffang/mnemos/server/internal/llm"
+)
+
+var tidbCloudInferenceStatusPattern = regexp.MustCompile(
+	`(?i)\btidb cloud inference:\s*(?:status code|status|http status|http)\s*:?\s*([1-5][0-9]{2})\b`,
+)
+
+type internalErrorClassification struct {
+	class          string
+	source         string
+	retryable      bool
+	dbErrorCode    uint16
+	upstreamStatus int
+}
+
+func classifyInternalError(err error) internalErrorClassification {
+	classification := internalErrorClassification{
+		class:  "unknown",
+		source: "internal",
+	}
+
+	var dbErr *mysql.MySQLError
+	if errors.As(err, &dbErr) {
+		classification.dbErrorCode = dbErr.Number
+	}
+
+	var upstreamErr *llm.HTTPStatusError
+	isInferenceError := errors.As(err, &upstreamErr)
+	if isInferenceError {
+		classification.upstreamStatus = upstreamErr.Code
+	} else if status, ok := tidbCloudInferenceStatus(err); ok {
+		isInferenceError = true
+		classification.upstreamStatus = status
+	}
+
+	switch {
+	case isTiFlashMemoryLimit(err):
+		classification.class = "tiflash_memory_limit"
+		classification.source = "tiflash"
+		classification.retryable = true
+	case isInferenceError && classification.upstreamStatus >= http.StatusInternalServerError &&
+		classification.upstreamStatus < 600:
+		classification.class = "inference_upstream_5xx"
+		classification.source = "inference"
+		classification.retryable = true
+	case isInferenceError:
+		classification.class = "inference_http_error"
+		classification.source = "inference"
+		classification.retryable = classification.upstreamStatus == http.StatusTooManyRequests
+	case errors.Is(err, context.Canceled):
+		classification.class = "context_canceled"
+		classification.source = "request_context"
+	case errors.Is(err, context.DeadlineExceeded):
+		classification.class = "context_deadline_exceeded"
+		classification.source = "request_context"
+		classification.retryable = true
+	case errors.Is(err, sql.ErrConnDone) || strings.Contains(strings.ToLower(err.Error()), "database is closed"):
+		classification.class = "database_closed"
+		classification.source = "tenant_database"
+		classification.retryable = true
+	case dbErr != nil:
+		classification.class = "database_error"
+		classification.source = "tenant_database"
+	}
+
+	return classification
+}
+
+func tidbCloudInferenceStatus(err error) (int, bool) {
+	match := tidbCloudInferenceStatusPattern.FindStringSubmatch(err.Error())
+	if len(match) != 2 {
+		return 0, false
+	}
+	status, parseErr := strconv.Atoi(match[1])
+	if parseErr != nil {
+		return 0, false
+	}
+	return status, true
+}
+
+func isTiFlashMemoryLimit(err error) bool {
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "memory limit exceeded") &&
+		(strings.Contains(message, "tiflash") || strings.Contains(message, "[flash:"))
+}

--- a/server/internal/handler/internal_error.go
+++ b/server/internal/handler/internal_error.go
@@ -45,9 +45,10 @@ func classifyInternalError(err error) internalErrorClassification {
 		isInferenceError = true
 		classification.upstreamStatus = status
 	}
+	message := strings.ToLower(err.Error())
 
 	switch {
-	case isTiFlashMemoryLimit(err):
+	case isTiFlashMemoryLimit(message):
 		classification.class = "tiflash_memory_limit"
 		classification.source = "tiflash"
 		classification.retryable = true
@@ -67,8 +68,12 @@ func classifyInternalError(err error) internalErrorClassification {
 		classification.class = "context_deadline_exceeded"
 		classification.source = "request_context"
 		classification.retryable = true
-	case errors.Is(err, sql.ErrConnDone) || strings.Contains(strings.ToLower(err.Error()), "database is closed"):
+	case errors.Is(err, sql.ErrConnDone) || strings.Contains(message, "database is closed"):
 		classification.class = "database_closed"
+		classification.source = "tenant_database"
+		classification.retryable = true
+	case strings.Contains(message, "operation was canceled"):
+		classification.class = "database_error"
 		classification.source = "tenant_database"
 		classification.retryable = true
 	case dbErr != nil:
@@ -91,8 +96,8 @@ func tidbCloudInferenceStatus(err error) (int, bool) {
 	return status, true
 }
 
-func isTiFlashMemoryLimit(err error) bool {
-	message := strings.ToLower(err.Error())
-	return strings.Contains(message, "memory limit exceeded") &&
+func isTiFlashMemoryLimit(message string) bool {
+	return strings.Contains(message, "memory limit") &&
+		strings.Contains(message, "exceeded") &&
 		(strings.Contains(message, "tiflash") || strings.Contains(message, "[flash:"))
 }

--- a/server/internal/handler/internal_error_test.go
+++ b/server/internal/handler/internal_error_test.go
@@ -12,7 +12,9 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 
+	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/llm"
+	"github.com/qiffang/mnemos/server/internal/middleware"
 	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
@@ -40,6 +42,13 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 			wantDBErrorCode: 1105,
 		},
 		{
+			name:          "TiFlash flash error",
+			err:           errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]"),
+			wantClass:     "tiflash_memory_limit",
+			wantSource:    "tiflash",
+			wantRetryable: true,
+		},
+		{
 			name: "TiDB Cloud Inference through MySQL",
 			err: fmt.Errorf("auto vector search: %w", &mysql.MySQLError{
 				Number:  1105,
@@ -52,12 +61,20 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 			wantUpstreamStatus: http.StatusServiceUnavailable,
 		},
 		{
-			name:               "typed inference upstream unavailable",
+			name:               "typed LLM upstream unavailable",
 			err:                &llm.HTTPStatusError{Code: http.StatusServiceUnavailable, Body: "upstream unavailable"},
-			wantClass:          "inference_upstream_5xx",
-			wantSource:         "inference",
+			wantClass:          "llm_upstream_5xx",
+			wantSource:         "llm_provider",
 			wantRetryable:      true,
 			wantUpstreamStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:               "typed LLM rate limited",
+			err:                &llm.HTTPStatusError{Code: http.StatusTooManyRequests, Body: "rate limited"},
+			wantClass:          "llm_http_error",
+			wantSource:         "llm_provider",
+			wantRetryable:      true,
+			wantUpstreamStatus: http.StatusTooManyRequests,
 		},
 		{
 			name:               "inference rate limited",
@@ -119,7 +136,10 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 			var logBuf bytes.Buffer
 			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
 			srv := &Server{logger: logger}
-			ctx := reqid.NewContext(context.Background(), "request-123")
+			ctx := middleware.WithAuthContext(
+				reqid.NewContext(context.Background(), "request-123"),
+				&domain.AuthInfo{ClusterID: "cluster-123"},
+			)
 			recorder := httptest.NewRecorder()
 			err := fmt.Errorf("recall failed: %w", tt.err)
 
@@ -134,6 +154,7 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 
 			entry := findHandlerLogEntry(t, decodeHandlerLogs(t, &logBuf), "internal error")
 			assertHandlerLogField(t, entry, "request_id", "request-123")
+			assertHandlerLogField(t, entry, "cluster_id", "cluster-123")
 			assertHandlerLogField(t, entry, "error_role", "final")
 			assertHandlerLogField(t, entry, "error_class", tt.wantClass)
 			assertHandlerLogField(t, entry, "error_source", tt.wantSource)

--- a/server/internal/handler/internal_error_test.go
+++ b/server/internal/handler/internal_error_test.go
@@ -32,7 +32,7 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 			name: "TiFlash memory limit",
 			err: &mysql.MySQLError{
 				Number:  1105,
-				Message: "[FLASH:Coprocessor:Memory limit exceeded for instance]",
+				Message: "TiFlashException: Memory limit (total) exceeded",
 			},
 			wantClass:       "tiflash_memory_limit",
 			wantSource:      "tiflash",
@@ -95,6 +95,13 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 			wantSource:      "tenant_database",
 			wantRetryable:   false,
 			wantDBErrorCode: 1064,
+		},
+		{
+			name:          "database network operation canceled",
+			err:           errors.New("dial tcp 192.0.2.1:4000: operation was canceled"),
+			wantClass:     "database_error",
+			wantSource:    "tenant_database",
+			wantRetryable: true,
 		},
 		{
 			name:          "unknown",

--- a/server/internal/handler/internal_error_test.go
+++ b/server/internal/handler/internal_error_test.go
@@ -1,0 +1,160 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/qiffang/mnemos/server/internal/llm"
+	"github.com/qiffang/mnemos/server/internal/reqid"
+)
+
+func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		err                error
+		wantClass          string
+		wantSource         string
+		wantRetryable      bool
+		wantDBErrorCode    float64
+		wantUpstreamStatus float64
+	}{
+		{
+			name: "TiFlash memory limit",
+			err: &mysql.MySQLError{
+				Number:  1105,
+				Message: "[FLASH:Coprocessor:Memory limit exceeded for instance]",
+			},
+			wantClass:       "tiflash_memory_limit",
+			wantSource:      "tiflash",
+			wantRetryable:   true,
+			wantDBErrorCode: 1105,
+		},
+		{
+			name: "TiDB Cloud Inference through MySQL",
+			err: fmt.Errorf("auto vector search: %w", &mysql.MySQLError{
+				Number:  1105,
+				Message: "TiDB Cloud Inference: status code 503, service unavailable",
+			}),
+			wantClass:          "inference_upstream_5xx",
+			wantSource:         "inference",
+			wantRetryable:      true,
+			wantDBErrorCode:    1105,
+			wantUpstreamStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:               "typed inference upstream unavailable",
+			err:                &llm.HTTPStatusError{Code: http.StatusServiceUnavailable, Body: "upstream unavailable"},
+			wantClass:          "inference_upstream_5xx",
+			wantSource:         "inference",
+			wantRetryable:      true,
+			wantUpstreamStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:               "inference rate limited",
+			err:                errors.New("TiDB Cloud Inference: HTTP status 429"),
+			wantClass:          "inference_http_error",
+			wantSource:         "inference",
+			wantRetryable:      true,
+			wantUpstreamStatus: http.StatusTooManyRequests,
+		},
+		{
+			name:          "context canceled",
+			err:           context.Canceled,
+			wantClass:     "context_canceled",
+			wantSource:    "request_context",
+			wantRetryable: false,
+		},
+		{
+			name:          "context deadline exceeded",
+			err:           context.DeadlineExceeded,
+			wantClass:     "context_deadline_exceeded",
+			wantSource:    "request_context",
+			wantRetryable: true,
+		},
+		{
+			name:          "database closed",
+			err:           errors.New("sql: database is closed"),
+			wantClass:     "database_closed",
+			wantSource:    "tenant_database",
+			wantRetryable: true,
+		},
+		{
+			name:            "generic MySQL error",
+			err:             &mysql.MySQLError{Number: 1064, Message: "syntax error"},
+			wantClass:       "database_error",
+			wantSource:      "tenant_database",
+			wantRetryable:   false,
+			wantDBErrorCode: 1064,
+		},
+		{
+			name:          "unknown",
+			err:           errors.New("unexpected failure"),
+			wantClass:     "unknown",
+			wantSource:    "internal",
+			wantRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logBuf bytes.Buffer
+			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+			srv := &Server{logger: logger}
+			ctx := reqid.NewContext(context.Background(), "request-123")
+			recorder := httptest.NewRecorder()
+			err := fmt.Errorf("recall failed: %w", tt.err)
+
+			srv.handleError(ctx, recorder, err)
+
+			if recorder.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+			}
+			if got := recorder.Body.String(); got != "{\"error\":\"internal server error\"}\n" {
+				t.Fatalf("body = %q, want internal server error response", got)
+			}
+
+			entry := findHandlerLogEntry(t, decodeHandlerLogs(t, &logBuf), "internal error")
+			assertHandlerLogField(t, entry, "request_id", "request-123")
+			assertHandlerLogField(t, entry, "error_role", "final")
+			assertHandlerLogField(t, entry, "error_class", tt.wantClass)
+			assertHandlerLogField(t, entry, "error_source", tt.wantSource)
+			assertHandlerLogField(t, entry, "retryable", tt.wantRetryable)
+			assertHandlerLogField(t, entry, "err", err.Error())
+			assertOptionalHandlerLogField(t, entry, "db_error_code", tt.wantDBErrorCode)
+			assertOptionalHandlerLogField(t, entry, "upstream_status", tt.wantUpstreamStatus)
+		})
+	}
+}
+
+func assertHandlerLogField(t *testing.T, entry map[string]any, key string, want any) {
+	t.Helper()
+	if got := entry[key]; got != want {
+		t.Fatalf("%s = %#v, want %#v", key, got, want)
+	}
+}
+
+func assertOptionalHandlerLogField(t *testing.T, entry map[string]any, key string, want float64) {
+	t.Helper()
+	got, ok := entry[key]
+	if want == 0 {
+		if ok {
+			t.Fatalf("%s = %#v, want field omitted", key, got)
+		}
+		return
+	}
+	if !ok || got != want {
+		t.Fatalf("%s = %#v, want %#v", key, got, want)
+	}
+}


### PR DESCRIPTION
## What Changed

- Final HTTP internal-error logs emit `error_role`, `error_class`, `error_source`, `retryable`, and authenticated `cluster_id`.
- MySQL and upstream HTTP failures include `db_error_code` and `upstream_status` when available.
- Incident families cover TiFlash memory limits, TiDB Cloud Inference failures, configured LLM-provider failures, context cancellation and deadlines, tenant-database failures, and unknown errors.
- Handler tests use the production TiFlash and Inference message shapes and preserve the existing HTTP 500 response.

## Why

- Production 5xx analysis currently depends on parsing free-text error messages.
- Stable low-cardinality fields make final request failures directly aggregatable by cause and cluster while retaining the raw error for diagnosis.

## Review Path

1. Classification precedence and taxonomy in `server/internal/handler/internal_error.go`.
2. Final logging boundary and optional cluster field in `server/internal/handler/handler.go`.
3. Production fixtures and response contract in `server/internal/handler/internal_error_test.go`.

## Validation

- `cd server && go test -race -count=1 ./internal/handler/`
- `cd server && go vet ./...`
- Combined with #404, #405, and #407: `make test`, `make vet`, and `git diff --check upstream/main...HEAD`
