### PR TITLE
test(e2e): align unified session list expectation

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -132,7 +132,7 @@ confirms the deleted chain key is no longer active.
 Regression tests for raw session storage (PR #103). Provisions a fresh tenant,
 ingests messages, and verifies session-specific behavior: unified recall inclusion,
 `memory_type` filtering, metadata projection, no-query session listing, per-ID
-get/delete fallback, batch delete, no-query unified-list exclusion, and deduplication.
+get/delete fallback, batch delete, no-query unified-list inclusion, and deduplication.
 Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
 
 | #   | Case                                    | What is verified                                                                                     |
@@ -144,7 +144,7 @@ Supports both v1alpha1 and v1alpha2 via `MNEMO_API_VERSION`.
 | 5   | `memory_type=session` filter            | All results have `memory_type=session`; no other types                                               |
 | 6   | `memory_type=insight` excludes sessions | No `memory_type=session` rows when insight filter applied                                            |
 | 7   | Session metadata projection             | First session result has `role`, `seq`, `content_type` in `metadata`                                 |
-| 8   | No-query list excludes sessions         | `GET /memories` (no `?q=`) returns no `memory_type=session` rows                                     |
+| 8   | No-query list includes sessions         | `GET /memories` (no `?q=`) returns `memory_type=session` rows in the unified all-types list           |
 | 9   | `session_id` scoped filter              | All results belong to the expected `session_id`                                                      |
 | 10  | Deduplication                           | Re-sending identical messages does not increase row count                                            |
 | 11  | No-query session listing                | `GET /memories?session_id=...&memory_type=session` returns raw session rows without `q`              |

--- a/e2e/api-smoke-test-sessions.sh
+++ b/e2e/api-smoke-test-sessions.sh
@@ -11,7 +11,7 @@
 #   5. memory_type=session filter returns only sessions
 #   6. memory_type=insight filter excludes sessions
 #   7. Session metadata projection (role, seq, content_type in metadata field)
-#   8. No-query list excludes sessions
+#   8. No-query list includes sessions
 #   9. session_id scoped filter
 #  10. Deduplication — same messages sent twice produce no extra rows
 #  11. No-query memory_type=session list returns raw sessions
@@ -291,9 +291,9 @@ print('missing:' + ','.join(missing) if missing else 'ok')
 check "first session has role, seq, content_type in metadata" "$META_CHECK" "ok"
 
 # ============================================================================
-# TEST 8 — No-query list excludes sessions
+# TEST 8 — No-query list includes sessions
 # ============================================================================
-step "8" "No-query list (GET /memories) excludes sessions"
+step "8" "No-query list (GET /memories) includes sessions"
 resp=$(curl_mem_json "$MEM_BASE?limit=50")
 code=$(http_code "$resp")
 bdy=$(body "$resp")
@@ -304,7 +304,7 @@ import sys, json
 mems = json.load(sys.stdin).get('memories', [])
 print('yes' if any(m.get('memory_type') == 'session' for m in mems) else 'no')
 " 2>/dev/null || true)
-check "list without query has no memory_type=session rows" "$HAS_SESSION_IN_LIST" "no"
+check "list without query has memory_type=session rows" "$HAS_SESSION_IN_LIST" "yes"
 
 # ============================================================================
 # TEST 9 — session_id scoped filter


### PR DESCRIPTION
## What Changed
- make session smoke test case 8 expect raw session rows in the no-query all-types list
- synchronize the E2E coverage table with the executable assertion

## Review Path
1. `e2e/api-smoke-test-sessions.sh` — live assertion
2. `e2e/AGENTS.md` — coverage contract

## Validation
- `bash -n e2e/api-smoke-test-sessions.sh`
- `go test -race -count=1 -run TestListMemories_DefaultAllTypesIncludesSessions ./internal/handler/`