### PR TITLE
Reject disabled Space Chain keys from management APIs

### DIFF
--- a/server/internal/handler/runtime_state_test.go
+++ b/server/internal/handler/runtime_state_test.go
@@ -336,9 +336,6 @@ func (r *runtimeStateSpaceChainRepo) GetByKey(context.Context, string) (*domain.
 	r.getByKeyCalls++
 	return nil, domain.ErrNotFound
 }
-func (r *runtimeStateSpaceChainRepo) GetByKeyIncludingDisabled(context.Context, string) (*domain.SpaceChain, error) {
-	return nil, domain.ErrNotFound
-}
 func (r *runtimeStateSpaceChainRepo) Update(context.Context, *domain.SpaceChain) error { return nil }
 func (r *runtimeStateSpaceChainRepo) SoftDelete(context.Context, string, string) error { return nil }
 func (r *runtimeStateSpaceChainRepo) CreateBinding(context.Context, *domain.SpaceChainBinding) error {

--- a/server/internal/middleware/auth_test.go
+++ b/server/internal/middleware/auth_test.go
@@ -751,13 +751,6 @@ func (r *stubSpaceChainRepo) GetByKey(context.Context, string) (*domain.SpaceCha
 	return r.chain, nil
 }
 
-func (r *stubSpaceChainRepo) GetByKeyIncludingDisabled(context.Context, string) (*domain.SpaceChain, error) {
-	if r.err != nil {
-		return nil, r.err
-	}
-	return r.chain, nil
-}
-
 func (r *stubSpaceChainRepo) Update(context.Context, *domain.SpaceChain) error { return nil }
 
 func (r *stubSpaceChainRepo) SoftDelete(context.Context, string, string) error { return nil }

--- a/server/internal/repository/postgres/space_chain.go
+++ b/server/internal/repository/postgres/space_chain.go
@@ -101,24 +101,6 @@ func (r *SpaceChainRepoImpl) GetByKey(ctx context.Context, key string) (*domain.
 	return chain, nil
 }
 
-func (r *SpaceChainRepoImpl) GetByKeyIncludingDisabled(ctx context.Context, key string) (*domain.SpaceChain, error) {
-	row := r.db.QueryRowContext(ctx,
-		`SELECT sc.id, sc.project_id, sc.name, sc.description, sc.created_by_user_id, sc.deleted_at, sc.deleted_by_user_id, sc.created_at, sc.updated_at
-		 FROM space_chain_bindings AS b
-		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
-		 WHERE b.chain_api_key = $1 AND sc.deleted_at IS NULL`,
-		key,
-	)
-	chain, err := scanSpaceChain(row)
-	if err != nil {
-		return nil, err
-	}
-	if err := r.hydrate(ctx, chain); err != nil {
-		return nil, err
-	}
-	return chain, nil
-}
-
 func (r *SpaceChainRepoImpl) Update(ctx context.Context, chain *domain.SpaceChain) error {
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE space_chains

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -67,7 +67,6 @@ type SpaceChainRepo interface {
 	Create(ctx context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error
 	GetByID(ctx context.Context, id string) (*domain.SpaceChain, error)
 	GetByKey(ctx context.Context, key string) (*domain.SpaceChain, error)
-	GetByKeyIncludingDisabled(ctx context.Context, key string) (*domain.SpaceChain, error)
 	Update(ctx context.Context, chain *domain.SpaceChain) error
 	SoftDelete(ctx context.Context, id, deletedByUserID string) error
 

--- a/server/internal/repository/tidb/space_chain.go
+++ b/server/internal/repository/tidb/space_chain.go
@@ -142,24 +142,6 @@ func (r *SpaceChainRepoImpl) GetByKey(ctx context.Context, key string) (*domain.
 	return chain, nil
 }
 
-func (r *SpaceChainRepoImpl) GetByKeyIncludingDisabled(ctx context.Context, key string) (*domain.SpaceChain, error) {
-	row := r.db.QueryRowContext(ctx,
-		`SELECT sc.id, sc.project_id, sc.name, sc.description, sc.created_by_user_id, sc.deleted_at, sc.deleted_by_user_id, sc.created_at, sc.updated_at
-		 FROM space_chain_bindings AS b
-		 INNER JOIN space_chains AS sc ON sc.id = b.chain_id
-		 WHERE b.chain_api_key = ? AND sc.deleted_at IS NULL`,
-		key,
-	)
-	chain, err := scanSpaceChain(row)
-	if err != nil {
-		return nil, err
-	}
-	if err := r.hydrate(ctx, chain); err != nil {
-		return nil, err
-	}
-	return chain, nil
-}
-
 func (r *SpaceChainRepoImpl) Update(ctx context.Context, chain *domain.SpaceChain) error {
 	res, err := r.db.ExecContext(ctx,
 		`UPDATE space_chains

--- a/server/internal/service/space_chain.go
+++ b/server/internal/service/space_chain.go
@@ -136,21 +136,7 @@ func (s *SpaceChainService) Authorize(ctx context.Context, chainID, key string) 
 }
 
 func (s *SpaceChainService) AuthorizeManagement(ctx context.Context, chainID, key string) (*domain.SpaceChain, error) {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return nil, &domain.ValidationError{Field: "X-API-Key", Message: "missing or malformed X-API-Key"}
-	}
-	if !strings.HasPrefix(key, domain.ChainKeyPrefix) {
-		return nil, &domain.ValidationError{Field: "X-API-Key", Message: "not a chain key"}
-	}
-	chain, err := s.chains.GetByKeyIncludingDisabled(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-	if chain.ID != chainID {
-		return nil, domain.ErrNotFound
-	}
-	return chain, nil
+	return s.Authorize(ctx, chainID, key)
 }
 
 func (s *SpaceChainService) Update(ctx context.Context, chainID string, req UpdateSpaceChainRequest) (*domain.SpaceChain, error) {

--- a/server/internal/service/space_chain_test.go
+++ b/server/internal/service/space_chain_test.go
@@ -182,10 +182,34 @@ func TestSpaceChainDisableBindingRejectsLastActiveKey(t *testing.T) {
 	}
 }
 
+func TestSpaceChainAuthorizeManagementRejectsDisabledKey(t *testing.T) {
+	repo := &fakeSpaceChainRepo{
+		chain: &domain.SpaceChain{
+			ID: "chain-1",
+			Bindings: []domain.SpaceChainBinding{
+				{
+					ID:          "binding-1",
+					ChainID:     "chain-1",
+					ChainAPIKey: "chain_disabled",
+					Disabled:    true,
+				},
+			},
+		},
+		getByKeyErr: domain.ErrNotFound,
+	}
+	svc := NewSpaceChainService(repo)
+
+	_, err := svc.AuthorizeManagement(context.Background(), "chain-1", "chain_disabled")
+	if !errors.Is(err, domain.ErrNotFound) {
+		t.Fatalf("expected disabled key to be rejected, got %T: %v", err, err)
+	}
+}
+
 type fakeSpaceChainRepo struct {
 	chain             *domain.SpaceChain
 	nodes             []domain.SpaceChainNode
 	disabledBindingID string
+	getByKeyErr       error
 }
 
 func (r *fakeSpaceChainRepo) Create(_ context.Context, chain *domain.SpaceChain, binding *domain.SpaceChainBinding) error {
@@ -207,13 +231,9 @@ func (r *fakeSpaceChainRepo) GetByID(_ context.Context, id string) (*domain.Spac
 }
 
 func (r *fakeSpaceChainRepo) GetByKey(_ context.Context, _ string) (*domain.SpaceChain, error) {
-	if r.chain == nil {
-		return nil, domain.ErrNotFound
+	if r.getByKeyErr != nil {
+		return nil, r.getByKeyErr
 	}
-	return r.chain, nil
-}
-
-func (r *fakeSpaceChainRepo) GetByKeyIncludingDisabled(_ context.Context, _ string) (*domain.SpaceChain, error) {
 	if r.chain == nil {
 		return nil, domain.ErrNotFound
 	}


### PR DESCRIPTION
## What Changed
- Space Chain management authorization now uses the active-only key lookup and rejects disabled bindings.
- Repository implementations and test fakes drop the disabled-inclusive lookup; a regression test locks the revoked-access behavior.

## Why
- Disabling a Space Chain key must revoke runtime and management access while preserving its masked Console history.

## Review Path
1. Start with `server/internal/service/space_chain.go` for the unified authorization path.
2. Check `server/internal/repository/repository.go` plus the TiDB/Postgres implementations for the removed lookup.
3. Finish with `server/internal/service/space_chain_test.go` and the adjusted repository fakes.

## Validation
- `go test -race -count=1 -run TestSpaceChainAuthorizeManagementRejectsDisabledKey ./internal/service/`
- `make vet`
- `make test`
- `make build`