### PR TITLE
fix(dashboard): bound memory profile graph work

### DIFF
--- a/dashboard/app/src/components/space/memory-overview-tabs.tsx
+++ b/dashboard/app/src/components/space/memory-overview-tabs.tsx
@@ -113,7 +113,6 @@ export function MemoryOverviewTabs({
           cards={cards}
           snapshot={snapshot}
           range={range}
-          matchMap={matchMap}
           facetSummary={profileFacetData}
           loading={loading}
           className="!mt-0"

--- a/dashboard/app/src/components/space/memory-profile-overview.test.tsx
+++ b/dashboard/app/src/components/space/memory-profile-overview.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import "@/i18n";
+import {
+  calculateCompanionDays,
+  MemoryProfileOverview,
+} from "./memory-profile-overview";
+import type { Memory } from "@/types/memory";
+
+const { useBackgroundMemoryInsightGraph } = vi.hoisted(() => ({
+  useBackgroundMemoryInsightGraph: vi.fn(() => ({
+    data: {
+      nodes: [],
+      edges: [],
+      cards: [
+        {
+          id: "card:legacy",
+          kind: "card" as const,
+          category: "legacy",
+          label: "Legacy graph topic",
+          count: 99,
+          confidence: 1,
+          size: 100,
+          branchKey: "legacy",
+          parentId: null,
+          depth: 0 as const,
+        },
+      ],
+      tags: [],
+      entities: [],
+      memories: [],
+    },
+    isComputing: false,
+  })),
+}));
+
+vi.mock("@/lib/memory-insight-background", () => ({
+  useBackgroundMemoryInsightGraph,
+}));
+
+vi.mock("@/api/analysis-queries", () => ({
+  useUserProfile: () => ({
+    data: undefined,
+    isLoading: false,
+  }),
+}));
+
+function createMemory(): Memory {
+  return {
+    id: "mem-1",
+    content: "Dashboard profile memory",
+    memory_type: "insight",
+    source: "agent",
+    tags: ["dashboard"],
+    metadata: null,
+    agent_id: "agent",
+    session_id: "session",
+    state: "active",
+    version: 1,
+    updated_by: "agent",
+    created_at: "2026-03-10T00:00:00Z",
+    updated_at: "2026-03-10T00:00:00Z",
+  };
+}
+
+describe("MemoryProfileOverview", () => {
+  it("renders the topic radar from cards without starting an insight graph computation", () => {
+    render(
+      <MemoryProfileOverview
+        spaceId="space-1"
+        stats={{ total: 12, pinned: 3, insight: 9 }}
+        memories={[createMemory()]}
+        cards={[
+          { category: "Projects", count: 12, confidence: 0.9 },
+          { category: "Preferences", count: 7, confidence: 0.8 },
+        ]}
+        snapshot={null}
+        range="all"
+        facetSummary={undefined}
+        loading={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Projects: 12" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Preferences: 7" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: "Legacy graph topic: 99" }),
+    ).not.toBeInTheDocument();
+    expect(useBackgroundMemoryInsightGraph).not.toHaveBeenCalled();
+  });
+
+  it("calculates companion days for a memory set larger than the function argument limit", () => {
+    const recentMemory = {
+      ...createMemory(),
+      created_at: "2026-07-29T00:00:00Z",
+    };
+    const memories = new Array<Memory>(150_000).fill(recentMemory);
+    memories[memories.length - 1] = {
+      ...recentMemory,
+      id: "mem-oldest",
+      created_at: "2026-07-20T00:00:00Z",
+    };
+
+    expect(
+      calculateCompanionDays(
+        memories,
+        Date.parse("2026-07-30T00:00:00Z"),
+      ),
+    ).toBe(10);
+  });
+});

--- a/dashboard/app/src/components/space/memory-profile-overview.tsx
+++ b/dashboard/app/src/components/space/memory-profile-overview.tsx
@@ -6,16 +6,13 @@ import { MemoryCompositionChart } from "@/components/space/memory-composition-ch
 import { MemoryRhythmChart } from "@/components/space/memory-rhythm-chart";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { buildFacetComposition, buildMemoryPulseData, buildPulseComposition } from "@/lib/memory-pulse";
-import { useBackgroundMemoryInsightGraph } from "@/lib/memory-insight-background";
 import { cn } from "@/lib/utils";
 import type {
   AnalysisCategoryCard,
   AnalysisJobSnapshotResponse,
-  MemoryAnalysisMatch,
   UserProfileImageItem,
   UserProfileItemKind,
 } from "@/types/analysis";
-import type { MemoryInsightCardNode } from "@/lib/memory-insight";
 import type { Memory, MemoryStats, TopicSummary } from "@/types/memory";
 import type { TimeRangePreset } from "@/types/time-range";
 
@@ -25,14 +22,32 @@ const PROFILE_ITEM_SECTIONS = [
   { key: "constraint", kind: "robot_constraint", color: "bg-emerald-400" },
 ] as const satisfies readonly { key: string; kind: UserProfileItemKind; color: string }[];
 
-export function MemoryProfileOverview({ spaceId, stats, memories, cards, snapshot, range, matchMap, facetSummary, loading, className }: { spaceId: string; stats: MemoryStats | undefined; memories: Memory[]; cards: AnalysisCategoryCard[]; snapshot: AnalysisJobSnapshotResponse | null; range: TimeRangePreset; matchMap: Map<string, MemoryAnalysisMatch>; facetSummary: TopicSummary | undefined; loading: boolean; className?: string }) {
+export function calculateCompanionDays(
+  memories: Memory[],
+  now = Date.now(),
+): number {
+  let earliestTimestamp = Number.POSITIVE_INFINITY;
+
+  for (const memory of memories) {
+    const timestamp = Date.parse(memory.created_at);
+    if (Number.isFinite(timestamp) && timestamp < earliestTimestamp) {
+      earliestTimestamp = timestamp;
+    }
+  }
+
+  return Number.isFinite(earliestTimestamp)
+    ? Math.max(1, Math.ceil((now - earliestTimestamp) / 86_400_000))
+    : 0;
+}
+
+export function MemoryProfileOverview({ spaceId, stats, memories, cards, snapshot, range, facetSummary, loading, className }: { spaceId: string; stats: MemoryStats | undefined; memories: Memory[]; cards: AnalysisCategoryCard[]; snapshot: AnalysisJobSnapshotResponse | null; range: TimeRangePreset; facetSummary: TopicSummary | undefined; loading: boolean; className?: string }) {
   const { i18n, t } = useTranslation();
   const profileQuery = useUserProfile(spaceId);
   const profile = profileQuery.data;
-  const companionDays = useMemo(() => {
-    const values = memories.map((memory) => Date.parse(memory.created_at)).filter(Number.isFinite);
-    return values.length ? Math.max(1, Math.ceil((Date.now() - Math.min(...values)) / 86_400_000)) : 0;
-  }, [memories]);
+  const companionDays = useMemo(
+    () => calculateCompanionDays(memories),
+    [memories],
+  );
   const memoryCount = stats?.total ?? memories.length;
   const currentUnderstanding = profile?.summary.text?.trim()
     || (profileQuery.isLoading ? t("memory_profile.current_understanding.loading") : t("memory_profile.current_understanding.description"));
@@ -63,7 +78,6 @@ export function MemoryProfileOverview({ spaceId, stats, memories, cards, snapsho
       range,
     });
   }, [cards, memories, range, snapshot, stats]);
-  const { data: insightGraph } = useBackgroundMemoryInsightGraph({ cards, memories, matchMap });
   const profileGridClass = "grid gap-4 xl:grid-cols-[calc((100%_-_1rem)*0.2776_+_100px)_minmax(0,calc((100%_-_1rem)*0.7224_-_100px))]";
 
   if (loading && !stats && memories.length === 0) return <ProfileSkeleton className={className} />;
@@ -81,7 +95,7 @@ export function MemoryProfileOverview({ spaceId, stats, memories, cards, snapsho
     </div>
 
     <div className={cn("mt-4", profileGridClass)}>
-      <ProfileCard title={t("memory_profile.topics.title")}><RadarChart nodes={insightGraph.cards} /></ProfileCard>
+      <ProfileCard title={t("memory_profile.topics.title")}><RadarChart cards={cards} /></ProfileCard>
       <article className="surface-card min-h-[260px] p-5"><MemoryRhythmChart buckets={pulse?.trend.buckets ?? []} maxCount={pulse?.trend.maxCount ?? 0} locale={i18n.language} /></article>
     </div>
 
@@ -132,7 +146,7 @@ function ProfileItemRow({ item }: { item: UserProfileImageItem }) {
   );
 }
 
-function RadarChart({ nodes }: { nodes: MemoryInsightCardNode[] }) {
+function RadarChart({ cards }: { cards: AnalysisCategoryCard[] }) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
   const labels = [
     { x: 130, y: 14, anchor: "middle", countDy: "1em" },
@@ -142,17 +156,18 @@ function RadarChart({ nodes }: { nodes: MemoryInsightCardNode[] }) {
     { x: 56, y: 85, anchor: "end", countDy: "1.25em" },
   ] as const;
   const points = [[130,39],[199,86],[174,145],[89,142],[65,92]] as const;
-  const topicNodes = [...nodes]
-    .sort((left, right) => right.count - left.count || left.label.localeCompare(right.label, "en"))
+  const topicCards = cards
+    .filter((card) => card.count > 0)
+    .sort((left, right) => right.count - left.count || left.category.localeCompare(right.category, "en"))
     .slice(0, 5);
-  const path = topicNodes.length > 1
-    ? `${topicNodes.map((_, index) => `${index === 0 ? "M" : "L"}${points[index]![0]} ${points[index]![1]}`).join(" ")}${topicNodes.length > 2 ? " Z" : ""}`
+  const path = topicCards.length > 1
+    ? `${topicCards.map((_, index) => `${index === 0 ? "M" : "L"}${points[index]![0]} ${points[index]![1]}`).join(" ")}${topicCards.length > 2 ? " Z" : ""}`
     : "";
 
   return <svg viewBox="0 0 260 190" className="profile-radar mx-auto h-[190px] w-full max-w-[280px]" aria-label="Memory Insight topics">
     <g fill="none" stroke="currentColor" className="text-foreground/10"><path d="M130 14 235 80 195 171 65 171 25 80Z" /><path d="M130 43 205 89 177 150 83 150 55 89Z" /><path d="M130 71 175 98 160 129 100 129 85 98Z" /></g>
     {path && <path className="profile-radar-area" d={path} fill="rgba(59,130,246,.35)" stroke="#3b82f6" strokeWidth="2" />}
-    {topicNodes.map((node, index) => { const [x, y] = points[index]!; const label = labels[index]!; const active = hoveredIndex === index; return <g key={node.id} tabIndex={0} role="img" aria-label={`${node.label}: ${node.count}`} onMouseEnter={() => setHoveredIndex(index)} onMouseLeave={() => setHoveredIndex(null)} onFocus={() => setHoveredIndex(index)} onBlur={() => setHoveredIndex(null)} className="cursor-pointer"><text x={label.x} y={label.y} textAnchor={label.anchor} className={cn("text-[10px] font-medium transition-all duration-200", active ? "fill-blue-500" : "fill-muted-foreground")} style={{ transform: active ? "translateY(-2px)" : "translateY(0)" }}><tspan x={label.x}>{node.label}</tspan><tspan x={label.x} dy={label.countDy} className={cn("text-[9px] tabular-nums transition-colors duration-200", active ? "fill-blue-500/75" : "fill-foreground/60")}>{node.count}</tspan></text><circle cx={x} cy={y} r={active ? 12 : 7} fill="#3b82f6" opacity={active ? .2 : 0} className="transition-all duration-200" /><circle className="profile-radar-node transition-all duration-200" cx={x} cy={y} r={active ? 6 : 4} fill="#3b82f6" /><title>{`${node.label}: ${node.count}`}</title></g>; })}
+    {topicCards.map((card, index) => { const [x, y] = points[index]!; const label = labels[index]!; const active = hoveredIndex === index; return <g key={card.category} tabIndex={0} role="img" aria-label={`${card.category}: ${card.count}`} onMouseEnter={() => setHoveredIndex(index)} onMouseLeave={() => setHoveredIndex(null)} onFocus={() => setHoveredIndex(index)} onBlur={() => setHoveredIndex(null)} className="cursor-pointer"><text x={label.x} y={label.y} textAnchor={label.anchor} className={cn("text-[10px] font-medium transition-all duration-200", active ? "fill-blue-500" : "fill-muted-foreground")} style={{ transform: active ? "translateY(-2px)" : "translateY(0)" }}><tspan x={label.x}>{card.category}</tspan><tspan x={label.x} dy={label.countDy} className={cn("text-[9px] tabular-nums transition-colors duration-200", active ? "fill-blue-500/75" : "fill-foreground/60")}>{card.count}</tspan></text><circle cx={x} cy={y} r={active ? 12 : 7} fill="#3b82f6" opacity={active ? .2 : 0} className="transition-all duration-200" /><circle className="profile-radar-node transition-all duration-200" cx={x} cy={y} r={active ? 6 : 4} fill="#3b82f6" /><title>{`${card.category}: ${card.count}`}</title></g>; })}
   </svg>;
 }
 

--- a/dashboard/app/src/lib/memory-insight-background.test.ts
+++ b/dashboard/app/src/lib/memory-insight-background.test.ts
@@ -1,14 +1,21 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildBoundedMemoryInsightGraphInput,
+  buildBoundedMemoryInsightRelationGraphInput,
   projectInsightWorkerMemory,
   shouldUseDerivedSignalsWorker,
 } from "./memory-insight-background";
+import { buildMemoryInsightRelationGraph } from "./memory-insight-relations";
+import type { MemoryAnalysisMatch } from "@/types/analysis";
 import type { Memory } from "@/types/memory";
 
-function createMemory(): Memory {
+function createMemory(
+  id = "mem-1",
+  content = "Investigate dashboard query flow",
+): Memory {
   return {
-    id: "mem-1",
-    content: "Investigate dashboard query flow",
+    id,
+    content,
     memory_type: "insight",
     source: "agent",
     tags: ["dashboard", "query"],
@@ -52,5 +59,94 @@ describe("memory insight background helpers", () => {
       updated_at: "2026-03-28T01:00:00Z",
       tags: ["dashboard", "query"],
     });
+  });
+
+  it("limits insight graph worker input and keeps only matching lookup entries", () => {
+    const memories = [
+      createMemory("mem-1"),
+      createMemory("mem-2"),
+      createMemory("mem-3"),
+    ];
+    const matchMap = new Map<string, MemoryAnalysisMatch>(
+      memories.map((memory) => [
+        memory.id,
+        {
+          memoryId: memory.id,
+          categories: ["project"],
+          categoryScores: { project: 1 },
+        },
+      ]),
+    );
+
+    const bounded = buildBoundedMemoryInsightGraphInput({
+      memories,
+      matchMap,
+      budget: {
+        maxSourceMemories: 2,
+        maxMemories: 10,
+        maxNodes: 20,
+        maxEdges: 20,
+      },
+    });
+
+    expect(bounded.memories.map((memory) => memory.id)).toEqual([
+      "mem-1",
+      "mem-2",
+    ]);
+    expect(bounded.matches.map((match) => match.memoryId)).toEqual([
+      "mem-1",
+      "mem-2",
+    ]);
+    expect([...bounded.matchMap.keys()]).toEqual(["mem-1", "mem-2"]);
+  });
+
+  it("bounds a 40k relation graph before worker transfer and throughout its output", () => {
+    const memories = Array.from({ length: 40_000 }, (_, index) =>
+      createMemory(
+        `mem-${index}`,
+        index < 100
+          ? `Use \`shared-core\` with \`module-${index}-a\`, \`module-${index}-b\`, and \`module-${index}-c\``
+          : "plain note",
+      ),
+    );
+    const matchMap = new Map<string, MemoryAnalysisMatch>(
+      ["mem-0", "mem-399", "mem-400", "mem-39999"].map((memoryId) => [
+        memoryId,
+        {
+          memoryId,
+          categories: ["project"],
+          categoryScores: { project: 1 },
+        },
+      ]),
+    );
+    const budget = {
+      maxSourceMemories: 400,
+      maxEntities: 80,
+      maxEdges: 60,
+    };
+
+    const boundedInput = buildBoundedMemoryInsightRelationGraphInput({
+      memories,
+      matchMap,
+      budget,
+    });
+    const graph = buildMemoryInsightRelationGraph({
+      cards: [],
+      memories,
+      matchMap,
+      budget,
+    });
+
+    expect(boundedInput.memories).toHaveLength(400);
+    expect(boundedInput.matches.map((match) => match.memoryId)).toEqual([
+      "mem-0",
+      "mem-399",
+    ]);
+    expect([...boundedInput.matchMap.keys()]).toEqual(["mem-0", "mem-399"]);
+    expect(graph.totalMemories).toBe(400);
+    expect(graph.entities.length).toBeLessThanOrEqual(80);
+    expect(graph.entitiesById.size).toBeLessThanOrEqual(80);
+    expect(graph.edges.length).toBeLessThanOrEqual(60);
+    expect(graph.edgesById.size).toBeLessThanOrEqual(60);
   });
 });

--- a/dashboard/app/src/lib/memory-insight-background.ts
+++ b/dashboard/app/src/lib/memory-insight-background.ts
@@ -5,11 +5,15 @@ import {
 } from "@/lib/memory-derived-signals";
 import {
   buildMemoryInsightGraph,
+  DEFAULT_MEMORY_INSIGHT_GRAPH_BUDGET,
   type MemoryInsightGraph,
+  type MemoryInsightGraphBudget,
 } from "@/lib/memory-insight";
 import {
   buildMemoryInsightRelationGraph,
+  DEFAULT_MEMORY_INSIGHT_RELATION_GRAPH_BUDGET,
   type MemoryInsightRelationGraph,
+  type MemoryInsightRelationGraphBudget,
   type MemoryInsightRelationType,
 } from "@/lib/memory-insight-relations";
 import type {
@@ -129,6 +133,75 @@ export function projectInsightWorkerMemory(memory: Memory): InsightWorkerMemory 
     created_at: memory.created_at,
     updated_at: memory.updated_at,
     tags: memory.tags.slice(),
+  };
+}
+
+export function buildBoundedMemoryInsightGraphInput({
+  memories,
+  matchMap,
+  budget = DEFAULT_MEMORY_INSIGHT_GRAPH_BUDGET,
+}: {
+  memories: Memory[];
+  matchMap: Map<string, MemoryAnalysisMatch>;
+  budget?: MemoryInsightGraphBudget;
+}): {
+  memories: Memory[];
+  matches: MemoryAnalysisMatch[];
+  matchMap: Map<string, MemoryAnalysisMatch>;
+} {
+  const boundedMemories = memories.length > budget.maxSourceMemories
+    ? memories.slice(0, budget.maxSourceMemories)
+    : memories;
+  const boundedMatches: MemoryAnalysisMatch[] = [];
+  const boundedMatchMap = new Map<string, MemoryAnalysisMatch>();
+
+  for (const memory of boundedMemories) {
+    const match = matchMap.get(memory.id);
+    if (match) {
+      boundedMatches.push(match);
+      boundedMatchMap.set(memory.id, match);
+    }
+  }
+
+  return {
+    memories: boundedMemories,
+    matches: boundedMatches,
+    matchMap: boundedMatchMap,
+  };
+}
+
+export function buildBoundedMemoryInsightRelationGraphInput({
+  memories,
+  matchMap,
+  budget = DEFAULT_MEMORY_INSIGHT_RELATION_GRAPH_BUDGET,
+}: {
+  memories: Memory[];
+  matchMap: Map<string, MemoryAnalysisMatch>;
+  budget?: MemoryInsightRelationGraphBudget;
+}): {
+  memories: Memory[];
+  matches: MemoryAnalysisMatch[];
+  matchMap: Map<string, MemoryAnalysisMatch>;
+} {
+  const boundedMemories =
+    memories.length > budget.maxSourceMemories
+      ? memories.slice(0, budget.maxSourceMemories)
+      : memories;
+  const boundedMatches: MemoryAnalysisMatch[] = [];
+  const boundedMatchMap = new Map<string, MemoryAnalysisMatch>();
+
+  for (const memory of boundedMemories) {
+    const match = matchMap.get(memory.id);
+    if (match) {
+      boundedMatches.push(match);
+      boundedMatchMap.set(memory.id, match);
+    }
+  }
+
+  return {
+    memories: boundedMemories,
+    matches: boundedMatches,
+    matchMap: boundedMatchMap,
   };
 }
 
