### PR TITLE
feat(server): make local rate-limit denials actionable

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2491,10 +2491,25 @@
       },
       "RateLimited": {
         "description": "Rate limit exceeded.",
+        "headers": {
+          "Retry-After": {
+            "description": "Seconds after which the client can retry.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/LocalRateLimitError"
+                },
+                {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              ]
             }
           }
         }
@@ -2632,6 +2647,9 @@
                   "$ref": "#/components/schemas/RuntimeQuotaError"
                 },
                 {
+                  "$ref": "#/components/schemas/LocalRateLimitError"
+                },
+                {
                   "$ref": "#/components/schemas/ErrorResponse"
                 }
               ]
@@ -2667,7 +2685,8 @@
               },
               "genericApiRateLimited": {
                 "value": {
-                  "error": "rate limit exceeded"
+                  "error": "rate limit exceeded",
+                  "code": "local_rate_limited"
                 }
               }
             }
@@ -2985,6 +3004,27 @@
             "type": "string"
           }
         }
+      },
+      "LocalRateLimitError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          },
+          {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "local_rate_limited"
+                ]
+              }
+            }
+          }
+        ]
       },
       "CreateMemoryRequest": {
         "type": "object",

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -288,7 +288,7 @@ func main() {
 		tenantMW = middleware.ResolveTenant(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist)
 		apiKeyMW = middleware.ResolveApiKey(tenantRepo, tenantPool, encryptor, cfg.ClusterBlacklist, middleware.WithSpaceChainRepo(spaceChainRepo))
 	}
-	rl := middleware.NewRateLimiter(cfg.RateLimit, cfg.RateBurst)
+	rl := middleware.NewRateLimiter(cfg.RateLimit, cfg.RateBurst, cfg.RuntimeUsageInternalSecret)
 	defer rl.Stop()
 	rateMW := rl.Middleware()
 

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -197,8 +197,8 @@ func (s *Server) Router(
 	r.Use(requestLogger(s.logger))
 	r.Use(chimw.Recoverer)
 	r.Use(corsMW)
-	r.Use(rateLimitMW)
 	r.Use(metrics.Middleware)
+	r.Use(rateLimitMW)
 
 	// Health check.
 	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -65,8 +65,36 @@ func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	if !containsRef(anyOf, "#/components/schemas/RuntimeQuotaError") {
 		t.Fatalf("MemoryRouteRateLimited should include RuntimeQuotaError in anyOf: %#v", anyOf)
 	}
+	if !containsRef(anyOf, "#/components/schemas/LocalRateLimitError") {
+		t.Fatalf("MemoryRouteRateLimited should include LocalRateLimitError in anyOf: %#v", anyOf)
+	}
 	if !containsRef(anyOf, "#/components/schemas/ErrorResponse") {
-		t.Fatalf("MemoryRouteRateLimited should include generic ErrorResponse in anyOf: %#v", anyOf)
+		t.Fatalf("MemoryRouteRateLimited should preserve generic quota errors in anyOf: %#v", anyOf)
+	}
+
+	localRateLimitError := objectValue(t, schemas, "LocalRateLimitError")
+	localRateLimitAllOf := objectSlice(t, localRateLimitError["allOf"])
+	if !containsRef(localRateLimitAllOf, "#/components/schemas/ErrorResponse") {
+		t.Fatalf("LocalRateLimitError should extend ErrorResponse: %#v", localRateLimitAllOf)
+	}
+	if !allOfRequiresProperty(localRateLimitAllOf, "code") {
+		t.Fatalf("LocalRateLimitError.code should be required: %#v", localRateLimitAllOf)
+	}
+	if !allOfHasPropertyEnum(localRateLimitAllOf, "code", []string{"local_rate_limited"}) {
+		t.Fatalf("LocalRateLimitError.code should identify local limiter denials: %#v", localRateLimitAllOf)
+	}
+	genericRateLimited := objectValue(t, responses, "RateLimited")
+	if _, ok := objectValue(t, genericRateLimited, "headers")["Retry-After"]; !ok {
+		t.Fatal("RateLimited response missing Retry-After header")
+	}
+	genericRateLimitedContent := objectValue(t, genericRateLimited, "content")
+	genericRateLimitedJSON := objectValue(t, genericRateLimitedContent, "application/json")
+	genericRateLimitedSchema := objectValue(t, genericRateLimitedJSON, "schema")
+	genericRateLimitedAnyOf := objectSlice(t, genericRateLimitedSchema["anyOf"])
+	for _, ref := range []string{"#/components/schemas/LocalRateLimitError", "#/components/schemas/ErrorResponse"} {
+		if !containsRef(genericRateLimitedAnyOf, ref) {
+			t.Fatalf("RateLimited schema missing %s: %#v", ref, genericRateLimitedAnyOf)
+		}
 	}
 
 	runtimeQuotaError := objectValue(t, schemas, "RuntimeQuotaError")
@@ -537,6 +565,33 @@ func allOfRequiresProperty(values []map[string]any, target string) bool {
 				return true
 			}
 		}
+	}
+	return false
+}
+
+func allOfHasPropertyEnum(values []map[string]any, property string, want []string) bool {
+	for _, value := range values {
+		properties, ok := value["properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		definition, ok := properties[property].(map[string]any)
+		if !ok {
+			continue
+		}
+		enum, ok := definition["enum"].([]any)
+		if !ok {
+			continue
+		}
+		got := make([]string, 0, len(enum))
+		for _, item := range enum {
+			text, ok := item.(string)
+			if !ok {
+				return false
+			}
+			got = append(got, text)
+		}
+		return reflect.DeepEqual(got, want)
 	}
 	return false
 }

--- a/server/internal/handler/rate_limit_metrics_test.go
+++ b/server/internal/handler/rate_limit_metrics_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/middleware"
+	"github.com/qiffang/mnemos/server/internal/service"
+)
+
+func TestRouterRecordsLocalRateLimitDenialsInHTTPMetrics(t *testing.T) {
+	metrics.HTTPRequestsTotal.Reset()
+	rl := middleware.NewRateLimiter(0.001, 1, "fingerprint-secret")
+	defer rl.Stop()
+	identity := func(next http.Handler) http.Handler { return next }
+	srv := NewServer(nil, nil, "", nil, nil, "", false, service.ModeSmart, "", slog.New(slog.NewTextHandler(io.Discard, nil)))
+	router := srv.Router(identity, rl.Middleware(), identity, identity)
+
+	first := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	first.RemoteAddr = "10.0.0.1:1234"
+	firstRR := httptest.NewRecorder()
+	router.ServeHTTP(firstRR, first)
+	if firstRR.Code != http.StatusOK {
+		t.Fatalf("first status = %d, want %d", firstRR.Code, http.StatusOK)
+	}
+
+	second := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	second.RemoteAddr = "10.0.0.1:1234"
+	secondRR := httptest.NewRecorder()
+	router.ServeHTTP(secondRR, second)
+	if secondRR.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want %d", secondRR.Code, http.StatusTooManyRequests)
+	}
+
+	// A global middleware denial happens before chi selects the route handler, so
+	// the bounded fallback route label is expected for this response.
+	counter, err := metrics.HTTPRequestsTotal.GetMetricWithLabelValues(http.MethodGet, "unmatched", "429")
+	if err != nil {
+		t.Fatalf("get HTTP request metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("HTTP request metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write HTTP request metric: %v", err)
+	}
+	if pb.Counter == nil || pb.Counter.GetValue() != 1 {
+		t.Fatalf("HTTP 429 request metric = %#v, want 1", pb.Counter)
+	}
+}

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -35,6 +35,17 @@ var (
 		[]string{"method", "route"},
 	)
 
