### PR TITLE
Log confidence recall failure summaries

### DIFF
--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -385,7 +385,7 @@ func classifyRecallError(err error) recallErrorClassification {
 
 	message := strings.ToLower(err.Error())
 	switch {
-	case strings.Contains(message, "memory limit exceeded") &&
+	case strings.Contains(message, "memory limit") && strings.Contains(message, "exceeded") &&
 		(strings.Contains(message, "tiflash") || strings.Contains(message, "[flash:")):
 		classification.class = "tiflash_memory_limit"
 		classification.source = "tiflash"

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -2,9 +2,13 @@ package handler
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"log/slog"
+	"net/http"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -88,6 +92,7 @@ var (
 	recallCoverageEnglishTokenRe = regexp.MustCompile(`\b[a-z][a-z0-9'-]{3,}\b`)
 	recallCoverageCJKTokenRe     = regexp.MustCompile(`[\p{Han}]{2,6}`)
 	recallCoverageSpaceRe        = regexp.MustCompile(`\s+`)
+	recallHTTPStatusRe           = regexp.MustCompile(`(?i)(?:status(?:\s+code)?|http(?:\s+status)?)\D{0,8}([1-5]\d{2})`)
 )
 
 type recallTemporalIntent int
@@ -135,6 +140,19 @@ type recallSelectionStats struct {
 	backfillCount          int
 }
 
+type recallBranchResult struct {
+	name     string
+	duration time.Duration
+	err      error
+}
+
+type recallErrorClassification struct {
+	class          string
+	source         string
+	retryable      bool
+	upstreamStatus int
+}
+
 func (s *Server) defaultConfidenceRecallSearch(
 	ctx context.Context,
 	auth *domain.AuthInfo,
@@ -163,16 +181,17 @@ func (s *Server) defaultConfidenceRecallSearch(
 		pinnedCandidates  []service.RecallCandidate
 		insightCandidates []service.RecallCandidate
 		sessionCandidates []service.RecallCandidate
-		pinnedDuration    time.Duration
-		insightDuration   time.Duration
-		sessionDuration   time.Duration
+		pinnedResult      = recallBranchResult{name: string(service.RecallSourcePinned)}
+		insightResult     = recallBranchResult{name: string(service.RecallSourceInsight)}
+		sessionResult     = recallBranchResult{name: string(service.RecallSourceSession)}
 	)
 
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		branchStart := time.Now()
 		candidates, err := svc.memory.SearchCandidates(groupCtx, pinnedFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
-		pinnedDuration = time.Since(branchStart)
+		pinnedResult.duration = time.Since(branchStart)
+		pinnedResult.err = err
 		if err != nil {
 			return err
 		}
@@ -182,7 +201,8 @@ func (s *Server) defaultConfidenceRecallSearch(
 	group.Go(func() error {
 		branchStart := time.Now()
 		candidates, err := svc.memory.SearchCandidates(groupCtx, insightFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
-		insightDuration = time.Since(branchStart)
+		insightResult.duration = time.Since(branchStart)
+		insightResult.err = err
 		if err != nil {
 			return err
 		}
@@ -192,7 +212,8 @@ func (s *Server) defaultConfidenceRecallSearch(
 	group.Go(func() error {
 		branchStart := time.Now()
 		candidates, err := svc.session.SearchCandidates(groupCtx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
-		sessionDuration = time.Since(branchStart)
+		sessionResult.duration = time.Since(branchStart)
+		sessionResult.err = err
 		if err != nil {
 			return err
 		}
@@ -200,6 +221,11 @@ func (s *Server) defaultConfidenceRecallSearch(
 		return nil
 	})
 	if err := group.Wait(); err != nil {
+		s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, err, [3]recallBranchResult{
+			pinnedResult,
+			insightResult,
+			sessionResult,
+		})
 		return nil, 0, err
 	}
 
@@ -231,13 +257,159 @@ func (s *Server) defaultConfidenceRecallSearch(
 		"backfill_selected", stats.backfillCount,
 		"returned", len(memories),
 		"cutoff_reason", cutoffReason,
-		"pinned_ms", pinnedDuration.Milliseconds(),
-		"insight_ms", insightDuration.Milliseconds(),
-		"session_ms", sessionDuration.Milliseconds(),
+		"pinned_ms", pinnedResult.duration.Milliseconds(),
+		"insight_ms", insightResult.duration.Milliseconds(),
+		"session_ms", sessionResult.duration.Milliseconds(),
 		"selection_ms", selectionDuration.Milliseconds(),
 		"total_ms", time.Since(start).Milliseconds(),
 	)
 	return memories, len(memories), nil
+}
+
+func (s *Server) logConfidenceRecallFailure(
+	ctx context.Context,
+	clusterID string,
+	start time.Time,
+	primaryErr error,
+	branches [3]recallBranchResult,
+) {
+	primaryBranch := recallPrimaryBranch(primaryErr, branches)
+	primaryCause := primaryErr
+	cancelOrigin := "none"
+	if ctxErr := ctx.Err(); ctxErr != nil && recallBranchCanceled(primaryErr) {
+		primaryBranch = "request"
+		primaryCause = ctxErr
+		switch {
+		case errors.Is(ctxErr, context.DeadlineExceeded):
+			cancelOrigin = "deadline"
+		case errors.Is(ctxErr, context.Canceled):
+			cancelOrigin = "client"
+		}
+	} else if recallHasCanceledSibling(primaryBranch, branches) {
+		cancelOrigin = "sibling_failure"
+	}
+	classification := classifyRecallError(primaryCause)
+
+	logger := s.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	attrs := []slog.Attr{
+		slog.String("error_role", "recall_summary"),
+		slog.String("cluster_id", clusterID),
+		slog.String("primary_branch", primaryBranch),
+		slog.String("primary_error_class", classification.class),
+		slog.String("primary_error_source", classification.source),
+		slog.Bool("primary_retryable", classification.retryable),
+		slog.Any("canceled_branches", recallCanceledBranches(primaryBranch, branches)),
+		slog.String("cancel_origin", cancelOrigin),
+		slog.String("pinned_outcome", recallBranchOutcome(branches[0].err)),
+		slog.Int64("pinned_ms", branches[0].duration.Milliseconds()),
+		slog.String("insight_outcome", recallBranchOutcome(branches[1].err)),
+		slog.Int64("insight_ms", branches[1].duration.Milliseconds()),
+		slog.String("session_outcome", recallBranchOutcome(branches[2].err)),
+		slog.Int64("session_ms", branches[2].duration.Milliseconds()),
+		slog.Int64("total_ms", time.Since(start).Milliseconds()),
+		slog.Any("err", primaryErr),
+	}
+	if classification.upstreamStatus != 0 {
+		attrs = append(attrs, slog.Int("primary_upstream_status", classification.upstreamStatus))
+	}
+	logger.LogAttrs(ctx, slog.LevelError, "confidence recall search failed", attrs...)
+}
+
+func recallPrimaryBranch(primaryErr error, branches [3]recallBranchResult) string {
+	for _, branch := range branches {
+		if branch.err != nil && errors.Is(primaryErr, branch.err) && errors.Is(branch.err, primaryErr) {
+			return branch.name
+		}
+	}
+	return "unknown"
+}
+
+func recallHasCanceledSibling(primaryBranch string, branches [3]recallBranchResult) bool {
+	for _, branch := range branches {
+		if branch.name != primaryBranch && recallBranchCanceled(branch.err) {
+			return true
+		}
+	}
+	return false
+}
+
+func recallCanceledBranches(primaryBranch string, branches [3]recallBranchResult) []string {
+	canceled := make([]string, 0, len(branches))
+	for _, branch := range branches {
+		if branch.name != primaryBranch && recallBranchCanceled(branch.err) {
+			canceled = append(canceled, branch.name)
+		}
+	}
+	return canceled
+}
+
+func recallBranchCanceled(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func recallBranchOutcome(err error) string {
+	switch {
+	case err == nil:
+		return "success"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	default:
+		return "failed"
+	}
+}
+
+func classifyRecallError(err error) recallErrorClassification {
+	classification := recallErrorClassification{
+		class:  "unknown",
+		source: "internal",
+	}
+
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		classification.class = "context_deadline_exceeded"
+		classification.source = "request_context"
+		classification.retryable = true
+		return classification
+	case errors.Is(err, context.Canceled):
+		classification.class = "context_canceled"
+		classification.source = "request_context"
+		return classification
+	case err == nil:
+		return classification
+	}
+
+	message := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(message, "memory limit exceeded") &&
+		(strings.Contains(message, "tiflash") || strings.Contains(message, "[flash:")):
+		classification.class = "tiflash_memory_limit"
+		classification.source = "tiflash"
+		classification.retryable = true
+	case strings.Contains(message, "inference"):
+		classification.class = "inference_http_error"
+		classification.source = "inference"
+		if matches := recallHTTPStatusRe.FindStringSubmatch(message); len(matches) == 2 {
+			if status, parseErr := strconv.Atoi(matches[1]); parseErr == nil {
+				classification.upstreamStatus = status
+				if status >= http.StatusInternalServerError {
+					classification.class = "inference_upstream_5xx"
+					classification.retryable = true
+				} else if status == http.StatusTooManyRequests {
+					classification.retryable = true
+				}
+			}
+		}
+	case errors.Is(err, sql.ErrConnDone) || strings.Contains(message, "database is closed"):
+		classification.class = "database_closed"
+		classification.source = "tenant_database"
+		classification.retryable = true
+	}
+	return classification
 }
 
 func (s *Server) singlePoolConfidenceRecallSearch(

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -13,6 +13,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/go-sql-driver/mysql"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
@@ -384,6 +385,8 @@ func classifyRecallError(err error) recallErrorClassification {
 	}
 
 	message := strings.ToLower(err.Error())
+	var dbErr *mysql.MySQLError
+	errors.As(err, &dbErr)
 	switch {
 	case strings.Contains(message, "memory limit") && strings.Contains(message, "exceeded") &&
 		(strings.Contains(message, "tiflash") || strings.Contains(message, "[flash:")):
@@ -406,6 +409,13 @@ func classifyRecallError(err error) recallErrorClassification {
 		}
 	case errors.Is(err, sql.ErrConnDone) || strings.Contains(message, "database is closed"):
 		classification.class = "database_closed"
+		classification.source = "tenant_database"
+		classification.retryable = true
+	case dbErr != nil:
+		classification.class = "database_error"
+		classification.source = "tenant_database"
+	case strings.Contains(message, "operation was canceled"):
+		classification.class = "database_error"
 		classification.source = "tenant_database"
 		classification.retryable = true
 	}

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -93,7 +93,7 @@ var (
 	recallCoverageEnglishTokenRe = regexp.MustCompile(`\b[a-z][a-z0-9'-]{3,}\b`)
 	recallCoverageCJKTokenRe     = regexp.MustCompile(`[\p{Han}]{2,6}`)
 	recallCoverageSpaceRe        = regexp.MustCompile(`\s+`)
-	recallHTTPStatusRe           = regexp.MustCompile(`(?i)(?:status(?:\s+code)?|http(?:\s+status)?)\D{0,8}([1-5]\d{2})`)
+	recallInferenceStatusRe      = regexp.MustCompile(`(?i)\btidb cloud inference:\s*(?:status code|status|http status|http)\s*:?\s*([1-5][0-9]{2})\b`)
 )
 
 type recallTemporalIntent int
@@ -393,10 +393,10 @@ func classifyRecallError(err error) recallErrorClassification {
 		classification.class = "tiflash_memory_limit"
 		classification.source = "tiflash"
 		classification.retryable = true
-	case strings.Contains(message, "inference"):
+	case strings.Contains(message, "tidb cloud inference"):
 		classification.class = "inference_http_error"
 		classification.source = "inference"
-		if matches := recallHTTPStatusRe.FindStringSubmatch(message); len(matches) == 2 {
+		if matches := recallInferenceStatusRe.FindStringSubmatch(message); len(matches) == 2 {
 			if status, parseErr := strconv.Atoi(matches[1]); parseErr == nil {
 				classification.upstreamStatus = status
 				if status >= http.StatusInternalServerError {

--- a/server/internal/handler/recall_failure_log_test.go
+++ b/server/internal/handler/recall_failure_log_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
+
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/reqid"
 )
@@ -182,6 +184,19 @@ func TestClassifyRecallError(t *testing.T) {
 			name:          "database closed",
 			err:           errors.New("sql: database is closed"),
 			wantClass:     "database_closed",
+			wantSource:    "tenant_database",
+			wantRetryable: true,
+		},
+		{
+			name:       "database error",
+			err:        &mysql.MySQLError{Number: 1064, Message: "syntax error"},
+			wantClass:  "database_error",
+			wantSource: "tenant_database",
+		},
+		{
+			name:          "database operation canceled",
+			err:           errors.New("dial tcp 192.0.2.1:4000: operation was canceled"),
+			wantClass:     "database_error",
 			wantSource:    "tenant_database",
 			wantRetryable: true,
 		},

--- a/server/internal/handler/recall_failure_log_test.go
+++ b/server/internal/handler/recall_failure_log_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestDefaultConfidenceRecallSearch_LogsPrimaryFailureAndSiblingCancellation(t *testing.T) {
-	primaryErr := errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]")
+	primaryErr := errors.New("TiFlashException: Memory limit (total) exceeded")
 	allStarted := make(chan struct{})
 	var started atomic.Int32
 	startBranch := func() {
@@ -157,7 +157,7 @@ func TestClassifyRecallError(t *testing.T) {
 	}{
 		{
 			name:          "TiFlash memory limit",
-			err:           errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]"),
+			err:           errors.New("TiFlashException: Memory limit (total) exceeded"),
 			wantClass:     "tiflash_memory_limit",
 			wantSource:    "tiflash",
 			wantRetryable: true,

--- a/server/internal/handler/recall_failure_log_test.go
+++ b/server/internal/handler/recall_failure_log_test.go
@@ -1,0 +1,268 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"slices"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/reqid"
+)
+
+func TestDefaultConfidenceRecallSearch_LogsPrimaryFailureAndSiblingCancellation(t *testing.T) {
+	primaryErr := errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]")
+	allStarted := make(chan struct{})
+	var started atomic.Int32
+	startBranch := func() {
+		if started.Add(1) == 3 {
+			close(allStarted)
+		}
+		<-allStarted
+	}
+
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			startBranch()
+			if filter.MemoryType == string(domain.TypePinned) {
+				return nil, primaryErr
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			startBranch()
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	srv, logBuf := newRecallFailureLogTestServer(memRepo, sessRepo)
+	auth := &domain.AuthInfo{ClusterID: "cluster-recall"}
+	ctx := reqid.NewContext(context.Background(), "request-recall")
+
+	_, _, err := srv.defaultConfidenceRecallSearch(ctx, auth, srv.resolveServices(auth), domain.MemoryFilter{
+		Query: "what happened",
+		Limit: 10,
+	})
+	if !errors.Is(err, primaryErr) {
+		t.Fatalf("error = %v, want wrapped primary error", err)
+	}
+	if errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want primary branch error; got sibling cancellation", err)
+	}
+
+	entry := decodeRecallFailureLog(t, logBuf)
+	assertRecallLogField(t, entry, "msg", "confidence recall search failed")
+	assertRecallLogField(t, entry, "request_id", "request-recall")
+	assertRecallLogField(t, entry, "cluster_id", "cluster-recall")
+	assertRecallLogField(t, entry, "primary_branch", "pinned")
+	assertRecallLogField(t, entry, "primary_error_class", "tiflash_memory_limit")
+	assertRecallLogField(t, entry, "primary_error_source", "tiflash")
+	assertRecallLogField(t, entry, "primary_retryable", true)
+	assertRecallLogField(t, entry, "cancel_origin", "sibling_failure")
+	assertRecallLogField(t, entry, "pinned_outcome", "failed")
+	assertRecallLogField(t, entry, "insight_outcome", "canceled")
+	assertRecallLogField(t, entry, "session_outcome", "canceled")
+	assertRecallLogStrings(t, entry, "canceled_branches", []string{"insight", "session"})
+	assertRecallLogDurations(t, entry)
+}
+
+func TestDefaultConfidenceRecallSearch_LogsRequestCancellationOrigin(t *testing.T) {
+	tests := []struct {
+		name          string
+		newContext    func(context.Context) (context.Context, context.CancelFunc)
+		wantErr       error
+		wantClass     string
+		wantOrigin    string
+		wantOutcome   string
+		wantRetryable bool
+	}{
+		{
+			name: "client cancellation",
+			newContext: func(parent context.Context) (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(parent)
+				cancel()
+				return ctx, cancel
+			},
+			wantErr:     context.Canceled,
+			wantClass:   "context_canceled",
+			wantOrigin:  "client",
+			wantOutcome: "canceled",
+		},
+		{
+			name: "request deadline",
+			newContext: func(parent context.Context) (context.Context, context.CancelFunc) {
+				return context.WithDeadline(parent, time.Unix(0, 0))
+			},
+			wantErr:       context.DeadlineExceeded,
+			wantClass:     "context_deadline_exceeded",
+			wantOrigin:    "deadline",
+			wantOutcome:   "deadline_exceeded",
+			wantRetryable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			search := func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+				return nil, ctx.Err()
+			}
+			memRepo := &testMemoryRepo{keywordSearchHook: search}
+			sessRepo := &testSessionRepo{keywordSearchHook: search}
+			srv, logBuf := newRecallFailureLogTestServer(memRepo, sessRepo)
+			auth := &domain.AuthInfo{ClusterID: "cluster-request"}
+			baseCtx := reqid.NewContext(context.Background(), "request-context")
+			ctx, cancel := tt.newContext(baseCtx)
+			defer cancel()
+
+			_, _, err := srv.defaultConfidenceRecallSearch(ctx, auth, srv.resolveServices(auth), domain.MemoryFilter{
+				Query: "what happened",
+				Limit: 10,
+			})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tt.wantErr)
+			}
+
+			entry := decodeRecallFailureLog(t, logBuf)
+			assertRecallLogField(t, entry, "request_id", "request-context")
+			assertRecallLogField(t, entry, "primary_branch", "request")
+			assertRecallLogField(t, entry, "primary_error_class", tt.wantClass)
+			assertRecallLogField(t, entry, "primary_error_source", "request_context")
+			assertRecallLogField(t, entry, "primary_retryable", tt.wantRetryable)
+			assertRecallLogField(t, entry, "cancel_origin", tt.wantOrigin)
+			assertRecallLogField(t, entry, "pinned_outcome", tt.wantOutcome)
+			assertRecallLogField(t, entry, "insight_outcome", tt.wantOutcome)
+			assertRecallLogField(t, entry, "session_outcome", tt.wantOutcome)
+			assertRecallLogStrings(t, entry, "canceled_branches", []string{"pinned", "insight", "session"})
+			assertRecallLogDurations(t, entry)
+		})
+	}
+}
+
+func TestClassifyRecallError(t *testing.T) {
+	tests := []struct {
+		name               string
+		err                error
+		wantClass          string
+		wantSource         string
+		wantRetryable      bool
+		wantUpstreamStatus int
+	}{
+		{
+			name:          "TiFlash memory limit",
+			err:           errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]"),
+			wantClass:     "tiflash_memory_limit",
+			wantSource:    "tiflash",
+			wantRetryable: true,
+		},
+		{
+			name:               "inference upstream 503",
+			err:                errors.New("TiDB Cloud Inference: status code 503"),
+			wantClass:          "inference_upstream_5xx",
+			wantSource:         "inference",
+			wantRetryable:      true,
+			wantUpstreamStatus: 503,
+		},
+		{
+			name:               "inference rate limited",
+			err:                errors.New("TiDB Cloud Inference: status code 429"),
+			wantClass:          "inference_http_error",
+			wantSource:         "inference",
+			wantRetryable:      true,
+			wantUpstreamStatus: 429,
+		},
+		{
+			name:          "database closed",
+			err:           errors.New("sql: database is closed"),
+			wantClass:     "database_closed",
+			wantSource:    "tenant_database",
+			wantRetryable: true,
+		},
+		{
+			name:       "unknown",
+			err:        errors.New("unexpected dependency failure"),
+			wantClass:  "unknown",
+			wantSource: "internal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyRecallError(tt.err)
+			if got.class != tt.wantClass {
+				t.Fatalf("class = %q, want %q", got.class, tt.wantClass)
+			}
+			if got.source != tt.wantSource {
+				t.Fatalf("source = %q, want %q", got.source, tt.wantSource)
+			}
+			if got.retryable != tt.wantRetryable {
+				t.Fatalf("retryable = %t, want %t", got.retryable, tt.wantRetryable)
+			}
+			if got.upstreamStatus != tt.wantUpstreamStatus {
+				t.Fatalf("upstream status = %d, want %d", got.upstreamStatus, tt.wantUpstreamStatus)
+			}
+		})
+	}
+}
+
+func newRecallFailureLogTestServer(memRepo *testMemoryRepo, sessRepo *testSessionRepo) (*Server, *bytes.Buffer) {
+	srv := newTestServer(memRepo, sessRepo)
+	logBuf := &bytes.Buffer{}
+	srv.logger = slog.New(reqid.NewHandler(slog.NewJSONHandler(logBuf, nil)))
+	return srv, logBuf
+}
+
+func decodeRecallFailureLog(t *testing.T, logBuf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := bytes.Split(bytes.TrimSpace(logBuf.Bytes()), []byte("\n"))
+	if len(lines) != 1 {
+		t.Fatalf("log lines = %d, want 1: %s", len(lines), logBuf.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(lines[0], &entry); err != nil {
+		t.Fatalf("decode log: %v", err)
+	}
+	return entry
+}
+
+func assertRecallLogField(t *testing.T, entry map[string]any, key string, want any) {
+	t.Helper()
+	if got := entry[key]; got != want {
+		t.Fatalf("%s = %#v, want %#v", key, got, want)
+	}
+}
+
+func assertRecallLogStrings(t *testing.T, entry map[string]any, key string, want []string) {
+	t.Helper()
+	values, ok := entry[key].([]any)
+	if !ok {
+		t.Fatalf("%s = %#v, want string array", key, entry[key])
+	}
+	got := make([]string, len(values))
+	for i, value := range values {
+		got[i], ok = value.(string)
+		if !ok {
+			t.Fatalf("%s[%d] = %#v, want string", key, i, value)
+		}
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s = %v, want %v", key, got, want)
+	}
+}
+
+func assertRecallLogDurations(t *testing.T, entry map[string]any) {
+	t.Helper()
+	for _, key := range []string{"pinned_ms", "insight_ms", "session_ms", "total_ms"} {
+		value, ok := entry[key].(float64)
+		if !ok || value < 0 {
+			t.Fatalf("%s = %#v, want non-negative number", key, entry[key])
+		}
+	}
+}

--- a/server/internal/handler/recall_failure_log_test.go
+++ b/server/internal/handler/recall_failure_log_test.go
@@ -165,6 +165,13 @@ func TestClassifyRecallError(t *testing.T) {
 			wantRetryable: true,
 		},
 		{
+			name:          "TiFlash flash error",
+			err:           errors.New("[FLASH:Coprocessor:Memory limit exceeded for instance]"),
+			wantClass:     "tiflash_memory_limit",
+			wantSource:    "tiflash",
+			wantRetryable: true,
+		},
+		{
 			name:               "inference upstream 503",
 			err:                errors.New("TiDB Cloud Inference: status code 503"),
 			wantClass:          "inference_upstream_5xx",
@@ -179,6 +186,14 @@ func TestClassifyRecallError(t *testing.T) {
 			wantSource:         "inference",
 			wantRetryable:      true,
 			wantUpstreamStatus: 429,
+		},
+		{
+			name:               "inference HTTP status 504",
+			err:                errors.New("TiDB Cloud Inference: HTTP status 504"),
+			wantClass:          "inference_upstream_5xx",
+			wantSource:         "inference",
+			wantRetryable:      true,
+			wantUpstreamStatus: 504,
 		},
 		{
 			name:          "database closed",


### PR DESCRIPTION
## What Changed
- Confidence recall failures emit one request-level structured summary after all three search branches finish.
- Logs identify the primary branch and error class, propagated cancellations, request cancellation origin, and per-branch outcomes and durations.
- Focused tests cover TiFlash failure propagation, client cancellation, request deadlines, and shared production error classes.

## Why
- Production 500 analysis could not distinguish first failures from sibling `context canceled` results through a single aggregation.
- The summary preserves the existing `errgroup.Wait` error and recall response behavior.

## Review Path
1. Start with the branch result capture and failure hook in `server/internal/handler/recall.go`.
2. Review the structured fields and local error taxonomy helpers in the same file.
3. Finish with deterministic concurrency and logging coverage in `server/internal/handler/recall_failure_log_test.go`.

## Validation
- `cd server && go test -race -count=1 -run 'Test(DefaultConfidenceRecallSearch_Logs|ClassifyRecallError)' ./internal/handler/`
- `cd server && go test -race -count=1 ./internal/handler/`
- `cd server && go test -count=1 ./...`
- `make vet`