@@ -322,7 +395,10 @@ export function useBackgroundMemoryInsightGraph({
   matchMap: Map<string, MemoryAnalysisMatch>;
 }): { data: MemoryInsightGraph; isComputing: boolean } {
   const workerEnabled = shouldUseBackgroundWorker();
-  const matches = useMemo(() => [...matchMap.values()], [matchMap]);
+  const boundedInput = useMemo(
+    () => buildBoundedMemoryInsightGraphInput({ memories, matchMap }),
+    [memories, matchMap],
+  );
 
   return useBackgroundComputation({
     workerEnabled,
@@ -330,18 +406,18 @@ export function useBackgroundMemoryInsightGraph({
       type: "insight-graph",
       payload: {
         cards,
-        memories,
-        matches,
+        memories: boundedInput.memories,
+        matches: boundedInput.matches,
       },
     },
     computeSync: () =>
       buildMemoryInsightGraph({
         cards,
-        memories,
-        matchMap,
+        memories: boundedInput.memories,
+        matchMap: boundedInput.matchMap,
       }),
     emptyValue: EMPTY_MEMORY_INSIGHT_GRAPH,
-    deps: [workerEnabled, cards, memories, matches, matchMap],
+    deps: [workerEnabled, cards, boundedInput],
   });
 }
 
@@ -363,7 +439,10 @@ export function useBackgroundMemoryInsightRelationGraph({
   minimumCoOccurrence?: number;
 }): { data: MemoryInsightRelationGraph; isComputing: boolean } {
   const workerEnabled = shouldUseBackgroundWorker();
-  const matches = useMemo(() => [...matchMap.values()], [matchMap]);
+  const boundedInput = useMemo(
+    () => buildBoundedMemoryInsightRelationGraphInput({ memories, matchMap }),
+    [memories, matchMap],
+  );
 
   return useBackgroundComputation({
     workerEnabled,
@@ -371,8 +450,8 @@ export function useBackgroundMemoryInsightRelationGraph({
       type: "relation-graph",
       payload: {
         cards,
-        memories,
-        matches,
+        memories: boundedInput.memories,
+        matches: boundedInput.matches,
         activeCategory,
         activeTag,
         relationType,
@@ -382,8 +461,8 @@ export function useBackgroundMemoryInsightRelationGraph({
     computeSync: () =>
       buildMemoryInsightRelationGraph({
         cards,
-        memories,
-        matchMap,
+        memories: boundedInput.memories,
+        matchMap: boundedInput.matchMap,
         activeCategory,
         activeTag,
         relationType,
@@ -393,9 +472,7 @@ export function useBackgroundMemoryInsightRelationGraph({
     deps: [
       workerEnabled,
       cards,
-      memories,
-      matches,
-      matchMap,
+      boundedInput,
       activeCategory,
       activeTag,
       relationType,

--- a/dashboard/app/src/lib/memory-insight-relations.ts
+++ b/dashboard/app/src/lib/memory-insight-relations.ts
@@ -74,11 +74,24 @@ export interface MemoryInsightRelationGraph {
   risingEntities: MemoryInsightRelationEntity[];
 }
 
+export interface MemoryInsightRelationGraphBudget {
+  maxSourceMemories: number;
+  maxEntities: number;
+  maxEdges: number;
+}
+
+export const DEFAULT_MEMORY_INSIGHT_RELATION_GRAPH_BUDGET: MemoryInsightRelationGraphBudget = {
+  maxSourceMemories: 1_000,
+  maxEntities: 500,
+  maxEdges: 1_000,
+};
+
 interface BuildInput {
   cards: AnalysisCategoryCard[];
   memories: Memory[];
   matchMap: Map<string, MemoryAnalysisMatch>;
   signalIndex?: LocalDerivedSignalIndex | null;
+  budget?: MemoryInsightRelationGraphBudget;
   activeCategory?: string;
   activeTag?: string;
   relationType?: MemoryInsightRelationType;
@@ -310,11 +323,16 @@ function collectCluster(
 }
 
 export function buildMemoryInsightRelationGraph(input: BuildInput): MemoryInsightRelationGraph {
+  const budget = input.budget ?? DEFAULT_MEMORY_INSIGHT_RELATION_GRAPH_BUDGET;
+  const sourceMemories =
+    input.memories.length > budget.maxSourceMemories
+      ? input.memories.slice(0, budget.maxSourceMemories)
+      : input.memories;
   const signalIndex = input.signalIndex ?? buildLocalDerivedSignalIndex({
-    memories: input.memories,
+    memories: sourceMemories,
     matchMap: input.matchMap,
   });
-  const filteredMemories = input.memories.filter((memory) => {
+  const filteredMemories = sourceMemories.filter((memory) => {
     if (
       input.activeTag &&
       !getCombinedTagsForMemory(memory, signalIndex).some(
@@ -355,8 +373,22 @@ export function buildMemoryInsightRelationGraph(input: BuildInput): MemoryInsigh
     const uniqueEntities = Array.from(
       new Map(entities.map((entity) => [entity.id, entity])).values(),
     );
+    const retainedEntities: typeof uniqueEntities = [];
+    let remainingEntitySlots = Math.max(
+      budget.maxEntities - entityAggregates.size,
+      0,
+    );
 
-    uniqueEntities.forEach((entity) => {
+    for (const entity of uniqueEntities) {
+      if (entityAggregates.has(entity.id)) {
+        retainedEntities.push(entity);
+      } else if (remainingEntitySlots > 0) {
+        retainedEntities.push(entity);
+        remainingEntitySlots -= 1;
+      }
+    }
+
+    retainedEntities.forEach((entity) => {
       const aggregate = entityAggregates.get(entity.id) ?? {
         id: entity.id,
         label: entity.label,
@@ -385,26 +417,34 @@ export function buildMemoryInsightRelationGraph(input: BuildInput): MemoryInsigh
       entityAggregates.set(entity.id, aggregate);
     });
 
-    for (let leftIndex = 0; leftIndex < uniqueEntities.length; leftIndex += 1) {
-      for (let rightIndex = leftIndex + 1; rightIndex < uniqueEntities.length; rightIndex += 1) {
-        const left = uniqueEntities[leftIndex]!;
-        const right = uniqueEntities[rightIndex]!;
+    for (let leftIndex = 0; leftIndex < retainedEntities.length; leftIndex += 1) {
+      for (let rightIndex = leftIndex + 1; rightIndex < retainedEntities.length; rightIndex += 1) {
+        const left = retainedEntities[leftIndex]!;
+        const right = retainedEntities[rightIndex]!;
         const sortedIDs = [left.id, right.id].sort((a, b) => a.localeCompare(b, "en"));
         const sourceId = sortedIDs[0]!;
         const targetId = sortedIDs[1]!;
         const edgeId = `${sourceId}=>${targetId}`;
         const relationType = chooseRelationType(memory, left, right);
-        const aggregate = edgeAggregates.get(edgeId) ?? {
-          id: edgeId,
-          sourceId,
-          targetId,
-          evidenceMemoryIds: new Set<string>(),
-          sharedTags: new Map<string, number>(),
-          sharedCategories: new Map<string, number>(),
-          coOccurrenceCount: 0,
-          recencyTotal: 0,
-          relationTypeCounts: new Map<MemoryInsightRelationType, number>(),
-        };
+        let aggregate = edgeAggregates.get(edgeId);
+
+        if (!aggregate) {
+          if (edgeAggregates.size >= budget.maxEdges) {
+            continue;
+          }
+
+          aggregate = {
+            id: edgeId,
+            sourceId,
+            targetId,
+            evidenceMemoryIds: new Set<string>(),
+            sharedTags: new Map<string, number>(),
+            sharedCategories: new Map<string, number>(),
+            coOccurrenceCount: 0,
+            recencyTotal: 0,
+            relationTypeCounts: new Map<MemoryInsightRelationType, number>(),
+          };
+        }
 
         if (!aggregate.evidenceMemoryIds.has(memory.id)) {
           aggregate.evidenceMemoryIds.add(memory.id);

--- a/dashboard/app/src/lib/memory-insight.test.ts
+++ b/dashboard/app/src/lib/memory-insight.test.ts
@@ -348,6 +348,46 @@ describe("memory-insight", () => {
     expect(graph.tags.some((tag) => tag.synthetic)).toBe(false);
   });
 
+  it("caps graph memories, nodes, and edges while preserving every reference", () => {
+    const memories = Array.from({ length: 8 }, (_, index) =>
+      createMemory(`mem-${index + 1}`, {
+        content: "Coordinate `Dashboard` delivery.",
+        tags: ["project"],
+      }),
+    );
+    const graph = buildMemoryInsightGraph({
+      cards: [createCard("project", memories.length)],
+      memories,
+      matchMap: new Map(
+        memories.map((memory) => [
+          memory.id,
+          createMatch(memory.id, ["project"]),
+        ]),
+      ),
+      budget: {
+        maxSourceMemories: 4,
+        maxMemories: 3,
+        maxNodes: 6,
+        maxEdges: 5,
+      },
+    });
+
+    expect(graph.memories).toHaveLength(3);
+    expect(graph.nodes).toHaveLength(6);
+    expect(graph.edges).toHaveLength(5);
+
+    const nodeIds = new Set(graph.nodes.map((node) => node.id));
+    for (const edge of graph.edges) {
+      expect(nodeIds.has(edge.source)).toBe(true);
+      expect(nodeIds.has(edge.target)).toBe(true);
+    }
+    for (const node of graph.nodes) {
+      if (node.parentId) {
+        expect(nodeIds.has(node.parentId)).toBe(true);
+      }
+    }
+  });
+
   it("matches memories against an entity filter", () => {
     const memory = createMemory("mem-3", {
       content: "Follow up with @alice on `mem9-ui` after 2h",

--- a/dashboard/app/src/lib/memory-insight.ts
+++ b/dashboard/app/src/lib/memory-insight.ts
@@ -134,12 +134,27 @@ export interface MemoryInsightGraph {
   memories: MemoryInsightMemoryNode[];
 }
 
+export interface MemoryInsightGraphBudget {
+  maxSourceMemories: number;
+  maxMemories: number;
+  maxNodes: number;
+  maxEdges: number;
+}
+
+export const DEFAULT_MEMORY_INSIGHT_GRAPH_BUDGET: MemoryInsightGraphBudget = {
+  maxSourceMemories: 1_000,
+  maxMemories: 1_000,
+  maxNodes: 2_000,
+  maxEdges: 2_000,
+};
+
 export interface BuildMemoryInsightGraphInput {
   cards: AnalysisCategoryCard[];
   memories: Memory[];
   matches?: MemoryAnalysisMatch[] | null;
   matchMap?: Map<string, MemoryAnalysisMatch> | null;
   signalIndex?: LocalDerivedSignalIndex | null;
+  budget?: MemoryInsightGraphBudget;
 }
 
 interface TagBucket {
@@ -541,6 +556,10 @@ function createMemoryNode(
 export function buildMemoryInsightGraph(
   input: BuildMemoryInsightGraphInput,
 ): MemoryInsightGraph {
+  const budget = input.budget ?? DEFAULT_MEMORY_INSIGHT_GRAPH_BUDGET;
+  const sourceMemories = input.memories.length > budget.maxSourceMemories
+    ? input.memories.slice(0, budget.maxSourceMemories)
+    : input.memories;
   const matchLookup = createMatchLookup(input.matches, input.matchMap);
   const cards = input.cards
     .filter((card) => card.count > 0)
@@ -558,7 +577,11 @@ export function buildMemoryInsightGraph(
   const edges: MemoryInsightEdge[] = [];
 
   for (const card of cards) {
-    const cardMemories = getCardMemories(card.category, input.memories, matchLookup);
+    if (nodes.length >= budget.maxNodes) {
+      break;
+    }
+
+    const cardMemories = getCardMemories(card.category, sourceMemories, matchLookup);
     const cardNode = createCardNode(
       card.category,
       Math.max(card.count, cardMemories.length),
@@ -569,6 +592,10 @@ export function buildMemoryInsightGraph(
 
     const tagBuckets = buildTagBuckets(cardMemories, matchLookup, input.signalIndex);
     for (const tagBucket of tagBuckets) {
+      if (nodes.length >= budget.maxNodes || edges.length >= budget.maxEdges) {
+        break;
+      }
+
       const tagNode = createTagNode(
         card.category,
         tagBucket.tagValue,
@@ -588,6 +615,10 @@ export function buildMemoryInsightGraph(
 
       const entityBuckets = buildEntityBuckets(tagBucket.memories);
       for (const entityBucket of entityBuckets) {
+        if (nodes.length >= budget.maxNodes || edges.length >= budget.maxEdges) {
+          break;
+        }
+
         const entityNode = createEntityNode(
           card.category,
           tagBucket.tagValue,
@@ -607,6 +638,14 @@ export function buildMemoryInsightGraph(
 
         const seenMemoryIds = new Set<string>();
         for (const memory of entityBucket.memories) {
+          if (
+            memoryNodes.length >= budget.maxMemories ||
+            nodes.length >= budget.maxNodes ||
+            edges.length >= budget.maxEdges
+          ) {
+            break;
+          }
+
           if (seenMemoryIds.has(memory.id)) {
             continue;
           }


### PR DESCRIPTION
## What Changed
- Render Profile topics from aggregate cards without starting a detail graph.
- Cap insight and relation graph inputs and outputs.
- Replace the large-array date spread with a constant-memory scan.

## Why
Large spaces could clone and retain hundreds of thousands of graph objects on the default Your Memory view.

## Review Path
- `memory-profile-overview.tsx`
- `memory-insight.ts`
- `memory-insight-relations.ts`
- `memory-insight-background.ts`

## Validation
- Focused graph and Profile tests
- `pnpm typecheck`
- Combined-stack production build
