### PR TITLE
fix(server): propagate canonical request IDs

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -193,11 +193,10 @@ func (s *Server) Router(
 	r := chi.NewRouter()
 
 	// Global middleware.
+	r.Use(reqid.Middleware)
+	r.Use(requestLogger(s.logger))
 	r.Use(chimw.Recoverer)
 	r.Use(corsMW)
-	r.Use(chimw.RequestID)
-	r.Use(reqid.NewContextMiddleware)
-	r.Use(requestLogger(s.logger))
 	r.Use(rateLimitMW)
 	r.Use(metrics.Middleware)
 

--- a/server/internal/handler/request_id_test.go
+++ b/server/internal/handler/request_id_test.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/reqid"
+)
+
+func TestRouterPreservesCanonicalRequestID(t *testing.T) {
+	const requestID = "req_AAAAAAAAAAAAAAAAAAAAAA"
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	pass := func(h http.Handler) http.Handler { return h }
+	router := srv.Router(pass, pass, pass, pass)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("X-Request-Id", requestID)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
+	}
+	if got := recorder.Header().Get("X-Request-Id"); got != requestID {
+		t.Fatalf("X-Request-Id header = %q, want %q", got, requestID)
+	}
+}
+
+func TestRouterPanicResponseAndLogShareRequestID(t *testing.T) {
+	const requestID = "req_AAAAAAAAAAAAAAAAAAAAAA"
+	var logBuffer bytes.Buffer
+	logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuffer, nil)))
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	srv.logger = logger
+	pass := func(h http.Handler) http.Handler { return h }
+	panicMiddleware := func(http.Handler) http.Handler {
+		return http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			panic("request-id-test")
+		})
+	}
+	router := srv.Router(pass, panicMiddleware, pass, pass)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req.Header.Set("X-Request-Id", requestID)
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if got := recorder.Header().Get("X-Request-Id"); got != requestID {
+		t.Fatalf("X-Request-Id header = %q, want %q", got, requestID)
+	}
+	var entry map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(logBuffer.Bytes()), &entry); err != nil {
+		t.Fatalf("decode request log: %v\n%s", err, logBuffer.String())
+	}
+	if got := entry["request_id"]; got != requestID {
+		t.Fatalf("request_id = %v, want %q", got, requestID)
+	}
+	if got := entry["status"]; got != float64(http.StatusInternalServerError) {
+		t.Fatalf("status = %v, want %d", got, http.StatusInternalServerError)
+	}
+}

--- a/server/internal/middleware/cors.go
+++ b/server/internal/middleware/cors.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"net/http"
+
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 const corsMaxAge = "86400"
@@ -39,7 +41,8 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key, X-Mnemo-Agent-Id, Authorization, If-Match")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key, X-Mnemo-Agent-Id, Authorization, If-Match, "+reqid.Header)
+			w.Header().Set("Access-Control-Expose-Headers", reqid.Header)
 			w.Header().Set("Access-Control-Max-Age", corsMaxAge)
 
 			if r.Method == http.MethodOptions {

--- a/server/internal/middleware/cors_test.go
+++ b/server/internal/middleware/cors_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 func TestCORS_AllowsPreflightBeforeNext(t *testing.T) {
@@ -16,7 +18,7 @@ func TestCORS_AllowsPreflightBeforeNext(t *testing.T) {
 	req := httptest.NewRequest(http.MethodOptions, "/v1alpha2/mem9s/memories", nil)
 	req.Header.Set("Origin", "http://localhost:4321")
 	req.Header.Set("Access-Control-Request-Method", "GET")
-	req.Header.Set("Access-Control-Request-Headers", "X-API-Key")
+	req.Header.Set("Access-Control-Request-Headers", "X-API-Key, "+reqid.Header)
 	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
@@ -35,6 +37,9 @@ func TestCORS_AllowsPreflightBeforeNext(t *testing.T) {
 	}
 	if got := rr.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(got, "If-Match") {
 		t.Fatalf("allow headers = %q, want If-Match", got)
+	}
+	if got := rr.Header().Get("Access-Control-Allow-Headers"); !strings.Contains(got, reqid.Header) {
+		t.Fatalf("allow headers = %q, want %s", got, reqid.Header)
 	}
 }
 
@@ -73,5 +78,8 @@ func TestCORS_AddsHeadersForAllowedRequest(t *testing.T) {
 	}
 	if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "https://mem9.ai" {
 		t.Fatalf("allow origin = %q", got)
+	}
+	if got := rr.Header().Get("Access-Control-Expose-Headers"); !strings.Contains(got, reqid.Header) {
+		t.Fatalf("expose headers = %q, want %s", got, reqid.Header)
 	}
 }

--- a/server/internal/reqid/reqid.go
+++ b/server/internal/reqid/reqid.go
@@ -2,11 +2,24 @@ package reqid
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	chimw "github.com/go-chi/chi/v5/middleware"
 )
