### PR TITLE
feat(server): restore bounded all-type memory listing

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2053,7 +2053,7 @@
         "name": "sort_by",
         "in": "query",
         "required": false,
-        "description": "Sort field used when listing memories.",
+        "description": "Sort field used when listing memories. All-types lists support updated_at and memory_type; content and tags require an explicit memory_type.",
         "schema": {
           "type": "string",
           "enum": [

--- a/server/internal/domain/types.go
+++ b/server/internal/domain/types.go
@@ -159,6 +159,7 @@ type MemoryFilter struct {
 	Limit      int
 	Offset     int
 	ScanAll    bool
+	AllTypes   bool    // internal list hint: align session ordering with the merged all-types projection
 	MinScore   float64 // minimum cosine similarity for vector results; 0 = use default (0.3); -1 = disabled (return all)
 	// CreatedAfter / CreatedBefore bound results to a created_at window
 	// (closed interval). nil = unbounded on that side. Currently consumed

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -1070,7 +1070,10 @@ func (s *Server) listLocalMemoriesContentKeyword(ctx context.Context, svc resolv
 	}
 }
 
-const localMemoryListPageSize = 200
+const (
+	localMemoryListPageSize         = 200
+	localAllTypeMemoryListMaxWindow = 3000
+)
 
 type localMemoryListSource struct {
 	name     string
@@ -1085,7 +1088,10 @@ type localMemoryListPrefix struct {
 }
 
 func (s *Server) listLocalAllTypeMemoriesPage(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
-	window := mergedMemoryWindow(filter.Offset, filter.Limit)
+	window, err := localAllTypeMemoryListWindow(filter)
+	if err != nil {
+		return nil, 0, err
+	}
 	memorySource := localMemoryListSource{
 		name:     "memory",
 		filter:   filter,
@@ -1171,6 +1177,24 @@ func loadLocalMemoryListPrefix(ctx context.Context, source localMemoryListSource
 	return localMemoryListPrefix{memories: memories, total: total}, nil
 }
 
+func localAllTypeMemoryListWindow(filter domain.MemoryFilter) (int, error) {
+	window := mergedMemoryWindow(filter.Offset, filter.Limit)
+	if window > localAllTypeMemoryListMaxWindow {
+		return 0, &domain.ValidationError{
+			Field:   "offset",
+			Message: fmt.Sprintf("offset plus limit exceeds the all-types maximum of %d", localAllTypeMemoryListMaxWindow),
+		}
+	}
+	switch strings.TrimSpace(filter.SortBy) {
+	case "content", "tags":
+		return 0, &domain.ValidationError{
+			Field:   "sort_by",
+			Message: "content and tags sorting require an explicit memory_type",
+		}
+	}
+	return window, nil
+}
+
 func mergedMemoryWindow(offset, limit int) int {
 	maxInt := int(^uint(0) >> 1)
 	if limit > maxInt-offset {
@@ -1218,15 +1242,8 @@ func mergeLocalMemoryListPrefixes(left, right []domain.Memory, filter domain.Mem
 func localMemoryListCompare(left, right domain.Memory, filter domain.MemoryFilter) int {
 	comparison := 0
 	switch strings.TrimSpace(filter.SortBy) {
-	case "content":
-		comparison = strings.Compare(strings.ToLower(left.Content), strings.ToLower(right.Content))
 	case "memory_type":
 		comparison = strings.Compare(string(left.MemoryType), string(right.MemoryType))
-	case "tags":
-		comparison = strings.Compare(
-			strings.ToLower(strings.Join(left.Tags, ",")),
-			strings.ToLower(strings.Join(right.Tags, ",")),
-		)
 	case "updated_at", "":
 		comparison = left.UpdatedAt.Compare(right.UpdatedAt)
 	default:

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 	"github.com/qiffang/mnemos/server/internal/service"
+	"golang.org/x/sync/errgroup"
 )
 
 var (
@@ -895,6 +896,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	} else {
 		svc := s.resolveServices(auth)
 		switch {
+		case filter.Query == "" && filter.MemoryType == "":
+			memories, total, err = s.listLocalAllTypeMemoriesPage(listCtx, svc, filter)
 		case filter.Query != "" && contentKeywordSearch:
 			memories, total, err = s.listLocalMemoriesContentKeyword(listCtx, svc, filter)
 		case filter.Query != "" && filter.ScanAll:
@@ -1065,6 +1068,188 @@ func (s *Server) listLocalMemoriesContentKeyword(ctx context.Context, svc resolv
 	default:
 		return svc.memory.ContentKeywordSearch(ctx, filter)
 	}
+}
+
+const localMemoryListPageSize = 200
+
+type localMemoryListSource struct {
+	name     string
+	filter   domain.MemoryFilter
+	count    func(context.Context, domain.MemoryFilter) (int, error)
+	listPage func(context.Context, domain.MemoryFilter) ([]domain.Memory, error)
+}
+
+type localMemoryListPrefix struct {
+	memories []domain.Memory
+	total    int
+}
+
+func (s *Server) listLocalAllTypeMemoriesPage(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	window := mergedMemoryWindow(filter.Offset, filter.Limit)
+	memorySource := localMemoryListSource{
+		name:     "memory",
+		filter:   filter,
+		count:    svc.memory.CountList,
+		listPage: svc.memory.ListPage,
+	}
+	sessionFilter := filter
+	sessionFilter.AllTypes = true
+	sessionSource := localMemoryListSource{
+		name:     "session",
+		filter:   sessionFilter,
+		count:    svc.session.CountList,
+		listPage: svc.session.ListPage,
+	}
+
+	var memoryPrefix, sessionPrefix localMemoryListPrefix
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.Go(func() error {
+		var err error
+		memoryPrefix, err = loadLocalMemoryListPrefix(groupCtx, memorySource, window)
+		return err
+	})
+	group.Go(func() error {
+		var err error
+		sessionPrefix, err = loadLocalMemoryListPrefix(groupCtx, sessionSource, window)
+		return err
+	})
+	if err := group.Wait(); err != nil {
+		return nil, 0, err
+	}
+
+	mergeStartedAt := time.Now()
+	merged := mergeLocalMemoryListPrefixes(memoryPrefix.memories, sessionPrefix.memories, filter, window)
+	memories := pageLocalMemoryList(merged, filter.Offset, filter.Limit)
+	if observation := memoryListObservationFromContext(ctx); observation != nil {
+		observation.recordMerge(time.Since(mergeStartedAt))
+	}
+	// IDs are generated as UUIDs across both tables, and Get already relies on
+	// that cross-table uniqueness. The merged total can therefore sum both counts.
+	return memories, saturatingListTotal(memoryPrefix.total, sessionPrefix.total), nil
+}
+
+func loadLocalMemoryListPrefix(ctx context.Context, source localMemoryListSource, window int) (localMemoryListPrefix, error) {
+	countStartedAt := time.Now()
+	total, err := source.count(ctx, source.filter)
+	if observation := memoryListObservationFromContext(ctx); observation != nil {
+		observation.recordCount(source.name, time.Since(countStartedAt))
+	}
+	if err != nil {
+		return localMemoryListPrefix{}, fmt.Errorf("count %s list: %w", source.name, err)
+	}
+	if total <= 0 || window <= 0 {
+		return localMemoryListPrefix{total: total}, nil
+	}
+
+	needed := min(total, window)
+	memories := make([]domain.Memory, 0, needed)
+	pageFilter := source.filter
+	pageFilter.Offset = 0
+	for len(memories) < needed {
+		pageFilter.Limit = min(localMemoryListPageSize, needed-len(memories))
+		pageStartedAt := time.Now()
+		page, err := source.listPage(ctx, pageFilter)
+		if observation := memoryListObservationFromContext(ctx); observation != nil {
+			observation.recordPage(source.name, len(page), time.Since(pageStartedAt))
+		}
+		if err != nil {
+			return localMemoryListPrefix{}, fmt.Errorf("read %s list page: %w", source.name, err)
+		}
+		if len(page) == 0 {
+			break
+		}
+		remaining := needed - len(memories)
+		if len(page) > remaining {
+			page = page[:remaining]
+		}
+		memories = append(memories, page...)
+		if len(page) < pageFilter.Limit {
+			break
+		}
+		pageFilter.Offset += pageFilter.Limit
+	}
+	return localMemoryListPrefix{memories: memories, total: total}, nil
+}
+
+func mergedMemoryWindow(offset, limit int) int {
+	maxInt := int(^uint(0) >> 1)
+	if limit > maxInt-offset {
+		return maxInt
+	}
+	return offset + limit
+}
+
+func saturatingListTotal(left, right int) int {
+	maxInt := int(^uint(0) >> 1)
+	if right > maxInt-left {
+		return maxInt
+	}
+	return left + right
+}
+
+func mergeLocalMemoryListPrefixes(left, right []domain.Memory, filter domain.MemoryFilter, limit int) []domain.Memory {
+	merged := make([]domain.Memory, 0, min(limit, len(left)+len(right)))
+	seen := make(map[string]struct{}, cap(merged))
+	for (len(left) > 0 || len(right) > 0) && len(merged) < limit {
+		var next domain.Memory
+		switch {
+		case len(right) == 0:
+			next, left = left[0], left[1:]
+		case len(left) == 0:
+			next, right = right[0], right[1:]
+		case localMemoryListCompare(left[0], right[0], filter) <= 0:
+			next, left = left[0], left[1:]
+		default:
+			next, right = right[0], right[1:]
+		}
+		key := next.ID
+		if key == "" {
+			key = string(next.MemoryType) + ":" + next.Content
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		merged = append(merged, next)
+	}
+	return merged
+}
+
+func localMemoryListCompare(left, right domain.Memory, filter domain.MemoryFilter) int {
+	comparison := 0
+	switch strings.TrimSpace(filter.SortBy) {
+	case "content":
+		comparison = strings.Compare(strings.ToLower(left.Content), strings.ToLower(right.Content))
+	case "memory_type":
+		comparison = strings.Compare(string(left.MemoryType), string(right.MemoryType))
+	case "tags":
+		comparison = strings.Compare(
+			strings.ToLower(strings.Join(left.Tags, ",")),
+			strings.ToLower(strings.Join(right.Tags, ",")),
+		)
+	case "updated_at", "":
+		comparison = left.UpdatedAt.Compare(right.UpdatedAt)
+	default:
+		comparison = left.UpdatedAt.Compare(right.UpdatedAt)
+	}
+	if comparison == 0 {
+		comparison = strings.Compare(left.ID, right.ID)
+	}
+	if !strings.EqualFold(strings.TrimSpace(filter.SortDir), "asc") {
+		comparison = -comparison
+	}
+	return comparison
+}
+
+func pageLocalMemoryList(memories []domain.Memory, offset, limit int) []domain.Memory {
+	if offset >= len(memories) {
+		return []domain.Memory{}
+	}
+	end := len(memories)
+	if limit < end-offset {
+		end = offset + limit
+	}
+	return memories[offset:end]
 }
 
 func (s *Server) listLocalAllTypeMemoriesContentKeyword(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -31,6 +31,8 @@ type memoryListObservation struct {
 	mergeDuration        time.Duration
 	memoryQueryDuration  time.Duration
 	sessionQueryDuration time.Duration
+	memoryCountDuration  time.Duration
+	sessionCountDuration time.Duration
 	memoryPages          int
 	memoryRows           int
 	sessionPages         int
@@ -88,6 +90,9 @@ func memoryListMode(auth *domain.AuthInfo, filter domain.MemoryFilter, contentKe
 	if filter.MemoryType == string(domain.TypeSession) {
 		return "session_list"
 	}
+	if filter.MemoryType == "" {
+		return "all_types_list"
+	}
 	return "durable_list"
 }
 
@@ -135,6 +140,18 @@ func (o *memoryListObservation) recordPage(resource string, rows int, duration t
 	}
 }
 
+func (o *memoryListObservation) recordCount(resource string, duration time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	switch resource {
+	case "memory":
+		o.memoryCountDuration += duration
+	case "session":
+		o.sessionCountDuration += duration
+	}
+}
+
 func (o *memoryListObservation) recordMerge(duration time.Duration) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -151,6 +168,9 @@ func (o *memoryListObservation) recordDirectList(auth *domain.AuthInfo, filter d
 	if filter.Query != "" && filter.MemoryType == "" {
 		return
 	}
+	if filter.Query == "" && filter.MemoryType == "" {
+		return
+	}
 	if filter.MemoryType == string(domain.TypeSession) {
 		o.sessionPages = 1
 		o.sessionRows = rows
@@ -165,6 +185,17 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 	status := memoryListStatus(ctx, err)
 	metrics.MemoryListRequestsTotal.WithLabelValues(o.mode, status).Inc()
 	metrics.MemoryListDuration.WithLabelValues(o.mode, status).Observe(duration.Seconds())
+	countDuration := o.memoryCountDuration + o.sessionCountDuration
+	pageDuration := o.memoryQueryDuration + o.sessionQueryDuration
+	if countDuration > 0 {
+		metrics.MemoryListPhaseDuration.WithLabelValues(o.mode, "count").Observe(countDuration.Seconds())
+	}
+	if pageDuration > 0 {
+		metrics.MemoryListPhaseDuration.WithLabelValues(o.mode, "page_read").Observe(pageDuration.Seconds())
+	}
+	if o.mergeDuration > 0 {
+		metrics.MemoryListPhaseDuration.WithLabelValues(o.mode, "merge").Observe(o.mergeDuration.Seconds())
+	}
 
 	if status == "ok" && duration < memoryListSlowRequestThreshold {
 		return
@@ -191,6 +222,8 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		slog.Int("memory_rows", o.memoryRows),
 		slog.Int("session_pages", o.sessionPages),
 		slog.Int("session_rows", o.sessionRows),
+		slog.Int64("memory_count_ms", o.memoryCountDuration.Milliseconds()),
+		slog.Int64("session_count_ms", o.sessionCountDuration.Milliseconds()),
 		slog.Int("chain_pages", o.chainPages),
 		slog.Int("chain_rows", o.chainRows),
 		slog.Int64("memory_query_ms", o.memoryQueryDuration.Milliseconds()),

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -35,7 +35,8 @@ func TestMemoryListMode(t *testing.T) {
 		{name: "default recall", filter: domain.MemoryFilter{Query: "term"}, want: "default_recall"},
 		{name: "single pool recall", filter: domain.MemoryFilter{Query: "term", MemoryType: string(domain.TypeInsight)}, want: "single_pool_recall"},
 		{name: "session list", filter: domain.MemoryFilter{MemoryType: string(domain.TypeSession)}, want: "session_list"},
-		{name: "durable list", filter: domain.MemoryFilter{}, want: "durable_list"},
+		{name: "all types list", filter: domain.MemoryFilter{}, want: "all_types_list"},
+		{name: "durable list", filter: domain.MemoryFilter{MemoryType: string(domain.TypeInsight)}, want: "durable_list"},
 		{name: "unknown recall pool", filter: domain.MemoryFilter{Query: "term", MemoryType: "future"}, want: "other"},
 	}
 
@@ -74,10 +75,10 @@ func TestListMemories_RecordsMemoryListMetrics(t *testing.T) {
 
 			srv.listMemories(rr, req)
 
-			if got := memoryListRequestCount(t, "durable_list", tt.wantStatus); got != 1 {
+			if got := memoryListRequestCount(t, "all_types_list", tt.wantStatus); got != 1 {
 				t.Fatalf("memory list request count = %v, want 1", got)
 			}
-			if got := memoryListDurationCount(t, "durable_list", tt.wantStatus); got != 1 {
+			if got := memoryListDurationCount(t, "all_types_list", tt.wantStatus); got != 1 {
 				t.Fatalf("memory list duration count = %d, want 1", got)
 			}
 		})
@@ -147,6 +148,11 @@ func TestMemoryListObservation_LogsSlowSummary(t *testing.T) {
 	observation.startedAt = time.Now().Add(-2100 * time.Millisecond)
 	observation.queryDuration = 1500 * time.Millisecond
 	observation.overlayDuration = 100 * time.Millisecond
+	observation.memoryCountDuration = 20 * time.Millisecond
+	observation.sessionCountDuration = 30 * time.Millisecond
+	observation.memoryQueryDuration = 900 * time.Millisecond
+	observation.sessionQueryDuration = 500 * time.Millisecond
+	observation.mergeDuration = 80 * time.Millisecond
 	observation.memoryPages = 2
 	observation.memoryRows = 250
 	observation.sessionPages = 1
@@ -171,12 +177,35 @@ func TestMemoryListObservation_LogsSlowSummary(t *testing.T) {
 	assertMemoryListLogField(t, entry, "memory_rows", float64(250))
 	assertMemoryListLogField(t, entry, "session_pages", float64(1))
 	assertMemoryListLogField(t, entry, "session_rows", float64(40))
+	assertMemoryListLogField(t, entry, "memory_count_ms", float64(20))
+	assertMemoryListLogField(t, entry, "session_count_ms", float64(30))
+	assertMemoryListLogField(t, entry, "memory_query_ms", float64(900))
+	assertMemoryListLogField(t, entry, "session_query_ms", float64(500))
 	assertMemoryListLogField(t, entry, "query_ms", float64(1500))
+	assertMemoryListLogField(t, entry, "merge_ms", float64(80))
 	assertMemoryListLogField(t, entry, "overlay_ms", float64(100))
 	assertMemoryListLogField(t, entry, "outcome", "ok")
 	assertMemoryListLogField(t, entry, "cancel_origin", "none")
 	if got, ok := entry["duration_ms"].(float64); !ok || got < 2000 {
 		t.Fatalf("duration_ms = %#v, want at least 2000", entry["duration_ms"])
+	}
+}
+
+func TestMemoryListObservation_RecordsBoundedPhaseMetrics(t *testing.T) {
+	resetMemoryListMetrics()
+	observation := newMemoryListObservation(slog.Default(), &domain.AuthInfo{}, domain.MemoryFilter{}, false)
+	observation.memoryCountDuration = 20 * time.Millisecond
+	observation.sessionCountDuration = 30 * time.Millisecond
+	observation.memoryQueryDuration = 40 * time.Millisecond
+	observation.sessionQueryDuration = 50 * time.Millisecond
+	observation.mergeDuration = 10 * time.Millisecond
+
+	observation.finish(context.Background(), nil, 1, 2)
+
+	for _, phase := range []string{"count", "page_read", "merge"} {
+		if got := memoryListPhaseDurationCount(t, "all_types_list", phase); got != 1 {
+			t.Fatalf("%s phase sample count = %d, want 1", phase, got)
+		}
 	}
 }
 
@@ -190,11 +219,13 @@ func TestMemoryListObservation_RecordsConcurrentChainWork(t *testing.T) {
 		group.Add(3)
 		go func() {
 			defer group.Done()
+			observation.recordCount("memory", time.Millisecond)
 			observation.recordPage("memory", 2, time.Millisecond)
 			observation.recordMerge(time.Millisecond)
 		}()
 		go func() {
 			defer group.Done()
+			observation.recordCount("session", time.Millisecond)
 			observation.recordPage("session", 3, time.Millisecond)
 		}()
 		go func() {
@@ -218,6 +249,9 @@ func TestMemoryListObservation_RecordsConcurrentChainWork(t *testing.T) {
 	}
 	if observation.mergeDuration != 10*time.Millisecond {
 		t.Fatalf("merge duration = %s, want 10ms", observation.mergeDuration)
+	}
+	if observation.memoryCountDuration != 10*time.Millisecond || observation.sessionCountDuration != 10*time.Millisecond {
+		t.Fatalf("count durations = memory:%s session:%s, want 10ms each", observation.memoryCountDuration, observation.sessionCountDuration)
 	}
 }
 
@@ -294,7 +328,7 @@ func TestListMemories_LogsFailureAndCancellationOrigin(t *testing.T) {
 			entry := findMemoryListLogEntry(t, &logBuf, "memory list failed")
 			assertMemoryListLogField(t, entry, "request_id", "request-list-failure")
 			assertMemoryListLogField(t, entry, "cluster_id", "cluster-list-failure")
-			assertMemoryListLogField(t, entry, "mode", "durable_list")
+			assertMemoryListLogField(t, entry, "mode", "all_types_list")
 			assertMemoryListLogField(t, entry, "outcome", tt.wantStatus)
 			assertMemoryListLogField(t, entry, "cancel_origin", tt.wantOrigin)
 		})
@@ -304,6 +338,7 @@ func TestListMemories_LogsFailureAndCancellationOrigin(t *testing.T) {
 func resetMemoryListMetrics() {
 	metrics.MemoryListRequestsTotal.Reset()
 	metrics.MemoryListDuration.Reset()
+	metrics.MemoryListPhaseDuration.Reset()
 }
 
 func memoryListRequestCount(t *testing.T, mode, status string) float64 {
@@ -339,6 +374,26 @@ func memoryListDurationCount(t *testing.T, mode, status string) uint64 {
 	var pb dto.Metric
 	if err := metric.Write(&pb); err != nil {
 		t.Fatalf("write memory list duration metric: %v", err)
+	}
+	if pb.Histogram == nil {
+		return 0
+	}
+	return pb.Histogram.GetSampleCount()
+}
+
+func memoryListPhaseDurationCount(t *testing.T, mode, phase string) uint64 {
+	t.Helper()
+	observer, err := metrics.MemoryListPhaseDuration.GetMetricWithLabelValues(mode, phase)
+	if err != nil {
+		t.Fatalf("get memory list phase metric: %v", err)
+	}
+	metric, ok := observer.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("memory list phase metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write memory list phase metric: %v", err)
 	}
 	if pb.Histogram == nil {
 		return 0

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -94,12 +94,12 @@ func TestListMemories_RecordsValidationMetrics(t *testing.T) {
 		{
 			name: "oversized app ID",
 			path: "/memories?appId=" + strings.Repeat("a", maxAppIDLen+1),
-			mode: "durable_list",
+			mode: "all_types_list",
 		},
 		{
 			name: "malformed timestamp",
 			path: "/memories?created_after=not-a-time",
-			mode: "durable_list",
+			mode: "all_types_list",
 		},
 		{
 			name: "inverted session range",
@@ -109,7 +109,7 @@ func TestListMemories_RecordsValidationMetrics(t *testing.T) {
 		{
 			name: "range on durable pool",
 			path: "/memories?created_after=2026-07-23T01:00:00Z",
-			mode: "durable_list",
+			mode: "all_types_list",
 		},
 	}
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1338,6 +1338,61 @@ func TestListMemories_DefaultListUsesConstantFirstPageWorkForLargeTotals(t *test
 	}
 }
 
+func TestListMemories_DefaultListRejectsDeepPaginationBeforeRepositoryWork(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	sessionRepo := &testSessionRepo{}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories?limit=1&offset=3000", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if memRepo.countListCalls != 0 || sessionRepo.countListCalls != 0 ||
+		memRepo.listPageCalls != 0 || sessionRepo.listPageCalls != 0 {
+		t.Fatalf("repository calls = memory count/page %d/%d, session count/page %d/%d, want 0/0 each",
+			memRepo.countListCalls, memRepo.listPageCalls, sessionRepo.countListCalls, sessionRepo.listPageCalls)
+	}
+}
+
+func TestListMemories_DefaultListRejectsSourceSpecificSortsBeforeRepositoryWork(t *testing.T) {
+	for _, sortBy := range []string{"content", "tags"} {
+		t.Run(sortBy, func(t *testing.T) {
+			memRepo := &testMemoryRepo{}
+			sessionRepo := &testSessionRepo{}
+			srv := newTestServer(memRepo, sessionRepo)
+			req := makeRequest(t, http.MethodGet, "/memories?sort_by="+sortBy, nil)
+			rr := httptest.NewRecorder()
+
+			srv.listMemories(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+			}
+			if memRepo.countListCalls != 0 || sessionRepo.countListCalls != 0 ||
+				memRepo.listPageCalls != 0 || sessionRepo.listPageCalls != 0 {
+				t.Fatalf("repository calls = memory count/page %d/%d, session count/page %d/%d, want 0/0 each",
+					memRepo.countListCalls, memRepo.listPageCalls, sessionRepo.countListCalls, sessionRepo.listPageCalls)
+			}
+		})
+	}
+}
+
+func TestLocalAllTypeMemoryListWindowAllowsMaximum(t *testing.T) {
+	window, err := localAllTypeMemoryListWindow(domain.MemoryFilter{
+		Offset: localAllTypeMemoryListMaxWindow - 1,
+		Limit:  1,
+	})
+	if err != nil {
+		t.Fatalf("localAllTypeMemoryListWindow: %v", err)
+	}
+	if window != localAllTypeMemoryListMaxWindow {
+		t.Fatalf("window = %d, want %d", window, localAllTypeMemoryListMaxWindow)
+	}
+}
+
 func TestListMemories_DefaultListPaginatesMergedOrderAndPreservesFilters(t *testing.T) {
 	now := time.Now()
 	memRepo := &testMemoryRepo{
@@ -1426,16 +1481,6 @@ func TestMergeLocalMemoryListPrefixesOrdersAndDeduplicates(t *testing.T) {
 			right:  []domain.Memory{{ID: "c", MemoryType: domain.TypeSession}},
 			filter: domain.MemoryFilter{SortBy: "memory_type", SortDir: "asc"},
 			want:   []string{"a", "b", "c"},
-		},
-		{
-			name: "content ascending",
-			left: []domain.Memory{
-				{ID: "a", Content: "apple"},
-				{ID: "z", Content: "zebra"},
-			},
-			right:  []domain.Memory{{ID: "m", Content: "Mango"}},
-			filter: domain.MemoryFilter{SortBy: "content", SortDir: "asc"},
-			want:   []string{"a", "m", "z"},
 		},
 		{
 			name: "duplicate id",

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -50,6 +50,11 @@ type testMemoryRepo struct {
 	listErr              error
 	lastListFilter       domain.MemoryFilter
 	listCalls            int
+	countListCalls       int
+	countListFilters     []domain.MemoryFilter
+	listPageCalls        int
+	listPageRows         int
+	listPageFilters      []domain.MemoryFilter
 	softDeleteCalls      []string
 	softDeleteResult     int64
 	softDeleteErr        error
@@ -129,6 +134,29 @@ func (m *testMemoryRepo) List(_ context.Context, filter domain.MemoryFilter) ([]
 	}
 	return append([]domain.Memory(nil), m.listResults...), m.listTotal, nil
 }
+func (m *testMemoryRepo) CountList(_ context.Context, filter domain.MemoryFilter) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.countListCalls++
+	m.countListFilters = append(m.countListFilters, filter)
+	if m.listErr != nil {
+		return 0, m.listErr
+	}
+	return m.listTotal, nil
+}
+func (m *testMemoryRepo) ListPage(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listPageCalls++
+	m.lastListFilter = filter
+	m.listPageFilters = append(m.listPageFilters, filter)
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	page := testMemoryPage(m.listResults, filter)
+	m.listPageRows += len(page)
+	return page, nil
+}
 func (m *testMemoryRepo) Count(context.Context) (int, error) { return 0, nil }
 func (m *testMemoryRepo) BulkCreate(ctx context.Context, _ []*domain.Memory) error {
 	m.mu.Lock()
@@ -204,6 +232,11 @@ type testSessionRepo struct {
 	listTotal            int
 	lastListFilter       domain.MemoryFilter
 	listCalls            int
+	countListCalls       int
+	countListFilters     []domain.MemoryFilter
+	listPageCalls        int
+	listPageRows         int
+	listPageFilters      []domain.MemoryFilter
 	softDeleteCalls      []string
 	softDeleteErr        error
 	bulkSoftDeleteCalls  [][]string
@@ -249,6 +282,44 @@ func (s *testSessionRepo) List(_ context.Context, filter domain.MemoryFilter) ([
 	s.listCalls++
 	s.lastListFilter = filter
 	return append([]domain.Memory(nil), s.listResults...), s.listTotal, nil
+}
+
+func (s *testSessionRepo) CountList(_ context.Context, filter domain.MemoryFilter) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.countListCalls++
+	s.countListFilters = append(s.countListFilters, filter)
+	return s.listTotal, nil
+}
+
+func (s *testSessionRepo) ListPage(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listPageCalls++
+	s.lastListFilter = filter
+	s.listPageFilters = append(s.listPageFilters, filter)
+	page := testMemoryPage(s.listResults, filter)
+	s.listPageRows += len(page)
+	return page, nil
+}
+
+func testMemoryPage(memories []domain.Memory, filter domain.MemoryFilter) []domain.Memory {
+	start := filter.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start >= len(memories) {
+		return nil
+	}
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = len(memories)
+	}
+	end := start + limit
+	if end > len(memories) {
+		end = len(memories)
+	}
+	return append([]domain.Memory(nil), memories[start:end]...)
 }
 
 func (s *testSessionRepo) SoftDelete(_ context.Context, id, _ string) (int64, error) {
@@ -1172,7 +1243,7 @@ func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 	}
 }
 
-func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
+func TestListMemories_DefaultListMergesAllTypes(t *testing.T) {
 	now := time.Now()
 	memRepo := &testMemoryRepo{
 		listResults: []domain.Memory{
@@ -1185,7 +1256,7 @@ func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
 				UpdatedAt:  now.Add(-time.Hour),
 			},
 		},
-		listTotal: 1000,
+		listTotal: 1,
 	}
 	sessionRepo := &testSessionRepo{
 		listResults: []domain.Memory{
@@ -1198,7 +1269,49 @@ func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
 				UpdatedAt:  now,
 			},
 		},
-		listTotal: 1000,
+		listTotal: 1,
+	}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodGet, "/memories?limit=10", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 2 || resp.Limit != 10 || resp.Offset != 0 {
+		t.Fatalf("page = total:%d limit:%d offset:%d, want 2/10/0", resp.Total, resp.Limit, resp.Offset)
+	}
+	if len(resp.Memories) != 2 || resp.Memories[0].ID != "session-1" || resp.Memories[1].ID != "insight-1" {
+		t.Fatalf("memories = %+v, want session then insight", resp.Memories)
+	}
+	if memRepo.countListCalls != 1 || sessionRepo.countListCalls != 1 || memRepo.listPageCalls != 1 || sessionRepo.listPageCalls != 1 {
+		t.Fatalf("bounded calls = memory count/page %d/%d, session count/page %d/%d, want 1/1 each",
+			memRepo.countListCalls, memRepo.listPageCalls, sessionRepo.countListCalls, sessionRepo.listPageCalls)
+	}
+	if memRepo.lastListFilter.Limit != 1 || memRepo.lastListFilter.Offset != 0 {
+		t.Fatalf("memory filter = %+v, want one-row bounded prefix", memRepo.lastListFilter)
+	}
+}
+
+func TestListMemories_DefaultListUsesConstantFirstPageWorkForLargeTotals(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		listResults: []domain.Memory{{
+			ID: "insight-1", MemoryType: domain.TypeInsight, UpdatedAt: now.Add(-time.Minute),
+		}},
+		listTotal: 1_000_000,
+	}
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{{
+			ID: "session-1", MemoryType: domain.TypeSession, UpdatedAt: now,
+		}},
+		listTotal: 1_000_000,
 	}
 	srv := newTestServer(memRepo, sessionRepo)
 	req := makeRequest(t, http.MethodGet, "/memories?limit=1", nil)
@@ -1213,17 +1326,142 @@ func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Total != 1000 || resp.Limit != 1 || resp.Offset != 0 {
-		t.Fatalf("page = total:%d limit:%d offset:%d, want 1000/1/0", resp.Total, resp.Limit, resp.Offset)
+	if resp.Total != 2_000_000 || len(resp.Memories) != 1 || resp.Memories[0].ID != "session-1" {
+		t.Fatalf("response = total:%d memories:%+v, want newest row from 2,000,000", resp.Total, resp.Memories)
 	}
-	if len(resp.Memories) != 1 || resp.Memories[0].ID != "insight-1" {
-		t.Fatalf("memories = %+v, want durable memory page", resp.Memories)
+	if memRepo.countListCalls != 1 || sessionRepo.countListCalls != 1 || memRepo.listPageCalls != 1 || sessionRepo.listPageCalls != 1 {
+		t.Fatalf("bounded calls = memory count/page %d/%d, session count/page %d/%d, want 1/1 each",
+			memRepo.countListCalls, memRepo.listPageCalls, sessionRepo.countListCalls, sessionRepo.listPageCalls)
 	}
-	if memRepo.listCalls != 1 || sessionRepo.listCalls != 0 {
-		t.Fatalf("list calls = memory:%d session:%d, want 1/0", memRepo.listCalls, sessionRepo.listCalls)
+	if memRepo.listPageRows != 1 || sessionRepo.listPageRows != 1 {
+		t.Fatalf("materialized rows = memory:%d session:%d, want 1/1", memRepo.listPageRows, sessionRepo.listPageRows)
 	}
-	if memRepo.lastListFilter.Limit != 1 || memRepo.lastListFilter.Offset != 0 {
-		t.Fatalf("memory filter = %+v, want limit=1 offset=0", memRepo.lastListFilter)
+}
+
+func TestListMemories_DefaultListPaginatesMergedOrderAndPreservesFilters(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		listResults: []domain.Memory{
+			{ID: "memory-4", MemoryType: domain.TypePinned, UpdatedAt: now.Add(4 * time.Minute)},
+			{ID: "memory-2", MemoryType: domain.TypeInsight, UpdatedAt: now.Add(2 * time.Minute)},
+			{ID: "memory-0", MemoryType: domain.TypeInsight, UpdatedAt: now},
+		},
+		listTotal: 3,
+	}
+	sessionRepo := &testSessionRepo{
+		listResults: []domain.Memory{
+			{ID: "session-5", MemoryType: domain.TypeSession, UpdatedAt: now.Add(5 * time.Minute)},
+			{ID: "session-3", MemoryType: domain.TypeSession, UpdatedAt: now.Add(3 * time.Minute)},
+			{ID: "session-1", MemoryType: domain.TypeSession, UpdatedAt: now.Add(time.Minute)},
+		},
+		listTotal: 3,
+	}
+	srv := newTestServer(memRepo, sessionRepo)
+	req := makeRequest(t, http.MethodGet,
+		"/memories?limit=2&offset=2&state=active&agent_id=agent-a&session_id=sess-a&source=cli&appId=app-a&tags=alpha,beta&sort_by=updated_at&sort_dir=desc", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var resp listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 6 || len(resp.Memories) != 2 || resp.Memories[0].ID != "session-3" || resp.Memories[1].ID != "memory-2" {
+		t.Fatalf("response = total:%d memories:%+v, want merged page [session-3 memory-2]", resp.Total, resp.Memories)
+	}
+
+	for name, filters := range map[string][]domain.MemoryFilter{
+		"memory count":  memRepo.countListFilters,
+		"memory page":   memRepo.listPageFilters,
+		"session count": sessionRepo.countListFilters,
+		"session page":  sessionRepo.listPageFilters,
+	} {
+		if len(filters) != 1 {
+			t.Fatalf("%s filters = %d, want 1", name, len(filters))
+		}
+		filter := filters[0]
+		if filter.State != "active" || filter.AgentID != "agent-a" || filter.SessionID != "sess-a" ||
+			filter.Source != "cli" || filter.AppID == nil || *filter.AppID != "app-a" || !reflect.DeepEqual(filter.Tags, []string{"alpha", "beta"}) ||
+			filter.SortBy != "updated_at" || filter.SortDir != "desc" {
+			t.Fatalf("%s filter = %+v, want shared list filters", name, filter)
+		}
+	}
+	if memRepo.listPageFilters[0].Limit != 3 || memRepo.listPageFilters[0].Offset != 0 ||
+		sessionRepo.listPageFilters[0].Limit != 3 || sessionRepo.listPageFilters[0].Offset != 0 {
+		t.Fatalf("page filters = memory:%+v session:%+v, want three-row prefixes", memRepo.listPageFilters[0], sessionRepo.listPageFilters[0])
+	}
+}
+
+func TestMergeLocalMemoryListPrefixesOrdersAndDeduplicates(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name   string
+		left   []domain.Memory
+		right  []domain.Memory
+		filter domain.MemoryFilter
+		want   []string
+	}{
+		{
+			name: "updated at descending with id tie breaker",
+			left: []domain.Memory{
+				{ID: "b", UpdatedAt: now},
+				{ID: "a", UpdatedAt: now.Add(-time.Minute)},
+			},
+			right: []domain.Memory{
+				{ID: "c", UpdatedAt: now},
+				{ID: "d", UpdatedAt: now.Add(-2 * time.Minute)},
+			},
+			want: []string{"c", "b", "a", "d"},
+		},
+		{
+			name: "memory type ascending",
+			left: []domain.Memory{
+				{ID: "a", MemoryType: domain.TypeInsight},
+				{ID: "b", MemoryType: domain.TypePinned},
+			},
+			right:  []domain.Memory{{ID: "c", MemoryType: domain.TypeSession}},
+			filter: domain.MemoryFilter{SortBy: "memory_type", SortDir: "asc"},
+			want:   []string{"a", "b", "c"},
+		},
+		{
+			name: "content ascending",
+			left: []domain.Memory{
+				{ID: "a", Content: "apple"},
+				{ID: "z", Content: "zebra"},
+			},
+			right:  []domain.Memory{{ID: "m", Content: "Mango"}},
+			filter: domain.MemoryFilter{SortBy: "content", SortDir: "asc"},
+			want:   []string{"a", "m", "z"},
+		},
+		{
+			name: "duplicate id",
+			left: []domain.Memory{
+				{ID: "shared", UpdatedAt: now},
+				{ID: "memory", UpdatedAt: now.Add(-2 * time.Minute)},
+			},
+			right: []domain.Memory{
+				{ID: "shared", UpdatedAt: now.Add(-time.Minute)},
+				{ID: "session", UpdatedAt: now.Add(-3 * time.Minute)},
+			},
+			want: []string{"shared", "memory", "session"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			merged := mergeLocalMemoryListPrefixes(tt.left, tt.right, tt.filter, len(tt.left)+len(tt.right))
+			got := make([]string, 0, len(merged))
+			for _, memory := range merged {
+				got = append(got, memory.ID)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("merged IDs = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -202,6 +202,18 @@ var (
 		[]string{"mode", "status"},
 	)
 
+	// MemoryListPhaseDuration isolates bounded list work by phase.
+	// phase values: count, page_read, merge.
+	MemoryListPhaseDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "mnemo",
+			Name:      "memory_list_phase_duration_seconds",
+			Help:      "Memory list duration split by bounded execution phase.",
+			Buckets:   []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30},
+		},
+		[]string{"mode", "phase"},
+	)
+
 	// ActiveMemoryTotal is the current server-level total number of active memories.
 	ActiveMemoryTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "mnemo",

--- a/server/internal/repository/factory.go
+++ b/server/internal/repository/factory.go
@@ -117,6 +117,12 @@ func (stubSessionRepo) GetByID(_ context.Context, _ string) (*domain.Memory, err
 func (stubSessionRepo) List(_ context.Context, _ domain.MemoryFilter) ([]domain.Memory, int, error) {
 	return nil, 0, fmt.Errorf("session memories: %w", domain.ErrNotSupported)
 }
+func (stubSessionRepo) CountList(_ context.Context, _ domain.MemoryFilter) (int, error) {
+	return 0, nil
+}
+func (stubSessionRepo) ListPage(_ context.Context, _ domain.MemoryFilter) ([]domain.Memory, error) {
+	return nil, nil
+}
 func (stubSessionRepo) SoftDelete(_ context.Context, _, _ string) (int64, error) {
 	return 0, fmt.Errorf("session memory delete: %w", domain.ErrNotSupported)
 }

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -211,17 +211,31 @@ func (r *MemoryRepo) SetState(ctx context.Context, id string, state domain.Memor
 }
 
 func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	total, err := r.CountList(ctx, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	memories, err := r.ListPage(ctx, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	return memories, total, nil
+}
+
+func (r *MemoryRepo) CountList(ctx context.Context, f domain.MemoryFilter) (int, error) {
 	where, args := r.buildWhere(f)
 
-	// Count total matches.
 	var total int
 	countQuery := "SELECT COUNT(*) FROM memories WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
 		slog.ErrorContext(ctx, "list memories: count failed", "cluster_id", r.clusterID, "err", err)
-		return nil, 0, fmt.Errorf("count memories: %w", err)
+		return 0, fmt.Errorf("count memories: %w", err)
 	}
+	return total, nil
+}
 
-	// Fetch page.
+func (r *MemoryRepo) ListPage(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
+	where, args := r.buildWhere(f)
 	limit := f.Limit
 	if limit <= 0 || limit > 200 {
 		limit = 50
@@ -241,7 +255,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
 		slog.ErrorContext(ctx, "list memories: query failed", "cluster_id", r.clusterID, "err", err)
-		return nil, 0, fmt.Errorf("list memories: %w", err)
+		return nil, fmt.Errorf("list memories: %w", err)
 	}
 	defer rows.Close()
 
@@ -249,11 +263,11 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	for rows.Next() {
 		m, err := scanMemoryRows(rows)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		memories = append(memories, *m)
 	}
-	return memories, total, rows.Err()
+	return memories, rows.Err()
 }
 
 func memoryListOrderBy(f domain.MemoryFilter) string {

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -18,6 +18,8 @@ type MemoryRepo interface {
 	ArchiveAndCreate(ctx context.Context, archiveID, supersededBy string, newMem *domain.Memory) error
 	SetState(ctx context.Context, id string, state domain.MemoryState) error
 	List(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, total int, err error)
+	CountList(ctx context.Context, f domain.MemoryFilter) (total int, err error)
+	ListPage(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, err error)
 	Count(ctx context.Context) (int, error)
 	BulkCreate(ctx context.Context, memories []*domain.Memory) error
 
@@ -107,6 +109,8 @@ type SessionRepo interface {
 	PatchTags(ctx context.Context, appID, sessionID, contentHash string, tags []string) error
 	GetByID(ctx context.Context, id string) (*domain.Memory, error)
 	List(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, total int, err error)
+	CountList(ctx context.Context, f domain.MemoryFilter) (total int, err error)
+	ListPage(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, err error)
 	SoftDelete(ctx context.Context, id, agentName string) (int64, error)
 	BulkSoftDelete(ctx context.Context, ids []string, agentName string) (int64, error)
 	AutoVectorSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error)

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -135,6 +135,34 @@ func TestMemoryListSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
 	}
 }
 
+func TestMemoryListPageUsesBoundedIndexedOrderWithoutCount(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{{
+		mustContain: []string{
+			"SELECT " + searchColumns + " FROM memories",
+			"WHERE state = 'active'",
+			"ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
+		},
+		wantArgs: []any{1, 0},
+		rows: &scriptedRows{
+			columns: memorySearchColumns(),
+			values: [][]driver.Value{
+				memorySearchRow("m-page-1", "bounded page", "agent-1", "session-1", "active", []byte(`[]`), now),
+			},
+		},
+	}})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.ListPage(context.Background(), domain.MemoryFilter{Limit: 1})
+	if err != nil {
+		t.Fatalf("ListPage: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "m-page-1" {
+		t.Fatalf("ListPage results = %+v, want m-page-1", results)
+	}
+}
+
 func TestMemoryListBootstrapSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	db := newScriptedTestDB(t, []*queryExpectation{{

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -297,17 +297,31 @@ func (r *MemoryRepo) SetState(ctx context.Context, id string, state domain.Memor
 }
 
 func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	total, err := r.CountList(ctx, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	memories, err := r.ListPage(ctx, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	return memories, total, nil
+}
+
+func (r *MemoryRepo) CountList(ctx context.Context, f domain.MemoryFilter) (int, error) {
 	where, args := r.buildWhere(f)
 
-	// Count total matches.
 	var total int
 	countQuery := "SELECT COUNT(*) FROM memories WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
 		slog.ErrorContext(ctx, "list memories: count failed", "cluster_id", r.clusterID, "err", err)
-		return nil, 0, fmt.Errorf("count memories: %w", err)
+		return 0, fmt.Errorf("count memories: %w", err)
 	}
+	return total, nil
+}
 
-	// Fetch page.
+func (r *MemoryRepo) ListPage(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
+	where, args := r.buildWhere(f)
 	limit := f.Limit
 	if limit <= 0 || limit > 200 {
 		limit = 50
@@ -327,7 +341,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
 		slog.ErrorContext(ctx, "list memories: query failed", "cluster_id", r.clusterID, "err", err)
-		return nil, 0, fmt.Errorf("list memories: %w", err)
+		return nil, fmt.Errorf("list memories: %w", err)
 	}
 	defer rows.Close()
 
@@ -335,11 +349,11 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	for rows.Next() {
 		m, err := scanSearchMemoryRows(rows)
 		if err != nil {
-			return nil, 0, err
+			return nil, err
 		}
 		memories = append(memories, *m)
 	}
-	return memories, total, rows.Err()
+	return memories, rows.Err()
 }
 
 func memoryListOrderBy(f domain.MemoryFilter) string {

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -247,6 +247,18 @@ func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, 
 }
 
 func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	total, err := r.CountList(ctx, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	memories, err := r.ListPage(ctx, f)
+	if err != nil {
+		return nil, 0, err
+	}
+	return memories, total, nil
+}
+
+func (r *SessionRepo) CountList(ctx context.Context, f domain.MemoryFilter) (int, error) {
 	conds, args := r.buildSessionFilterConds(f)
 	if f.Query != "" {
 		conds = append(conds, "content LIKE ?")
@@ -258,12 +270,21 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 	countQuery := "SELECT COUNT(*) FROM sessions WHERE " + where
 	if err := r.db.QueryRowContext(ctx, countQuery, args...).Scan(&total); err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
-			return nil, 0, nil
+			return 0, nil
 		}
 		slog.ErrorContext(ctx, "list session memories: count failed", "cluster_id", r.clusterID, "err", err)
-		return nil, 0, fmt.Errorf("count session memories: %w", err)
+		return 0, fmt.Errorf("count session memories: %w", err)
 	}
+	return total, nil
+}
 
+func (r *SessionRepo) ListPage(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
+	conds, args := r.buildSessionFilterConds(f)
+	if f.Query != "" {
+		conds = append(conds, "content LIKE ?")
+		args = append(args, "%"+f.Query+"%")
+	}
+	where := strings.Join(conds, " AND ")
 	limit := f.Limit
 	if limit <= 0 || limit > 200 {
 		limit = 50
@@ -282,29 +303,38 @@ func (r *SessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain
 	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
-			return nil, 0, nil
+			return nil, nil
 		}
 		slog.ErrorContext(ctx, "list session memories: query failed", "cluster_id", r.clusterID, "err", err)
-		return nil, 0, fmt.Errorf("list session memories: %w", err)
+		return nil, fmt.Errorf("list session memories: %w", err)
 	}
 	defer rows.Close()
 
 	memories, err := scanSessionRows(rows)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
-	return memories, total, nil
+	return memories, nil
 }
 
 func sessionListOrderBy(f domain.MemoryFilter) string {
 	column := "updated_at"
+	if f.AllTypes {
+		column = "created_at"
+	}
 	switch strings.TrimSpace(f.SortBy) {
 	case "content":
 		column = "content"
 	case "tags":
 		column = "tags"
-	case "updated_at", "memory_type", "":
-		column = "updated_at"
+	case "memory_type":
+		if f.AllTypes {
+			column = "id"
+		}
+	case "updated_at", "":
+		if f.AllTypes {
+			column = "created_at"
+		}
 	}
 
 	direction := "DESC"
@@ -312,6 +342,9 @@ func sessionListOrderBy(f domain.MemoryFilter) string {
 		direction = "ASC"
 	}
 
+	if column == "id" {
+		return column + " " + direction
+	}
 	return column + " " + direction + ", id " + direction
 }
 

--- a/server/internal/repository/tidb/sessions_test.go
+++ b/server/internal/repository/tidb/sessions_test.go
@@ -107,6 +107,55 @@ func TestSessionRepoListSortsByContent(t *testing.T) {
 	}
 }
 
+func TestSessionRepoListPageUsesBoundedMergedOrderWithoutCount(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	tests := []struct {
+		name      string
+		filter    domain.MemoryFilter
+		wantOrder string
+	}{
+		{
+			name:      "updated projection uses created index",
+			filter:    domain.MemoryFilter{AllTypes: true, Limit: 1},
+			wantOrder: "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?",
+		},
+		{
+			name:      "memory type ties use id",
+			filter:    domain.MemoryFilter{AllTypes: true, SortBy: "memory_type", SortDir: "asc", Limit: 1},
+			wantOrder: "ORDER BY id ASC LIMIT ? OFFSET ?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := newScriptedTestDB(t, []*queryExpectation{{
+				mustContain: []string{
+					"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at",
+					"FROM sessions WHERE state = 'active'",
+					tt.wantOrder,
+				},
+				wantArgs: []any{int64(1), int64(0)},
+				rows: &scriptedRows{
+					columns: sessionColumns(),
+					values: [][]driver.Value{
+						sessionRow("s-page-1", "sess-1", "agent-1", "chat", 1, "assistant", "bounded page", []byte(`[]`), "active", now),
+					},
+				},
+			}})
+			defer db.Close()
+
+			repo := NewSessionRepo(db, "", false, "cluster-1")
+			results, err := repo.ListPage(context.Background(), tt.filter)
+			if err != nil {
+				t.Fatalf("ListPage: %v", err)
+			}
+			if len(results) != 1 || results[0].ID != "s-page-1" {
+				t.Fatalf("ListPage results = %+v, want s-page-1", results)
+			}
+		})
+	}
+}
+
 func TestSessionRepoGetByIDMissingTableReturnsNotFound(t *testing.T) {
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1824,6 +1824,14 @@ func (m *memoryRepoMock) List(ctx context.Context, f domain.MemoryFilter) ([]dom
 	return nil, 0, nil
 }
 
+func (m *memoryRepoMock) CountList(context.Context, domain.MemoryFilter) (int, error) {
+	return len(m.listResults), nil
+}
+
+func (m *memoryRepoMock) ListPage(context.Context, domain.MemoryFilter) ([]domain.Memory, error) {
+	return append([]domain.Memory(nil), m.listResults...), nil
+}
+
 func (m *memoryRepoMock) Count(ctx context.Context) (int, error) {
 	return 0, nil
 }

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -182,6 +182,18 @@ func (s *MemoryService) List(ctx context.Context, filter domain.MemoryFilter) ([
 	return finalizeSearchResults(mems, filter.Query), total, nil
 }
 
+func (s *MemoryService) CountList(ctx context.Context, filter domain.MemoryFilter) (int, error) {
+	return s.memories.CountList(ctx, filter)
+}
+
+func (s *MemoryService) ListPage(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, error) {
+	memories, err := s.memories.ListPage(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	return finalizeSearchResults(memories, filter.Query), nil
+}
+
 func (s *MemoryService) Search(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
 	if filter.Query == "" {
 		return s.List(ctx, filter)

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -80,6 +80,14 @@ func (s *SessionService) List(ctx context.Context, f domain.MemoryFilter) ([]dom
 	return s.sessions.List(ctx, f)
 }
 
+func (s *SessionService) CountList(ctx context.Context, f domain.MemoryFilter) (int, error) {
+	return s.sessions.CountList(ctx, f)
+}
+
+func (s *SessionService) ListPage(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
+	return s.sessions.ListPage(ctx, f)
+}
+
 func (s *SessionService) Delete(ctx context.Context, id, agentName string) (int64, error) {
 	return s.sessions.SoftDelete(ctx, id, agentName)
 }

--- a/server/internal/service/session_test.go
+++ b/server/internal/service/session_test.go
@@ -83,6 +83,15 @@ func (s *stubSessionRepo) List(_ context.Context, f domain.MemoryFilter) ([]doma
 	return append([]domain.Memory(nil), s.listResults...), s.listTotal, nil
 }
 
+func (s *stubSessionRepo) CountList(_ context.Context, _ domain.MemoryFilter) (int, error) {
+	return s.listTotal, nil
+}
+
+func (s *stubSessionRepo) ListPage(_ context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
+	s.listFilter = f
+	return append([]domain.Memory(nil), s.listResults...), nil
+}
+
 func (s *stubSessionRepo) SoftDelete(_ context.Context, id, _ string) (int64, error) {
 	s.softDeleteID = id
 	return 1, nil
@@ -622,6 +631,12 @@ func (c *capturingSessionRepo) GetByID(ctx context.Context, id string) (*domain.
 }
 func (c *capturingSessionRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
 	return c.stub.List(ctx, f)
+}
+func (c *capturingSessionRepo) CountList(ctx context.Context, f domain.MemoryFilter) (int, error) {
+	return c.stub.CountList(ctx, f)
+}
+func (c *capturingSessionRepo) ListPage(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, error) {
+	return c.stub.ListPage(ctx, f)
 }
 func (c *capturingSessionRepo) SoftDelete(ctx context.Context, id, agentName string) (int64, error) {
 	return c.stub.SoftDelete(ctx, id, agentName)

--- a/server/internal/tenant/provisioner_test.go
+++ b/server/internal/tenant/provisioner_test.go
@@ -139,6 +139,7 @@ func (c *schemaInitConnector) recordDDL(query string) {
 		c.existingTables["memories"] = true
 		c.existingCols["memories.app_id"] = true
 		c.indexColumns["idx_app"] = []string{"app_id"}
+		c.indexColumns["idx_state_updated_id"] = []string{"state", "updated_at", "id"}
 	case strings.Contains(lowerQuery, "create table if not exists session_edits"):
 		c.existingTables["session_edits"] = true
 		c.existingCols["session_edits.edited_content"] = true
@@ -146,14 +147,19 @@ func (c *schemaInitConnector) recordDDL(query string) {
 		c.existingTables["sessions"] = true
 		c.existingCols["sessions.app_id"] = true
 		c.indexColumns["idx_sess_app"] = []string{"app_id"}
+		c.indexColumns["idx_sess_state_created_id"] = []string{"state", "created_at", "id"}
 		c.indexColumns["idx_sess_dedup"] = []string{"app_id", "session_id", "content_hash"}
 		c.nonUniqueIndexes["idx_sess_dedup"] = false
 	case strings.Contains(lowerQuery, "alter table memories add vector index idx_cosine"):
 		c.indexColumns["idx_cosine"] = []string{"embedding"}
+	case strings.Contains(lowerQuery, "alter table memories add index idx_state_updated_id"):
+		c.indexColumns["idx_state_updated_id"] = []string{"state", "updated_at", "id"}
 	case strings.Contains(lowerQuery, "alter table memories add fulltext index idx_fts_content"):
 		c.indexColumns["idx_fts_content"] = []string{"content"}
 	case strings.Contains(lowerQuery, "alter table sessions add vector index idx_sess_cosine"):
 		c.indexColumns["idx_sess_cosine"] = []string{"embedding"}
+	case strings.Contains(lowerQuery, "alter table sessions add index idx_sess_state_created_id"):
+		c.indexColumns["idx_sess_state_created_id"] = []string{"state", "created_at", "id"}
 	case strings.Contains(lowerQuery, "alter table sessions add fulltext index idx_sess_fts"):
 		c.indexColumns["idx_sess_fts"] = []string{"content"}
 	}
@@ -544,7 +550,9 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesSkipsCreate(t *testing.T)
 		t.Fatalf("existing tables should skip CREATE TABLE:\n%s", executed)
 	}
 	wantSubstrings := []string{
+		"ALTER TABLE memories ADD INDEX idx_state_updated_id (state, updated_at, id)",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
+		"ALTER TABLE sessions ADD INDEX idx_sess_state_created_id (state, created_at, id)",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
 	}
 	for _, want := range wantSubstrings {
@@ -605,7 +613,7 @@ func TestTiDBCloudProvisioner_InitSchema_ExistingTablesRejectsStaleAppSchema(t *
 	}
 }
 
-func TestEnsureTiDBTenantRuntimeSchema_CreatesSearchIndexesOnly(t *testing.T) {
+func TestEnsureTiDBTenantRuntimeSchema_CreatesRuntimeIndexesOnly(t *testing.T) {
 	recorder := &schemaInitConnector{
 		existingTables: map[string]bool{
 			"memories":      true,
@@ -631,8 +639,10 @@ func TestEnsureTiDBTenantRuntimeSchema_CreatesSearchIndexesOnly(t *testing.T) {
 	}
 	executed := strings.Join(recorder.execs, "\n")
 	wantSubstrings := []string{
+		"ALTER TABLE memories ADD INDEX idx_state_updated_id (state, updated_at, id)",
 		"ALTER TABLE memories ADD VECTOR INDEX idx_cosine",
 		"ALTER TABLE memories ADD FULLTEXT INDEX idx_fts_content",
+		"ALTER TABLE sessions ADD INDEX idx_sess_state_created_id (state, created_at, id)",
 		"ALTER TABLE sessions ADD VECTOR INDEX idx_sess_cosine",
 		"ALTER TABLE sessions ADD FULLTEXT INDEX idx_sess_fts",
 	}
@@ -653,6 +663,13 @@ func TestEnsureTiDBTenantRuntimeSchema_CreatesSearchIndexesOnly(t *testing.T) {
 			t.Fatalf("runtime ensure should not run app schema migration %q\n%s", unwanted, executed)
 		}
 	}
+	recorder.execs = nil
+	if err := EnsureTiDBTenantRuntimeSchema(context.Background(), db, "", 1024, 1536, true); err != nil {
+		t.Fatalf("second EnsureTiDBTenantRuntimeSchema failed: %v", err)
+	}
+	if len(recorder.execs) != 0 {
+		t.Fatalf("second runtime ensure should be idempotent, got DDL %v", recorder.execs)
+	}
 }
 
 func TestValidateTiDBTenantRuntimeSchema_SuccessDoesNotMutate(t *testing.T) {
@@ -668,13 +685,15 @@ func TestValidateTiDBTenantRuntimeSchema_SuccessDoesNotMutate(t *testing.T) {
 			"session_edits.edited_content": true,
 		},
 		indexColumns: map[string][]string{
-			"idx_app":         {"app_id"},
-			"idx_cosine":      {"embedding"},
-			"idx_fts_content": {"content"},
-			"idx_sess_app":    {"app_id"},
-			"idx_sess_dedup":  {"app_id", "session_id", "content_hash"},
-			"idx_sess_cosine": {"embedding"},
-			"idx_sess_fts":    {"content"},
+			"idx_app":                   {"app_id"},
+			"idx_state_updated_id":      {"state", "updated_at", "id"},
+			"idx_cosine":                {"embedding"},
+			"idx_fts_content":           {"content"},
+			"idx_sess_app":              {"app_id"},
+			"idx_sess_state_created_id": {"state", "created_at", "id"},
+			"idx_sess_dedup":            {"app_id", "session_id", "content_hash"},
+			"idx_sess_cosine":           {"embedding"},
+			"idx_sess_fts":              {"content"},
 		},
 	}
 	db := sql.OpenDB(recorder)
@@ -700,11 +719,13 @@ func TestValidateTiDBTenantRuntimeSchema_RejectsOldSessionsDedupIndex(t *testing
 			"sessions.app_id": true,
 		},
 		indexColumns: map[string][]string{
-			"idx_app":         {"app_id"},
-			"idx_cosine":      {"embedding"},
-			"idx_sess_app":    {"app_id"},
-			"idx_sess_dedup":  {"session_id", "content_hash"},
-			"idx_sess_cosine": {"embedding"},
+			"idx_app":                   {"app_id"},
+			"idx_state_updated_id":      {"state", "updated_at", "id"},
+			"idx_cosine":                {"embedding"},
+			"idx_sess_app":              {"app_id"},
+			"idx_sess_state_created_id": {"state", "created_at", "id"},
+			"idx_sess_dedup":            {"session_id", "content_hash"},
+			"idx_sess_cosine":           {"embedding"},
 		},
 	}
 	db := sql.OpenDB(recorder)
@@ -734,11 +755,13 @@ func TestValidateTiDBTenantRuntimeSchema_RejectsNonUniqueSessionsDedupIndex(t *t
 			"sessions.app_id": true,
 		},
 		indexColumns: map[string][]string{
-			"idx_app":         {"app_id"},
-			"idx_cosine":      {"embedding"},
-			"idx_sess_app":    {"app_id"},
-			"idx_sess_dedup":  {"app_id", "session_id", "content_hash"},
-			"idx_sess_cosine": {"embedding"},
+			"idx_app":                   {"app_id"},
+			"idx_state_updated_id":      {"state", "updated_at", "id"},
+			"idx_cosine":                {"embedding"},
+			"idx_sess_app":              {"app_id"},
+			"idx_sess_state_created_id": {"state", "created_at", "id"},
+			"idx_sess_dedup":            {"app_id", "session_id", "content_hash"},
+			"idx_sess_cosine":           {"embedding"},
 		},
 		nonUniqueIndexes: map[string]bool{
 			"idx_sess_dedup": true,

--- a/server/internal/tenant/schema.go
+++ b/server/internal/tenant/schema.go
@@ -31,7 +31,8 @@ const TenantMemorySchemaBase = `CREATE TABLE IF NOT EXISTS memories (
     INDEX idx_agent               (agent_id),
     INDEX idx_session             (session_id),
     INDEX idx_app                 (app_id),
-    INDEX idx_updated             (updated_at)
+    INDEX idx_updated             (updated_at),
+    INDEX idx_state_updated_id    (state, updated_at, id)
 )`
 
 // TenantMemorySchemaPostgres is the PostgreSQL schema with pgvector support.
@@ -155,6 +156,7 @@ const TenantSessionsSchemaBase = `CREATE TABLE IF NOT EXISTS sessions (
     INDEX        idx_sess_app     (app_id),
     INDEX        idx_sess_state   (state),
     INDEX        idx_sess_created (created_at),
+    INDEX        idx_sess_state_created_id (state, created_at, id),
     UNIQUE INDEX idx_sess_dedup   (app_id, session_id, content_hash)
 )`
 
@@ -212,10 +214,10 @@ func InitTiDBTenantSchema(ctx context.Context, db *sql.DB, autoModel string, aut
 	return nil
 }
 
-// EnsureTiDBTenantRuntimeSchema creates missing tenant tables and search indexes,
+// EnsureTiDBTenantRuntimeSchema creates missing tenant tables and runtime indexes,
 // then validates the offline-migrated app-scoped schema without mutating it.
 func EnsureTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
-	if err := ensureTiDBTenantTablesAndSearchIndexes(ctx, db, autoModel, autoDims, clientDims, ftsEnabled); err != nil {
+	if err := ensureTiDBTenantTablesAndIndexes(ctx, db, autoModel, autoDims, clientDims, ftsEnabled); err != nil {
 		return err
 	}
 	if err := ValidateTiDBTenantRuntimeSchema(ctx, db, autoModel, ftsEnabled); err != nil {
@@ -224,7 +226,7 @@ func EnsureTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel st
 	return nil
 }
 
-func ensureTiDBTenantTablesAndSearchIndexes(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
+func ensureTiDBTenantTablesAndIndexes(ctx context.Context, db *sql.DB, autoModel string, autoDims int, clientDims int, ftsEnabled bool) error {
 	if db == nil {
 		return fmt.Errorf("db connection is nil")
 	}
@@ -235,6 +237,9 @@ func ensureTiDBTenantTablesAndSearchIndexes(ctx context.Context, db *sql.DB, aut
 
 	if err := ensureTable(ctx, db, "memories", BuildMemorySchema(autoModel, autoDims, clientDims)); err != nil {
 		return fmt.Errorf("memories table: %w", err)
+	}
+	if err := ensureBTreeIndex(ctx, db, "memories", "idx_state_updated_id", "state, updated_at, id"); err != nil {
+		return fmt.Errorf("memories list index: %w", err)
 	}
 	if err := ensureVectorIndex(ctx, db, "memories", "idx_cosine"); err != nil {
 		return fmt.Errorf("memories vector index: %w", err)
@@ -247,6 +252,9 @@ func ensureTiDBTenantTablesAndSearchIndexes(ctx context.Context, db *sql.DB, aut
 
 	if err := ensureTable(ctx, db, "sessions", BuildSessionsSchema(autoModel, autoDims, clientDims)); err != nil {
 		return fmt.Errorf("sessions table: %w", err)
+	}
+	if err := ensureBTreeIndex(ctx, db, "sessions", "idx_sess_state_created_id", "state, created_at, id"); err != nil {
+		return fmt.Errorf("sessions list index: %w", err)
 	}
 	if err := ensureVectorIndex(ctx, db, "sessions", "idx_sess_cosine"); err != nil {
 		return fmt.Errorf("sessions vector index: %w", err)
@@ -284,6 +292,9 @@ func ValidateTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel 
 	if err := requireIndex(ctx, db, "memories", "idx_app"); err != nil {
 		return fmt.Errorf("validate schema: memories app_id index: %w", err)
 	}
+	if err := requireIndexColumns(ctx, db, "memories", "idx_state_updated_id", []string{"state", "updated_at", "id"}); err != nil {
+		return fmt.Errorf("validate schema: memories list index: %w", err)
+	}
 	if err := requireIndex(ctx, db, "memories", "idx_cosine"); err != nil {
 		return fmt.Errorf("validate schema: memories vector index: %w", err)
 	}
@@ -301,6 +312,9 @@ func ValidateTiDBTenantRuntimeSchema(ctx context.Context, db *sql.DB, autoModel 
 	}
 	if err := requireIndex(ctx, db, "sessions", "idx_sess_app"); err != nil {
 		return fmt.Errorf("validate schema: sessions app_id index: %w", err)
+	}
+	if err := requireIndexColumns(ctx, db, "sessions", "idx_sess_state_created_id", []string{"state", "created_at", "id"}); err != nil {
+		return fmt.Errorf("validate schema: sessions list index: %w", err)
 	}
 	if err := requireUniqueIndexColumns(ctx, db, "sessions", "idx_sess_dedup", []string{"app_id", "session_id", "content_hash"}); err != nil {
 		return fmt.Errorf("validate schema: sessions dedup index: %w", err)
@@ -444,6 +458,17 @@ func requireUniqueIndexColumns(ctx context.Context, db *sql.DB, table, indexName
 	return nil
 }
 
+func requireIndexColumns(ctx context.Context, db *sql.DB, table, indexName string, want []string) error {
+	columns, _, err := indexDefinition(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check index columns: %w", err)
+	}
+	if strings.Join(columns, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("%s.%s columns = %q, want %q", table, indexName, strings.Join(columns, ","), strings.Join(want, ","))
+	}
+	return nil
+}
+
 func indexDefinition(ctx context.Context, db *sql.DB, table, indexName string) ([]string, bool, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT COLUMN_NAME, NON_UNIQUE
@@ -485,6 +510,25 @@ func ensureTable(ctx context.Context, db *sql.DB, table, createSQL string) error
 	}
 	if _, err := db.ExecContext(ctx, createSQL); err != nil {
 		return fmt.Errorf("create: %w", err)
+	}
+	return nil
+}
+
+func ensureBTreeIndex(ctx context.Context, db *sql.DB, table, indexName, columns string) error {
+	exists, err := IndexExists(ctx, db, table, indexName)
+	if err != nil {
+		return fmt.Errorf("check index: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, fmt.Sprintf(
+		`ALTER TABLE %s ADD INDEX %s (%s)`,
+		table,
+		indexName,
+		columns,
+	)); err != nil && !IsIndexExistsError(err) {
+		return err
 	}
 	return nil
 }

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -114,7 +114,8 @@ CREATE TABLE IF NOT EXISTS memories (
   INDEX idx_agent               (agent_id),
   INDEX idx_session             (session_id),
   INDEX idx_app                 (app_id),
-  INDEX idx_updated             (updated_at)
+  INDEX idx_updated             (updated_at),
+  INDEX idx_state_updated_id    (state, updated_at, id)
 );
 
 -- Full-text search index (TiDB Cloud Serverless with MULTILINGUAL tokenizer).


### PR DESCRIPTION
## What Changed
- restore the default untyped list across durable memories and raw sessions
- cap the merged offset-plus-limit window at 3,000 rows per source and reject unsupported cross-source content/tags ordering before repository work
- count each source once, read ordered 200-row prefixes, then merge and deduplicate
- add phase metrics and idempotent TiDB list indexes for bounded database plans

## Review Path
1. `server/internal/handler/memory.go` — two-source pagination, hard work bound, and shared ordering contract
2. `server/internal/repository/` + `server/internal/tenant/schema.go` — split count/page reads and runtime indexes
3. handler, repository, and tenant tests — ordering, filters, boundary rejection, pagination, constant first-page work, and migration idempotence

## Query Plan Evidence
TiDB Cloud Zero with 20,000 synthetic rows in each source:
- before: `TopN` above `idx_state`, `keep order:false`
- after memories: `idx_state_updated_id`, `keep order:true`, embedded `LIMIT 1`
- after sessions: `idx_sess_state_created_id`, `keep order:true`, embedded `LIMIT 1`

## Validation
- `cd server && go test ./...`
- `cd server && go test -race -count=1 ./internal/handler ./internal/repository/tidb`
- `cd server && go vet ./...`
- [Server and plugin checks](https://github.com/mem9-ai/mem9/actions/runs/29990564045)

Closes #417
