### PR TITLE
fix(server): bound explicit all-type memory scans

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -338,6 +338,9 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "422": {
+            "$ref": "#/components/responses/MemoryListBudgetExceeded"
+          },
           "429": {
             "$ref": "#/components/responses/MemoryRouteRateLimited"
           },
@@ -803,6 +806,9 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "422": {
+            "$ref": "#/components/responses/MemoryListBudgetExceeded"
           },
           "429": {
             "$ref": "#/components/responses/MemoryRouteRateLimited"
@@ -2629,6 +2635,28 @@
           }
         }
       },
+      "MemoryListBudgetExceeded": {
+        "description": "The explicit all-types memory scan exceeded its server-owned page, row, or elapsed-time budget.",
+        "headers": {
+          "X-Request-Id": {
+            "description": "Canonical request ID for correlating the budget error with server logs.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/MemoryListBudgetError"
+            },
+            "example": {
+              "error": "all-types memory list budget exceeded",
+              "code": "memory_list_budget_exceeded"
+            }
+          }
+        }
+      },
       "MemoryRouteRateLimited": {
         "description": "Memory route rate limit. The response can be a generic API rate-limit envelope from global middleware or a runtime quota rate-limit envelope from the runtime usage provider.",
         "headers": {
@@ -3020,6 +3048,27 @@
                 "type": "string",
                 "enum": [
                   "local_rate_limited"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "MemoryListBudgetError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          },
+          {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "memory_list_budget_exceeded"
                 ]
               }
             }

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -314,7 +314,13 @@ func respondError(w http.ResponseWriter, status int, msg string) {
 
 // handleError maps domain errors to HTTP status codes.
 func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err error) {
+	var budgetErr *memoryListBudgetExceededError
 	switch {
+	case errors.As(err, &budgetErr):
+		respond(w, http.StatusUnprocessableEntity, map[string]string{
+			"error": memoryListBudgetErrorMessage,
+			"code":  memoryListBudgetErrorCode,
+		})
 	case errors.Is(err, domain.ErrNotFound):
 		respondError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, domain.ErrWriteConflict):

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -1144,6 +1144,9 @@ func collectLocalListPages(
 			return nil, resultErr
 		}
 		all = append(all, page...)
+		if budget.rows == budget.limits.maxRows && pageFilter.Offset+len(page) < pageTotal {
+			return nil, &memoryListBudgetExceededError{dimension: "rows", source: resource}
+		}
 		if len(page) == 0 || pageFilter.Offset+pageFilter.Limit >= pageTotal {
 			return all, nil
 		}

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -1068,11 +1068,13 @@ func (s *Server) listLocalMemoriesContentKeyword(ctx context.Context, svc resolv
 }
 
 func (s *Server) listLocalAllTypeMemoriesContentKeyword(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
-	memoryPages, err := collectLocalListPages(ctx, filter, "memory", svc.memory.ContentKeywordSearch)
+	budgetCtx, budget, cancel := newLocalListBudget(ctx, defaultLocalListBudgetLimits())
+	defer cancel()
+	memoryPages, err := collectLocalListPages(budgetCtx, filter, "memory", budget, svc.memory.ContentKeywordSearch)
 	if err != nil {
 		return nil, 0, err
 	}
-	sessionPages, err := collectLocalListPages(ctx, filter, "session", svc.session.ContentKeywordSearch)
+	sessionPages, err := collectLocalListPages(budgetCtx, filter, "session", budget, svc.session.ContentKeywordSearch)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1092,11 +1094,13 @@ func (s *Server) listLocalAllTypeMemoriesContentKeyword(ctx context.Context, svc
 }
 
 func (s *Server) listLocalAllTypeMemoriesScanAll(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
-	memoryPages, err := collectLocalListPages(ctx, filter, "memory", svc.memory.List)
+	budgetCtx, budget, cancel := newLocalListBudget(ctx, defaultLocalListBudgetLimits())
+	defer cancel()
+	memoryPages, err := collectLocalListPages(budgetCtx, filter, "memory", budget, svc.memory.List)
 	if err != nil {
 		return nil, 0, err
 	}
-	sessionPages, err := collectLocalListPages(ctx, filter, "session", svc.session.List)
+	sessionPages, err := collectLocalListPages(budgetCtx, filter, "session", budget, svc.session.List)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -1119,21 +1123,25 @@ func collectLocalListPages(
 	ctx context.Context,
 	filter domain.MemoryFilter,
 	resource string,
+	budget *localListBudget,
 	list func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error),
 ) ([]domain.Memory, error) {
 	pageFilter := filter
-	pageFilter.Limit = 200
 	pageFilter.Offset = 0
 
 	var all []domain.Memory
 	for {
+		if err := budget.preparePage(ctx, resource, &pageFilter); err != nil {
+			return nil, err
+		}
 		pageStartedAt := time.Now()
 		page, pageTotal, err := list(ctx, pageFilter)
+		budget.recordPage(len(page))
 		if observation := memoryListObservationFromContext(ctx); observation != nil {
 			observation.recordPage(resource, len(page), time.Since(pageStartedAt))
 		}
-		if err != nil {
-			return nil, err
+		if resultErr := budget.pageResultError(ctx, resource, err); resultErr != nil {
+			return nil, resultErr
 		}
 		all = append(all, page...)
 		if len(page) == 0 || pageFilter.Offset+pageFilter.Limit >= pageTotal {

--- a/server/internal/handler/memory_list_budget.go
+++ b/server/internal/handler/memory_list_budget.go
@@ -66,8 +66,12 @@ func (b *localListBudget) preparePage(ctx context.Context, source string, filter
 		return &memoryListBudgetExceededError{dimension: "pages", source: source}
 	}
 	remainingRows := b.limits.maxRows - b.rows
-	if remainingRows <= 0 {
+	if remainingRows < 0 {
 		return &memoryListBudgetExceededError{dimension: "rows", source: source}
+	}
+	if remainingRows == 0 {
+		filter.Limit = 1
+		return nil
 	}
 	filter.Limit = min(b.limits.pageSize, remainingRows)
 	return nil

--- a/server/internal/handler/memory_list_budget.go
+++ b/server/internal/handler/memory_list_budget.go
@@ -1,0 +1,103 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+const (
+	memoryListBudgetErrorMessage = "all-types memory list budget exceeded"
+	memoryListBudgetErrorCode    = "memory_list_budget_exceeded"
+
+	localAllTypeMaxPages   = 20
+	localAllTypeMaxRows    = 3000
+	localAllTypeMaxElapsed = 5 * time.Second
+	localAllTypePageSize   = 200
+)
+
+type memoryListBudgetExceededError struct {
+	dimension string
+	source    string
+}
+
+func (e *memoryListBudgetExceededError) Error() string {
+	return memoryListBudgetErrorMessage
+}
+
+type localListBudgetLimits struct {
+	maxPages   int
+	maxRows    int
+	maxElapsed time.Duration
+	pageSize   int
+}
+
+type localListBudget struct {
+	limits localListBudgetLimits
+	pages  int
+	rows   int
+}
+
+func defaultLocalListBudgetLimits() localListBudgetLimits {
+	return localListBudgetLimits{
+		maxPages:   localAllTypeMaxPages,
+		maxRows:    localAllTypeMaxRows,
+		maxElapsed: localAllTypeMaxElapsed,
+		pageSize:   localAllTypePageSize,
+	}
+}
+
+func newLocalListBudget(
+	parent context.Context,
+	limits localListBudgetLimits,
+) (context.Context, *localListBudget, context.CancelFunc) {
+	cause := &memoryListBudgetExceededError{dimension: "elapsed"}
+	ctx, cancel := context.WithTimeoutCause(parent, limits.maxElapsed, cause)
+	return ctx, &localListBudget{limits: limits}, cancel
+}
+
+func (b *localListBudget) preparePage(ctx context.Context, source string, filter *domain.MemoryFilter) error {
+	if err := b.contextError(ctx, source); err != nil {
+		return err
+	}
+	if b.pages >= b.limits.maxPages {
+		return &memoryListBudgetExceededError{dimension: "pages", source: source}
+	}
+	remainingRows := b.limits.maxRows - b.rows
+	if remainingRows <= 0 {
+		return &memoryListBudgetExceededError{dimension: "rows", source: source}
+	}
+	filter.Limit = min(b.limits.pageSize, remainingRows)
+	return nil
+}
+
+func (b *localListBudget) recordPage(rows int) {
+	b.pages++
+	b.rows += rows
+}
+
+func (b *localListBudget) pageResultError(ctx context.Context, source string, err error) error {
+	if contextErr := b.contextError(ctx, source); contextErr != nil {
+		return contextErr
+	}
+	if err != nil {
+		return err
+	}
+	if b.rows > b.limits.maxRows {
+		return &memoryListBudgetExceededError{dimension: "rows", source: source}
+	}
+	return nil
+}
+
+func (b *localListBudget) contextError(ctx context.Context, source string) error {
+	if ctx.Err() == nil {
+		return nil
+	}
+	var budgetErr *memoryListBudgetExceededError
+	if errors.As(context.Cause(ctx), &budgetErr) {
+		return &memoryListBudgetExceededError{dimension: budgetErr.dimension, source: source}
+	}
+	return ctx.Err()
+}

--- a/server/internal/handler/memory_list_budget_test.go
+++ b/server/internal/handler/memory_list_budget_test.go
@@ -1,0 +1,272 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/reqid"
+)
+
+func TestCollectLocalListPagesStopsAtMemoryRowBudget(t *testing.T) {
+	observation := newMemoryListObservation(slog.Default(), &domain.AuthInfo{}, domain.MemoryFilter{
+		Query:   "term",
+		ScanAll: true,
+	}, false)
+	parent := withMemoryListObservation(context.Background(), observation)
+	ctx, budget, cancel := newLocalListBudget(parent, localListBudgetLimits{
+		maxPages:   10,
+		maxRows:    2,
+		maxElapsed: time.Second,
+		pageSize:   2,
+	})
+	defer cancel()
+	calls := 0
+
+	_, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "memory", budget, func(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+		calls++
+		return makeBudgetTestMemories(filter.Limit), 3, nil
+	})
+
+	assertMemoryListBudgetError(t, err, "rows", "memory")
+	if calls != 1 {
+		t.Fatalf("repository calls = %d, want 1", calls)
+	}
+	if observation.memoryPages != 1 || observation.memoryRows != 2 {
+		t.Fatalf("observed memory work = %d pages/%d rows, want 1/2", observation.memoryPages, observation.memoryRows)
+	}
+}
+
+func TestCollectLocalListPagesStopsAtSessionPageBudget(t *testing.T) {
+	ctx, budget, cancel := newLocalListBudget(context.Background(), localListBudgetLimits{
+		maxPages:   2,
+		maxRows:    100,
+		maxElapsed: time.Second,
+		pageSize:   1,
+	})
+	defer cancel()
+	memoryCalls := 0
+	sessionCalls := 0
+
+	_, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "memory", budget, func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
+		memoryCalls++
+		return makeBudgetTestMemories(1), 1, nil
+	})
+	if err != nil {
+		t.Fatalf("memory collection: %v", err)
+	}
+	_, err = collectLocalListPages(ctx, domain.MemoryFilter{}, "session", budget, func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
+		sessionCalls++
+		return makeBudgetTestMemories(1), 3, nil
+	})
+
+	assertMemoryListBudgetError(t, err, "pages", "session")
+	if memoryCalls != 1 || sessionCalls != 1 {
+		t.Fatalf("repository calls = memory:%d session:%d, want 1/1", memoryCalls, sessionCalls)
+	}
+}
+
+func TestCollectLocalListPagesStopsAtElapsedBudget(t *testing.T) {
+	ctx, budget, cancel := newLocalListBudget(context.Background(), localListBudgetLimits{
+		maxPages:   10,
+		maxRows:    100,
+		maxElapsed: 10 * time.Millisecond,
+		pageSize:   1,
+	})
+	defer cancel()
+	calls := 0
+
+	_, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "memory", budget, func(ctx context.Context, _ domain.MemoryFilter) ([]domain.Memory, int, error) {
+		calls++
+		<-ctx.Done()
+		return nil, 0, ctx.Err()
+	})
+
+	assertMemoryListBudgetError(t, err, "elapsed", "memory")
+	if calls != 1 {
+		t.Fatalf("repository calls = %d, want 1", calls)
+	}
+}
+
+func TestCollectLocalListPagesPreservesRequestCancellation(t *testing.T) {
+	tests := []struct {
+		name       string
+		newContext func() (context.Context, context.CancelFunc)
+		want       error
+	}{
+		{
+			name: "canceled",
+			newContext: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, cancel
+			},
+			want: context.Canceled,
+		},
+		{
+			name: "deadline",
+			newContext: func() (context.Context, context.CancelFunc) {
+				return context.WithDeadline(context.Background(), time.Unix(0, 0))
+			},
+			want: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent, cancelParent := tt.newContext()
+			defer cancelParent()
+			ctx, budget, cancelBudget := newLocalListBudget(parent, localListBudgetLimits{
+				maxPages:   10,
+				maxRows:    100,
+				maxElapsed: time.Second,
+				pageSize:   1,
+			})
+			defer cancelBudget()
+			calls := 0
+
+			_, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "memory", budget, func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
+				calls++
+				return nil, 0, nil
+			})
+
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("error = %v, want %v", err, tt.want)
+			}
+			var budgetErr *memoryListBudgetExceededError
+			if errors.As(err, &budgetErr) {
+				t.Fatalf("error = %v, want request context classification", err)
+			}
+			if calls != 0 {
+				t.Fatalf("repository calls = %d, want 0", calls)
+			}
+		})
+	}
+}
+
+func TestCollectLocalListPagesWithinBudgetPreservesPagination(t *testing.T) {
+	ctx, budget, cancel := newLocalListBudget(context.Background(), localListBudgetLimits{
+		maxPages:   4,
+		maxRows:    4,
+		maxElapsed: time.Second,
+		pageSize:   2,
+	})
+	defer cancel()
+	all := makeBudgetTestMemories(3)
+	var filters []domain.MemoryFilter
+	filter := domain.MemoryFilter{
+		Query:   "term",
+		Tags:    []string{"important"},
+		SortBy:  "updated_at",
+		SortDir: "desc",
+	}
+
+	got, err := collectLocalListPages(ctx, filter, "memory", budget, func(_ context.Context, pageFilter domain.MemoryFilter) ([]domain.Memory, int, error) {
+		filters = append(filters, pageFilter)
+		end := min(pageFilter.Offset+pageFilter.Limit, len(all))
+		return append([]domain.Memory(nil), all[pageFilter.Offset:end]...), len(all), nil
+	})
+	if err != nil {
+		t.Fatalf("collect pages: %v", err)
+	}
+	if !reflect.DeepEqual(got, all) {
+		t.Fatalf("memories = %+v, want %+v", got, all)
+	}
+	if len(filters) != 2 || filters[0].Offset != 0 || filters[1].Offset != 2 {
+		t.Fatalf("page filters = %+v, want offsets 0 and 2", filters)
+	}
+	for _, gotFilter := range filters {
+		if gotFilter.Query != filter.Query || !reflect.DeepEqual(gotFilter.Tags, filter.Tags) ||
+			gotFilter.SortBy != filter.SortBy || gotFilter.SortDir != filter.SortDir {
+			t.Fatalf("filter fields changed: %+v", gotFilter)
+		}
+	}
+}
+
+func TestMemoryListBudgetErrorResponseReturnsCanonicalRequestID(t *testing.T) {
+	srv := &Server{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	handler := reqid.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv.handleError(r.Context(), w, &memoryListBudgetExceededError{dimension: "rows", source: "memory"})
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/memories", nil)
+	req.Header.Set(reqid.Header, "req_AAAAAAAAAAAAAAAAAAAAAA")
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusUnprocessableEntity)
+	}
+	if rr.Header().Get(reqid.Header) != "req_AAAAAAAAAAAAAAAAAAAAAA" {
+		t.Fatalf("request ID = %q, want canonical inbound ID", rr.Header().Get(reqid.Header))
+	}
+	var response map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["error"] != memoryListBudgetErrorMessage || response["code"] != memoryListBudgetErrorCode {
+		t.Fatalf("response = %#v, want stable budget error", response)
+	}
+}
+
+func TestMemoryListObservationRecordsBudgetExceededOutcome(t *testing.T) {
+	resetMemoryListMetrics()
+	var logBuf bytes.Buffer
+	logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+	observation := newMemoryListObservation(logger, &domain.AuthInfo{ClusterID: "cluster-budget"}, domain.MemoryFilter{
+		Query:   "term",
+		ScanAll: true,
+		Limit:   10,
+	}, false)
+	observation.memoryPages = 2
+	observation.memoryRows = 400
+	err := &memoryListBudgetExceededError{dimension: "rows", source: "memory"}
+	ctx := reqid.NewContext(context.Background(), "request-budget")
+
+	observation.finish(ctx, err, 0, 0)
+
+	if got := memoryListRequestCount(t, "scan_all", "budget_exceeded"); got != 1 {
+		t.Fatalf("budget-exceeded request metric = %v, want 1", got)
+	}
+	if got := memoryListDurationCount(t, "scan_all", "budget_exceeded"); got != 1 {
+		t.Fatalf("budget-exceeded duration count = %d, want 1", got)
+	}
+	entry := findMemoryListLogEntry(t, &logBuf, "memory list failed")
+	assertMemoryListLogField(t, entry, "request_id", "request-budget")
+	assertMemoryListLogField(t, entry, "outcome", "budget_exceeded")
+	assertMemoryListLogField(t, entry, "pages", float64(2))
+	assertMemoryListLogField(t, entry, "rows", float64(400))
+	assertMemoryListLogField(t, entry, "budget_dimension", "rows")
+	assertMemoryListLogField(t, entry, "budget_source", "memory")
+	if _, ok := entry["duration_ms"]; !ok {
+		t.Fatal("budget-exceeded operation log missing duration_ms")
+	}
+}
+
+func assertMemoryListBudgetError(t *testing.T, err error, dimension, source string) {
+	t.Helper()
+	var budgetErr *memoryListBudgetExceededError
+	if !errors.As(err, &budgetErr) {
+		t.Fatalf("error = %v, want memoryListBudgetExceededError", err)
+	}
+	if budgetErr.dimension != dimension || budgetErr.source != source {
+		t.Fatalf("budget error = dimension:%q source:%q, want %q/%q", budgetErr.dimension, budgetErr.source, dimension, source)
+	}
+}
+
+func makeBudgetTestMemories(count int) []domain.Memory {
+	memories := make([]domain.Memory, count)
+	for i := range memories {
+		memories[i] = domain.Memory{ID: string(rune('a' + i)), MemoryType: domain.TypeInsight}
+	}
+	return memories
+}

