### PR TITLE
fix(server): restore bounded default memory list

### DIFF
--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -884,8 +884,6 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	} else {
 		svc := s.resolveServices(auth)
 		switch {
-		case filter.Query == "" && filter.MemoryType == "":
-			memories, total, err = s.listLocalAllTypeMemoriesScanAll(r.Context(), svc, filter)
 		case filter.Query != "" && contentKeywordSearch:
 			memories, total, err = s.listLocalMemoriesContentKeyword(r.Context(), svc, filter)
 		case filter.Query != "" && filter.ScanAll:

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1172,7 +1172,7 @@ func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 	}
 }
 
-func TestListMemories_DefaultAllTypesIncludesSessions(t *testing.T) {
+func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
 	now := time.Now()
 	memRepo := &testMemoryRepo{
 		listResults: []domain.Memory{
@@ -1185,7 +1185,7 @@ func TestListMemories_DefaultAllTypesIncludesSessions(t *testing.T) {
 				UpdatedAt:  now.Add(-time.Hour),
 			},
 		},
-		listTotal: 1,
+		listTotal: 1000,
 	}
 	sessionRepo := &testSessionRepo{
 		listResults: []domain.Memory{
@@ -1198,10 +1198,10 @@ func TestListMemories_DefaultAllTypesIncludesSessions(t *testing.T) {
 				UpdatedAt:  now,
 			},
 		},
-		listTotal: 1,
+		listTotal: 1000,
 	}
 	srv := newTestServer(memRepo, sessionRepo)
-	req := makeRequest(t, http.MethodGet, "/memories?limit=10&offset=0&state=active", nil)
+	req := makeRequest(t, http.MethodGet, "/memories?limit=1", nil)
 	rr := httptest.NewRecorder()
 
 	srv.listMemories(rr, req)
@@ -1213,17 +1213,17 @@ func TestListMemories_DefaultAllTypesIncludesSessions(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Total != 2 || resp.Limit != 10 || resp.Offset != 0 {
-		t.Fatalf("page = total:%d limit:%d offset:%d, want 2/10/0", resp.Total, resp.Limit, resp.Offset)
+	if resp.Total != 1000 || resp.Limit != 1 || resp.Offset != 0 {
+		t.Fatalf("page = total:%d limit:%d offset:%d, want 1000/1/0", resp.Total, resp.Limit, resp.Offset)
 	}
-	if len(resp.Memories) != 2 {
-		t.Fatalf("len(memories) = %d, want 2", len(resp.Memories))
+	if len(resp.Memories) != 1 || resp.Memories[0].ID != "insight-1" {
+		t.Fatalf("memories = %+v, want durable memory page", resp.Memories)
 	}
-	if resp.Memories[0].ID != "session-1" || resp.Memories[1].ID != "insight-1" {
-		t.Fatalf("memory order = [%s %s], want [session-1 insight-1]", resp.Memories[0].ID, resp.Memories[1].ID)
+	if memRepo.listCalls != 1 || sessionRepo.listCalls != 0 {
+		t.Fatalf("list calls = memory:%d session:%d, want 1/0", memRepo.listCalls, sessionRepo.listCalls)
 	}
-	if memRepo.listCalls != 1 || sessionRepo.listCalls != 1 {
-		t.Fatalf("list calls = memory:%d session:%d, want 1/1", memRepo.listCalls, sessionRepo.listCalls)
+	if memRepo.lastListFilter.Limit != 1 || memRepo.lastListFilter.Offset != 0 {
+		t.Fatalf("memory filter = %+v, want limit=1 offset=0", memRepo.lastListFilter)
 	}
 }
 


### PR DESCRIPTION
## What Changed
- Restore the pre-regression default durable-memory list for untyped v1 and v2 requests.
- Keep raw sessions available through `memory_type=session` and retain explicit `scanAll=true` behavior.
- Add regression coverage for `limit=1` using one memory read and zero session scans.

## Why
- The default all-types branch scanned every memory and session page before applying the requested limit, causing large early tenants to time out.
- This emergency mitigation restores the production behavior from before PR #370; database-level merged pagination will follow separately.

## Review Path
1. Start with the dispatch rollback in `server/internal/handler/memory.go`.
2. Verify the bounded large-tenant case in `server/internal/handler/memory_test.go`.

## Validation
- `go test -race -count=1 ./internal/handler/`
- `make vet`
- `make test`