+	// LocalRateLimitDenialsTotal counts denials from the in-process IP and API-key limiters.
+	// PromQL: sum by (scope) (rate(mnemo_local_rate_limit_denials_total[5m]))
+	LocalRateLimitDenialsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "local_rate_limit_denials_total",
+			Help:      "Total local rate-limit denials, split by bounded scope.",
+		},
+		[]string{"scope"},
+	)
+
 	// ProvisionStepDuration observes the duration of each step in the provision flow.
 	// step labels: tidb_zero_create_instance, create_tenant_record,
 	//              init_schema_create_table, init_schema_vector_index,

--- a/server/internal/middleware/ratelimit.go
+++ b/server/internal/middleware/ratelimit.go
@@ -1,13 +1,24 @@
 package middleware
 
 import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"golang.org/x/time/rate"
+
+	"github.com/qiffang/mnemos/server/internal/metrics"
 )
 
 type visitor struct {
@@ -15,25 +26,29 @@ type visitor struct {
 	lastSeen time.Time
 }
 
+const rateLimitFingerprintKeyDomain = "mnemo/local-rate-limit-fingerprint/v1\x00"
+
 // RateLimiter provides per-tenant rate limiting middleware.
 // The rate-limit key is the tenantID extracted from the URL path parameter
 // {tenantID} or the X-API-Key header on v1alpha2 routes. For routes without a
 // tenant key (e.g. POST /v1alpha1/mem9s), the client IP is used as fallback.
 type RateLimiter struct {
-	mu       sync.Mutex
-	visitors map[string]*visitor
-	limit    rate.Limit
-	burst    int
-	done     chan struct{}
+	mu             sync.Mutex
+	visitors       map[string]*visitor
+	limit          rate.Limit
+	burst          int
+	fingerprintKey []byte
+	done           chan struct{}
 }
 
-// NewRateLimiter creates a rate limiter with the given requests/sec and burst.
-func NewRateLimiter(rps float64, burst int) *RateLimiter {
+// NewRateLimiter creates a limiter and derives a log-fingerprint key from secret.
+func NewRateLimiter(rps float64, burst int, fingerprintSecret string) *RateLimiter {
 	rl := &RateLimiter{
-		visitors: make(map[string]*visitor),
-		limit:    rate.Limit(rps),
-		burst:    burst,
-		done:     make(chan struct{}),
+		visitors:       make(map[string]*visitor),
+		limit:          rate.Limit(rps),
+		burst:          burst,
+		fingerprintKey: newRateLimitFingerprintKey(fingerprintSecret),
+		done:           make(chan struct{}),
 	}
 	go rl.cleanup()
 	return rl
@@ -53,8 +68,8 @@ func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 				ip = r.RemoteAddr
 			}
 
-			if !rl.getLimiter(ip).Allow() {
-				writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
+			if allowed, retryDelay := allowRateLimit(rl.getLimiter(ip)); !allowed {
+				rl.deny(w, r, "ip", "", retryDelay)
 				return
 			}
 
@@ -63,8 +78,8 @@ func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 				key = r.Header.Get(APIKeyHeader)
 			}
 			if key != "" {
-				if !rl.getLimiter(key).Allow() {
-					writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
+				if allowed, retryDelay := allowRateLimit(rl.getLimiter(key)); !allowed {
+					rl.deny(w, r, "api_key", key, retryDelay)
 					return
 				}
 			}
@@ -72,6 +87,69 @@ func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func allowRateLimit(limiter *rate.Limiter) (bool, time.Duration) {
+	now := time.Now()
+	reservation := limiter.ReserveN(now, 1)
+	if !reservation.OK() {
+		return false, rate.InfDuration
+	}
+	retryDelay := reservation.DelayFrom(now)
+	if retryDelay <= 0 {
+		return true, 0
+	}
+	reservation.CancelAt(now)
+	return false, retryDelay
+}
+
+func (rl *RateLimiter) deny(w http.ResponseWriter, r *http.Request, scope, apiKey string, retryDelay time.Duration) {
+	retryAfter := retryAfterSeconds(retryDelay)
+	w.Header().Set("Retry-After", retryAfter)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error": "rate limit exceeded",
+		"code":  "local_rate_limited",
+	})
+
+	attrs := []any{
+		"scope", scope,
+		"limit_rps", float64(rl.limit),
+		"burst", rl.burst,
+		"retry_after_ms", retryDelay.Milliseconds(),
+	}
+	if scope == "api_key" {
+		attrs = append(attrs, "api_key_fingerprint", rl.apiKeyFingerprint(apiKey))
+	}
+	slog.WarnContext(r.Context(), "local rate limit denied", attrs...)
+	metrics.LocalRateLimitDenialsTotal.WithLabelValues(scope).Inc()
+}
+
+func retryAfterSeconds(delay time.Duration) string {
+	seconds := int64(math.Ceil(delay.Seconds()))
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.FormatInt(seconds, 10)
+}
+
+func newRateLimitFingerprintKey(secret string) []byte {
+	if secret != "" {
+		sum := sha256.Sum256([]byte(rateLimitFingerprintKeyDomain + secret))
+		return sum[:]
+	}
+	key := make([]byte, sha256.Size)
+	if _, err := rand.Read(key); err != nil {
+		panic(fmt.Sprintf("generate rate-limit fingerprint key: %v", err))
+	}
+	return key
+}
+
+func (rl *RateLimiter) apiKeyFingerprint(apiKey string) string {
+	mac := hmac.New(sha256.New, rl.fingerprintKey)
+	_, _ = mac.Write([]byte(apiKey))
+	return hex.EncodeToString(mac.Sum(nil)[:12])
 }
 
 func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {

--- a/server/internal/middleware/ratelimit.go
+++ b/server/internal/middleware/ratelimit.go
@@ -22,6 +22,7 @@ import (
 )
 
 type visitor struct {
+	mu       sync.Mutex
 	limiter  *rate.Limiter
 	lastSeen time.Time
 }
@@ -89,9 +90,15 @@ func (rl *RateLimiter) Middleware() func(http.Handler) http.Handler {
 	}
 }
 
-func allowRateLimit(limiter *rate.Limiter) (bool, time.Duration) {
-	now := time.Now()
-	reservation := limiter.ReserveN(now, 1)
+func allowRateLimit(visitor *visitor) (bool, time.Duration) {
+	return allowRateLimitAt(visitor, time.Now())
+}
+
+func allowRateLimitAt(visitor *visitor, now time.Time) (bool, time.Duration) {
+	visitor.mu.Lock()
+	defer visitor.mu.Unlock()
+
+	reservation := visitor.limiter.ReserveN(now, 1)
 	if !reservation.OK() {
 		return false, rate.InfDuration
 	}
@@ -152,18 +159,18 @@ func (rl *RateLimiter) apiKeyFingerprint(apiKey string) string {
 	return hex.EncodeToString(mac.Sum(nil)[:12])
 }
 
-func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {
+func (rl *RateLimiter) getLimiter(key string) *visitor {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
 	v, ok := rl.visitors[key]
 	if !ok {
-		limiter := rate.NewLimiter(rl.limit, rl.burst)
-		rl.visitors[key] = &visitor{limiter: limiter, lastSeen: time.Now()}
-		return limiter
+		v = &visitor{limiter: rate.NewLimiter(rl.limit, rl.burst), lastSeen: time.Now()}
+		rl.visitors[key] = v
+		return v
 	}
 	v.lastSeen = time.Now()
-	return v.limiter
+	return v
 }
 
 // cleanup removes stale entries every 3 minutes until stopped.

--- a/server/internal/middleware/ratelimit_test.go
+++ b/server/internal/middleware/ratelimit_test.go
@@ -1,38 +1,165 @@
 package middleware
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
-func TestRateLimiterUsesAPIKeyHeaderForV1Alpha2(t *testing.T) {
-	rl := NewRateLimiter(1, 1)
-	defer rl.Stop()
+func TestRateLimiterDenialsAreActionable(t *testing.T) {
+	previousLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
 
-	router := chi.NewRouter()
-	router.Use(rl.Middleware())
-	router.Get("/v1alpha2/mem9s/memories", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
-
-	first := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
-	first.RemoteAddr = "10.0.0.1:1234"
-	first.Header.Set(APIKeyHeader, "tenant-1")
-	firstRR := httptest.NewRecorder()
-	router.ServeHTTP(firstRR, first)
-	if firstRR.Code != http.StatusNoContent {
-		t.Fatalf("first status = %d, want %d", firstRR.Code, http.StatusNoContent)
+	tests := []struct {
+		name            string
+		firstIP         string
+		secondIP        string
+		apiKey          string
+		wantScope       string
+		wantFingerprint bool
+	}{
+		{
+			name:      "client IP",
+			firstIP:   "10.0.0.1:1234",
+			secondIP:  "10.0.0.1:1234",
+			wantScope: "ip",
+		},
+		{
+			name:            "API key",
+			firstIP:         "10.0.0.1:1234",
+			secondIP:        "10.0.0.2:1234",
+			apiKey:          "mem9_secret_customer_key",
+			wantScope:       "api_key",
+			wantFingerprint: true,
+		},
 	}
 
-	second := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
-	second.RemoteAddr = "10.0.0.2:1234"
-	second.Header.Set(APIKeyHeader, "tenant-1")
-	secondRR := httptest.NewRecorder()
-	router.ServeHTTP(secondRR, second)
-	if secondRR.Code != http.StatusTooManyRequests {
-		t.Fatalf("second status = %d, want %d", secondRR.Code, http.StatusTooManyRequests)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics.LocalRateLimitDenialsTotal.Reset()
+			var logBuf bytes.Buffer
+			slog.SetDefault(slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil))))
+			rl := NewRateLimiter(0.001, 1, "fingerprint-secret")
+			defer rl.Stop()
+
+			router := chi.NewRouter()
+			router.Use(reqid.Middleware)
+			router.Use(rl.Middleware())
+			router.Get("/v1alpha2/mem9s/memories", func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			first := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+			first.RemoteAddr = tt.firstIP
+			first.Header.Set(APIKeyHeader, tt.apiKey)
+			firstRR := httptest.NewRecorder()
+			router.ServeHTTP(firstRR, first)
+			if firstRR.Code != http.StatusNoContent {
+				t.Fatalf("first status = %d, want %d", firstRR.Code, http.StatusNoContent)
+			}
+
+			second := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories", nil)
+			second.RemoteAddr = tt.secondIP
+			second.Header.Set(APIKeyHeader, tt.apiKey)
+			secondRR := httptest.NewRecorder()
+			router.ServeHTTP(secondRR, second)
+
+			if secondRR.Code != http.StatusTooManyRequests {
+				t.Fatalf("second status = %d, want %d", secondRR.Code, http.StatusTooManyRequests)
+			}
+			var response map[string]string
+			if err := json.NewDecoder(secondRR.Body).Decode(&response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response["error"] != "rate limit exceeded" {
+				t.Fatalf("error = %q, want existing message", response["error"])
+			}
+			if response["code"] != "local_rate_limited" {
+				t.Fatalf("code = %q, want local_rate_limited", response["code"])
+			}
+			retryAfter, err := strconv.Atoi(secondRR.Header().Get("Retry-After"))
+			if err != nil || retryAfter < 1 {
+				t.Fatalf("Retry-After = %q, want positive integer", secondRR.Header().Get("Retry-After"))
+			}
+
+			var entry map[string]any
+			if err := json.Unmarshal(bytes.TrimSpace(logBuf.Bytes()), &entry); err != nil {
+				t.Fatalf("decode denial log: %v; log = %s", err, logBuf.String())
+			}
+			if entry["msg"] != "local rate limit denied" || entry["level"] != "WARN" {
+				t.Fatalf("log = %#v, want warning denial summary", entry)
+			}
+			if entry["request_id"] != secondRR.Header().Get(reqid.Header) {
+				t.Fatalf("request_id = %v, want response request ID %q", entry["request_id"], secondRR.Header().Get(reqid.Header))
+			}
+			if entry["scope"] != tt.wantScope || entry["limit_rps"] != 0.001 || entry["burst"] != float64(1) {
+				t.Fatalf("limiter fields = scope:%v limit:%v burst:%v", entry["scope"], entry["limit_rps"], entry["burst"])
+			}
+			if retryMS, ok := entry["retry_after_ms"].(float64); !ok || retryMS < 1 {
+				t.Fatalf("retry_after_ms = %#v, want positive duration", entry["retry_after_ms"])
+			}
+			fingerprint, hasFingerprint := entry["api_key_fingerprint"].(string)
+			if hasFingerprint != tt.wantFingerprint {
+				t.Fatalf("api_key_fingerprint present = %v, want %v", hasFingerprint, tt.wantFingerprint)
+			}
+			if tt.wantFingerprint && (fingerprint == "" || strings.Contains(logBuf.String(), tt.apiKey)) {
+				t.Fatalf("API-key denial log exposed raw key or omitted fingerprint: %s", logBuf.String())
+			}
+			if got := localRateLimitDenialCount(t, tt.wantScope); got != 1 {
+				t.Fatalf("local denial metric = %v, want 1", got)
+			}
+		})
 	}
+}
+
+func TestRateLimiterAPIKeyFingerprintIsStableAndKeyed(t *testing.T) {
+	first := NewRateLimiter(1, 1, "secret-a")
+	defer first.Stop()
+	second := NewRateLimiter(1, 1, "secret-b")
+	defer second.Stop()
+
+	fingerprint := first.apiKeyFingerprint("mem9_customer_key")
+	if fingerprint != first.apiKeyFingerprint("mem9_customer_key") {
+		t.Fatal("fingerprint changed for the same API key")
+	}
+	if fingerprint == second.apiKeyFingerprint("mem9_customer_key") {
+		t.Fatal("fingerprint did not change with the HMAC key")
+	}
+	plain := sha256.Sum256([]byte("mem9_customer_key"))
+	if fingerprint == hex.EncodeToString(plain[:12]) {
+		t.Fatal("fingerprint equals the unkeyed SHA-256 digest")
+	}
+}
+
+func localRateLimitDenialCount(t *testing.T, scope string) float64 {
+	t.Helper()
+	counter, err := metrics.LocalRateLimitDenialsTotal.GetMetricWithLabelValues(scope)
+	if err != nil {
+		t.Fatalf("get local rate-limit metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("local rate-limit metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write local rate-limit metric: %v", err)
+	}
+	if pb.Counter == nil {
+		return 0
+	}
+	return pb.Counter.GetValue()
 }

--- a/server/internal/middleware/ratelimit_test.go
+++ b/server/internal/middleware/ratelimit_test.go
@@ -10,10 +10,13 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	dto "github.com/prometheus/client_model/go"
+	"golang.org/x/time/rate"
 
 	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/reqid"
@@ -141,6 +144,40 @@ func TestRateLimiterAPIKeyFingerprintIsStableAndKeyed(t *testing.T) {
 	plain := sha256.Sum256([]byte("mem9_customer_key"))
 	if fingerprint == hex.EncodeToString(plain[:12]) {
 		t.Fatal("fingerprint equals the unkeyed SHA-256 digest")
+	}
+}
+
+func TestAllowRateLimitConcurrentDenialsPreserveCapacity(t *testing.T) {
+	const deniedRequests = 100
+	now := time.Now()
+	visitor := &visitor{limiter: rate.NewLimiter(10, 1)}
+	if !visitor.limiter.AllowN(now, 1) {
+		t.Fatal("initial request was denied")
+	}
+
+	start := make(chan struct{})
+	results := make(chan bool, deniedRequests)
+	var group sync.WaitGroup
+	for range deniedRequests {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			allowed, _ := allowRateLimitAt(visitor, now)
+			results <- allowed
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(results)
+
+	for allowed := range results {
+		if allowed {
+			t.Fatal("concurrent request was unexpectedly allowed")
+		}
+	}
+	if !visitor.limiter.AllowN(now.Add(101*time.Millisecond), 1) {
+		t.Fatal("concurrent denials consumed future limiter capacity")
 	}
 }
 


### PR DESCRIPTION
## What Changed

- Added correlated warning logs and bounded Prometheus counts for local IP/API-key denials.
- Added `code: local_rate_limited` and a valid `Retry-After` header while preserving the existing error message.
- Serialized each visitor reservation lifecycle so concurrent denials preserve future limiter capacity.
- Added HMAC-based API-key fingerprints and kept raw keys out of denial logs.
- Kept local 429 responses in general HTTP metrics and documented the distinct OpenAPI envelope.

## Review Path

1. `server/internal/middleware/ratelimit.go`: atomic reservation/cancellation, retry calculation, denial response, warning fields, and keyed fingerprinting.
2. `server/internal/middleware/ratelimit_test.go`: concurrent-denial capacity regression coverage.
3. `server/internal/handler/handler.go`: middleware ordering for general HTTP metrics.
4. `docs/api/openapi.json`: local 429 contract alongside existing runtime and cluster-quota responses.

## Validation

- `go test ./...`
- `go test -race -count=1 ./internal/middleware -run 'Test(RateLimiterDenialsAreActionable|RateLimiterAPIKeyFingerprintIsStableAndKeyed|AllowRateLimitConcurrentDenialsPreserveCapacity)'`
- `go vet ./...`

Closes #415