--- a/server/internal/handler/memory_list_budget_test.go
+++ b/server/internal/handler/memory_list_budget_test.go
@@ -46,6 +46,62 @@ func TestCollectLocalListPagesStopsAtMemoryRowBudget(t *testing.T) {
 	}
 }
 
+func TestCollectLocalListPagesAllowsEmptySecondSourceAtExactRowBudget(t *testing.T) {
+	ctx, budget, cancel := newLocalListBudget(context.Background(), localListBudgetLimits{
+		maxPages:   3,
+		maxRows:    3,
+		maxElapsed: time.Second,
+		pageSize:   3,
+	})
+	defer cancel()
+
+	memoryRows, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "memory", budget, func(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+		if filter.Limit != 3 {
+			t.Fatalf("memory limit = %d, want 3", filter.Limit)
+		}
+		return makeBudgetTestMemories(3), 3, nil
+	})
+	if err != nil {
+		t.Fatalf("memory collection: %v", err)
+	}
+	sessionCalls := 0
+	sessionRows, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "session", budget, func(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+		sessionCalls++
+		if filter.Limit != 1 {
+			t.Fatalf("session probe limit = %d, want 1", filter.Limit)
+		}
+		return nil, 0, nil
+	})
+	if err != nil {
+		t.Fatalf("empty session collection: %v", err)
+	}
+	if len(memoryRows) != 3 || len(sessionRows) != 0 || sessionCalls != 1 {
+		t.Fatalf("results = memory:%d session:%d calls:%d, want 3/0/1", len(memoryRows), len(sessionRows), sessionCalls)
+	}
+}
+
+func TestCollectLocalListPagesRejectsNonemptySecondSourceAtExactRowBudget(t *testing.T) {
+	ctx, budget, cancel := newLocalListBudget(context.Background(), localListBudgetLimits{
+		maxPages:   3,
+		maxRows:    3,
+		maxElapsed: time.Second,
+		pageSize:   3,
+	})
+	defer cancel()
+
+	_, err := collectLocalListPages(ctx, domain.MemoryFilter{}, "memory", budget, func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
+		return makeBudgetTestMemories(3), 3, nil
+	})
+	if err != nil {
+		t.Fatalf("memory collection: %v", err)
+	}
+	_, err = collectLocalListPages(ctx, domain.MemoryFilter{}, "session", budget, func(context.Context, domain.MemoryFilter) ([]domain.Memory, int, error) {
+		return makeBudgetTestMemories(1), 1, nil
+	})
+
+	assertMemoryListBudgetError(t, err, "rows", "session")
+}
+
 func TestCollectLocalListPagesStopsAtSessionPageBudget(t *testing.T) {
 	ctx, budget, cancel := newLocalListBudget(context.Background(), localListBudgetLimits{
 		maxPages:   2,

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -162,7 +162,7 @@ func (o *memoryListObservation) recordDirectList(auth *domain.AuthInfo, filter d
 
 func (o *memoryListObservation) finish(ctx context.Context, err error, returned, total int) {
 	duration := time.Since(o.startedAt)
-	status := memoryRecallStatus(ctx, err)
+	status := memoryListStatus(ctx, err)
 	metrics.MemoryListRequestsTotal.WithLabelValues(o.mode, status).Inc()
 	metrics.MemoryListDuration.WithLabelValues(o.mode, status).Observe(duration.Seconds())
 
@@ -203,7 +203,16 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		slog.String("outcome", status),
 		slog.String("cancel_origin", memoryListCancelOrigin(ctx, err)),
 	}
-	if status != "ok" {
+	var budgetErr *memoryListBudgetExceededError
+	if errors.As(err, &budgetErr) {
+		attrs = append(attrs,
+			slog.String("budget_dimension", budgetErr.dimension),
+			slog.String("budget_source", budgetErr.source),
+			slog.String("error_class", "budget_exceeded"),
+			slog.String("error_source", "server_budget"),
+			slog.Bool("retryable", false),
+		)
+	} else if status != "ok" {
 		cause := err
 		if cause == nil && ctx != nil {
 			cause = ctx.Err()
@@ -223,6 +232,14 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		level = slog.LevelError
 	}
 	o.logger.LogAttrs(ctx, level, message, attrs...)
+}
+
+func memoryListStatus(ctx context.Context, err error) string {
+	var budgetErr *memoryListBudgetExceededError
+	if errors.As(err, &budgetErr) {
+		return "budget_exceeded"
+	}
+	return memoryRecallStatus(ctx, err)
 }
 
 func memoryListCancelOrigin(ctx context.Context, err error) string {

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
 const (
@@ -39,6 +41,51 @@ func TestOpenAPIRuntimeQuotaResponses(t *testing.T) {
 	assertResponseRef(t, getByIDResponses, "429", genericRateLimitedRef)
 	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "402", runtimeAccessBlockedRef)
 	assertNoResponseRef(t, operationResponses(t, openapi, "/v1alpha1/mem9s/{tenantID}/memories/{id}", "get"), "429", memoryRouteRateLimitedRef)
+}
+
+func TestOpenAPIMemoryListBudgetResponse(t *testing.T) {
+	openapi := loadOpenAPI(t)
+	for _, path := range []string{
+		"/v1alpha1/mem9s/{tenantID}/memories",
+		"/v1alpha2/mem9s/memories",
+	} {
+		responses := operationResponses(t, openapi, path, "get")
+		assertResponseRef(t, responses, "422", "#/components/responses/MemoryListBudgetExceeded")
+	}
+
+	components := objectValue(t, openapi, "components")
+	responses := objectValue(t, components, "responses")
+	schemas := objectValue(t, components, "schemas")
+	response := objectValue(t, responses, "MemoryListBudgetExceeded")
+	if _, ok := objectValue(t, response, "headers")[reqid.Header]; !ok {
+		t.Fatalf("MemoryListBudgetExceeded response missing %s header", reqid.Header)
+	}
+	content := objectValue(t, response, "content")
+	jsonContent := objectValue(t, content, "application/json")
+	schema := objectValue(t, jsonContent, "schema")
+	if schema["$ref"] != "#/components/schemas/MemoryListBudgetError" {
+		t.Fatalf("budget response schema = %#v, want MemoryListBudgetError", schema["$ref"])
+	}
+
+	budgetError := objectValue(t, schemas, "MemoryListBudgetError")
+	allOf := objectSlice(t, budgetError["allOf"])
+	if !containsRef(allOf, "#/components/schemas/ErrorResponse") || !allOfRequiresProperty(allOf, "code") {
+		t.Fatalf("MemoryListBudgetError contract = %#v", allOf)
+	}
+	codeEnumFound := false
+	for _, part := range allOf {
+		properties, ok := part["properties"].(map[string]any)
+		if !ok {
+			continue
+		}
+		code, ok := properties["code"].(map[string]any)
+		if ok && reflect.DeepEqual(stringSlice(t, code["enum"]), []string{memoryListBudgetErrorCode}) {
+			codeEnumFound = true
+		}
+	}
+	if !codeEnumFound {
+		t.Fatalf("MemoryListBudgetError.code = %#v, want %q", allOf, memoryListBudgetErrorCode)
+	}
 }
 
 func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -178,7 +178,8 @@ var (
 	)
 
 	// MemoryListRequestsTotal counts all GET /memories operations.
-	// mode and status values are bounded in handler.memoryListMode and memoryRecallStatus.
+	// mode and status values are bounded in handler.memoryListMode and memoryListStatus.
+	// status labels: ok, error, timeout, canceled, budget_exceeded
 	// PromQL: sum by (mode, status) (rate(mnemo_memory_list_requests_total[5m]))
 	MemoryListRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
## What Changed

- add a shared 20-page, 3,000-row, 5-second work budget across memory and session sources for explicit all-types scans
- allow an empty second source at the exact row cap through a one-row probe, while returning 422 when that source contains another row
- add a stable `memory_list_budget_exceeded` response with request ID and bounded source/dimension/page/row/elapsed evidence
- preserve parent cancellation/deadline classification and in-budget merge behavior

## Review Path

1. `server/internal/handler/memory_list_budget.go` — budget state and parent-context precedence
2. `server/internal/handler/memory.go` — shared budget collection and exact-cap source probe
3. `server/internal/handler/memory_list_observability.go` — distinct budget outcome and structured fields

## Validation

- `cd server && go test ./...`
- `cd server && go test -race -count=1 ./internal/handler`
- `cd server && go vet ./...`
- [Server and plugin checks](https://github.com/mem9-ai/mem9/actions/runs/29990216427)

Closes #416