+
+const (
+	Header          = "X-Request-Id"
+	albTraceHeader  = "X-Amzn-Trace-Id"
+	maxALBTraceSize = 8 << 10
+)
+
+var readRandom = rand.Read
 
 type contextKey struct{}
 
@@ -19,11 +32,109 @@ func NewContext(ctx context.Context, id string) context.Context {
 	return context.WithValue(ctx, contextKey{}, id)
 }
 
-func NewContextMiddleware(next http.Handler) http.Handler {
+func Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := NewContext(r.Context(), chimw.GetReqID(r.Context()))
+		requestID, err := resolve(r.Header)
+		if err != nil {
+			slog.LogAttrs(r.Context(), slog.LevelError, "failed to generate request id", slog.String("error_type", fmt.Sprintf("%T", err)))
+			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+			return
+		}
+
+		r.Header.Set(Header, requestID)
+		w.Header().Set(Header, requestID)
+
+		ctx := context.WithValue(r.Context(), chimw.RequestIDKey, requestID)
+		ctx = NewContext(ctx, requestID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func resolve(header http.Header) (string, error) {
+	if trace := header.Get(albTraceHeader); trace != "" {
+		if requestID, ok := albRequestID(trace); ok {
+			return requestID, nil
+		}
+		return generate()
+	}
+
+	if requestID := header.Get(Header); valid(requestID) {
+		return requestID, nil
+	}
+	return generate()
+}
+
+func albRequestID(trace string) (string, bool) {
+	if len(trace) > maxALBTraceSize {
+		return "", false
+	}
+
+	var self, root string
+	var seenSelf, seenRoot bool
+	for field := range strings.SplitSeq(trace, ";") {
+		key, value, ok := strings.Cut(strings.TrimSpace(field), "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "Self":
+			if seenSelf {
+				return "", false
+			}
+			seenSelf = true
+			self = strings.TrimSpace(value)
+		case "Root":
+			if seenRoot {
+				return "", false
+			}
+			seenRoot = true
+			root = strings.TrimSpace(value)
+		}
+	}
+	if seenSelf {
+		return self, validALB(self)
+	}
+	return root, seenRoot && validALB(root)
+}
+
+func valid(value string) bool {
+	return validGenerated(value) || validALB(value)
+}
+
+func validGenerated(value string) bool {
+	const prefix = "req_"
+	if len(value) != 26 || !strings.HasPrefix(value, prefix) {
+		return false
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(value, prefix))
+	return err == nil && len(raw) == 16
+}
+
+func validALB(value string) bool {
+	if len(value) != 35 || value[0] != '1' || value[1] != '-' || value[10] != '-' {
+		return false
+	}
+	for i, char := range value {
+		if i == 0 || i == 1 || i == 10 {
+			continue
+		}
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func generate() (string, error) {
+	var random [16]byte
+	n, err := readRandom(random[:])
+	if err != nil {
+		return "", err
+	}
+	if n != len(random) {
+		return "", io.ErrUnexpectedEOF
+	}
+	return "req_" + base64.RawURLEncoding.EncodeToString(random[:]), nil
 }
 
 type Handler struct {

--- a/server/internal/reqid/reqid_test.go
+++ b/server/internal/reqid/reqid_test.go
@@ -1,0 +1,144 @@
+package reqid
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	chimw "github.com/go-chi/chi/v5/middleware"
+)
+
+func TestMiddlewareResolvesCanonicalID(t *testing.T) {
+	const (
+		albRequestID      = "1-67891233-12456789abcdef0123456789"
+		internalRequestID = "req_AAAAAAAAAAAAAAAAAAAAAA"
+	)
+	tests := []struct {
+		name          string
+		albTraceID    string
+		inboundID     string
+		want          string
+		wantGenerated bool
+	}{
+		{
+			name:       "ALB Self takes precedence",
+			albTraceID: "Root=1-67891233-abcdef012345678912345678;Self=" + albRequestID,
+			inboundID:  internalRequestID,
+			want:       albRequestID,
+		},
+		{
+			name:       "ALB Root is used when Self is absent",
+			albTraceID: "Root=" + albRequestID,
+			inboundID:  internalRequestID,
+			want:       albRequestID,
+		},
+		{
+			name:      "internal generated ID is preserved",
+			inboundID: internalRequestID,
+			want:      internalRequestID,
+		},
+		{
+			name:      "internal ALB ID is preserved",
+			inboundID: albRequestID,
+			want:      albRequestID,
+		},
+		{
+			name:          "invalid internal ID generates a replacement",
+			inboundID:     "req_12345678",
+			wantGenerated: true,
+		},
+		{
+			name:          "oversized internal ID generates a replacement",
+			inboundID:     "req_" + strings.Repeat("a", maxALBTraceSize),
+			wantGenerated: true,
+		},
+		{
+			name:          "invalid ALB Self generates a replacement",
+			albTraceID:    "Root=1-67891233-abcdef012345678912345678;Self=invalid",
+			inboundID:     internalRequestID,
+			wantGenerated: true,
+		},
+		{
+			name:          "duplicate ALB Self generates a replacement",
+			albTraceID:    "Self=;Self=" + albRequestID,
+			wantGenerated: true,
+		},
+		{
+			name:          "oversized ALB trace generates a replacement",
+			albTraceID:    strings.Repeat("a", maxALBTraceSize+1),
+			wantGenerated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var contextRequestID string
+			var chiRequestID string
+			var forwardedRequestID string
+			handler := Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				contextRequestID = FromContext(r.Context())
+				chiRequestID = chimw.GetReqID(r.Context())
+				forwardedRequestID = r.Header.Get(Header)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+			request.Header.Set(albTraceHeader, tt.albTraceID)
+			request.Header.Set(Header, tt.inboundID)
+
+			handler.ServeHTTP(recorder, request)
+
+			got := recorder.Header().Get(Header)
+			if got == "" {
+				t.Fatalf("%s header is empty", Header)
+			}
+			if tt.wantGenerated && !validGenerated(got) {
+				t.Fatalf("%s header = %q, want generated request id", Header, got)
+			}
+			if !tt.wantGenerated && got != tt.want {
+				t.Fatalf("%s header = %q, want %q", Header, got, tt.want)
+			}
+			if contextRequestID != got {
+				t.Fatalf("context request id = %q, want %q", contextRequestID, got)
+			}
+			if chiRequestID != got {
+				t.Fatalf("chi request id = %q, want %q", chiRequestID, got)
+			}
+			if forwardedRequestID != got {
+				t.Fatalf("forwarded request id = %q, want %q", forwardedRequestID, got)
+			}
+		})
+	}
+}
+
+func TestMiddlewareFailsClosedWhenRandomSourceFails(t *testing.T) {
+	originalReadRandom := readRandom
+	t.Cleanup(func() {
+		readRandom = originalReadRandom
+	})
+	readRandom = func([]byte) (int, error) {
+		return 0, errors.New("random unavailable")
+	}
+
+	handlerCalled := false
+	handler := Middleware(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		handlerCalled = true
+	}))
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+
+	handler.ServeHTTP(recorder, request)
+
+	if handlerCalled {
+		t.Fatal("next handler was called")
+	}
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if got := recorder.Header().Get(Header); got != "" {
+		t.Fatalf("%s header = %q, want empty on random failure", Header, got)
+	}
+}

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 type HTTPClient struct {
@@ -77,6 +79,9 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	}
 	req.Header.Set("Authorization", "Bearer "+c.internalSecret)
 	req.Header.Set("X-API-Key", subject.APIKeySubject)
+	if requestID := reqid.FromContext(ctx); requestID != "" {
+		req.Header.Set(reqid.Header, requestID)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -50,6 +52,68 @@ func TestHTTPClientReserveAllowsNullRemainingIncludedUnits(t *testing.T) {
 	}
 	if reservation.RemainingIncludedUnits != nil {
 		t.Fatalf("RemainingIncludedUnits = %v, want nil", *reservation.RemainingIncludedUnits)
+	}
+}
+
+func TestHTTPClientPropagatesRequestID(t *testing.T) {
+	const requestID = "req_AAAAAAAAAAAAAAAAAAAAAA"
+	tests := []struct {
+		name     string
+		response string
+		call     func(context.Context, *HTTPClient) error
+	}{
+		{
+			name: "reserve",
+			response: `{
+				"operationId": "op-request-id",
+				"meter": "memory_write_requests",
+				"units": 1,
+				"status": "reserved",
+				"expiresAt": "2026-05-19T08:00:00Z",
+				"remainingIncludedUnits": 1,
+				"reservedUnits": 1,
+				"overageAllowed": false
+			}`,
+			call: func(ctx context.Context, client *HTTPClient) error {
+				_, err := client.Reserve(ctx, Subject{APIKeySubject: "api-key-subject"}, "op-request-id", Operation{
+					Meter: MeterMemoryWriteRequests,
+					Units: 1,
+				})
+				return err
+			},
+		},
+		{
+			name:     "finalize",
+			response: `{}`,
+			call: func(ctx context.Context, client *HTTPClient) error {
+				return client.FinalizeReservation(ctx, Subject{APIKeySubject: "api-key-subject"}, "op-request-id", ReservationStatusCommitted, reservationCommitReason)
+			},
+		},
+		{
+			name:     "runtime state",
+			response: `{"mem9ApiKey":{"status":"active"},"meters":[]}`,
+			call: func(ctx context.Context, client *HTTPClient) error {
+				_, err := client.RuntimeState(ctx, Subject{APIKeySubject: "api-key-subject"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if got := req.Header.Get("X-Request-Id"); got != requestID {
+					t.Fatalf("X-Request-Id = %q, want %q", got, requestID)
+				}
+				return jsonResponse(tt.response), nil
+			})}
+
+			ctx := reqid.NewContext(context.Background(), requestID)
+			if err := tt.call(ctx, client); err != nil {
+				t.Fatalf("call: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Resolve the same canonical `request_id` at mem9 ingress and return it in `X-Request-Id`.
- Preserve request correlation through normal responses, panic 5xx logs, and runtime-usage service calls.
- Allow browser clients to send and read `X-Request-Id` through CORS.
- Keep `operation_id` scoped to quota business operations.

## Review Path

1. `server/internal/reqid` owns canonical resolution, validation, context, and log correlation.
2. `server/internal/handler/handler.go` places request ID and completion logging around panic recovery.
3. `server/internal/middleware/cors.go` allows and exposes the canonical request ID for browser clients.
4. `server/internal/runtimeusage/client.go` forwards the context ID for reserve, finalize, and runtime-state calls.

## Validation

- `make test` (includes `go test -race -count=1 ./...`)
- `make vet`
- `gofmt` check
- `git diff --check`

Related to https://github.com/mem9-ai/mem9-console-server/issues/161.
