### PR TITLE
fix(server): avoid full-table counts in all-type lists

### DIFF
--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -1078,13 +1078,7 @@ const (
 type localMemoryListSource struct {
 	name     string
 	filter   domain.MemoryFilter
-	count    func(context.Context, domain.MemoryFilter) (int, error)
 	listPage func(context.Context, domain.MemoryFilter) ([]domain.Memory, error)
-}
-
-type localMemoryListPrefix struct {
-	memories []domain.Memory
-	total    int
 }
 
 func (s *Server) listLocalAllTypeMemoriesPage(ctx context.Context, svc resolvedSvc, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
@@ -1092,10 +1086,10 @@ func (s *Server) listLocalAllTypeMemoriesPage(ctx context.Context, svc resolvedS
 	if err != nil {
 		return nil, 0, err
 	}
+	prefixWindow := window + 1
 	memorySource := localMemoryListSource{
 		name:     "memory",
 		filter:   filter,
-		count:    svc.memory.CountList,
 		listPage: svc.memory.ListPage,
 	}
 	sessionFilter := filter
@@ -1103,20 +1097,19 @@ func (s *Server) listLocalAllTypeMemoriesPage(ctx context.Context, svc resolvedS
 	sessionSource := localMemoryListSource{
 		name:     "session",
 		filter:   sessionFilter,
-		count:    svc.session.CountList,
 		listPage: svc.session.ListPage,
 	}
 
-	var memoryPrefix, sessionPrefix localMemoryListPrefix
+	var memoryPrefix, sessionPrefix []domain.Memory
 	group, groupCtx := errgroup.WithContext(ctx)
 	group.Go(func() error {
 		var err error
-		memoryPrefix, err = loadLocalMemoryListPrefix(groupCtx, memorySource, window)
+		memoryPrefix, err = loadLocalMemoryListPrefix(groupCtx, memorySource, prefixWindow)
 		return err
 	})
 	group.Go(func() error {
 		var err error
-		sessionPrefix, err = loadLocalMemoryListPrefix(groupCtx, sessionSource, window)
+		sessionPrefix, err = loadLocalMemoryListPrefix(groupCtx, sessionSource, prefixWindow)
 		return err
 	})
 	if err := group.Wait(); err != nil {
@@ -1124,47 +1117,38 @@ func (s *Server) listLocalAllTypeMemoriesPage(ctx context.Context, svc resolvedS
 	}
 
 	mergeStartedAt := time.Now()
-	merged := mergeLocalMemoryListPrefixes(memoryPrefix.memories, sessionPrefix.memories, filter, window)
+	merged := mergeLocalMemoryListPrefixes(memoryPrefix, sessionPrefix, filter, prefixWindow)
 	memories := pageLocalMemoryList(merged, filter.Offset, filter.Limit)
 	if observation := memoryListObservationFromContext(ctx); observation != nil {
 		observation.recordMerge(time.Since(mergeStartedAt))
 	}
-	// IDs are generated as UUIDs across both tables, and Get already relies on
-	// that cross-table uniqueness. The merged total can therefore sum both counts.
-	return memories, saturatingListTotal(memoryPrefix.total, sessionPrefix.total), nil
+	// Keep total bounded to the requested window plus one. This preserves
+	// next-page detection without an unbounded COUNT over large tenant tables.
+	return memories, len(merged), nil
 }
 
-func loadLocalMemoryListPrefix(ctx context.Context, source localMemoryListSource, window int) (localMemoryListPrefix, error) {
-	countStartedAt := time.Now()
-	total, err := source.count(ctx, source.filter)
-	if observation := memoryListObservationFromContext(ctx); observation != nil {
-		observation.recordCount(source.name, time.Since(countStartedAt))
-	}
-	if err != nil {
-		return localMemoryListPrefix{}, fmt.Errorf("count %s list: %w", source.name, err)
-	}
-	if total <= 0 || window <= 0 {
-		return localMemoryListPrefix{total: total}, nil
+func loadLocalMemoryListPrefix(ctx context.Context, source localMemoryListSource, window int) ([]domain.Memory, error) {
+	if window <= 0 {
+		return nil, nil
 	}
 
-	needed := min(total, window)
-	memories := make([]domain.Memory, 0, needed)
+	memories := make([]domain.Memory, 0, window)
 	pageFilter := source.filter
 	pageFilter.Offset = 0
-	for len(memories) < needed {
-		pageFilter.Limit = min(localMemoryListPageSize, needed-len(memories))
+	for len(memories) < window {
+		pageFilter.Limit = min(localMemoryListPageSize, window-len(memories))
 		pageStartedAt := time.Now()
 		page, err := source.listPage(ctx, pageFilter)
 		if observation := memoryListObservationFromContext(ctx); observation != nil {
 			observation.recordPage(source.name, len(page), time.Since(pageStartedAt))
 		}
 		if err != nil {
-			return localMemoryListPrefix{}, fmt.Errorf("read %s list page: %w", source.name, err)
+			return nil, fmt.Errorf("read %s list page: %w", source.name, err)
 		}
 		if len(page) == 0 {
 			break
 		}
-		remaining := needed - len(memories)
+		remaining := window - len(memories)
 		if len(page) > remaining {
 			page = page[:remaining]
 		}
@@ -1174,7 +1158,7 @@ func loadLocalMemoryListPrefix(ctx context.Context, source localMemoryListSource
 		}
 		pageFilter.Offset += pageFilter.Limit
 	}
-	return localMemoryListPrefix{memories: memories, total: total}, nil
+	return memories, nil
 }
 
 func localAllTypeMemoryListWindow(filter domain.MemoryFilter) (int, error) {
@@ -1201,14 +1185,6 @@ func mergedMemoryWindow(offset, limit int) int {
 		return maxInt
 	}
 	return offset + limit
-}
-
-func saturatingListTotal(left, right int) int {
-	maxInt := int(^uint(0) >> 1)
-	if right > maxInt-left {
-		return maxInt
-	}
-	return left + right
 }
 
 func mergeLocalMemoryListPrefixes(left, right []domain.Memory, filter domain.MemoryFilter, limit int) []domain.Memory {

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1290,27 +1290,29 @@ func TestListMemories_DefaultListMergesAllTypes(t *testing.T) {
 	if len(resp.Memories) != 2 || resp.Memories[0].ID != "session-1" || resp.Memories[1].ID != "insight-1" {
 		t.Fatalf("memories = %+v, want session then insight", resp.Memories)
 	}
-	if memRepo.countListCalls != 1 || sessionRepo.countListCalls != 1 || memRepo.listPageCalls != 1 || sessionRepo.listPageCalls != 1 {
-		t.Fatalf("bounded calls = memory count/page %d/%d, session count/page %d/%d, want 1/1 each",
+	if memRepo.countListCalls != 0 || sessionRepo.countListCalls != 0 || memRepo.listPageCalls != 1 || sessionRepo.listPageCalls != 1 {
+		t.Fatalf("bounded calls = memory count/page %d/%d, session count/page %d/%d, want 0/1 each",
 			memRepo.countListCalls, memRepo.listPageCalls, sessionRepo.countListCalls, sessionRepo.listPageCalls)
 	}
-	if memRepo.lastListFilter.Limit != 1 || memRepo.lastListFilter.Offset != 0 {
-		t.Fatalf("memory filter = %+v, want one-row bounded prefix", memRepo.lastListFilter)
+	if memRepo.lastListFilter.Limit != 11 || memRepo.lastListFilter.Offset != 0 {
+		t.Fatalf("memory filter = %+v, want eleven-row bounded lookahead", memRepo.lastListFilter)
 	}
 }
 
-func TestListMemories_DefaultListUsesConstantFirstPageWorkForLargeTotals(t *testing.T) {
+func TestListMemories_DefaultListUsesBoundedLookaheadForLargeTotals(t *testing.T) {
 	now := time.Now()
 	memRepo := &testMemoryRepo{
-		listResults: []domain.Memory{{
-			ID: "insight-1", MemoryType: domain.TypeInsight, UpdatedAt: now.Add(-time.Minute),
-		}},
+		listResults: []domain.Memory{
+			{ID: "insight-1", MemoryType: domain.TypeInsight, UpdatedAt: now.Add(-time.Minute)},
+			{ID: "insight-2", MemoryType: domain.TypeInsight, UpdatedAt: now.Add(-2 * time.Minute)},
+		},
 		listTotal: 1_000_000,
 	}
 	sessionRepo := &testSessionRepo{
-		listResults: []domain.Memory{{
-			ID: "session-1", MemoryType: domain.TypeSession, UpdatedAt: now,
-		}},
+		listResults: []domain.Memory{
+			{ID: "session-1", MemoryType: domain.TypeSession, UpdatedAt: now},
+			{ID: "session-2", MemoryType: domain.TypeSession, UpdatedAt: now.Add(-3 * time.Minute)},
+		},
 		listTotal: 1_000_000,
 	}
 	srv := newTestServer(memRepo, sessionRepo)
@@ -1326,15 +1328,15 @@ func TestListMemories_DefaultListUsesConstantFirstPageWorkForLargeTotals(t *test
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Total != 2_000_000 || len(resp.Memories) != 1 || resp.Memories[0].ID != "session-1" {
-		t.Fatalf("response = total:%d memories:%+v, want newest row from 2,000,000", resp.Total, resp.Memories)
+	if resp.Total != 2 || len(resp.Memories) != 1 || resp.Memories[0].ID != "session-1" {
+		t.Fatalf("response = total:%d memories:%+v, want newest row with next-page lookahead", resp.Total, resp.Memories)
 	}
-	if memRepo.countListCalls != 1 || sessionRepo.countListCalls != 1 || memRepo.listPageCalls != 1 || sessionRepo.listPageCalls != 1 {
-		t.Fatalf("bounded calls = memory count/page %d/%d, session count/page %d/%d, want 1/1 each",
+	if memRepo.countListCalls != 0 || sessionRepo.countListCalls != 0 || memRepo.listPageCalls != 1 || sessionRepo.listPageCalls != 1 {
+		t.Fatalf("bounded calls = memory count/page %d/%d, session count/page %d/%d, want 0/1 each",
 			memRepo.countListCalls, memRepo.listPageCalls, sessionRepo.countListCalls, sessionRepo.listPageCalls)
 	}
-	if memRepo.listPageRows != 1 || sessionRepo.listPageRows != 1 {
-		t.Fatalf("materialized rows = memory:%d session:%d, want 1/1", memRepo.listPageRows, sessionRepo.listPageRows)
+	if memRepo.listPageRows != 2 || sessionRepo.listPageRows != 2 {
+		t.Fatalf("materialized rows = memory:%d session:%d, want 2/2", memRepo.listPageRows, sessionRepo.listPageRows)
 	}
 }
 
@@ -1425,15 +1427,13 @@ func TestListMemories_DefaultListPaginatesMergedOrderAndPreservesFilters(t *test
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Total != 6 || len(resp.Memories) != 2 || resp.Memories[0].ID != "session-3" || resp.Memories[1].ID != "memory-2" {
-		t.Fatalf("response = total:%d memories:%+v, want merged page [session-3 memory-2]", resp.Total, resp.Memories)
+	if resp.Total != 5 || len(resp.Memories) != 2 || resp.Memories[0].ID != "session-3" || resp.Memories[1].ID != "memory-2" {
+		t.Fatalf("response = total:%d memories:%+v, want bounded total 5 and merged page [session-3 memory-2]", resp.Total, resp.Memories)
 	}
 
 	for name, filters := range map[string][]domain.MemoryFilter{
-		"memory count":  memRepo.countListFilters,
-		"memory page":   memRepo.listPageFilters,
-		"session count": sessionRepo.countListFilters,
-		"session page":  sessionRepo.listPageFilters,
+		"memory page":  memRepo.listPageFilters,
+		"session page": sessionRepo.listPageFilters,
 	} {
 		if len(filters) != 1 {
 			t.Fatalf("%s filters = %d, want 1", name, len(filters))
@@ -1445,9 +1445,9 @@ func TestListMemories_DefaultListPaginatesMergedOrderAndPreservesFilters(t *test
 			t.Fatalf("%s filter = %+v, want shared list filters", name, filter)
 		}
 	}
-	if memRepo.listPageFilters[0].Limit != 3 || memRepo.listPageFilters[0].Offset != 0 ||
-		sessionRepo.listPageFilters[0].Limit != 3 || sessionRepo.listPageFilters[0].Offset != 0 {
-		t.Fatalf("page filters = memory:%+v session:%+v, want three-row prefixes", memRepo.listPageFilters[0], sessionRepo.listPageFilters[0])
+	if memRepo.listPageFilters[0].Limit != 5 || memRepo.listPageFilters[0].Offset != 0 ||
+		sessionRepo.listPageFilters[0].Limit != 5 || sessionRepo.listPageFilters[0].Offset != 0 {
+		t.Fatalf("page filters = memory:%+v session:%+v, want five-row lookahead prefixes", memRepo.listPageFilters[0], sessionRepo.listPageFilters[0])
 	}
 }
 


### PR DESCRIPTION
## What Changed
- `GET /memories` all-type lists read bounded memory and session prefixes without exact table counts.
- Handler tests cover bounded lookahead, merged pagination, and zero count calls.

## Why
- A large early tenant reproduced 30-second stalls in both pre-page `COUNT(*)` queries for `limit=1`.
- One-row lookahead preserves next-page detection while bounding work to `offset + limit + 1` rows per source.

## Review Path
1. Start with `listLocalAllTypeMemoriesPage` and `loadLocalMemoryListPrefix` in `memory.go`.
2. Check the updated default-list and pagination cases in `memory_test.go`.

## Validation
- `make vet`
- `make test`

## Notes
- `total` stays exact when the result set fits the observed prefix. While more pages exist, it reports the current window plus one as a lower bound.
- Production currently runs the previously verified pre-all-type-list image; this PR restores the newer release behavior without the blocking counts.