### PR TITLE
feat(server): make memory list latency diagnosable

### DIFF
--- a/server/internal/handler/chain_runtime.go
+++ b/server/internal/handler/chain_runtime.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -436,9 +437,13 @@ func (s *Server) listChainMemoriesContentKeyword(ctx context.Context, auth *doma
 	for i, node := range auth.Chain.Nodes {
 		i, node := i, node
 		group.Go(func() error {
+			nodeStartedAt := time.Now()
 			nodeAuth := chainNodeAuth(auth, node)
 			svc := s.resolveServices(nodeAuth)
 			memories, _, err := s.listLocalMemoriesContentKeyword(groupCtx, svc, perNodeFilter)
+			if observation := memoryListObservationFromContext(groupCtx); observation != nil {
+				observation.recordPage("chain", len(memories), time.Since(nodeStartedAt))
+			}
 			if err != nil {
 				return err
 			}
@@ -500,6 +505,7 @@ func (s *Server) listChainNodeMemories(
 	profile recallQueryProfile,
 	queryMode bool,
 ) (chainNodeMemoryResult, error) {
+	nodeStartedAt := time.Now()
 	nodeAuth := chainNodeAuth(auth, node)
 	svc := s.resolveServices(nodeAuth)
 
@@ -518,6 +524,9 @@ func (s *Server) listChainNodeMemories(
 		memories, _, err = svc.session.List(ctx, filter)
 	case filter.MemoryType != string(domain.TypeSession):
 		memories, _, err = svc.memory.Search(ctx, filter)
+	}
+	if observation := memoryListObservationFromContext(ctx); observation != nil {
+		observation.recordPage("chain", len(memories), time.Since(nodeStartedAt))
 	}
 	if err != nil {
 		return chainNodeMemoryResult{}, err

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -792,16 +792,42 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	if offset < 0 {
 		offset = 0
 	}
+	var tags []string
+	if t := q.Get("tags"); t != "" {
+		tags = strings.Split(t, ",")
+	}
+	filter := domain.MemoryFilter{
+		Query:      query,
+		Tags:       tags,
+		Source:     q.Get("source"),
+		State:      q.Get("state"),
+		MemoryType: q.Get("memory_type"),
+		AgentID:    q.Get("agent_id"),
+		SessionID:  q.Get("session_id"),
+		SortBy:     q.Get("sort_by"),
+		SortDir:    q.Get("sort_dir"),
+		Limit:      limit,
+		Offset:     offset,
+		ScanAll:    parseBoolQuery(q.Get("scanAll")),
+	}
+	var (
+		memories []domain.Memory
+		total    int
+		err      error
+	)
+	listObservation := newMemoryListObservation(s.logger, auth, filter, contentKeywordSearch)
+	listObservation.startedAt = requestStartedAt
+	listCtx := withMemoryListObservation(r.Context(), listObservation)
+	defer func() {
+		listObservation.finish(r.Context(), err, len(memories), total)
+	}()
+
 	appIDFilter, err := parseAppIDFilter(q)
 	if err != nil {
 		s.handleError(r.Context(), w, err)
 		return
 	}
-
-	var tags []string
-	if t := q.Get("tags"); t != "" {
-		tags = strings.Split(t, ",")
-	}
+	filter.AppID = appIDFilter
 
 	createdAfter, err := parseTimeParam(q.Get("created_after"), "created_after")
 	if err != nil {
@@ -814,9 +840,10 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if createdAfter != nil && createdBefore != nil && createdAfter.After(*createdBefore) {
-		s.handleError(r.Context(), w, &domain.ValidationError{
+		err = &domain.ValidationError{
 			Field: "created_after", Message: "must not be after created_before",
-		})
+		}
+		s.handleError(r.Context(), w, err)
 		return
 	}
 	// The created_at window is consumed only by the session pool. Reject
@@ -824,39 +851,15 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	// (session filtered, pinned/insight not) — same "explicit 400, never
 	// silent" stance as the RFC3339 parse above.
 	if (createdAfter != nil || createdBefore != nil) && q.Get("memory_type") != string(domain.TypeSession) {
-		s.handleError(r.Context(), w, &domain.ValidationError{
+		err = &domain.ValidationError{
 			Field: "created_after", Message: "time-range filter requires memory_type=session",
-		})
+		}
+		s.handleError(r.Context(), w, err)
 		return
 	}
-
-	filter := domain.MemoryFilter{
-		Query:         query,
-		Tags:          tags,
-		Source:        q.Get("source"),
-		State:         q.Get("state"),
-		MemoryType:    q.Get("memory_type"),
-		AgentID:       q.Get("agent_id"),
-		SessionID:     q.Get("session_id"),
-		AppID:         appIDFilter,
-		SortBy:        q.Get("sort_by"),
-		SortDir:       q.Get("sort_dir"),
-		Limit:         limit,
-		Offset:        offset,
-		ScanAll:       parseBoolQuery(q.Get("scanAll")),
-		CreatedAfter:  createdAfter,
-		CreatedBefore: createdBefore,
-	}
+	filter.CreatedAfter = createdAfter
+	filter.CreatedBefore = createdBefore
 	onlySession := filter.MemoryType == string(domain.TypeSession)
-
-	var memories []domain.Memory
-	var total int
-	listObservation := newMemoryListObservation(s.logger, auth, filter, contentKeywordSearch)
-	listObservation.startedAt = requestStartedAt
-	listCtx := withMemoryListObservation(r.Context(), listObservation)
-	defer func() {
-		listObservation.finish(r.Context(), err, len(memories), total)
-	}()
 	var recallLease *runtimeusage.OperationLease
 	recallFinalized := false
 	recallSearch := filter.Query != "" && !contentKeywordSearch

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -774,6 +774,7 @@ func memoryRecallStatus(ctx context.Context, err error) string {
 }
 
 func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
+	requestStartedAt := time.Now()
 	auth := authInfo(r)
 	q := r.URL.Query()
 	rawQuery := q.Get("q")
@@ -850,6 +851,12 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 
 	var memories []domain.Memory
 	var total int
+	listObservation := newMemoryListObservation(s.logger, auth, filter, contentKeywordSearch)
+	listObservation.startedAt = requestStartedAt
+	listCtx := withMemoryListObservation(r.Context(), listObservation)
+	defer func() {
+		listObservation.finish(r.Context(), err, len(memories), total)
+	}()
 	var recallLease *runtimeusage.OperationLease
 	recallFinalized := false
 	recallSearch := filter.Query != "" && !contentKeywordSearch
@@ -875,31 +882,34 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		}()
 	}
 
+	queryStartedAt := time.Now()
 	if auth.IsChain() {
 		if filter.Query != "" && contentKeywordSearch {
-			memories, total, err = s.listChainMemoriesContentKeyword(r.Context(), auth, filter)
+			memories, total, err = s.listChainMemoriesContentKeyword(listCtx, auth, filter)
 		} else {
-			memories, total, err = s.listChainMemories(r.Context(), auth, filter)
+			memories, total, err = s.listChainMemories(listCtx, auth, filter)
 		}
 	} else {
 		svc := s.resolveServices(auth)
 		switch {
 		case filter.Query != "" && contentKeywordSearch:
-			memories, total, err = s.listLocalMemoriesContentKeyword(r.Context(), svc, filter)
+			memories, total, err = s.listLocalMemoriesContentKeyword(listCtx, svc, filter)
 		case filter.Query != "" && filter.ScanAll:
-			memories, total, err = s.listLocalMemoriesScanAll(r.Context(), svc, filter)
+			memories, total, err = s.listLocalMemoriesScanAll(listCtx, svc, filter)
 		case filter.Query != "" && filter.MemoryType == "":
-			memories, total, err = s.defaultConfidenceRecallSearch(r.Context(), auth, svc, filter)
+			memories, total, err = s.defaultConfidenceRecallSearch(listCtx, auth, svc, filter)
 		case filter.Query != "" && (filter.MemoryType == string(domain.TypeSession) ||
 			filter.MemoryType == string(domain.TypePinned) ||
 			filter.MemoryType == string(domain.TypeInsight)):
-			memories, total, err = s.singlePoolConfidenceRecallSearch(r.Context(), auth, svc, filter)
+			memories, total, err = s.singlePoolConfidenceRecallSearch(listCtx, auth, svc, filter)
 		case onlySession:
-			memories, total, err = svc.session.List(r.Context(), filter)
+			memories, total, err = svc.session.List(listCtx, filter)
 		case !onlySession:
-			memories, total, err = svc.memory.Search(r.Context(), filter)
+			memories, total, err = svc.memory.Search(listCtx, filter)
 		}
 	}
+	listObservation.queryDuration = time.Since(queryStartedAt)
+	listObservation.recordDirectList(auth, filter, contentKeywordSearch, len(memories))
 
 	if err != nil {
 		if s.runtimeUsageEnabled() && recallLease != nil {
@@ -918,7 +928,9 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	// aggregation is out of scope for v0. Non-session memories are left
 	// untouched, so memory/fact recall is unaffected.
 	if !auth.IsChain() {
-		memories = s.resolveServices(auth).session.ApplySessionOverlay(r.Context(), memories)
+		overlayStartedAt := time.Now()
+		memories = s.resolveServices(auth).session.ApplySessionOverlay(listCtx, memories)
+		listObservation.overlayDuration = time.Since(overlayStartedAt)
 	}
 	if !contentKeywordSearch && rawQuery != "" && classifyRecallQueryShape(rawQuery) == recallQueryShapeTime {
 		for i := range memories {
@@ -1053,46 +1065,57 @@ func (s *Server) listLocalMemoriesContentKeyword(ctx context.Context, svc resolv
 }
 
 func (s *Server) listLocalAllTypeMemoriesContentKeyword(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
-	memoryPages, err := collectLocalListPages(ctx, filter, svc.memory.ContentKeywordSearch)
+	memoryPages, err := collectLocalListPages(ctx, filter, "memory", svc.memory.ContentKeywordSearch)
 	if err != nil {
 		return nil, 0, err
 	}
-	sessionPages, err := collectLocalListPages(ctx, filter, svc.session.ContentKeywordSearch)
+	sessionPages, err := collectLocalListPages(ctx, filter, "session", svc.session.ContentKeywordSearch)
 	if err != nil {
 		return nil, 0, err
 	}
 
+	mergeStartedAt := time.Now()
 	combined := make([]domain.Memory, 0, len(memoryPages)+len(sessionPages))
 	combined = append(combined, memoryPages...)
 	combined = append(combined, sessionPages...)
 	combined = uniqueChainMemories(combined)
 
 	total := len(combined)
-	return finalizeChainMemories(combined, filter, filter.Limit, filter.Offset, false), total, nil
+	memories := finalizeChainMemories(combined, filter, filter.Limit, filter.Offset, false)
+	if observation := memoryListObservationFromContext(ctx); observation != nil {
+		observation.recordMerge(time.Since(mergeStartedAt))
+	}
+	return memories, total, nil
 }
 
 func (s *Server) listLocalAllTypeMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
-	memoryPages, err := collectLocalListPages(ctx, filter, svc.memory.List)
+	memoryPages, err := collectLocalListPages(ctx, filter, "memory", svc.memory.List)
 	if err != nil {
 		return nil, 0, err
 	}
-	sessionPages, err := collectLocalListPages(ctx, filter, svc.session.List)
+	sessionPages, err := collectLocalListPages(ctx, filter, "session", svc.session.List)
 	if err != nil {
 		return nil, 0, err
 	}
 
+	mergeStartedAt := time.Now()
 	combined := make([]domain.Memory, 0, len(memoryPages)+len(sessionPages))
 	combined = append(combined, memoryPages...)
 	combined = append(combined, sessionPages...)
 	combined = uniqueChainMemories(combined)
 
 	total := len(combined)
-	return finalizeChainMemories(combined, filter, filter.Limit, filter.Offset, false), total, nil
+	memories := finalizeChainMemories(combined, filter, filter.Limit, filter.Offset, false)
+	if observation := memoryListObservationFromContext(ctx); observation != nil {
+		observation.recordMerge(time.Since(mergeStartedAt))
+	}
+	return memories, total, nil
 }
 
 func collectLocalListPages(
 	ctx context.Context,
 	filter domain.MemoryFilter,
+	resource string,
 	list func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error),
 ) ([]domain.Memory, error) {
 	pageFilter := filter
@@ -1101,7 +1124,11 @@ func collectLocalListPages(
 
 	var all []domain.Memory
 	for {
+		pageStartedAt := time.Now()
 		page, pageTotal, err := list(ctx, pageFilter)
+		if observation := memoryListObservationFromContext(ctx); observation != nil {
+			observation.recordPage(resource, len(page), time.Since(pageStartedAt))
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -35,6 +35,9 @@ type memoryListObservation struct {
 	memoryRows           int
 	sessionPages         int
 	sessionRows          int
+	chainPages           int
+	chainRows            int
+	chainQueryDuration   time.Duration
 }
 
 func newMemoryListObservation(
@@ -125,6 +128,10 @@ func (o *memoryListObservation) recordPage(resource string, rows int, duration t
 		o.sessionPages++
 		o.sessionRows += rows
 		o.sessionQueryDuration += duration
+	case "chain":
+		o.chainPages++
+		o.chainRows += rows
+		o.chainQueryDuration += duration
 	}
 }
 
@@ -163,6 +170,12 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		return
 	}
 
+	pages := o.memoryPages + o.sessionPages
+	rows := o.memoryRows + o.sessionRows
+	if pages == 0 && o.chainPages > 0 {
+		pages = o.chainPages
+		rows = o.chainRows
+	}
 	attrs := []slog.Attr{
 		slog.String("cluster_id", o.clusterID),
 		slog.String("mode", o.mode),
@@ -172,14 +185,17 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		slog.Int("offset", o.offset),
 		slog.Int("returned", returned),
 		slog.Int("total", total),
-		slog.Int("pages", o.memoryPages+o.sessionPages),
-		slog.Int("rows", o.memoryRows+o.sessionRows),
+		slog.Int("pages", pages),
+		slog.Int("rows", rows),
 		slog.Int("memory_pages", o.memoryPages),
 		slog.Int("memory_rows", o.memoryRows),
 		slog.Int("session_pages", o.sessionPages),
 		slog.Int("session_rows", o.sessionRows),
+		slog.Int("chain_pages", o.chainPages),
+		slog.Int("chain_rows", o.chainRows),
 		slog.Int64("memory_query_ms", o.memoryQueryDuration.Milliseconds()),
 		slog.Int64("session_query_ms", o.sessionQueryDuration.Milliseconds()),
+		slog.Int64("chain_query_ms", o.chainQueryDuration.Milliseconds()),
 		slog.Int64("query_ms", o.queryDuration.Milliseconds()),
 		slog.Int64("merge_ms", o.mergeDuration.Milliseconds()),
 		slog.Int64("overlay_ms", o.overlayDuration.Milliseconds()),

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -1,0 +1,225 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
+)
+
+const memoryListSlowRequestThreshold = 2 * time.Second
+
+type memoryListObservationContextKey struct{}
+
+type memoryListObservation struct {
+	mu                   sync.Mutex
+	logger               *slog.Logger
+	clusterID            string
+	mode                 string
+	memoryType           string
+	scanAll              bool
+	limit                int
+	offset               int
+	startedAt            time.Time
+	queryDuration        time.Duration
+	overlayDuration      time.Duration
+	mergeDuration        time.Duration
+	memoryQueryDuration  time.Duration
+	sessionQueryDuration time.Duration
+	memoryPages          int
+	memoryRows           int
+	sessionPages         int
+	sessionRows          int
+}
+
+func newMemoryListObservation(
+	logger *slog.Logger,
+	auth *domain.AuthInfo,
+	filter domain.MemoryFilter,
+	contentKeywordSearch bool,
+) *memoryListObservation {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	clusterID := ""
+	if auth != nil {
+		clusterID = auth.ClusterID
+	}
+	return &memoryListObservation{
+		logger:     logger,
+		clusterID:  clusterID,
+		mode:       memoryListMode(auth, filter, contentKeywordSearch),
+		memoryType: memoryListTypeLabel(filter.MemoryType),
+		scanAll:    filter.ScanAll,
+		limit:      filter.Limit,
+		offset:     filter.Offset,
+		startedAt:  time.Now(),
+	}
+}
+
+func memoryListMode(auth *domain.AuthInfo, filter domain.MemoryFilter, contentKeywordSearch bool) string {
+	if auth != nil && auth.IsChain() {
+		return "chain"
+	}
+	if filter.Query != "" && contentKeywordSearch {
+		return "content_keyword"
+	}
+	if filter.Query != "" && filter.ScanAll {
+		return "scan_all"
+	}
+	if filter.Query != "" {
+		switch filter.MemoryType {
+		case "":
+			return "default_recall"
+		case string(domain.TypeSession), string(domain.TypePinned), string(domain.TypeInsight):
+			return "single_pool_recall"
+		default:
+			return "other"
+		}
+	}
+	if filter.MemoryType == string(domain.TypeSession) {
+		return "session_list"
+	}
+	return "durable_list"
+}
+
+func memoryListTypeLabel(memoryType string) string {
+	switch strings.TrimSpace(memoryType) {
+	case "":
+		return "all"
+	case string(domain.TypeSession):
+		return string(domain.TypeSession)
+	case string(domain.TypePinned):
+		return string(domain.TypePinned)
+	case string(domain.TypeInsight):
+		return string(domain.TypeInsight)
+	default:
+		return "other"
+	}
+}
+
+func withMemoryListObservation(ctx context.Context, observation *memoryListObservation) context.Context {
+	return context.WithValue(ctx, memoryListObservationContextKey{}, observation)
+}
+
+func memoryListObservationFromContext(ctx context.Context) *memoryListObservation {
+	observation, _ := ctx.Value(memoryListObservationContextKey{}).(*memoryListObservation)
+	return observation
+}
+
+func (o *memoryListObservation) recordPage(resource string, rows int, duration time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	switch resource {
+	case "memory":
+		o.memoryPages++
+		o.memoryRows += rows
+		o.memoryQueryDuration += duration
+	case "session":
+		o.sessionPages++
+		o.sessionRows += rows
+		o.sessionQueryDuration += duration
+	}
+}
+
+func (o *memoryListObservation) recordMerge(duration time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.mergeDuration += duration
+}
+
+func (o *memoryListObservation) recordDirectList(auth *domain.AuthInfo, filter domain.MemoryFilter, contentKeywordSearch bool, rows int) {
+	if auth != nil && auth.IsChain() {
+		return
+	}
+	if filter.Query != "" && !contentKeywordSearch && !filter.ScanAll {
+		return
+	}
+	if filter.Query != "" && filter.MemoryType == "" {
+		return
+	}
+	if filter.MemoryType == string(domain.TypeSession) {
+		o.sessionPages = 1
+		o.sessionRows = rows
+		return
+	}
+	o.memoryPages = 1
+	o.memoryRows = rows
+}
+
+func (o *memoryListObservation) finish(ctx context.Context, err error, returned, total int) {
+	duration := time.Since(o.startedAt)
+	status := memoryRecallStatus(ctx, err)
+	metrics.MemoryListRequestsTotal.WithLabelValues(o.mode, status).Inc()
+	metrics.MemoryListDuration.WithLabelValues(o.mode, status).Observe(duration.Seconds())
+
+	if status == "ok" && duration < memoryListSlowRequestThreshold {
+		return
+	}
+
+	attrs := []slog.Attr{
+		slog.String("cluster_id", o.clusterID),
+		slog.String("mode", o.mode),
+		slog.String("memory_type", o.memoryType),
+		slog.Bool("scan_all", o.scanAll),
+		slog.Int("limit", o.limit),
+		slog.Int("offset", o.offset),
+		slog.Int("returned", returned),
+		slog.Int("total", total),
+		slog.Int("pages", o.memoryPages+o.sessionPages),
+		slog.Int("rows", o.memoryRows+o.sessionRows),
+		slog.Int("memory_pages", o.memoryPages),
+		slog.Int("memory_rows", o.memoryRows),
+		slog.Int("session_pages", o.sessionPages),
+		slog.Int("session_rows", o.sessionRows),
+		slog.Int64("memory_query_ms", o.memoryQueryDuration.Milliseconds()),
+		slog.Int64("session_query_ms", o.sessionQueryDuration.Milliseconds()),
+		slog.Int64("query_ms", o.queryDuration.Milliseconds()),
+		slog.Int64("merge_ms", o.mergeDuration.Milliseconds()),
+		slog.Int64("overlay_ms", o.overlayDuration.Milliseconds()),
+		slog.Int64("duration_ms", duration.Milliseconds()),
+		slog.String("outcome", status),
+		slog.String("cancel_origin", memoryListCancelOrigin(ctx, err)),
+	}
+	if status != "ok" {
+		cause := err
+		if cause == nil && ctx != nil {
+			cause = ctx.Err()
+		}
+		classification := classifyInternalError(cause)
+		attrs = append(attrs,
+			slog.String("error_class", classification.class),
+			slog.String("error_source", classification.source),
+			slog.Bool("retryable", classification.retryable),
+		)
+	}
+
+	message := "memory list completed"
+	level := slog.LevelWarn
+	if status != "ok" {
+		message = "memory list failed"
+		level = slog.LevelError
+	}
+	o.logger.LogAttrs(ctx, level, message, attrs...)
+}
+
+func memoryListCancelOrigin(ctx context.Context, err error) string {
+	if ctx != nil {
+		switch {
+		case errors.Is(ctx.Err(), context.DeadlineExceeded):
+			return "deadline"
+		case errors.Is(ctx.Err(), context.Canceled):
+			return "client"
+		}
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return "downstream"
+	}
+	return "none"
+}

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -83,6 +84,56 @@ func TestListMemories_RecordsMemoryListMetrics(t *testing.T) {
 	}
 }
 
+func TestListMemories_RecordsValidationMetrics(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		mode string
+	}{
+		{
+			name: "oversized app ID",
+			path: "/memories?appId=" + strings.Repeat("a", maxAppIDLen+1),
+			mode: "durable_list",
+		},
+		{
+			name: "malformed timestamp",
+			path: "/memories?created_after=not-a-time",
+			mode: "durable_list",
+		},
+		{
+			name: "inverted session range",
+			path: "/memories?memory_type=session&created_after=2026-07-23T02:00:00Z&created_before=2026-07-23T01:00:00Z",
+			mode: "session_list",
+		},
+		{
+			name: "range on durable pool",
+			path: "/memories?created_after=2026-07-23T01:00:00Z",
+			mode: "durable_list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetMemoryListMetrics()
+			srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+			req := makeRequest(t, http.MethodGet, tt.path, nil)
+			rr := httptest.NewRecorder()
+
+			srv.listMemories(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+			}
+			if got := memoryListRequestCount(t, tt.mode, "error"); got != 1 {
+				t.Fatalf("memory list request count = %v, want 1", got)
+			}
+			if got := memoryListDurationCount(t, tt.mode, "error"); got != 1 {
+				t.Fatalf("memory list duration count = %d, want 1", got)
+			}
+		})
+	}
+}
+
 func TestMemoryListObservation_LogsSlowSummary(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
@@ -136,7 +187,7 @@ func TestMemoryListObservation_RecordsConcurrentChainWork(t *testing.T) {
 
 	var group sync.WaitGroup
 	for range 10 {
-		group.Add(2)
+		group.Add(3)
 		go func() {
 			defer group.Done()
 			observation.recordPage("memory", 2, time.Millisecond)
@@ -145,6 +196,10 @@ func TestMemoryListObservation_RecordsConcurrentChainWork(t *testing.T) {
 		go func() {
 			defer group.Done()
 			observation.recordPage("session", 3, time.Millisecond)
+		}()
+		go func() {
+			defer group.Done()
+			observation.recordPage("chain", 4, time.Millisecond)
 		}()
 	}
 	group.Wait()
@@ -155,8 +210,43 @@ func TestMemoryListObservation_RecordsConcurrentChainWork(t *testing.T) {
 	if observation.sessionPages != 10 || observation.sessionRows != 30 {
 		t.Fatalf("session work = %d pages/%d rows, want 10/30", observation.sessionPages, observation.sessionRows)
 	}
+	if observation.chainPages != 10 || observation.chainRows != 40 {
+		t.Fatalf("chain work = %d pages/%d rows, want 10/40", observation.chainPages, observation.chainRows)
+	}
+	if observation.chainQueryDuration != 10*time.Millisecond {
+		t.Fatalf("chain query duration = %s, want 10ms", observation.chainQueryDuration)
+	}
 	if observation.mergeDuration != 10*time.Millisecond {
 		t.Fatalf("merge duration = %s, want 10ms", observation.mergeDuration)
+	}
+}
+
+func TestListChainMemories_RecordsNodeWork(t *testing.T) {
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{{ID: "session-1", MemoryType: domain.TypeSession}},
+		listTotal:   1,
+	}
+	srv := newTestServer(&testMemoryRepo{}, sessionRepo)
+	req := makeChainRequestWithNodes(t, http.MethodGet, "/memories", nil, 2)
+	auth := authInfo(req)
+	observation := newMemoryListObservation(slog.Default(), auth, domain.MemoryFilter{
+		MemoryType: string(domain.TypeSession),
+		Limit:      10,
+	}, false)
+	ctx := withMemoryListObservation(req.Context(), observation)
+
+	memories, total, err := srv.listChainMemories(ctx, auth, domain.MemoryFilter{
+		MemoryType: string(domain.TypeSession),
+		Limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("list chain memories: %v", err)
+	}
+	if len(memories) != 1 || total != 1 {
+		t.Fatalf("result = %d memories/%d total, want 1/1", len(memories), total)
+	}
+	if observation.chainPages != 2 || observation.chainRows != 2 {
+		t.Fatalf("chain work = %d pages/%d rows, want 2/2", observation.chainPages, observation.chainRows)
 	}
 }
 

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -1,0 +1,280 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/middleware"
+	"github.com/qiffang/mnemos/server/internal/reqid"
+)
+
+func TestMemoryListMode(t *testing.T) {
+	tests := []struct {
+		name                 string
+		auth                 *domain.AuthInfo
+		filter               domain.MemoryFilter
+		contentKeywordSearch bool
+		want                 string
+	}{
+		{name: "chain", auth: &domain.AuthInfo{Chain: &domain.ChainAuth{ChainID: "chain-1"}}, want: "chain"},
+		{name: "content keyword", filter: domain.MemoryFilter{Query: "term"}, contentKeywordSearch: true, want: "content_keyword"},
+		{name: "scan all", filter: domain.MemoryFilter{Query: "term", ScanAll: true}, want: "scan_all"},
+		{name: "default recall", filter: domain.MemoryFilter{Query: "term"}, want: "default_recall"},
+		{name: "single pool recall", filter: domain.MemoryFilter{Query: "term", MemoryType: string(domain.TypeInsight)}, want: "single_pool_recall"},
+		{name: "session list", filter: domain.MemoryFilter{MemoryType: string(domain.TypeSession)}, want: "session_list"},
+		{name: "durable list", filter: domain.MemoryFilter{}, want: "durable_list"},
+		{name: "unknown recall pool", filter: domain.MemoryFilter{Query: "term", MemoryType: "future"}, want: "other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := memoryListMode(tt.auth, tt.filter, tt.contentKeywordSearch); got != tt.want {
+				t.Fatalf("memoryListMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListMemories_RecordsMemoryListMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		listErr    error
+		wantStatus string
+	}{
+		{name: "success", wantStatus: "ok"},
+		{name: "failure", listErr: errors.New("query failed"), wantStatus: "error"},
+		{name: "canceled", listErr: context.Canceled, wantStatus: "canceled"},
+		{name: "timeout", listErr: context.DeadlineExceeded, wantStatus: "timeout"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetMemoryListMetrics()
+			memRepo := &testMemoryRepo{
+				listResults: []domain.Memory{{ID: "insight-1", MemoryType: domain.TypeInsight}},
+				listTotal:   1,
+				listErr:     tt.listErr,
+			}
+			srv := newTestServer(memRepo, &testSessionRepo{})
+			req := makeRequest(t, http.MethodGet, "/memories?limit=1", nil)
+			rr := httptest.NewRecorder()
+
+			srv.listMemories(rr, req)
+
+			if got := memoryListRequestCount(t, "durable_list", tt.wantStatus); got != 1 {
+				t.Fatalf("memory list request count = %v, want 1", got)
+			}
+			if got := memoryListDurationCount(t, "durable_list", tt.wantStatus); got != 1 {
+				t.Fatalf("memory list duration count = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestMemoryListObservation_LogsSlowSummary(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+	auth := &domain.AuthInfo{ClusterID: "cluster-list"}
+	observation := newMemoryListObservation(logger, auth, domain.MemoryFilter{
+		Query:   "term",
+		Limit:   1,
+		Offset:  2,
+		ScanAll: true,
+	}, false)
+	observation.startedAt = time.Now().Add(-2100 * time.Millisecond)
+	observation.queryDuration = 1500 * time.Millisecond
+	observation.overlayDuration = 100 * time.Millisecond
+	observation.memoryPages = 2
+	observation.memoryRows = 250
+	observation.sessionPages = 1
+	observation.sessionRows = 40
+	ctx := reqid.NewContext(context.Background(), "request-list-slow")
+
+	observation.finish(ctx, nil, 1, 290)
+
+	entry := findMemoryListLogEntry(t, &logBuf, "memory list completed")
+	assertMemoryListLogField(t, entry, "request_id", "request-list-slow")
+	assertMemoryListLogField(t, entry, "cluster_id", "cluster-list")
+	assertMemoryListLogField(t, entry, "mode", "scan_all")
+	assertMemoryListLogField(t, entry, "memory_type", "all")
+	assertMemoryListLogField(t, entry, "scan_all", true)
+	assertMemoryListLogField(t, entry, "limit", float64(1))
+	assertMemoryListLogField(t, entry, "offset", float64(2))
+	assertMemoryListLogField(t, entry, "returned", float64(1))
+	assertMemoryListLogField(t, entry, "total", float64(290))
+	assertMemoryListLogField(t, entry, "pages", float64(3))
+	assertMemoryListLogField(t, entry, "rows", float64(290))
+	assertMemoryListLogField(t, entry, "memory_pages", float64(2))
+	assertMemoryListLogField(t, entry, "memory_rows", float64(250))
+	assertMemoryListLogField(t, entry, "session_pages", float64(1))
+	assertMemoryListLogField(t, entry, "session_rows", float64(40))
+	assertMemoryListLogField(t, entry, "query_ms", float64(1500))
+	assertMemoryListLogField(t, entry, "overlay_ms", float64(100))
+	assertMemoryListLogField(t, entry, "outcome", "ok")
+	assertMemoryListLogField(t, entry, "cancel_origin", "none")
+	if got, ok := entry["duration_ms"].(float64); !ok || got < 2000 {
+		t.Fatalf("duration_ms = %#v, want at least 2000", entry["duration_ms"])
+	}
+}
+
+func TestMemoryListObservation_RecordsConcurrentChainWork(t *testing.T) {
+	observation := newMemoryListObservation(slog.Default(), &domain.AuthInfo{
+		Chain: &domain.ChainAuth{ChainID: "chain-1"},
+	}, domain.MemoryFilter{}, false)
+
+	var group sync.WaitGroup
+	for range 10 {
+		group.Add(2)
+		go func() {
+			defer group.Done()
+			observation.recordPage("memory", 2, time.Millisecond)
+			observation.recordMerge(time.Millisecond)
+		}()
+		go func() {
+			defer group.Done()
+			observation.recordPage("session", 3, time.Millisecond)
+		}()
+	}
+	group.Wait()
+
+	if observation.memoryPages != 10 || observation.memoryRows != 20 {
+		t.Fatalf("memory work = %d pages/%d rows, want 10/20", observation.memoryPages, observation.memoryRows)
+	}
+	if observation.sessionPages != 10 || observation.sessionRows != 30 {
+		t.Fatalf("session work = %d pages/%d rows, want 10/30", observation.sessionPages, observation.sessionRows)
+	}
+	if observation.mergeDuration != 10*time.Millisecond {
+		t.Fatalf("merge duration = %s, want 10ms", observation.mergeDuration)
+	}
+}
+
+func TestListMemories_LogsFailureAndCancellationOrigin(t *testing.T) {
+	tests := []struct {
+		name       string
+		listErr    error
+		cancel     bool
+		deadline   bool
+		wantStatus string
+		wantOrigin string
+	}{
+		{name: "dependency failure", listErr: errors.New("database unavailable"), wantStatus: "error", wantOrigin: "none"},
+		{name: "dependency cancellation", listErr: context.Canceled, wantStatus: "canceled", wantOrigin: "downstream"},
+		{name: "dependency timeout", listErr: context.DeadlineExceeded, wantStatus: "timeout", wantOrigin: "downstream"},
+		{name: "client cancellation", listErr: context.Canceled, cancel: true, wantStatus: "canceled", wantOrigin: "client"},
+		{name: "request deadline", listErr: context.DeadlineExceeded, deadline: true, wantStatus: "timeout", wantOrigin: "deadline"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+			srv := newTestServer(&testMemoryRepo{listErr: tt.listErr}, &testSessionRepo{})
+			srv.logger = logger
+			req := makeRequest(t, http.MethodGet, "/memories?limit=1", nil)
+			ctx := middleware.WithAuthContext(reqid.NewContext(req.Context(), "request-list-failure"), &domain.AuthInfo{
+				AgentName: "test-agent",
+				ClusterID: "cluster-list-failure",
+			})
+			var cancel context.CancelFunc
+			switch {
+			case tt.cancel:
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			case tt.deadline:
+				ctx, cancel = context.WithDeadline(ctx, time.Unix(0, 0))
+				defer cancel()
+			}
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+
+			srv.listMemories(rr, req)
+
+			entry := findMemoryListLogEntry(t, &logBuf, "memory list failed")
+			assertMemoryListLogField(t, entry, "request_id", "request-list-failure")
+			assertMemoryListLogField(t, entry, "cluster_id", "cluster-list-failure")
+			assertMemoryListLogField(t, entry, "mode", "durable_list")
+			assertMemoryListLogField(t, entry, "outcome", tt.wantStatus)
+			assertMemoryListLogField(t, entry, "cancel_origin", tt.wantOrigin)
+		})
+	}
+}
+
+func resetMemoryListMetrics() {
+	metrics.MemoryListRequestsTotal.Reset()
+	metrics.MemoryListDuration.Reset()
+}
+
+func memoryListRequestCount(t *testing.T, mode, status string) float64 {
+	t.Helper()
+	counter, err := metrics.MemoryListRequestsTotal.GetMetricWithLabelValues(mode, status)
+	if err != nil {
+		t.Fatalf("get memory list request metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("memory list request metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write memory list request metric: %v", err)
+	}
+	if pb.Counter == nil {
+		return 0
+	}
+	return pb.Counter.GetValue()
+}
+
+func memoryListDurationCount(t *testing.T, mode, status string) uint64 {
+	t.Helper()
+	observer, err := metrics.MemoryListDuration.GetMetricWithLabelValues(mode, status)
+	if err != nil {
+		t.Fatalf("get memory list duration metric: %v", err)
+	}
+	metric, ok := observer.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("memory list duration metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write memory list duration metric: %v", err)
+	}
+	if pb.Histogram == nil {
+		return 0
+	}
+	return pb.Histogram.GetSampleCount()
+}
+
+func findMemoryListLogEntry(t *testing.T, logBuf *bytes.Buffer, message string) map[string]any {
+	t.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(logBuf.Bytes()))
+	for decoder.More() {
+		var entry map[string]any
+		if err := decoder.Decode(&entry); err != nil {
+			t.Fatalf("decode memory list log: %v; logs = %s", err, logBuf.String())
+		}
+		if entry["msg"] == message {
+			return entry
+		}
+	}
+	t.Fatalf("log message %q missing; logs = %s", message, logBuf.String())
+	return nil
+}
+
+func assertMemoryListLogField(t *testing.T, entry map[string]any, key string, want any) {
+	t.Helper()
+	if got := entry[key]; got != want {
+		t.Fatalf("%s = %#v, want %#v", key, got, want)
+	}
+}

--- a/server/internal/handler/tenant.go
+++ b/server/internal/handler/tenant.go
@@ -143,6 +143,15 @@ func (s *Server) resolveAPIKeyStatus(w http.ResponseWriter, r *http.Request) (ap
 		APIKeySubject: apiKey,
 		AgentName:     r.Header.Get(middleware.AgentIDHeader),
 	}
+	logger := s.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.InfoContext(r.Context(), "api key status resolved",
+		"auth_mode", "api_key",
+		"cluster_id", statusResult.ClusterID,
+		"api_key_status", statusResult.Status,
+	)
 	return apiKeyStatusResolution{Status: statusResult.Status, Auth: auth}, true
 }
 

--- a/server/internal/handler/tenant_test.go
+++ b/server/internal/handler/tenant_test.go
@@ -228,7 +228,7 @@ func TestGetKeyStatus(t *testing.T) {
 		{
 			name:      "active key",
 			apiKey:    "key-active",
-			tenant:    &domain.Tenant{Status: domain.TenantActive},
+			tenant:    &domain.Tenant{Status: domain.TenantActive, ClusterID: "cluster-active"},
 			wantCode:  http.StatusOK,
 			wantField: "status",
 			wantValue: string(domain.KeyStatusActive),
@@ -236,7 +236,7 @@ func TestGetKeyStatus(t *testing.T) {
 		{
 			name:      "inactive key",
 			apiKey:    "key-provisioning",
-			tenant:    &domain.Tenant{Status: domain.TenantProvisioning},
+			tenant:    &domain.Tenant{Status: domain.TenantProvisioning, ClusterID: "cluster-inactive"},
 			wantCode:  http.StatusOK,
 			wantField: "status",
 			wantValue: string(domain.KeyStatusInactive),
@@ -308,6 +308,17 @@ func TestGetKeyStatus(t *testing.T) {
 			}
 			if body[tt.wantField] != tt.wantValue {
 				t.Fatalf("response %s = %q, want %q; body = %#v", tt.wantField, body[tt.wantField], tt.wantValue, body)
+			}
+			if tt.wantCode == http.StatusOK {
+				for _, field := range []string{
+					`"msg":"api key status resolved"`,
+					`"cluster_id":"` + tt.tenant.ClusterID + `"`,
+					`"api_key_status":"` + tt.wantValue + `"`,
+				} {
+					if !strings.Contains(logBuf.String(), field) {
+						t.Fatalf("status resolution log missing %s: %s", field, logBuf.String())
+					}
+				}
 			}
 			if strings.Contains(logBuf.String(), tt.apiKey) && tt.apiKey != "" {
 				t.Fatalf("logs leaked API key: %s", logBuf.String())

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -166,6 +166,30 @@ var (
 		[]string{"mode"},
 	)
 
+	// MemoryListRequestsTotal counts all GET /memories operations.
+	// mode and status values are bounded in handler.memoryListMode and memoryRecallStatus.
+	// PromQL: sum by (mode, status) (rate(mnemo_memory_list_requests_total[5m]))
+	MemoryListRequestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "memory_list_requests_total",
+			Help:      "Total memory list requests, split by bounded mode and outcome.",
+		},
+		[]string{"mode", "status"},
+	)
+
+	// MemoryListDuration observes all GET /memories operations end to end.
+	// PromQL: histogram_quantile(0.95, sum by (le, mode) (rate(mnemo_memory_list_duration_seconds_bucket[5m])))
+	MemoryListDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mnemo",
+			Name:      "memory_list_duration_seconds",
+			Help:      "End-to-end memory list request duration in seconds.",
+			Buckets:   []float64{0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120},
+		},
+		[]string{"mode", "status"},
+	)
+
 	// ActiveMemoryTotal is the current server-level total number of active memories.
 	ActiveMemoryTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mnemo",

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -217,7 +217,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	var total int
 	countQuery := "SELECT COUNT(*) FROM memories WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
-		slog.Error("list memories: count failed", "cluster_id", r.clusterID, "err", err)
+		slog.ErrorContext(ctx, "list memories: count failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("count memories: %w", err)
 	}
 
@@ -240,7 +240,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
-		slog.Error("list memories: query failed", "cluster_id", r.clusterID, "err", err)
+		slog.ErrorContext(ctx, "list memories: query failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("list memories: %w", err)
 	}
 	defer rows.Close()

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -303,7 +303,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	var total int
 	countQuery := "SELECT COUNT(*) FROM memories WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
-		slog.Error("list memories: count failed", "cluster_id", r.clusterID, "err", err)
+		slog.ErrorContext(ctx, "list memories: count failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("count memories: %w", err)
 	}
 
@@ -326,7 +326,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
-		slog.Error("list memories: query failed", "cluster_id", r.clusterID, "err", err)
+		slog.ErrorContext(ctx, "list memories: query failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("list memories: %w", err)
 	}
 	defer rows.Close()

--- a/server/internal/repository/tidb/search_logging_test.go
+++ b/server/internal/repository/tidb/search_logging_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 func TestClassifySearchError(t *testing.T) {
@@ -236,6 +237,54 @@ func TestSearchMethodsLogRowIterationErrors(t *testing.T) {
 			}
 			if got := entry["error_class"]; got != searchErrorClassInferenceUpstream5xx {
 				t.Fatalf("error_class = %v, want %q", got, searchErrorClassInferenceUpstream5xx)
+			}
+		})
+	}
+}
+
+func TestListMethodsPreserveRequestIDInFailureLogs(t *testing.T) {
+	previousLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+
+	tests := []struct {
+		name string
+		run  func(context.Context, *sql.DB) error
+	}{
+		{
+			name: "memory list",
+			run: func(ctx context.Context, db *sql.DB) error {
+				_, _, err := NewMemoryRepo(db, "", false, "cluster-list").List(ctx, domain.MemoryFilter{})
+				return err
+			},
+		},
+		{
+			name: "session list",
+			run: func(ctx context.Context, db *sql.DB) error {
+				_, _, err := NewSessionRepo(db, "", false, "cluster-list").List(ctx, domain.MemoryFilter{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbErr := errors.New("count unavailable")
+			db := newScriptedTestDB(t, []*queryExpectation{{err: dbErr}})
+			defer db.Close()
+
+			var logBuf bytes.Buffer
+			slog.SetDefault(slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil))))
+			ctx := reqid.NewContext(context.Background(), "request-list-repository")
+			if err := tt.run(ctx, db); !errors.Is(err, dbErr) {
+				t.Fatalf("list error = %v, want %v", err, dbErr)
+			}
+
+			var entry map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(logBuf.Bytes()), &entry); err != nil {
+				t.Fatalf("decode list log: %v; log = %s", err, logBuf.String())
+			}
+			if got := entry["request_id"]; got != "request-list-repository" {
+				t.Fatalf("request_id = %v, want request-list-repository", got)
 			}
 		})
 	}

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -260,7 +260,7 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, 0, nil
 		}
-		slog.Error("list session memories: count failed", "cluster_id", r.clusterID, "err", err)
+		slog.ErrorContext(ctx, "list session memories: count failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("count session memories: %w", err)
 	}
 
@@ -284,7 +284,7 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, 0, nil
 		}
-		slog.Error("list session memories: query failed", "cluster_id", r.clusterID, "err", err)
+		slog.ErrorContext(ctx, "list session memories: query failed", "cluster_id", r.clusterID, "err", err)
 		return nil, 0, fmt.Errorf("list session memories: %w", err)
 	}
 	defer rows.Close()


### PR DESCRIPTION
## What Changed

- Added bounded mode/outcome counters and latency histograms for every `GET /memories` execution mode, including validation failures.
- Added correlated structured summaries for slow, failed, canceled, and timed-out requests, including phase, page, row, and Space Chain node work.
- Preserved request context in TiDB and Postgres list failure logs.
- Added a redacted API-key status event with request ID, cluster ID, and normalized active state for the production incident reporter.

## Review Path

1. `server/internal/handler/memory_list_observability.go`: label policy, summary schema, validation outcomes, and cancellation attribution.
2. `server/internal/handler/memory.go`: full request lifecycle plus query, merge, overlay, page, and row accounting.
3. `server/internal/handler/chain_runtime.go`: per-node chain page, row, and query-time accounting.
4. `server/internal/handler/tenant.go`: safe status-probe correlation for API-key incident investigation.
5. `server/internal/metrics/metrics.go` and repository changes: Prometheus surfaces and request-ID propagation.

## Validation

- `go test ./...`
- `go test -race -count=1 ./internal/handler`
- `go vet ./...`

Closes #414
