### PR TITLE
fix(server): classify duplicate Space Chain bindings

### DIFF
--- a/server/internal/repository/tidb/space_chain.go
+++ b/server/internal/repository/tidb/space_chain.go
@@ -3,9 +3,12 @@ package tidb
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
+
+	"github.com/go-sql-driver/mysql"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
@@ -204,6 +207,10 @@ func (r *SpaceChainRepoImpl) CreateBinding(ctx context.Context, binding *domain.
 		binding.ID, binding.ChainID, binding.ChainAPIKey, nullString(binding.CreatedByUserID),
 	)
 	if err != nil {
+		var mysqlErr *mysql.MySQLError
+		if errors.As(err, &mysqlErr) && mysqlErr.Number == 1062 {
+			return fmt.Errorf("create space chain binding: %w", domain.ErrDuplicateKey)
+		}
 		return fmt.Errorf("create space chain binding: %w", err)
 	}
 	return nil

--- a/server/internal/repository/tidb/space_chain_test.go
+++ b/server/internal/repository/tidb/space_chain_test.go
@@ -1,0 +1,60 @@
+package tidb
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestSpaceChainCreateBindingMapsDuplicateKey(t *testing.T) {
+	db := sql.OpenDB(spaceChainExecErrorConnector{
+		err: &mysql.MySQLError{Number: 1062, Message: "Duplicate entry for key idx_space_chain_bindings_key"},
+	})
+	t.Cleanup(func() { _ = db.Close() })
+
+	repo := NewSpaceChainRepo(db)
+	err := repo.CreateBinding(context.Background(), &domain.SpaceChainBinding{
+		ID:          "binding-2",
+		ChainID:     "chain-1",
+		ChainAPIKey: "chain_existing",
+	})
+	if !errors.Is(err, domain.ErrDuplicateKey) {
+		t.Fatalf("CreateBinding error = %v, want domain.ErrDuplicateKey", err)
+	}
+}
+
+type spaceChainExecErrorConnector struct {
+	err error
+}
+
+func (c spaceChainExecErrorConnector) Connect(context.Context) (driver.Conn, error) {
+	return spaceChainExecErrorConn{err: c.err}, nil
+}
+
+func (spaceChainExecErrorConnector) Driver() driver.Driver {
+	return spaceChainExecErrorDriver{}
+}
+
+type spaceChainExecErrorDriver struct{}
+
+func (spaceChainExecErrorDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("Open is unused with sql.OpenDB")
+}
+
+type spaceChainExecErrorConn struct {
+	err error
+}
+
+func (c spaceChainExecErrorConn) Prepare(string) (driver.Stmt, error) { return nil, driver.ErrSkip }
+func (c spaceChainExecErrorConn) Close() error                        { return nil }
+func (c spaceChainExecErrorConn) Begin() (driver.Tx, error)           { return nil, driver.ErrSkip }
+
+func (c spaceChainExecErrorConn) ExecContext(context.Context, string, []driver.NamedValue) (driver.Result, error) {
+	return nil, c.err
+}


### PR DESCRIPTION
## What Changed
- map TiDB error 1062 from Space Chain binding creation to `domain.ErrDuplicateKey`
- keep other database errors wrapped with their original cause

## Review Path
1. `server/internal/repository/tidb/space_chain.go` — error classification
2. `server/internal/repository/tidb/space_chain_test.go` — focused driver-level regression

## Validation
- `go test -race -count=1 -run TestSpaceChainCreateBindingMapsDuplicateKey ./internal/repository/tidb/`