### PR TITLE
fix(server): preserve pinned memory agent identity

### DIFF
--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -1135,6 +1135,7 @@ func (s *MemoryService) BulkCreate(ctx context.Context, agentName string, items 
 			ID:         uuid.New().String(),
 			Content:    item.Content,
 			Source:     agentName,
+			AgentID:    agentName,
 			Tags:       item.Tags,
 			Metadata:   item.Metadata,
 			Embedding:  embedding,

--- a/server/internal/service/memory_test.go
+++ b/server/internal/service/memory_test.go
@@ -680,6 +680,9 @@ func TestCreatePinnedUsesBulkCreateSemantics(t *testing.T) {
 	if created.Source != "agent-1" {
 		t.Fatalf("expected source agent-1, got %q", created.Source)
 	}
+	if created.AgentID != "agent-1" {
+		t.Fatalf("expected agent_id agent-1, got %q", created.AgentID)
+	}
 	if created.UpdatedBy != "agent-1" {
 		t.Fatalf("expected updated_by agent-1, got %q", created.UpdatedBy)
 	}
@@ -697,6 +700,9 @@ func TestCreatePinnedUsesBulkCreateSemantics(t *testing.T) {
 	}
 	if mem.MemoryType != domain.TypePinned {
 		t.Fatalf("expected returned memory type pinned, got %s", mem.MemoryType)
+	}
+	if mem.AgentID != "agent-1" {
+		t.Fatalf("expected returned agent_id agent-1, got %q", mem.AgentID)
 	}
 }
 


### PR DESCRIPTION
## What Changed
- populate `agent_id` for pinned memories created through `BulkCreate`
- cover the persisted and returned identity in the existing pinned-memory test

## Review Path
1. `server/internal/service/memory.go` — memory construction
2. `server/internal/service/memory_test.go` — regression assertions

## Validation
- `go test -race -count=1 -run TestCreatePinnedUsesBulkCreateSemantics ./internal/service/`