### PR TITLE
fix: stabilize dashboard memory pagination

### DIFF
--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -217,7 +217,7 @@ describe("httpProvider", () => {
     expect(result).toEqual({ messages: [] });
   });
 
-  it("exports more than 3000 durable memories through typed list pages", async () => {
+  it("exports more than 3000 pinned and insight memories", async () => {
     const memories = Array.from({ length: 3001 }, (_, index) => ({
       id: `mem-${index}`,
       content: `memory ${index}`,
@@ -239,14 +239,11 @@ describe("httpProvider", () => {
         const url = new URL(String(input), "https://mem9.ai");
         const limit = Number(url.searchParams.get("limit"));
         const offset = Number(url.searchParams.get("offset"));
-        if (
-          url.searchParams.get("memory_type") === null &&
-          offset + limit > 3000
-        ) {
+        const memoryType = url.searchParams.get("memory_type");
+        if (memoryType !== "pinned,insight") {
           return new Response(
             JSON.stringify({
-              error:
-                "offset plus limit exceeds the all-types maximum of 3000",
+              error: "memory_type is required",
             }),
             {
               status: 400,
@@ -271,6 +268,9 @@ describe("httpProvider", () => {
     const result = await httpProvider.exportMemories("space-1");
 
     expect(result.memories).toHaveLength(3001);
+    expect(new Set(result.memories.map((memory) => memory.memory_type))).toEqual(
+      new Set(["pinned", "insight"]),
+    );
     expect(fetchMock).toHaveBeenCalledTimes(16);
     for (const [url] of fetchMock.mock.calls) {
       expect(

--- a/dashboard/app/src/components/space/export-dialog.test.tsx
+++ b/dashboard/app/src/components/space/export-dialog.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import type { TFunction } from "i18next";
+import { describe, expect, it, vi } from "vitest";
+import { ExportDialog } from "@/components/space/export-dialog";
+
+describe("ExportDialog", () => {
+  it("shows the number of pinned and insight memories in the export count", () => {
+    const t = ((
+      key: string,
+      values?: Record<string, unknown>,
+    ): string => {
+      if (key === "export.count") {
+        return `${String(values?.count)} exportable memories`;
+      }
+      return key;
+    }) as unknown as TFunction;
+
+    render(
+      <ExportDialog
+        open
+        onOpenChange={vi.fn()}
+        onExport={vi.fn().mockResolvedValue(undefined)}
+        stats={{ total: 12, pinned: 2, insight: 3 }}
+        loading={false}
+        t={t}
+      />,
+    );
+
+    expect(screen.getByText("5 exportable memories")).toBeInTheDocument();
+  });
+});

--- a/dashboard/app/src/components/space/export-dialog.tsx
+++ b/dashboard/app/src/components/space/export-dialog.tsx
@@ -58,7 +58,9 @@ export function ExportDialog({
           {stats && (
             <div className="rounded-lg border bg-secondary/30 p-3">
               <div className="text-sm text-foreground">
-                {t("export.count", { count: stats.total })}
+                {t("export.count", {
+                  count: stats.pinned + stats.insight,
+                })}
               </div>
               <div className="mt-1 text-xs text-muted-foreground">
                 {t("export.breakdown", {

--- a/dashboard/app/src/components/space/use-space-data-model.test.tsx
+++ b/dashboard/app/src/components/space/use-space-data-model.test.tsx
@@ -194,6 +194,57 @@ describe("useSpaceDataModel", () => {
     );
   });
 
+  it("keeps the empty source-memory reference stable after a source query error", () => {
+    mocks.useSourceMemories.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      refetch: mocks.sourceRefetch,
+    });
+    const input = {
+      spaceId: "space-1",
+      q: undefined,
+      range: "all" as const,
+      facet: undefined,
+      analysisCategory: undefined,
+      tag: undefined,
+      memoryTypeFilter: "pinned,insight" as const,
+      timelineSelection: undefined,
+      importStatusOpen: false,
+      exportOpen: false,
+      isDesktopViewport: true,
+      mobileAnalysisOpen: false,
+      selected: null,
+      localVisibleCount: 50,
+      onSelectedMissing: vi.fn(),
+    };
+
+    const { rerender } = renderHook(() => useSpaceDataModel(input));
+    const firstAnalysisCall =
+      mocks.useSpaceAnalysis.mock.calls[
+        mocks.useSpaceAnalysis.mock.calls.length - 1
+      ];
+    const firstSourceMemories = (
+      firstAnalysisCall?.[0] as {
+        sourceMemories: Memory[];
+      }
+    ).sourceMemories;
+
+    rerender();
+
+    const secondAnalysisCall =
+      mocks.useSpaceAnalysis.mock.calls[
+        mocks.useSpaceAnalysis.mock.calls.length - 1
+      ];
+    const secondSourceMemories = (
+      secondAnalysisCall?.[0] as {
+        sourceMemories: Memory[];
+      }
+    ).sourceMemories;
+    expect(secondSourceMemories).toBe(firstSourceMemories);
+  });
+
   it("gates all-range stats behind the export dialog and only enables analysis signals when visible", () => {
     renderHook(() =>
       useSpaceDataModel({

--- a/dashboard/app/src/components/space/use-space-data-model.ts
+++ b/dashboard/app/src/components/space/use-space-data-model.ts
@@ -39,6 +39,8 @@ import type {
 import type { TimeRangePreset, TimelineSelection } from "@/types/time-range";
 import type { TagSummary } from "./tag-strip";
 
+const EMPTY_MEMORIES: Memory[] = [];
+
 export interface SpaceDataModel {
   stats: MemoryStats | undefined;
   totalStats: MemoryStats | undefined;
@@ -122,7 +124,7 @@ export function useSpaceDataModel(input: {
   const updateMutation = useUpdateMemory(spaceId);
   const exportMutation = useExportMemories(spaceId);
   const importMutation = useImportMemories(spaceId);
-  const allMemories = sourceQuery.data ?? [];
+  const allMemories = sourceQuery.data ?? EMPTY_MEMORIES;
   const analysis = useSpaceAnalysis({
     spaceId,
     range: input.range,

--- a/dashboard/docs/data-contract.md
+++ b/dashboard/docs/data-contract.md
@@ -284,18 +284,22 @@ If this route is not registered before launch, hide `Add memory`. Do not silentl
 
 ### 5.7 Export JSON
 
-Launch does not need a backend export endpoint. The frontend can export by paginating all current `active` memories and generating the file locally.
+Launch uses client-side export. The frontend paginates current `active` pinned
+and insight memories and generates the file locally.
 
 Recommended flow:
 
-1. Fetch the first page with `limit=200`
+1. Fetch the first page with `memory_type=pinned,insight&limit=200`
 2. Increment `offset` until all `total` records are collected
 3. Build the export JSON
 4. Trigger a browser download
 
-Launch exports only `active` memories, not archived or deleted records.
+Launch exports `active` pinned and insight memories.
 
-Page-level time range does not change export scope. Export covers all current `active` memories in the space by default.
+Export always covers all current `active` pinned and insight memories in the
+space, independently of the page-level time range.
+
+The export dialog count is the sum of the pinned and insight totals.
 
 ### 5.8 Import JSON
 

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -1260,16 +1260,38 @@ func TestListMemories_DefaultListUsesUnifiedAllTypesPage(t *testing.T) {
 	}
 }
 
-func TestListMemories_DefaultListRejectsDeepPagination(t *testing.T) {
+func TestListMemories_DefaultListAllowsPaginationWithinExpandedWindow(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	srv := newTestServer(memRepo, &testSessionRepo{})
-	req := makeRequest(t, http.MethodGet, "/memories?limit=1&offset=3000", nil)
+	req := makeRequest(t, http.MethodGet, "/memories?limit=200&offset=99800", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	if memRepo.allTypeListCalls != 1 {
+		t.Fatalf("all-types list calls = %d, want 1", memRepo.allTypeListCalls)
+	}
+	if memRepo.lastAllTypeListFilter.Limit != 200 || memRepo.lastAllTypeListFilter.Offset != 99800 {
+		t.Fatalf("all-types filter = %+v, want limit=200 offset=99800", memRepo.lastAllTypeListFilter)
+	}
+}
+
+func TestListMemories_DefaultListRejectsPaginationBeyondExpandedWindow(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?limit=200&offset=99801", nil)
 	rr := httptest.NewRecorder()
 
 	srv.listMemories(rr, req)
 
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "all-types maximum of 100000") {
+		t.Fatalf("body = %q, want expanded-window validation error", rr.Body.String())
 	}
 	if memRepo.allTypeListCalls != 0 {
 		t.Fatalf("all-types list calls = %d, want 0", memRepo.allTypeListCalls)

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -25,7 +25,7 @@ const (
 	maxTags              = 20
 	maxBulkSize          = 100
 	maxBulkDeleteSize    = 1000
-	maxAllTypeListWindow = 3000
+	maxAllTypeListWindow = 100000
 	defaultMinScore      = 0.3
 	maxLooseSearchTokens = 5
 


### PR DESCRIPTION
## What Changed

- Expanded the all-types list window from 3,000 to 100,000.
- Made only the export dialog total equal the pinned plus insight export scope.
- Stabilized the empty source state after query errors to prevent React's maximum-update-depth loop.
- Added regression coverage for typed exports beyond 3,000 memories.

## Review Path

- `server/internal/service/memory.go` and handler boundary tests
- `dashboard/app/src/components/space/export-dialog.tsx` for export-only count parity
- `dashboard/app/src/components/space/use-space-data-model.ts` for the error-state render loop

## Validation

- `make test`
- `make vet`
- Focused frontend tests: 17/17
- `pnpm typecheck`
- `pnpm build`
- Full frontend suite: 50/51 files; existing date-sensitive `space.test.tsx` failures remain

## Notes

Connect verification, global stats, source synchronization, and shared cache reads retain their all-types behavior. The 100,000 window is the requested immediate mitigation.
