### PR TITLE
fix(server): restore bounded all-types memory listing

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2053,7 +2053,7 @@
         "name": "sort_by",
         "in": "query",
         "required": false,
-        "description": "Sort field used when listing memories.",
+        "description": "Sort field used when listing memories. All-types lists support updated_at and memory_type; content and tags require an explicit memory_type.",
         "schema": {
           "type": "string",
           "enum": [

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2053,7 +2053,7 @@
         "name": "sort_by",
         "in": "query",
         "required": false,
-        "description": "Sort field used when listing memories. All-types lists support updated_at and memory_type; content and tags require an explicit memory_type.",
+        "description": "Sort field used when listing memories. All-types lists support updated_at; content, memory_type, and tags require an explicit memory_type.",
         "schema": {
           "type": "string",
           "enum": [

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -895,6 +895,8 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	} else {
 		svc := s.resolveServices(auth)
 		switch {
+		case filter.Query == "" && filter.MemoryType == "":
+			memories, total, err = svc.memory.ListAllTypes(listCtx, filter)
 		case filter.Query != "" && contentKeywordSearch:
 			memories, total, err = s.listLocalMemoriesContentKeyword(listCtx, svc, filter)
 		case filter.Query != "" && filter.ScanAll:
@@ -912,7 +914,9 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	listObservation.queryDuration = time.Since(queryStartedAt)
-	listObservation.recordDirectList(auth, filter, contentKeywordSearch, len(memories))
+	if err == nil {
+		listObservation.recordDirectList(auth, filter, contentKeywordSearch, len(memories))
+	}
 
 	if err != nil {
 		if s.runtimeUsageEnabled() && recallLease != nil {

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -35,6 +35,8 @@ type memoryListObservation struct {
 	memoryRows           int
 	sessionPages         int
 	sessionRows          int
+	allTypePages         int
+	allTypeRows          int
 	chainPages           int
 	chainRows            int
 	chainQueryDuration   time.Duration
@@ -87,6 +89,9 @@ func memoryListMode(auth *domain.AuthInfo, filter domain.MemoryFilter, contentKe
 	}
 	if filter.MemoryType == string(domain.TypeSession) {
 		return "session_list"
+	}
+	if filter.MemoryType == "" {
+		return "all_types_list"
 	}
 	return "durable_list"
 }
@@ -151,6 +156,11 @@ func (o *memoryListObservation) recordDirectList(auth *domain.AuthInfo, filter d
 	if filter.Query != "" && filter.MemoryType == "" {
 		return
 	}
+	if filter.Query == "" && filter.MemoryType == "" {
+		o.allTypePages = 1
+		o.allTypeRows = rows
+		return
+	}
 	if filter.MemoryType == string(domain.TypeSession) {
 		o.sessionPages = 1
 		o.sessionRows = rows
@@ -170,8 +180,8 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		return
 	}
 
-	pages := o.memoryPages + o.sessionPages
-	rows := o.memoryRows + o.sessionRows
+	pages := o.memoryPages + o.sessionPages + o.allTypePages
+	rows := o.memoryRows + o.sessionRows + o.allTypeRows
 	if pages == 0 && o.chainPages > 0 {
 		pages = o.chainPages
 		rows = o.chainRows
@@ -191,6 +201,8 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		slog.Int("memory_rows", o.memoryRows),
 		slog.Int("session_pages", o.sessionPages),
 		slog.Int("session_rows", o.sessionRows),
+		slog.Int("all_type_pages", o.allTypePages),
+		slog.Int("all_type_rows", o.allTypeRows),
 		slog.Int("chain_pages", o.chainPages),
 		slog.Int("chain_rows", o.chainRows),
 		slog.Int64("memory_query_ms", o.memoryQueryDuration.Milliseconds()),

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -35,7 +35,8 @@ func TestMemoryListMode(t *testing.T) {
 		{name: "default recall", filter: domain.MemoryFilter{Query: "term"}, want: "default_recall"},
 		{name: "single pool recall", filter: domain.MemoryFilter{Query: "term", MemoryType: string(domain.TypeInsight)}, want: "single_pool_recall"},
 		{name: "session list", filter: domain.MemoryFilter{MemoryType: string(domain.TypeSession)}, want: "session_list"},
-		{name: "durable list", filter: domain.MemoryFilter{}, want: "durable_list"},
+		{name: "all types list", filter: domain.MemoryFilter{}, want: "all_types_list"},
+		{name: "durable list", filter: domain.MemoryFilter{MemoryType: string(domain.TypeInsight)}, want: "durable_list"},
 		{name: "unknown recall pool", filter: domain.MemoryFilter{Query: "term", MemoryType: "future"}, want: "other"},
 	}
 
@@ -74,10 +75,10 @@ func TestListMemories_RecordsMemoryListMetrics(t *testing.T) {
 
 			srv.listMemories(rr, req)
 
-			if got := memoryListRequestCount(t, "durable_list", tt.wantStatus); got != 1 {
+			if got := memoryListRequestCount(t, "all_types_list", tt.wantStatus); got != 1 {
 				t.Fatalf("memory list request count = %v, want 1", got)
 			}
-			if got := memoryListDurationCount(t, "durable_list", tt.wantStatus); got != 1 {
+			if got := memoryListDurationCount(t, "all_types_list", tt.wantStatus); got != 1 {
 				t.Fatalf("memory list duration count = %d, want 1", got)
 			}
 		})
@@ -93,12 +94,12 @@ func TestListMemories_RecordsValidationMetrics(t *testing.T) {
 		{
 			name: "oversized app ID",
 			path: "/memories?appId=" + strings.Repeat("a", maxAppIDLen+1),
-			mode: "durable_list",
+			mode: "all_types_list",
 		},
 		{
 			name: "malformed timestamp",
 			path: "/memories?created_after=not-a-time",
-			mode: "durable_list",
+			mode: "all_types_list",
 		},
 		{
 			name: "inverted session range",
@@ -108,7 +109,7 @@ func TestListMemories_RecordsValidationMetrics(t *testing.T) {
 		{
 			name: "range on durable pool",
 			path: "/memories?created_after=2026-07-23T01:00:00Z",
-			mode: "durable_list",
+			mode: "all_types_list",
 		},
 	}
 
@@ -294,7 +295,7 @@ func TestListMemories_LogsFailureAndCancellationOrigin(t *testing.T) {
 			entry := findMemoryListLogEntry(t, &logBuf, "memory list failed")
 			assertMemoryListLogField(t, entry, "request_id", "request-list-failure")
 			assertMemoryListLogField(t, entry, "cluster_id", "cluster-list-failure")
-			assertMemoryListLogField(t, entry, "mode", "durable_list")
+			assertMemoryListLogField(t, entry, "mode", "all_types_list")
 			assertMemoryListLogField(t, entry, "outcome", tt.wantStatus)
 			assertMemoryListLogField(t, entry, "cancel_origin", tt.wantOrigin)
 		})

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -34,31 +34,36 @@ import (
 
 // testMemoryRepo is a minimal MemoryRepo mock for handler tests.
 type testMemoryRepo struct {
-	mu                   sync.Mutex
-	createCalls          []*domain.Memory
-	bulkCreateCalls      int
-	bulkCreateHook       func(context.Context)
-	updateCalls          []*domain.Memory
-	vectorSearchResults  []domain.Memory
-	keywordSearchResults []domain.Memory
-	keywordSearchHook    func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
-	lastKeywordQuery     string
-	lastKeywordFilter    domain.MemoryFilter
-	lastKeywordLimit     int
-	listResults          []domain.Memory
-	listTotal            int
-	listErr              error
-	lastListFilter       domain.MemoryFilter
-	listCalls            int
-	softDeleteCalls      []string
-	softDeleteResult     int64
-	softDeleteErr        error
-	bulkSoftDeleteCalls  [][]string
-	bulkSoftDeleteResult int64
-	countStatsTotal      int64
-	countStatsLast7d     int64
-	countStatsErr        error
-	countStatsCalls      int
+	mu                    sync.Mutex
+	createCalls           []*domain.Memory
+	bulkCreateCalls       int
+	bulkCreateHook        func(context.Context)
+	updateCalls           []*domain.Memory
+	vectorSearchResults   []domain.Memory
+	keywordSearchResults  []domain.Memory
+	keywordSearchHook     func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
+	lastKeywordQuery      string
+	lastKeywordFilter     domain.MemoryFilter
+	lastKeywordLimit      int
+	listResults           []domain.Memory
+	listTotal             int
+	listErr               error
+	lastListFilter        domain.MemoryFilter
+	listCalls             int
+	allTypeListResults    []domain.Memory
+	allTypeListTotal      int
+	allTypeListErr        error
+	lastAllTypeListFilter domain.MemoryFilter
+	allTypeListCalls      int
+	softDeleteCalls       []string
+	softDeleteResult      int64
+	softDeleteErr         error
+	bulkSoftDeleteCalls   [][]string
+	bulkSoftDeleteResult  int64
+	countStatsTotal       int64
+	countStatsLast7d      int64
+	countStatsErr         error
+	countStatsCalls       int
 }
 
 func (m *testMemoryRepo) Create(_ context.Context, mem *domain.Memory) error {
@@ -124,6 +129,22 @@ func (m *testMemoryRepo) List(_ context.Context, filter domain.MemoryFilter) ([]
 	defer m.mu.Unlock()
 	m.listCalls++
 	m.lastListFilter = filter
+	if m.listErr != nil {
+		return nil, 0, m.listErr
+	}
+	return append([]domain.Memory(nil), m.listResults...), m.listTotal, nil
+}
+func (m *testMemoryRepo) ListAllTypes(_ context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.allTypeListCalls++
+	m.lastAllTypeListFilter = filter
+	if m.allTypeListErr != nil {
+		return nil, 0, m.allTypeListErr
+	}
+	if m.allTypeListResults != nil {
+		return append([]domain.Memory(nil), m.allTypeListResults...), m.allTypeListTotal, nil
+	}
 	if m.listErr != nil {
 		return nil, 0, m.listErr
 	}
@@ -1172,7 +1193,7 @@ func TestListMemories_SessionTypeListsSessionRows(t *testing.T) {
 	}
 }
 
-func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
+func TestListMemories_DefaultListUsesUnifiedAllTypesPage(t *testing.T) {
 	now := time.Now()
 	memRepo := &testMemoryRepo{
 		listResults: []domain.Memory{
@@ -1186,6 +1207,17 @@ func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
 			},
 		},
 		listTotal: 1000,
+		allTypeListResults: []domain.Memory{
+			{
+				ID:         "session-1",
+				Content:    "raw conversation turn",
+				MemoryType: domain.TypeSession,
+				State:      domain.StateActive,
+				CreatedAt:  now,
+				UpdatedAt:  now,
+			},
+		},
+		allTypeListTotal: 2000,
 	}
 	sessionRepo := &testSessionRepo{
 		listResults: []domain.Memory{
@@ -1213,17 +1245,54 @@ func TestListMemories_DefaultListUsesDurableMemoryPage(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if resp.Total != 1000 || resp.Limit != 1 || resp.Offset != 0 {
-		t.Fatalf("page = total:%d limit:%d offset:%d, want 1000/1/0", resp.Total, resp.Limit, resp.Offset)
+	if resp.Total != 2000 || resp.Limit != 1 || resp.Offset != 0 {
+		t.Fatalf("page = total:%d limit:%d offset:%d, want 2000/1/0", resp.Total, resp.Limit, resp.Offset)
 	}
-	if len(resp.Memories) != 1 || resp.Memories[0].ID != "insight-1" {
-		t.Fatalf("memories = %+v, want durable memory page", resp.Memories)
+	if len(resp.Memories) != 1 || resp.Memories[0].ID != "session-1" {
+		t.Fatalf("memories = %+v, want unified all-types page", resp.Memories)
 	}
-	if memRepo.listCalls != 1 || sessionRepo.listCalls != 0 {
-		t.Fatalf("list calls = memory:%d session:%d, want 1/0", memRepo.listCalls, sessionRepo.listCalls)
+	if memRepo.allTypeListCalls != 1 || memRepo.listCalls != 0 || sessionRepo.listCalls != 0 {
+		t.Fatalf("list calls = all-types:%d memory:%d session:%d, want 1/0/0",
+			memRepo.allTypeListCalls, memRepo.listCalls, sessionRepo.listCalls)
 	}
-	if memRepo.lastListFilter.Limit != 1 || memRepo.lastListFilter.Offset != 0 {
-		t.Fatalf("memory filter = %+v, want limit=1 offset=0", memRepo.lastListFilter)
+	if memRepo.lastAllTypeListFilter.Limit != 1 || memRepo.lastAllTypeListFilter.Offset != 0 {
+		t.Fatalf("all-types filter = %+v, want limit=1 offset=0", memRepo.lastAllTypeListFilter)
+	}
+}
+
+func TestListMemories_DefaultListRejectsDeepPagination(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?limit=1&offset=3000", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if memRepo.allTypeListCalls != 0 {
+		t.Fatalf("all-types list calls = %d, want 0", memRepo.allTypeListCalls)
+	}
+}
+
+func TestListMemories_DefaultListRejectsUnboundedSorts(t *testing.T) {
+	for _, sortBy := range []string{"content", "tags"} {
+		t.Run(sortBy, func(t *testing.T) {
+			memRepo := &testMemoryRepo{}
+			srv := newTestServer(memRepo, &testSessionRepo{})
+			req := makeRequest(t, http.MethodGet, "/memories?sort_by="+sortBy, nil)
+			rr := httptest.NewRecorder()
+
+			srv.listMemories(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+			}
+			if memRepo.allTypeListCalls != 0 {
+				t.Fatalf("all-types list calls = %d, want 0", memRepo.allTypeListCalls)
+			}
+		})
 	}
 }
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1276,12 +1276,18 @@ func TestListMemories_DefaultListRejectsDeepPagination(t *testing.T) {
 	}
 }
 
-func TestListMemories_DefaultListRejectsUnboundedSorts(t *testing.T) {
-	for _, sortBy := range []string{"content", "tags"} {
-		t.Run(sortBy, func(t *testing.T) {
+func TestListMemories_DefaultListRejectsUnsupportedSortOptions(t *testing.T) {
+	for _, query := range []string{
+		"sort_by=content",
+		"sort_by=memory_type",
+		"sort_by=tags",
+		"sort_by=unknown",
+		"sort_dir=sideways",
+	} {
+		t.Run(query, func(t *testing.T) {
 			memRepo := &testMemoryRepo{}
 			srv := newTestServer(memRepo, &testSessionRepo{})
-			req := makeRequest(t, http.MethodGet, "/memories?sort_by="+sortBy, nil)
+			req := makeRequest(t, http.MethodGet, "/memories?"+query, nil)
 			rr := httptest.NewRecorder()
 
 			srv.listMemories(rr, req)

--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -256,6 +256,10 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	return memories, total, rows.Err()
 }
 
+func (r *MemoryRepo) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	return r.List(ctx, f)
+}
+
 func memoryListOrderBy(f domain.MemoryFilter) string {
 	column := "updated_at"
 	switch strings.TrimSpace(f.SortBy) {

--- a/server/internal/repository/repository.go
+++ b/server/internal/repository/repository.go
@@ -18,6 +18,8 @@ type MemoryRepo interface {
 	ArchiveAndCreate(ctx context.Context, archiveID, supersededBy string, newMem *domain.Memory) error
 	SetState(ctx context.Context, id string, state domain.MemoryState) error
 	List(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, total int, err error)
+	// ListAllTypes includes raw sessions on backends that store them.
+	ListAllTypes(ctx context.Context, f domain.MemoryFilter) (memories []domain.Memory, total int, err error)
 	Count(ctx context.Context) (int, error)
 	BulkCreate(ctx context.Context, memories []*domain.Memory) error
 

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"encoding/json"
 	"fmt"
 	"io"
 	"reflect"
@@ -13,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
@@ -132,6 +134,133 @@ func TestMemoryListSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
 	}
 	if len(results[0].Embedding) != 0 {
 		t.Fatalf("List hydrated embedding length = %d, want 0", len(results[0].Embedding))
+	}
+}
+
+func TestMemoryListAllTypesUsesBoundedUnionPage(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	appID := "app-1"
+	filterArgs := []any{"active", "agent-1", "sess-1", appID, "chat", `"tag-a"`}
+	countArgs := append(append([]any(nil), filterArgs...), filterArgs...)
+	pageArgs := append(append([]any(nil), filterArgs...), 5)
+	pageArgs = append(pageArgs, filterArgs...)
+	pageArgs = append(pageArgs, 5, 2, 3)
+
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"(SELECT COUNT(*) FROM memories WHERE state = ? AND agent_id = ? AND session_id = ? AND app_id = ? AND source = ? AND JSON_CONTAINS(tags, ?))",
+				"(SELECT COUNT(*) FROM sessions WHERE state = ? AND agent_id = ? AND session_id = ? AND app_id = ? AND source = ? AND JSON_CONTAINS(tags, ?))",
+			},
+			mustNotContain: []string{"ALTER TABLE", "CREATE INDEX"},
+			wantArgs:       countArgs,
+			rows: &scriptedRows{
+				columns: []string{"total"},
+				values:  [][]driver.Value{{int64(6)}},
+			},
+		},
+		{
+			mustContain: []string{
+				"WITH memory_page AS",
+				"SELECT " + searchColumns + ", updated_at AS sort_value",
+				"FROM memories",
+				"ORDER BY updated_at DESC, id DESC LIMIT ?",
+				"session_page AS",
+				"JSON_OBJECT('role', COALESCE(role, ''), 'seq', seq, 'content_type', COALESCE(content_type, '')) AS metadata",
+				"'session' AS memory_type",
+				"FROM sessions",
+				"ORDER BY created_at DESC, id DESC LIMIT ?",
+				"UNION ALL",
+				"ORDER BY sort_value DESC, id DESC",
+				"LIMIT ? OFFSET ?",
+			},
+			mustNotContain: []string{"embedding", "ALTER TABLE", "CREATE INDEX"},
+			wantArgs:       pageArgs,
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					{
+						"session-1", "raw turn", "chat", []byte(`["tag-a"]`),
+						[]byte(`{"role":"user","seq":2,"content_type":"text"}`), string(domain.TypeSession),
+						"agent-1", "sess-1", appID, "active", int64(0), nil, now, now, nil,
+					},
+					memorySearchRow("memory-1", "durable memory", "agent-1", "sess-1", "active", []byte(`["tag-a"]`), now.Add(-time.Minute)),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	memories, total, err := repo.ListAllTypes(context.Background(), domain.MemoryFilter{
+		State:     "active",
+		AgentID:   "agent-1",
+		SessionID: "sess-1",
+		AppID:     &appID,
+		Source:    "chat",
+		Tags:      []string{"tag-a"},
+		Limit:     2,
+		Offset:    3,
+	})
+	if err != nil {
+		t.Fatalf("ListAllTypes: %v", err)
+	}
+	if total != 6 || len(memories) != 2 {
+		t.Fatalf("page = total:%d memories:%+v, want 6/2", total, memories)
+	}
+	if memories[0].ID != "session-1" || memories[0].MemoryType != domain.TypeSession {
+		t.Fatalf("first memory = %+v, want session-1", memories[0])
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(memories[0].Metadata, &metadata); err != nil {
+		t.Fatalf("decode session metadata: %v", err)
+	}
+	if metadata["role"] != "user" || metadata["seq"] != float64(2) || metadata["content_type"] != "text" {
+		t.Fatalf("session metadata = %#v", metadata)
+	}
+}
+
+func TestMemoryListAllTypesFallsBackWhenSessionsTableIsMissing(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"(SELECT COUNT(*) FROM memories WHERE state = 'active')",
+				"(SELECT COUNT(*) FROM sessions WHERE state = 'active')",
+			},
+			err: &mysql.MySQLError{Number: 1146, Message: "Table doesn't exist"},
+		},
+		{
+			mustContain: []string{"SELECT COUNT(*) FROM memories WHERE state = 'active'"},
+			rows: &scriptedRows{
+				columns: []string{"COUNT(*)"},
+				values:  [][]driver.Value{{int64(1)}},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + searchColumns + " FROM memories",
+				"ORDER BY updated_at DESC, id DESC",
+				"LIMIT ? OFFSET ?",
+			},
+			wantArgs: []any{1, 0},
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					memorySearchRow("memory-1", "durable memory", "agent-1", "sess-1", "active", []byte(`[]`), now),
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	memories, total, err := repo.ListAllTypes(context.Background(), domain.MemoryFilter{Limit: 1})
+	if err != nil {
+		t.Fatalf("ListAllTypes: %v", err)
+	}
+	if total != 1 || len(memories) != 1 || memories[0].ID != "memory-1" {
+		t.Fatalf("page = total:%d memories:%+v, want durable fallback", total, memories)
 	}
 }
 

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -137,14 +137,12 @@ func TestMemoryListSelectsSearchColumnsWithoutEmbedding(t *testing.T) {
 	}
 }
 
-func TestMemoryListAllTypesUsesBoundedUnionPage(t *testing.T) {
+func TestMemoryListAllTypesMergesBoundedTimeOrderedPages(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	appID := "app-1"
 	filterArgs := []any{"active", "agent-1", "sess-1", appID, "chat", `"tag-a"`}
 	countArgs := append(append([]any(nil), filterArgs...), filterArgs...)
 	pageArgs := append(append([]any(nil), filterArgs...), 5)
-	pageArgs = append(pageArgs, filterArgs...)
-	pageArgs = append(pageArgs, 5, 2, 3)
 
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
@@ -161,30 +159,55 @@ func TestMemoryListAllTypesUsesBoundedUnionPage(t *testing.T) {
 		},
 		{
 			mustContain: []string{
-				"WITH memory_page AS",
-				"SELECT " + searchColumns + ", updated_at AS sort_value",
+				"SELECT " + searchColumns,
 				"FROM memories",
-				"ORDER BY updated_at DESC, id DESC LIMIT ?",
-				"session_page AS",
+				"ORDER BY updated_at DESC LIMIT ?",
+			},
+			mustNotContain: []string{
+				"embedding", "ALTER TABLE", "CREATE INDEX", "UNION ALL", ", id DESC",
+			},
+			wantArgs: pageArgs,
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					memorySearchRow("memory-1", "new durable memory", "agent-1", "sess-1", "active", []byte(`["tag-a"]`), now.Add(-time.Minute)),
+					memorySearchRow("memory-2", "older durable memory", "agent-1", "sess-1", "active", []byte(`["tag-a"]`), now.Add(-4*time.Minute)),
+					memorySearchRow("memory-3", "oldest durable memory", "agent-1", "sess-1", "active", []byte(`["tag-a"]`), now.Add(-6*time.Minute)),
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT id, content, source, tags",
 				"JSON_OBJECT('role', COALESCE(role, ''), 'seq', seq, 'content_type', COALESCE(content_type, '')) AS metadata",
 				"'session' AS memory_type",
 				"FROM sessions",
-				"ORDER BY created_at DESC, id DESC LIMIT ?",
-				"UNION ALL",
-				"ORDER BY sort_value DESC, id DESC",
-				"LIMIT ? OFFSET ?",
+				"ORDER BY created_at DESC LIMIT ?",
 			},
-			mustNotContain: []string{"embedding", "ALTER TABLE", "CREATE INDEX"},
-			wantArgs:       pageArgs,
+			mustNotContain: []string{
+				"embedding", "ALTER TABLE", "CREATE INDEX", "UNION ALL", ", id DESC",
+			},
+			wantArgs: pageArgs,
 			rows: &scriptedRows{
 				columns: memorySearchColumns(),
 				values: [][]driver.Value{
 					{
-						"session-1", "raw turn", "chat", []byte(`["tag-a"]`),
-						[]byte(`{"role":"user","seq":2,"content_type":"text"}`), string(domain.TypeSession),
+						"session-1", "newest raw turn", "chat", []byte(`["tag-a"]`),
+						[]byte(`{"role":"assistant","seq":1,"content_type":"text"}`), string(domain.TypeSession),
 						"agent-1", "sess-1", appID, "active", int64(0), nil, now, now, nil,
 					},
-					memorySearchRow("memory-1", "durable memory", "agent-1", "sess-1", "active", []byte(`["tag-a"]`), now.Add(-time.Minute)),
+					{
+						"session-2", "middle raw turn", "chat", []byte(`["tag-a"]`),
+						[]byte(`{"role":"assistant","seq":2,"content_type":"text"}`), string(domain.TypeSession),
+						"agent-1", "sess-1", appID, "active", int64(0), nil,
+						now.Add(-2 * time.Minute), now.Add(-2 * time.Minute), nil,
+					},
+					{
+						"session-3", "older raw turn", "chat", []byte(`["tag-a"]`),
+						[]byte(`{"role":"user","seq":3,"content_type":"text"}`), string(domain.TypeSession),
+						"agent-1", "sess-1", appID, "active", int64(0), nil,
+						now.Add(-3 * time.Minute), now.Add(-3 * time.Minute), nil,
+					},
 				},
 			},
 		},
@@ -208,15 +231,90 @@ func TestMemoryListAllTypesUsesBoundedUnionPage(t *testing.T) {
 	if total != 6 || len(memories) != 2 {
 		t.Fatalf("page = total:%d memories:%+v, want 6/2", total, memories)
 	}
-	if memories[0].ID != "session-1" || memories[0].MemoryType != domain.TypeSession {
-		t.Fatalf("first memory = %+v, want session-1", memories[0])
+	if memories[0].ID != "session-3" || memories[0].MemoryType != domain.TypeSession {
+		t.Fatalf("first memory = %+v, want session-3", memories[0])
+	}
+	if memories[1].ID != "memory-2" {
+		t.Fatalf("second memory = %+v, want memory-2", memories[1])
 	}
 	var metadata map[string]any
 	if err := json.Unmarshal(memories[0].Metadata, &metadata); err != nil {
 		t.Fatalf("decode session metadata: %v", err)
 	}
-	if metadata["role"] != "user" || metadata["seq"] != float64(2) || metadata["content_type"] != "text" {
+	if metadata["role"] != "user" || metadata["seq"] != float64(3) || metadata["content_type"] != "text" {
 		t.Fatalf("session metadata = %#v", metadata)
+	}
+}
+
+func TestMemoryListAllTypesMergesAscendingPages(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			mustContain: []string{
+				"(SELECT COUNT(*) FROM memories WHERE state = 'active')",
+				"(SELECT COUNT(*) FROM sessions WHERE state = 'active')",
+			},
+			rows: &scriptedRows{
+				columns: []string{"total"},
+				values:  [][]driver.Value{{int64(4)}},
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + searchColumns,
+				"FROM memories",
+				"ORDER BY updated_at ASC LIMIT ?",
+			},
+			mustNotContain: []string{", id ASC"},
+			wantArgs:       []any{3},
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					memorySearchRow("memory-1", "oldest durable", "", "", "active", []byte(`[]`), now.Add(-4*time.Minute)),
+					memorySearchRow("memory-2", "new durable", "", "", "active", []byte(`[]`), now.Add(-time.Minute)),
+				},
+			},
+		},
+		{
+			mustContain: []string{
+				"FROM sessions",
+				"ORDER BY created_at ASC LIMIT ?",
+			},
+			mustNotContain: []string{", id ASC"},
+			wantArgs:       []any{3},
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					{
+						"session-1", "older raw turn", "", []byte(`[]`), []byte(`{}`), string(domain.TypeSession),
+						"", "", "", "active", int64(0), nil,
+						now.Add(-3 * time.Minute), now.Add(-3 * time.Minute), nil,
+					},
+					{
+						"session-2", "newer raw turn", "", []byte(`[]`), []byte(`{}`), string(domain.TypeSession),
+						"", "", "", "active", int64(0), nil,
+						now.Add(-2 * time.Minute), now.Add(-2 * time.Minute), nil,
+					},
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	memories, total, err := repo.ListAllTypes(context.Background(), domain.MemoryFilter{
+		Limit:   2,
+		Offset:  1,
+		SortDir: "asc",
+	})
+	if err != nil {
+		t.Fatalf("ListAllTypes: %v", err)
+	}
+	if total != 4 || len(memories) != 2 {
+		t.Fatalf("page = total:%d memories:%+v, want 4/2", total, memories)
+	}
+	if memories[0].ID != "session-1" || memories[1].ID != "session-2" {
+		t.Fatalf("memories = %+v, want session-1/session-2", memories)
 	}
 }
 

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -347,6 +347,7 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 func (r *MemoryRepo) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
 	startedAt := time.Now()
 	var countDuration, pageDuration time.Duration
+	var memoryPageDuration, sessionPageDuration, mergeDuration time.Duration
 	total := 0
 	returned := 0
 	fallback := false
@@ -358,6 +359,9 @@ func (r *MemoryRepo) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([
 			"cluster_id", r.clusterID,
 			"count_ms", countDuration.Milliseconds(),
 			"page_ms", pageDuration.Milliseconds(),
+			"memory_page_ms", memoryPageDuration.Milliseconds(),
+			"session_page_ms", sessionPageDuration.Milliseconds(),
+			"merge_ms", mergeDuration.Milliseconds(),
 			"fallback", fallback,
 			"total", total,
 			"returned", returned,
@@ -416,42 +420,34 @@ func (r *MemoryRepo) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([
 		return []domain.Memory{}, total, nil
 	}
 	window := offset + limit
-	memorySort, sessionSort, direction := allTypeMemoryListOrder(f)
+	direction := "DESC"
+	if strings.EqualFold(strings.TrimSpace(f.SortDir), "asc") {
+		direction = "ASC"
+	}
 
-	dataQuery := `WITH memory_page AS (
-		SELECT ` + searchColumns + `, ` + memorySort + ` AS sort_value
+	memoryQuery := `SELECT ` + searchColumns + `
 		FROM memories
 		WHERE ` + memoryWhere + `
-		ORDER BY ` + memorySort + ` ` + direction + `, id ` + direction + ` LIMIT ?
-	),
-	session_page AS (
-		SELECT id, content, source, tags,
+		ORDER BY updated_at ` + direction + ` LIMIT ?`
+	memoryPageArgs := make([]any, len(memoryArgs), len(memoryArgs)+1)
+	copy(memoryPageArgs, memoryArgs)
+	memoryPageArgs = append(memoryPageArgs, window)
+
+	sessionQuery := `SELECT id, content, source, tags,
 			JSON_OBJECT('role', COALESCE(role, ''), 'seq', seq, 'content_type', COALESCE(content_type, '')) AS metadata,
 			'session' AS memory_type, agent_id, session_id, app_id, state, 0 AS version,
-			NULL AS updated_by, created_at, created_at AS updated_at, NULL AS superseded_by,
-			` + sessionSort + ` AS sort_value
+			NULL AS updated_by, created_at, created_at AS updated_at, NULL AS superseded_by
 		FROM sessions
 		WHERE ` + sessionWhere + `
-		ORDER BY ` + sessionSort + ` ` + direction + `, id ` + direction + ` LIMIT ?
-	),
-	all_type_rows AS (
-		SELECT * FROM memory_page
-		UNION ALL
-		SELECT * FROM session_page
-	)
-	SELECT ` + searchColumns + `
-	FROM all_type_rows
-	ORDER BY sort_value ` + direction + `, id ` + direction + `
-	LIMIT ? OFFSET ?`
-
-	dataArgs := make([]any, 0, len(memoryArgs)+len(sessionArgs)+4)
-	dataArgs = append(dataArgs, memoryArgs...)
-	dataArgs = append(dataArgs, window)
-	dataArgs = append(dataArgs, sessionArgs...)
-	dataArgs = append(dataArgs, window, limit, offset)
+		ORDER BY created_at ` + direction + ` LIMIT ?`
+	sessionPageArgs := make([]any, len(sessionArgs), len(sessionArgs)+1)
+	copy(sessionPageArgs, sessionArgs)
+	sessionPageArgs = append(sessionPageArgs, window)
 
 	pageStartedAt := time.Now()
-	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
+	memoryPageStartedAt := time.Now()
+	memoryPage, err := r.queryAllTypeMemoryPage(ctx, memoryQuery, memoryPageArgs)
+	memoryPageDuration = time.Since(memoryPageStartedAt)
 	if err != nil {
 		pageDuration = time.Since(pageStartedAt)
 		if internaltenant.IsTableNotFoundError(err) {
@@ -472,37 +468,91 @@ func (r *MemoryRepo) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([
 			"duration_ms", pageDuration.Milliseconds(),
 			"err", err,
 		)
-		return nil, 0, fmt.Errorf("list all-types memories: %w", err)
+		return nil, 0, fmt.Errorf("list all-types memory page: %w", err)
 	}
-	defer rows.Close()
 
-	memories := make([]domain.Memory, 0, limit)
-	for rows.Next() {
-		memory, scanErr := scanSearchMemoryRows(rows)
-		if scanErr != nil {
-			pageDuration = time.Since(pageStartedAt)
-			return nil, 0, scanErr
+	sessionPageStartedAt := time.Now()
+	sessionPage, err := r.queryAllTypeMemoryPage(ctx, sessionQuery, sessionPageArgs)
+	sessionPageDuration = time.Since(sessionPageStartedAt)
+	if err != nil {
+		pageDuration = time.Since(pageStartedAt)
+		if internaltenant.IsTableNotFoundError(err) {
+			fallback = true
+			slog.InfoContext(ctx, "all-types memory list using durable fallback",
+				"cluster_id", r.clusterID,
+				"phase", "page",
+			)
+			fallbackStartedAt := time.Now()
+			memories, fallbackTotal, fallbackErr := r.List(ctx, f)
+			pageDuration += time.Since(fallbackStartedAt)
+			total = fallbackTotal
+			returned = len(memories)
+			return memories, fallbackTotal, fallbackErr
 		}
-		memories = append(memories, *memory)
+		slog.ErrorContext(ctx, "list all-types memories: session page query failed",
+			"cluster_id", r.clusterID,
+			"duration_ms", pageDuration.Milliseconds(),
+			"err", err,
+		)
+		return nil, 0, fmt.Errorf("list all-types session page: %w", err)
 	}
+
+	mergeStartedAt := time.Now()
+	memories := mergeAllTypeMemoryPages(memoryPage, sessionPage, offset, limit, direction == "ASC")
+	mergeDuration = time.Since(mergeStartedAt)
 	pageDuration = time.Since(pageStartedAt)
-	if err := rows.Err(); err != nil {
-		return nil, 0, fmt.Errorf("iterate all-types memories: %w", err)
-	}
 	returned = len(memories)
 	return memories, total, nil
 }
 
-func allTypeMemoryListOrder(f domain.MemoryFilter) (memoryColumn, sessionColumn, direction string) {
-	memoryColumn, direction = memoryListSort(f)
-	sessionColumn = memoryColumn
-	switch memoryColumn {
-	case "memory_type":
-		sessionColumn = "'session'"
-	case "updated_at":
-		sessionColumn = "created_at"
+func (r *MemoryRepo) queryAllTypeMemoryPage(ctx context.Context, query string, args []any) ([]domain.Memory, error) {
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
 	}
-	return memoryColumn, sessionColumn, direction
+	defer rows.Close()
+
+	var memories []domain.Memory
+	for rows.Next() {
+		memory, err := scanSearchMemoryRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		memories = append(memories, *memory)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate all-types memory page: %w", err)
+	}
+	return memories, nil
+}
+
+func mergeAllTypeMemoryPages(memoryPage, sessionPage []domain.Memory, offset, limit int, ascending bool) []domain.Memory {
+	memories := make([]domain.Memory, 0, limit)
+	memoryIndex, sessionIndex, position := 0, 0, 0
+	for len(memories) < limit && (memoryIndex < len(memoryPage) || sessionIndex < len(sessionPage)) {
+		takeMemory := sessionIndex >= len(sessionPage)
+		if memoryIndex < len(memoryPage) && sessionIndex < len(sessionPage) {
+			if ascending {
+				takeMemory = !memoryPage[memoryIndex].UpdatedAt.After(sessionPage[sessionIndex].UpdatedAt)
+			} else {
+				takeMemory = !memoryPage[memoryIndex].UpdatedAt.Before(sessionPage[sessionIndex].UpdatedAt)
+			}
+		}
+
+		var memory domain.Memory
+		if takeMemory {
+			memory = memoryPage[memoryIndex]
+			memoryIndex++
+		} else {
+			memory = sessionPage[sessionIndex]
+			sessionIndex++
+		}
+		if position >= offset {
+			memories = append(memories, memory)
+		}
+		position++
+	}
+	return memories
 }
 
 func memoryListSort(f domain.MemoryFilter) (column, direction string) {

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/qiffang/mnemos/server/internal/domain"
+	internaltenant "github.com/qiffang/mnemos/server/internal/tenant"
 )
 
 type MemoryRepo struct {
@@ -39,6 +40,7 @@ const (
 	searchColumns            = `id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
 	maxFTSCandidatePageLimit = 10000
 	maxFTSFallbackPages      = 30
+	allTypeListSlowThreshold = 2 * time.Second
 	// TiDB Cloud FTS is only safe with fts_match_word as the only WHERE predicate,
 	// so wider recall uses bounded pure-FTS pages followed by post-filtering.
 	maxFTSFallbackCandidateLimit = maxFTSCandidatePageLimit * maxFTSFallbackPages
@@ -342,24 +344,183 @@ func (r *MemoryRepo) List(ctx context.Context, f domain.MemoryFilter) ([]domain.
 	return memories, total, rows.Err()
 }
 
-func memoryListOrderBy(f domain.MemoryFilter) string {
-	column := "updated_at"
-	switch strings.TrimSpace(f.SortBy) {
-	case "content":
-		column = "content"
-	case "memory_type":
-		column = "memory_type"
-	case "tags":
-		column = "tags"
-	case "updated_at", "":
-		column = "updated_at"
+func (r *MemoryRepo) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	startedAt := time.Now()
+	var countDuration, pageDuration time.Duration
+	total := 0
+	returned := 0
+	fallback := false
+	defer func() {
+		if time.Since(startedAt) < allTypeListSlowThreshold {
+			return
+		}
+		slog.InfoContext(ctx, "all-types memory list phases",
+			"cluster_id", r.clusterID,
+			"count_ms", countDuration.Milliseconds(),
+			"page_ms", pageDuration.Milliseconds(),
+			"fallback", fallback,
+			"total", total,
+			"returned", returned,
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+		)
+	}()
+
+	memoryFilter := f
+	memoryFilter.MemoryType = ""
+	memoryConds, memoryArgs := r.buildFilterConds(memoryFilter)
+	sessionConds, sessionArgs := buildSessionFilterConds(f)
+	memoryWhere := strings.Join(memoryConds, " AND ")
+	sessionWhere := strings.Join(sessionConds, " AND ")
+
+	countQuery := `SELECT
+		(SELECT COUNT(*) FROM memories WHERE ` + memoryWhere + `) +
+		(SELECT COUNT(*) FROM sessions WHERE ` + sessionWhere + `) AS total`
+	countArgs := make([]any, 0, len(memoryArgs)+len(sessionArgs))
+	countArgs = append(countArgs, memoryArgs...)
+	countArgs = append(countArgs, sessionArgs...)
+
+	countStartedAt := time.Now()
+	err := r.db.QueryRowContext(ctx, countQuery, countArgs...).Scan(&total)
+	countDuration = time.Since(countStartedAt)
+	if err != nil {
+		if internaltenant.IsTableNotFoundError(err) {
+			fallback = true
+			slog.InfoContext(ctx, "all-types memory list using durable fallback",
+				"cluster_id", r.clusterID,
+				"phase", "count",
+			)
+			fallbackStartedAt := time.Now()
+			memories, fallbackTotal, fallbackErr := r.List(ctx, f)
+			pageDuration = time.Since(fallbackStartedAt)
+			total = fallbackTotal
+			returned = len(memories)
+			return memories, fallbackTotal, fallbackErr
+		}
+		slog.ErrorContext(ctx, "list all-types memories: count failed",
+			"cluster_id", r.clusterID,
+			"duration_ms", countDuration.Milliseconds(),
+			"err", err,
+		)
+		return nil, 0, fmt.Errorf("count all-types memories: %w", err)
 	}
 
-	direction := "DESC"
+	limit := f.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := f.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	if total <= offset {
+		return []domain.Memory{}, total, nil
+	}
+	window := offset + limit
+	memorySort, sessionSort, direction := allTypeMemoryListOrder(f)
+
+	dataQuery := `WITH memory_page AS (
+		SELECT ` + searchColumns + `, ` + memorySort + ` AS sort_value
+		FROM memories
+		WHERE ` + memoryWhere + `
+		ORDER BY ` + memorySort + ` ` + direction + `, id ` + direction + ` LIMIT ?
+	),
+	session_page AS (
+		SELECT id, content, source, tags,
+			JSON_OBJECT('role', COALESCE(role, ''), 'seq', seq, 'content_type', COALESCE(content_type, '')) AS metadata,
+			'session' AS memory_type, agent_id, session_id, app_id, state, 0 AS version,
+			NULL AS updated_by, created_at, created_at AS updated_at, NULL AS superseded_by,
+			` + sessionSort + ` AS sort_value
+		FROM sessions
+		WHERE ` + sessionWhere + `
+		ORDER BY ` + sessionSort + ` ` + direction + `, id ` + direction + ` LIMIT ?
+	),
+	all_type_rows AS (
+		SELECT * FROM memory_page
+		UNION ALL
+		SELECT * FROM session_page
+	)
+	SELECT ` + searchColumns + `
+	FROM all_type_rows
+	ORDER BY sort_value ` + direction + `, id ` + direction + `
+	LIMIT ? OFFSET ?`
+
+	dataArgs := make([]any, 0, len(memoryArgs)+len(sessionArgs)+4)
+	dataArgs = append(dataArgs, memoryArgs...)
+	dataArgs = append(dataArgs, window)
+	dataArgs = append(dataArgs, sessionArgs...)
+	dataArgs = append(dataArgs, window, limit, offset)
+
+	pageStartedAt := time.Now()
+	rows, err := r.db.QueryContext(ctx, dataQuery, dataArgs...)
+	if err != nil {
+		pageDuration = time.Since(pageStartedAt)
+		if internaltenant.IsTableNotFoundError(err) {
+			fallback = true
+			slog.InfoContext(ctx, "all-types memory list using durable fallback",
+				"cluster_id", r.clusterID,
+				"phase", "page",
+			)
+			fallbackStartedAt := time.Now()
+			memories, fallbackTotal, fallbackErr := r.List(ctx, f)
+			pageDuration += time.Since(fallbackStartedAt)
+			total = fallbackTotal
+			returned = len(memories)
+			return memories, fallbackTotal, fallbackErr
+		}
+		slog.ErrorContext(ctx, "list all-types memories: page query failed",
+			"cluster_id", r.clusterID,
+			"duration_ms", pageDuration.Milliseconds(),
+			"err", err,
+		)
+		return nil, 0, fmt.Errorf("list all-types memories: %w", err)
+	}
+	defer rows.Close()
+
+	memories := make([]domain.Memory, 0, limit)
+	for rows.Next() {
+		memory, scanErr := scanSearchMemoryRows(rows)
+		if scanErr != nil {
+			pageDuration = time.Since(pageStartedAt)
+			return nil, 0, scanErr
+		}
+		memories = append(memories, *memory)
+	}
+	pageDuration = time.Since(pageStartedAt)
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate all-types memories: %w", err)
+	}
+	returned = len(memories)
+	return memories, total, nil
+}
+
+func allTypeMemoryListOrder(f domain.MemoryFilter) (memoryColumn, sessionColumn, direction string) {
+	memoryColumn, direction = memoryListSort(f)
+	sessionColumn = memoryColumn
+	switch memoryColumn {
+	case "memory_type":
+		sessionColumn = "'session'"
+	case "updated_at":
+		sessionColumn = "created_at"
+	}
+	return memoryColumn, sessionColumn, direction
+}
+
+func memoryListSort(f domain.MemoryFilter) (column, direction string) {
+	column = "updated_at"
+	switch strings.TrimSpace(f.SortBy) {
+	case "content", "memory_type", "tags":
+		column = strings.TrimSpace(f.SortBy)
+	case "updated_at", "":
+	}
+	direction = "DESC"
 	if strings.EqualFold(strings.TrimSpace(f.SortDir), "asc") {
 		direction = "ASC"
 	}
+	return column, direction
+}
 
+func memoryListOrderBy(f domain.MemoryFilter) string {
+	column, direction := memoryListSort(f)
 	return column + " " + direction + ", id " + direction
 }
 

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -192,6 +192,10 @@ func (r *SessionRepo) BulkSoftDelete(ctx context.Context, ids []string, agentNam
 }
 
 func (r *SessionRepo) buildSessionFilterConds(f domain.MemoryFilter) ([]string, []any) {
+	return buildSessionFilterConds(f)
+}
+
+func buildSessionFilterConds(f domain.MemoryFilter) ([]string, []any) {
 	conds := []string{}
 	args := []any{}
 

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -1824,6 +1824,10 @@ func (m *memoryRepoMock) List(ctx context.Context, f domain.MemoryFilter) ([]dom
 	return nil, 0, nil
 }
 
+func (m *memoryRepoMock) ListAllTypes(ctx context.Context, f domain.MemoryFilter) ([]domain.Memory, int, error) {
+	return m.List(ctx, f)
+}
+
 func (m *memoryRepoMock) Count(ctx context.Context) (int, error) {
 	return 0, nil
 }

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -25,6 +25,7 @@ const (
 	maxTags              = 20
 	maxBulkSize          = 100
 	maxBulkDeleteSize    = 1000
+	maxAllTypeListWindow = 3000
 	defaultMinScore      = 0.3
 	maxLooseSearchTokens = 5
 
@@ -178,6 +179,34 @@ func (s *MemoryService) List(ctx context.Context, filter domain.MemoryFilter) ([
 	mems, total, err := s.memories.List(ctx, filter)
 	if err != nil {
 		return nil, 0, err
+	}
+	return finalizeSearchResults(mems, filter.Query), total, nil
+}
+
+func (s *MemoryService) ListAllTypes(ctx context.Context, filter domain.MemoryFilter) ([]domain.Memory, int, error) {
+	if filter.Limit <= 0 || filter.Limit > 200 {
+		filter.Limit = DefaultSessionLimit
+	}
+	if filter.Offset < 0 {
+		filter.Offset = 0
+	}
+	if filter.Offset > maxAllTypeListWindow-filter.Limit {
+		return nil, 0, &domain.ValidationError{
+			Field:   "offset",
+			Message: fmt.Sprintf("offset plus limit exceeds the all-types maximum of %d", maxAllTypeListWindow),
+		}
+	}
+	switch strings.TrimSpace(filter.SortBy) {
+	case "content", "tags":
+		return nil, 0, &domain.ValidationError{
+			Field:   "sort_by",
+			Message: "content and tags sorting require an explicit memory_type",
+		}
+	}
+
+	mems, total, err := s.memories.ListAllTypes(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list all-types memories: %w", err)
 	}
 	return finalizeSearchResults(mems, filter.Query), total, nil
 }

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -197,10 +197,19 @@ func (s *MemoryService) ListAllTypes(ctx context.Context, filter domain.MemoryFi
 		}
 	}
 	switch strings.TrimSpace(filter.SortBy) {
-	case "content", "tags":
+	case "", "updated_at":
+	default:
 		return nil, 0, &domain.ValidationError{
 			Field:   "sort_by",
-			Message: "content and tags sorting require an explicit memory_type",
+			Message: "all-types lists only support updated_at sorting",
+		}
+	}
+	switch strings.ToLower(strings.TrimSpace(filter.SortDir)) {
+	case "", "asc", "desc":
+	default:
+		return nil, 0, &domain.ValidationError{
+			Field:   "sort_dir",
+			Message: "must be asc or desc",
 		}
 	}
 


### PR DESCRIPTION
## What Changed

- Restore `GET /memories` with empty `q` and empty `memory_type` to return pinned memories, insights, and raw session rows in one page.
- Keep the exact filtered total across `memories` and `sessions`.
- Query each table independently with its existing time index and `LIMIT offset + limit`: `memories.updated_at` and `sessions.created_at`.
- Merge the two already-sorted prefixes in Go, skip `offset`, and return at most `limit` rows.
- Keep `state`, agent, session, app, source, and tag filters in SQL.
- Keep explicit `memory_type=session|pinned|insight` routes on their existing paths.
- Fall back to durable memories for Postgres, DB9, and TiDB tenants whose `sessions` table is unavailable.
- Restrict all-types ordering to `updated_at` with `asc|desc`; unsupported sort values return 400.
- Add slow-phase fields for `count_ms`, `memory_page_ms`, `session_page_ms`, `merge_ms`, and total `page_ms`.

## Why This Shape

### History

- #370 established the product intent: Console All types includes pinned, insight, and raw session rows. Its scan-all implementation could read every matching row before sorting.
- #413 restored the durable-only default after large early tenants experienced timeouts.
- #421 restored bounded application-side merging and also added request-time schema/index ensure.
- Clinic evidence placed the 30-second failure in request-time schema ensure/DDL, before list query execution.
- #423 temporarily changed `total` to a lower bound; #424 restored exact totals because dashboard verification consumes that value.
- #425 reverted #421 while retaining the request-level observability from #418. This PR starts from that baseline and restores only the bounded read path.

### Decision

The previous CTE/`UNION ALL` query ordered by time plus UUID in TiDB. `EXPLAIN ANALYZE` showed that shape scanning all 100,000 memory rows and all 500,000 session rows before TopN.

The new path asks each table for its own top `offset + limit` rows using only the time column, then performs a two-pointer merge in Go. Each table prefix contains every row from that table that can enter the global top `offset + limit`, so the final page remains complete while database work stays bounded.

## Query Contract

| Request | TiDB | Postgres / DB9 |
| --- | --- | --- |
| empty `q`, empty `memory_type` | exact count + two bounded time pages + Go merge | durable-memory page |
| `memory_type=session` | existing session path | existing backend behavior |
| `memory_type=pinned|insight` | existing durable-memory path | existing durable-memory path |
| TiDB tenant without `sessions` | durable-memory fallback | n/a |

## Query Shape

1. Count: filtered `memories` count plus filtered `sessions` count.
2. Memory prefix: SQL filters, `ORDER BY updated_at`, `LIMIT offset + limit`.
3. Session prefix: SQL filters, `ORDER BY created_at`, `LIMIT offset + limit`.
4. Merge: compare `UpdatedAt` values, skip `offset`, collect `limit` rows.
5. Session projection: `memory_type=session`, `updated_at=created_at`, plus `role`, `seq`, and `content_type` metadata.

## Safety and Tradeoffs

- `offset + limit <= 3000` bounds each table prefix and the merge work.
- Schema/index diff: zero. Request-time DDL: zero.
- SQL ordering intentionally omits UUID. Rows sharing one timestamp may move relative to each other across requests; this is the accepted tradeoff for time-index TopN.
- Exact count remains a separate full count and the main scale-sensitive part of the request.
- Missing-session fallback emits the phase that triggered it.

## Performance Evidence

A disposable TiDB Cloud Zero v8.5.3 Serverless database used production tenant schemas with 100,000 memories and 500,000 sessions. Each case ran 15 sequential times after `ANALYZE TABLE`.

| Case | Previous p50 | New p50 | New p95 | New max |
| --- | ---: | ---: | ---: | ---: |
| `limit=1` | 2.127 s | 1.511 s | 1.699 s | 2.108 s |
| `limit=100` | 2.334 s | 1.516 s | 1.548 s | 1.622 s |
| `limit=100&offset=2900` | 2.188 s | 1.724 s | 2.081 s | 2.369 s |
| one-app filter, `limit=1` | 2.149 s | 1.656 s | 1.884 s | 2.073 s |

Every run returned the exact total of 600,000. The count phase remained about 0.8–1.4 seconds. A slow deep-page sample split the page into about 976 ms for memories, 529 ms for sessions, and less than 1 ms for the Go merge.

`EXPLAIN ANALYZE` confirmed the time-only queries use `idx_updated(updated_at)` and `idx_sess_created(created_at)`; latest-row samples completed in about 4–5 ms per table.

## DEV Validation

Commit `b00da1b` was built as an immutable image, temporarily rolled out to DEV, tested through a localhost-only port-forward, and then DEV was restored to its exact pre-test image.

- Fresh synthetic tenant: 1 pinned memory + 20 raw session rows.
- Default `limit=1`: 10/10 HTTP 200, exact total 21, first row was a session.
- End-to-end client timing: p50 1.806 s, p95/max 2.009 s.
- Deep page `limit=1&offset=20`: HTTP 200 in 1.472 s.
- Ascending and descending time order: verified across all 21 rows.
- `sort_by=memory_type` and `offset=3000&limit=1`: HTTP 400 as designed.
- Structured server logs placed successful GET duration around 1.0–1.4 seconds; the 2-second repository slow-event threshold was not crossed on this small DEV tenant.

A 3,000-session API seed was stopped because the normal write path generates embeddings row by row. The isolated 600,000-row TiDB data set provides the scale evidence; DEV provides deployed API and contract evidence.

Production was not deployed.

## Review Path

1. `internal/service/memory.go`: deep-page guard and strict all-types sort validation.
2. `internal/repository/tidb/memory.go`: exact count, bounded per-table queries, Go merge, fallback, and phase timings.
3. `internal/handler/memory.go` and `memory_list_observability.go`: all-types routing and request diagnostics.
4. Repository and handler tests: filters, totals, metadata, offset merge, ascending merge, fallback, and validation.
5. `docs/api/openapi.json`: all-types sort contract.

## Validation

- `make vet`
- `make test` (`go test -race -count=1 ./...`)
- `git diff --check upstream/main...HEAD`
- TiDB Cloud Zero 600,000-row benchmark and `EXPLAIN ANALYZE`
- Temporary DEV rollout and API verification

All code checks pass on commit `b00da1b`. PR remains open for review; production rollout requires explicit approval.