### PR TITLE
fix(dashboard): virtualize the memory list

### DIFF
--- a/dashboard/app/package.json
+++ b/dashboard/app/package.json
@@ -20,6 +20,7 @@
     "@sentry/react": "^10.46.0",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-router": "^1.166.7",
+    "@tanstack/react-virtual": "^3.14.9",
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/dashboard/app/pnpm-lock.yaml
+++ b/dashboard/app/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.166.7
         version: 1.166.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.9
+        version: 3.14.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1191,66 +1194,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1402,24 +1418,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -1479,12 +1499,21 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.14.9':
+    resolution: {integrity: sha512-qZyr0FZDP8rDC4WBhsryIZmAd9bveJvFGUJJtskWaew6/0dTRS6wZxnR6VQ5bY2KwL3LjerrHqQLk3a0GKcPXQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.166.7':
     resolution: {integrity: sha512-MCc8wYIIcxmbeidM8PL2QeaAjUIHyhEDIZPW6NGfn/uwvyi+K2ucn3AGCxxcXl4JGGm0Mx9+7buYl1v3HdcFrg==}
     engines: {node: '>=20.19'}
 
   '@tanstack/store@0.9.2':
     resolution: {integrity: sha512-K013lUJEFJK2ofFQ/hZKJUmCnpcV00ebLyOyFOWQvyQHUOZp/iYO84BM6aOGiV81JzwbX0APTVmW8YI7yiG5oA==}
+
+  '@tanstack/virtual-core@3.17.7':
+    resolution: {integrity: sha512-bp+v10y65sp2H7WpWfIMyxTNfl8ZVfxFTLRjPIFRryi6FV/J33z4IS53WO4pTk36KlvJ4iLiQz+oaydDC1xbcA==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -2027,24 +2056,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -3994,6 +4027,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.7
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.166.7':
     dependencies:
       '@tanstack/history': 1.161.4
@@ -4005,6 +4044,8 @@ snapshots:
       tiny-warning: 1.0.3
 
   '@tanstack/store@0.9.2': {}
+
+  '@tanstack/virtual-core@3.17.7': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/dashboard/app/src/api/analysis-client.test.ts
+++ b/dashboard/app/src/api/analysis-client.test.ts
@@ -125,6 +125,21 @@ describe("analysisApi", () => {
     expect(String(url)).toContain("/v1/deep-analysis/reports?limit=10&offset=20");
   });
 
+  it("forwards an abort signal to read requests", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ summary: { text: "" }, items: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await analysisApi.getUserProfile("space-1", controller.signal);
+
+    const [, init] = fetchMock.mock.calls[0] ?? [];
+    expect(init?.signal).toBe(controller.signal);
+  });
+
   it("downloads the duplicate cleanup csv with the same auth header contract", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response("duplicateMemoryId,clusterIndex\nmem_2,1\n", {

--- a/dashboard/app/src/api/analysis-client.ts
+++ b/dashboard/app/src/api/analysis-client.ts
@@ -142,15 +142,22 @@ export const analysisApi = {
     return request(spaceId, `/v1/analysis-jobs/${jobId}/updates?${params}`);
   },
 
-  getTaxonomy(spaceId: string, version?: string): Promise<TaxonomyResponse> {
+  getTaxonomy(
+    spaceId: string,
+    version?: string,
+    signal?: AbortSignal,
+  ): Promise<TaxonomyResponse> {
     const params = new URLSearchParams();
     if (version) params.set("version", version);
     const suffix = params.size > 0 ? `?${params}` : "";
-    return request(spaceId, `/v1/taxonomy${suffix}`);
+    return request(spaceId, `/v1/taxonomy${suffix}`, { signal });
   },
 
-  getUserProfile(spaceId: string): Promise<UserProfileResponse> {
-    return request(spaceId, "/v1/user-profile");
+  getUserProfile(
+    spaceId: string,
+    signal?: AbortSignal,
+  ): Promise<UserProfileResponse> {
+    return request(spaceId, "/v1/user-profile", { signal });
   },
 
   createDeepAnalysisReport(
@@ -167,19 +174,27 @@ export const analysisApi = {
     spaceId: string,
     limit = 20,
     offset = 0,
+    signal?: AbortSignal,
   ): Promise<DeepAnalysisReportListResponse> {
     const params = new URLSearchParams({
       limit: String(limit),
       offset: String(offset),
     });
-    return request(spaceId, `/v1/deep-analysis/reports?${params.toString()}`);
+    return request(
+      spaceId,
+      `/v1/deep-analysis/reports?${params.toString()}`,
+      { signal },
+    );
   },
 
   getDeepAnalysisReport(
     spaceId: string,
     reportId: string,
+    signal?: AbortSignal,
   ): Promise<DeepAnalysisReportDetail> {
-    return request(spaceId, `/v1/deep-analysis/reports/${reportId}`);
+    return request(spaceId, `/v1/deep-analysis/reports/${reportId}`, {
+      signal,
+    });
   },
 
   async downloadDeepAnalysisDuplicatesCsv(

--- a/dashboard/app/src/api/analysis-queries.ts
+++ b/dashboard/app/src/api/analysis-queries.ts
@@ -110,7 +110,7 @@ export function isAnalysisCacheFresh(
 export function useUserProfile(spaceId: string, enabled = true) {
   return useQuery<UserProfileResponse>({
     queryKey: ["space", spaceId, "user-profile"],
-    queryFn: () => analysisApi.getUserProfile(spaceId),
+    queryFn: ({ signal }) => analysisApi.getUserProfile(spaceId, signal),
     enabled: !!spaceId && enabled && !features.useMock,
     staleTime: 60_000,
   });
@@ -388,7 +388,8 @@ export function useSpaceAnalysis(input: {
 
   const taxonomyQuery = useQuery({
     queryKey: ["analysis", "taxonomy", spaceId, DEFAULT_TAXONOMY_VERSION],
-    queryFn: () => analysisApi.getTaxonomy(spaceId, DEFAULT_TAXONOMY_VERSION),
+    queryFn: ({ signal }) =>
+      analysisApi.getTaxonomy(spaceId, DEFAULT_TAXONOMY_VERSION, signal),
     enabled,
     staleTime: 5 * 60_000,
     retry: false,

--- a/dashboard/app/src/api/deep-analysis-queries.test.tsx
+++ b/dashboard/app/src/api/deep-analysis-queries.test.tsx
@@ -99,8 +99,17 @@ describe("useDeepAnalysisReports", () => {
     rerender({ active: true });
 
     await waitFor(() => {
-      expect(mocks.listDeepAnalysisReports).toHaveBeenCalledWith("space-1", 20, 0);
-      expect(mocks.getDeepAnalysisReport).toHaveBeenCalledWith("space-1", "dar_1");
+      expect(mocks.listDeepAnalysisReports).toHaveBeenCalledWith(
+        "space-1",
+        20,
+        0,
+        expect.any(AbortSignal),
+      );
+      expect(mocks.getDeepAnalysisReport).toHaveBeenCalledWith(
+        "space-1",
+        "dar_1",
+        expect.any(AbortSignal),
+      );
     });
   });
 

--- a/dashboard/app/src/api/deep-analysis-queries.ts
+++ b/dashboard/app/src/api/deep-analysis-queries.ts
@@ -44,7 +44,8 @@ export function useDeepAnalysisReports(spaceId: string, active: boolean) {
 
   const listQuery = useQuery({
     queryKey: getDeepAnalysisReportsQueryKey(spaceId),
-    queryFn: () => analysisApi.listDeepAnalysisReports(spaceId, 20, 0),
+    queryFn: ({ signal }) =>
+      analysisApi.listDeepAnalysisReports(spaceId, 20, 0, signal),
     enabled: !!spaceId && active,
     refetchInterval: (query) => {
       if (!active) return false;
@@ -68,7 +69,8 @@ export function useDeepAnalysisReports(spaceId: string, active: boolean) {
 
   const detailQuery = useQuery({
     queryKey: getDeepAnalysisReportDetailQueryKey(spaceId, selectedReportId),
-    queryFn: () => analysisApi.getDeepAnalysisReport(spaceId, selectedReportId!),
+    queryFn: ({ signal }) =>
+      analysisApi.getDeepAnalysisReport(spaceId, selectedReportId!, signal),
     enabled: !!spaceId && !!selectedReportId && active,
     refetchInterval: (query) => {
       if (!active) return false;

--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -53,6 +53,32 @@ describe("httpProvider", () => {
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
+  it("passes cancellation to memory list requests", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          memories: [],
+          total: 0,
+          limit: 50,
+          offset: 0,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await httpProvider.listMemories(
+      "space-1",
+      { limit: 50, offset: 0 },
+      controller.signal,
+    );
+
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+  });
+
   it("posts manual creates to /memories with explicit pinned memory_type", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -90,6 +90,7 @@ async function listMemoriesPage(
   apiKey: string,
   params: MemoryListParams,
   cacheResult: boolean,
+  signal?: AbortSignal,
 ): Promise<MemoryListResponse> {
   const qs = new URLSearchParams();
   if (params.q) qs.set("q", params.q);
@@ -104,6 +105,7 @@ async function listMemoriesPage(
   const response = await request<MemoryListResponse>(
     apiKey,
     `/memories?${qs}`,
+    { signal },
   );
   const normalized = normalizeMemoryListResponse(response);
   if (cacheResult) {
@@ -222,9 +224,11 @@ async function requestRaw(
 }
 
 export const httpProvider: DashboardProvider = {
-  async verifySpace(apiKey: string): Promise<SpaceInfo> {
+  async verifySpace(apiKey: string, signal?: AbortSignal): Promise<SpaceInfo> {
     const id = apiKey.trim();
-    const res = await request<MemoryListResponse>(id, "/memories?limit=1");
+    const res = await request<MemoryListResponse>(id, "/memories?limit=1", {
+      signal,
+    });
     return {
       tenant_id: id,
       name: id,
@@ -238,13 +242,15 @@ export const httpProvider: DashboardProvider = {
   async listMemories(
     apiKey: string,
     params: MemoryListParams = {},
+    signal?: AbortSignal,
   ): Promise<MemoryListResponse> {
-    return listMemoriesPage(apiKey, params, true);
+    return listMemoriesPage(apiKey, params, true, signal);
   },
 
   async listSessionMessages(
     apiKey: string,
     params: SessionMessageListParams,
+    signal?: AbortSignal,
   ): Promise<SessionMessageListResponse> {
     const sessionIDs = Array.from(
       new Set(
@@ -269,6 +275,7 @@ export const httpProvider: DashboardProvider = {
     const url = `${API_BASE}/session-messages?${qs}`;
     const res = await fetch(url, {
       headers: buildHeaders(apiKey),
+      signal,
     });
 
     if (res.status === 404 || res.status === 405 || res.status === 501) {
@@ -286,6 +293,7 @@ export const httpProvider: DashboardProvider = {
   async getStats(
     apiKey: string,
     params?: TimeRangeParams,
+    signal?: AbortSignal,
   ): Promise<MemoryStats> {
     const qs = new URLSearchParams({ limit: "1" });
     if (params?.updated_from) qs.set("updated_from", params.updated_from);
@@ -297,9 +305,9 @@ export const httpProvider: DashboardProvider = {
     qsInsight.set("memory_type", "insight");
 
     const [all, pinned, insight] = await Promise.all([
-      request<MemoryListResponse>(apiKey, `/memories?${qs}`),
-      request<MemoryListResponse>(apiKey, `/memories?${qsPinned}`),
-      request<MemoryListResponse>(apiKey, `/memories?${qsInsight}`),
+      request<MemoryListResponse>(apiKey, `/memories?${qs}`, { signal }),
+      request<MemoryListResponse>(apiKey, `/memories?${qsPinned}`, { signal }),
+      request<MemoryListResponse>(apiKey, `/memories?${qsInsight}`, { signal }),
     ]);
     return {
       total: all.total,
@@ -308,10 +316,15 @@ export const httpProvider: DashboardProvider = {
     };
   },
 
-  async getMemory(apiKey: string, memoryId: string): Promise<Memory> {
+  async getMemory(
+    apiKey: string,
+    memoryId: string,
+    signal?: AbortSignal,
+  ): Promise<Memory> {
     const response = await request<Memory>(
       apiKey,
       `/memories/${memoryId}`,
+      { signal },
     );
     const normalized = normalizeMemory(response);
     void upsertCachedMemories(apiKey, [normalized]);
@@ -430,12 +443,16 @@ export const httpProvider: DashboardProvider = {
   async getImportTask(
     apiKey: string,
     taskId: string,
+    signal?: AbortSignal,
   ): Promise<ImportTask> {
-    return request<ImportTask>(apiKey, `/imports/${taskId}`);
+    return request<ImportTask>(apiKey, `/imports/${taskId}`, { signal });
   },
 
-  async listImportTasks(apiKey: string): Promise<ImportTaskList> {
-    const tasks = await request<ImportTask[]>(apiKey, "/imports");
+  async listImportTasks(
+    apiKey: string,
+    signal?: AbortSignal,
+  ): Promise<ImportTaskList> {
+    const tasks = await request<ImportTask[]>(apiKey, "/imports", { signal });
     if (!tasks || tasks.length === 0) {
       return { tasks: [], status: "empty" };
     }
@@ -456,11 +473,14 @@ export const httpProvider: DashboardProvider = {
   async getTopicSummary(
     apiKey: string,
     params?: TimeRangeParams,
+    signal?: AbortSignal,
   ): Promise<TopicSummary> {
     const qs = new URLSearchParams();
     if (params?.updated_from) qs.set("updated_from", params.updated_from);
     if (params?.updated_to) qs.set("updated_to", params.updated_to);
-    const response = await request<unknown>(apiKey, `/summary?${qs}`);
+    const response = await request<unknown>(apiKey, `/summary?${qs}`, {
+      signal,
+    });
     return normalizeTopicSummary(response);
   },
 };

--- a/dashboard/app/src/api/provider.ts
+++ b/dashboard/app/src/api/provider.ts
@@ -14,17 +14,27 @@ import type { TimeRangeParams } from "@/types/time-range";
 import type { ImportTask, ImportTaskList } from "@/types/import";
 
 export interface DashboardProvider {
-  verifySpace(apiKey: string): Promise<SpaceInfo>;
+  verifySpace(apiKey: string, signal?: AbortSignal): Promise<SpaceInfo>;
   listMemories(
     apiKey: string,
     params: MemoryListParams,
+    signal?: AbortSignal,
   ): Promise<MemoryListResponse>;
   listSessionMessages(
     apiKey: string,
     params: SessionMessageListParams,
+    signal?: AbortSignal,
   ): Promise<SessionMessageListResponse>;
-  getStats(apiKey: string, params?: TimeRangeParams): Promise<MemoryStats>;
-  getMemory(apiKey: string, memoryId: string): Promise<Memory>;
+  getStats(
+    apiKey: string,
+    params?: TimeRangeParams,
+    signal?: AbortSignal,
+  ): Promise<MemoryStats>;
+  getMemory(
+    apiKey: string,
+    memoryId: string,
+    signal?: AbortSignal,
+  ): Promise<Memory>;
   createMemory(apiKey: string, input: MemoryCreateInput): Promise<Memory>;
   updateMemory(
     apiKey: string,
@@ -35,10 +45,15 @@ export interface DashboardProvider {
   deleteMemory(apiKey: string, memoryId: string): Promise<void>;
   exportMemories(apiKey: string): Promise<Blob>;
   importMemories(apiKey: string, file: File): Promise<ImportTask>;
-  getImportTask(apiKey: string, taskId: string): Promise<ImportTask>;
-  listImportTasks(apiKey: string): Promise<ImportTaskList>;
+  getImportTask(
+    apiKey: string,
+    taskId: string,
+    signal?: AbortSignal,
+  ): Promise<ImportTask>;
+  listImportTasks(apiKey: string, signal?: AbortSignal): Promise<ImportTaskList>;
   getTopicSummary(
     apiKey: string,
     params?: TimeRangeParams,
+    signal?: AbortSignal,
   ): Promise<TopicSummary>;
 }

--- a/dashboard/app/src/api/queries.test.ts
+++ b/dashboard/app/src/api/queries.test.ts
@@ -4,7 +4,9 @@ import type { Memory, SessionMessage } from "@/types/memory";
 const mocks = vi.hoisted(() => ({
   useQuery: vi.fn((options: unknown) => options),
   useMutation: vi.fn((options: unknown) => options),
+  useInfiniteQuery: vi.fn((options: unknown) => options),
   invalidateQueries: vi.fn(),
+  listMemories: vi.fn(),
   listSessionMessages: vi.fn(),
   exportMemories: vi.fn(),
 }));
@@ -18,6 +20,7 @@ vi.mock("@tanstack/react-query", async () => {
     ...actual,
     useQuery: (options: unknown) => mocks.useQuery(options),
     useMutation: (options: unknown) => mocks.useMutation(options),
+    useInfiniteQuery: (options: unknown) => mocks.useInfiniteQuery(options),
     useQueryClient: () => ({
       invalidateQueries: mocks.invalidateQueries,
     }),
@@ -26,6 +29,7 @@ vi.mock("@tanstack/react-query", async () => {
 
 vi.mock("./client", () => ({
   api: {
+    listMemories: (...args: unknown[]) => mocks.listMemories(...args),
     listSessionMessages: (...args: unknown[]) => mocks.listSessionMessages(...args),
     exportMemories: (...args: unknown[]) => mocks.exportMemories(...args),
   },
@@ -132,7 +136,7 @@ describe("useSelectedSessionMessages", () => {
       enabled: boolean;
       retry: number;
       queryKey: string[];
-      queryFn: () => Promise<SessionMessage[]>;
+      queryFn: (context: { signal: AbortSignal }) => Promise<SessionMessage[]>;
     };
 
     expect(mocks.useQuery).toHaveBeenCalledTimes(1);
@@ -142,11 +146,16 @@ describe("useSelectedSessionMessages", () => {
       queryKey: ["space", "space-1", "sessionMessages", "sess-1"],
     });
 
-    const messages = await options.queryFn();
+    const controller = new AbortController();
+    const messages = await options.queryFn({ signal: controller.signal });
 
-    expect(mocks.listSessionMessages).toHaveBeenCalledWith("space-1", {
-      session_ids: ["sess-1"],
-    });
+    expect(mocks.listSessionMessages).toHaveBeenCalledWith(
+      "space-1",
+      {
+        session_ids: ["sess-1"],
+      },
+      controller.signal,
+    );
     expect(messages).toEqual([createMessage("msg-1", "2026-03-19T00:00:00Z", 1)]);
   });
 
@@ -188,5 +197,38 @@ describe("useExportMemories", () => {
 
     expect(mocks.exportMemories).toHaveBeenCalledWith("space-1");
     expect(mocks.invalidateQueries).not.toHaveBeenCalled();
+  });
+});
+
+describe("useMemories", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("passes query cancellation to the memory provider", async () => {
+    mocks.listMemories.mockResolvedValue({
+      memories: [],
+      total: 0,
+      limit: 50,
+      offset: 0,
+    });
+
+    const { useMemories } = await importQueriesModule();
+    const options = useMemories("space-1", {}) as unknown as {
+      queryFn: (context: {
+        pageParam: number;
+        signal: AbortSignal;
+      }) => Promise<unknown>;
+    };
+    const controller = new AbortController();
+
+    await options.queryFn({ pageParam: 0, signal: controller.signal });
+
+    expect(mocks.listMemories).toHaveBeenCalledWith(
+      "space-1",
+      expect.objectContaining({ limit: 50, offset: 0 }),
+      controller.signal,
+    );
   });
 });

--- a/dashboard/app/src/api/queries.ts
+++ b/dashboard/app/src/api/queries.ts
@@ -55,7 +55,7 @@ export function useStats(
   const timeParams = range ? presetToParams(range) : undefined;
   return useQuery({
     queryKey: ["space", spaceId, "stats", range ?? "all"],
-    queryFn: () => api.getStats(spaceId, timeParams),
+    queryFn: ({ signal }) => api.getStats(spaceId, timeParams, signal),
     enabled: !!spaceId && enabled,
     placeholderData: keepPreviousData,
   });
@@ -74,16 +74,20 @@ export function useMemories(
   const timeParams = params.range ? presetToParams(params.range) : {};
   return useInfiniteQuery({
     queryKey: ["space", spaceId, "memories", params],
-    queryFn: ({ pageParam }) =>
-      api.listMemories(spaceId, {
-        q: params.q,
-        tags: params.tag ? [params.tag] : undefined,
-        memory_type: params.memory_type,
-        facet: params.facet,
-        ...timeParams,
-        limit: PAGE_SIZE,
-        offset: pageParam,
-      }),
+    queryFn: ({ pageParam, signal }) =>
+      api.listMemories(
+        spaceId,
+        {
+          q: params.q,
+          tags: params.tag ? [params.tag] : undefined,
+          memory_type: params.memory_type,
+          facet: params.facet,
+          ...timeParams,
+          limit: PAGE_SIZE,
+          offset: pageParam,
+        },
+        signal,
+      ),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       const next = lastPage.offset + lastPage.limit;
@@ -108,10 +112,14 @@ export function useSelectedSessionMessages(
 
   return useQuery({
     queryKey: ["space", spaceId, "sessionMessages", sessionID],
-    queryFn: async () => {
-      const response = await api.listSessionMessages(spaceId, {
-        session_ids: [sessionID],
-      });
+    queryFn: async ({ signal }) => {
+      const response = await api.listSessionMessages(
+        spaceId,
+        {
+          session_ids: [sessionID],
+        },
+        signal,
+      );
       return sortSessionMessages(
         response.messages.filter((message) => message.session_id === sessionID),
       );
@@ -124,7 +132,7 @@ export function useSelectedSessionMessages(
 export function useMemory(spaceId: string, memoryId: string | null) {
   return useQuery({
     queryKey: ["space", spaceId, "memory", memoryId],
-    queryFn: () => api.getMemory(spaceId, memoryId!),
+    queryFn: ({ signal }) => api.getMemory(spaceId, memoryId!, signal),
     enabled: !!spaceId && !!memoryId,
   });
 }
@@ -137,7 +145,7 @@ export function useTopicSummary(
   const timeParams = range ? presetToParams(range) : undefined;
   return useQuery({
     queryKey: ["space", spaceId, "topics", range ?? "all"],
-    queryFn: () => api.getTopicSummary(spaceId, timeParams),
+    queryFn: ({ signal }) => api.getTopicSummary(spaceId, timeParams, signal),
     enabled: !!spaceId && enabled,
     placeholderData: keepPreviousData,
   });
@@ -146,7 +154,7 @@ export function useTopicSummary(
 export function useImportTasks(spaceId: string, enabled = true) {
   return useQuery({
     queryKey: ["space", spaceId, "importTasks"],
-    queryFn: () => api.listImportTasks(spaceId),
+    queryFn: ({ signal }) => api.listImportTasks(spaceId, signal),
     enabled: !!spaceId && enabled,
     refetchInterval: (query) => {
       const data = query.state.data;
@@ -162,7 +170,7 @@ export function useImportTask(
 ) {
   return useQuery({
     queryKey: ["space", spaceId, "importTask", taskId],
-    queryFn: () => api.getImportTask(spaceId, taskId!),
+    queryFn: ({ signal }) => api.getImportTask(spaceId, taskId!, signal),
     enabled: !!spaceId && !!taskId,
     refetchInterval: (query) => {
       const status = query.state.data?.status;

--- a/dashboard/app/src/api/source-memories.test.ts
+++ b/dashboard/app/src/api/source-memories.test.ts
@@ -194,10 +194,15 @@ describe("loadSourceMemories", () => {
 
     const result = await sourceMemories.loadSourceMemories("space-1");
 
-    expect(api.listMemories).toHaveBeenNthCalledWith(2, "space-1", {
-      limit: sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.pageSize,
-      offset: 2,
-    });
+    expect(api.listMemories).toHaveBeenNthCalledWith(
+      2,
+      "space-1",
+      {
+        limit: sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.pageSize,
+        offset: 2,
+      },
+      undefined,
+    );
     expect(result).toHaveLength(3);
     expect(localCache.patchSyncState).toHaveBeenCalledWith(
       "space-1",
@@ -240,5 +245,44 @@ describe("useSourceMemories", () => {
     expect(localCache.readCachedMemories).not.toHaveBeenCalled();
     expect(localCache.readSyncState).not.toHaveBeenCalled();
     expect(api.listMemories).not.toHaveBeenCalled();
+  });
+
+  it("keeps concurrent sync requests bound to their own abort signals", async () => {
+    const { sourceMemories, api } = await importModules();
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+
+    vi.mocked(api.listMemories)
+      .mockResolvedValueOnce({
+        memories: [createMemory("first")],
+        total: 1,
+        limit: 200,
+        offset: 0,
+      })
+      .mockResolvedValueOnce({
+        memories: [createMemory("second")],
+        total: 1,
+        limit: 200,
+        offset: 0,
+      });
+
+    await Promise.all([
+      sourceMemories.syncAllMemories("space-1", firstController.signal),
+      sourceMemories.syncAllMemories("space-1", secondController.signal),
+    ]);
+
+    expect(api.listMemories).toHaveBeenCalledTimes(2);
+    expect(api.listMemories).toHaveBeenNthCalledWith(
+      1,
+      "space-1",
+      { limit: 200, offset: 0 },
+      firstController.signal,
+    );
+    expect(api.listMemories).toHaveBeenNthCalledWith(
+      2,
+      "space-1",
+      { limit: 200, offset: 0 },
+      secondController.signal,
+    );
   });
 });

--- a/dashboard/app/src/api/source-memories.ts
+++ b/dashboard/app/src/api/source-memories.ts
@@ -15,76 +15,68 @@ export const SOURCE_MEMORY_SYNC_BUDGET = {
   maxPages: 5,
   maxRecords: 1_000,
 } as const;
-const activeSyncs = new Map<string, Promise<Memory[]>>();
 
 export function getSourceMemoriesQueryKey(spaceId: string): string[] {
   return ["space", spaceId, "sourceMemories"];
 }
 
-export async function syncAllMemories(spaceId: string): Promise<Memory[]> {
-  const existing = activeSyncs.get(spaceId);
-  if (existing) {
-    return existing;
-  }
+export async function syncAllMemories(
+  spaceId: string,
+  signal?: AbortSignal,
+): Promise<Memory[]> {
+  const all: Memory[] = [];
+  let offset = 0;
+  let total = Number.POSITIVE_INFINITY;
+  let pagesFetched = 0;
 
-  const syncRun = (async () => {
-    const all: Memory[] = [];
-    let offset = 0;
-    let total = Number.POSITIVE_INFINITY;
-    let pagesFetched = 0;
-
-    while (
-      offset < total &&
-      pagesFetched < SOURCE_MEMORY_SYNC_BUDGET.maxPages &&
-      all.length < SOURCE_MEMORY_SYNC_BUDGET.maxRecords
-    ) {
-      const limit = Math.min(
-        SOURCE_MEMORY_SYNC_BUDGET.pageSize,
-        SOURCE_MEMORY_SYNC_BUDGET.maxRecords - all.length,
-      );
-      const page = await api.listMemories(spaceId, {
+  while (
+    offset < total &&
+    pagesFetched < SOURCE_MEMORY_SYNC_BUDGET.maxPages &&
+    all.length < SOURCE_MEMORY_SYNC_BUDGET.maxRecords
+  ) {
+    const limit = Math.min(
+      SOURCE_MEMORY_SYNC_BUDGET.pageSize,
+      SOURCE_MEMORY_SYNC_BUDGET.maxRecords - all.length,
+    );
+    const page = await api.listMemories(
+      spaceId,
+      {
         limit,
         offset,
-      });
-      all.push(
-        ...page.memories.slice(
-          0,
-          SOURCE_MEMORY_SYNC_BUDGET.maxRecords - all.length,
-        ),
-      );
-      total = page.total;
-      pagesFetched += 1;
-      offset += page.memories.length;
+      },
+      signal,
+    );
+    all.push(
+      ...page.memories.slice(
+        0,
+        SOURCE_MEMORY_SYNC_BUDGET.maxRecords - all.length,
+      ),
+    );
+    total = page.total;
+    pagesFetched += 1;
+    offset += page.memories.length;
 
-      if (page.memories.length === 0) {
-        break;
-      }
-    }
-
-    const hasFullCache = all.length >= total;
-    await clearCachedMemoriesForSpace(spaceId);
-    await upsertCachedMemories(spaceId, all);
-    await patchSyncState(spaceId, {
-      hasFullCache,
-      lastSyncedAt: new Date().toISOString(),
-      incrementalCursor: null,
-    });
-
-    return sortMemoriesByCreatedAtDesc(all);
-  })();
-
-  activeSyncs.set(spaceId, syncRun);
-
-  try {
-    return await syncRun;
-  } finally {
-    if (activeSyncs.get(spaceId) === syncRun) {
-      activeSyncs.delete(spaceId);
+    if (page.memories.length === 0) {
+      break;
     }
   }
+
+  const hasFullCache = all.length >= total;
+  await clearCachedMemoriesForSpace(spaceId);
+  await upsertCachedMemories(spaceId, all);
+  await patchSyncState(spaceId, {
+    hasFullCache,
+    lastSyncedAt: new Date().toISOString(),
+    incrementalCursor: null,
+  });
+
+  return sortMemoriesByCreatedAtDesc(all);
 }
 
-export async function loadSourceMemories(spaceId: string): Promise<Memory[]> {
+export async function loadSourceMemories(
+  spaceId: string,
+  signal?: AbortSignal,
+): Promise<Memory[]> {
   const [cached, syncState] = await Promise.all([
     readCachedMemories(spaceId),
     readSyncState(spaceId),
@@ -94,7 +86,7 @@ export async function loadSourceMemories(spaceId: string): Promise<Memory[]> {
     return sortMemoriesByCreatedAtDesc(cached);
   }
 
-  return syncAllMemories(spaceId);
+  return syncAllMemories(spaceId, signal);
 }
 
 export function useSourceMemories(
@@ -109,7 +101,7 @@ export function useSourceMemories(
 ) {
   return useQuery({
     queryKey: [...getSourceMemoriesQueryKey(spaceId), refreshToken],
-    queryFn: () => loadSourceMemories(spaceId),
+    queryFn: ({ signal }) => loadSourceMemories(spaceId, signal),
     enabled: enabled && !!spaceId,
     staleTime: 30_000,
     retry: 1,

--- a/dashboard/app/src/components/space/memory-card.test.tsx
+++ b/dashboard/app/src/components/space/memory-card.test.tsx
@@ -57,4 +57,26 @@ describe("MemoryCard", () => {
 
     expect(screen.queryByText("From a conversation")).not.toBeInTheDocument();
   });
+
+  it("keeps large memory content out of the list DOM", () => {
+    const memory = createMemory("");
+    memory.content = "x".repeat(2_000);
+
+    render(
+      <MemoryCard
+        memory={memory}
+        derivedTags={[]}
+        hasLinkedSession={false}
+        isSelected={false}
+        onClick={vi.fn()}
+        onDelete={vi.fn()}
+        t={i18n.t}
+        delay={0}
+      />,
+    );
+
+    const preview = screen.getByText(/^x+…$/);
+    expect(preview.textContent).toHaveLength(601);
+    expect(screen.queryByText(memory.content)).not.toBeInTheDocument();
+  });
 });

--- a/dashboard/app/src/components/space/memory-card.tsx
+++ b/dashboard/app/src/components/space/memory-card.tsx
@@ -6,6 +6,8 @@ import type { Memory, MemoryFacet } from "@/types/memory";
 import { FacetBadge } from "./topic-strip";
 import { features } from "@/config/features";
 
+const MEMORY_PREVIEW_MAX_LENGTH = 600;
+
 export const MemoryCard = ({
   memory: m,
   derivedTags = [],
@@ -27,6 +29,10 @@ export const MemoryCard = ({
 }) => {
   const isPinned = m.memory_type === "pinned";
   const tags = m.tags ?? [];
+  const contentPreview =
+    m.content.length > MEMORY_PREVIEW_MAX_LENGTH
+      ? `${m.content.slice(0, MEMORY_PREVIEW_MAX_LENGTH)}…`
+      : m.content;
   const facet = features.enableFacet
     ? ((m.metadata as Record<string, unknown> | null)?.facet as
         | MemoryFacet
@@ -77,7 +83,7 @@ export const MemoryCard = ({
 
         <div className="min-w-0 flex-1">
           <p className="line-clamp-3 text-sm leading-relaxed text-foreground/90 font-medium">
-            {m.content}
+            {contentPreview}
           </p>
           {hasLinkedSession && (
             <div className="mt-3">

--- a/dashboard/app/src/components/space/space-page-layout.tsx
+++ b/dashboard/app/src/components/space/space-page-layout.tsx
@@ -1,4 +1,12 @@
-import { useState, type Dispatch, type SetStateAction } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import {
   Search,
   BarChart3,
@@ -107,6 +115,9 @@ export const SpacePageLayout = ({
   onHandleFarmAction,
 }: SpacePageLayoutProps) => {
   const [activeOverviewTab, setActiveOverviewTab] = useState<MemoryInsightTab>("profile");
+  const [memoryListScrollMargin, setMemoryListScrollMargin] = useState(0);
+  const memoryListLayoutRef = useRef<HTMLDivElement>(null);
+  const memoryRowsRef = useRef<HTMLDivElement>(null);
   const isMemoryListTab = activeOverviewTab === "pulse";
   const supportsMemoryDetail = isMemoryListTab || activeOverviewTab === "insight";
   const selectedMemoryForDetail = supportsMemoryDetail ? routeState.selected : null;
@@ -132,6 +143,61 @@ export const SpacePageLayout = ({
     features.enableAnalysis,
     showSelectedMemoryDetail,
   );
+  const getMemoryKey = useCallback(
+    (index: number) => dataModel.displayedMemories[index]?.id ?? index,
+    [dataModel.displayedMemories],
+  );
+  const memoryListVirtualizer = useWindowVirtualizer({
+    count: isMemoryListTab ? dataModel.displayedMemories.length : 0,
+    enabled: isMemoryListTab,
+    estimateSize: () => 220,
+    getItemKey: getMemoryKey,
+    initialRect: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    },
+    measureElement: (element) =>
+      element.getBoundingClientRect().height || 220,
+    overscan: 5,
+    scrollMargin: memoryListScrollMargin,
+  });
+
+  useLayoutEffect(() => {
+    if (!isMemoryListTab) {
+      return;
+    }
+
+    const updateScrollMargin = () => {
+      const nextMargin =
+        (memoryRowsRef.current?.getBoundingClientRect().top ?? 0) +
+        window.scrollY;
+      setMemoryListScrollMargin((current) =>
+        current === nextMargin ? current : nextMargin,
+      );
+    };
+
+    updateScrollMargin();
+    window.addEventListener("resize", updateScrollMargin);
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateScrollMargin);
+    if (memoryListLayoutRef.current) {
+      resizeObserver?.observe(memoryListLayoutRef.current);
+    }
+    if (memoryRowsRef.current) {
+      resizeObserver?.observe(memoryRowsRef.current);
+    }
+
+    return () => {
+      window.removeEventListener("resize", updateScrollMargin);
+      resizeObserver?.disconnect();
+    };
+  }, [
+    dataModel.displayedMemories.length,
+    dataModel.isMemoryLoading,
+    isMemoryListTab,
+  ]);
 
   return (
     <div className="min-h-screen">
@@ -170,7 +236,11 @@ export const SpacePageLayout = ({
 
       <div className={`mx-auto px-6 ${pageShellClass}`}>
         <div className="flex flex-col gap-8 xl:flex-row">
-          <div className="min-w-0 flex-1 py-8 xl:order-2">
+          <div
+            ref={memoryListLayoutRef}
+            data-testid="memory-list-layout"
+            className="min-w-0 flex-1 py-8 xl:order-2"
+          >
             {dataModel.stats && (
               <div
                 style={{
@@ -492,26 +562,61 @@ export const SpacePageLayout = ({
                   </p>
                 </div>
               ) : (
-                <div className="space-y-3">
+                <div>
                   {dataModel.isMemoryLoading && (
                     <div className="flex items-center gap-2 rounded-xl bg-secondary/55 px-3 py-3 text-sm text-muted-foreground">
                       <Loader2 className="size-4 animate-spin" />
                       {t("list.loading")}
                     </div>
                   )}
-                  {dataModel.displayedMemories.map((memory, index) => (
-                    <MemoryCard
-                      key={memory.id}
-                      memory={memory}
-                      derivedTags={dataModel.getActiveDerivedTags(memory)}
-                      hasLinkedSession={memory.session_id.trim() !== ""}
-                      isSelected={routeState.selected?.id === memory.id}
-                      onClick={() => routeState.openMemoryDetail(memory, "list")}
-                      onDelete={() => setDeleteTarget(memory)}
-                      t={t}
-                      delay={index < dataModel.displayedFirstPageSize ? index * 30 : 0}
-                    />
-                  ))}
+                  <div
+                    ref={memoryRowsRef}
+                    data-testid="memory-list-rows"
+                    style={{
+                      height: `${memoryListVirtualizer.getTotalSize()}px`,
+                      position: "relative",
+                    }}
+                  >
+                    {memoryListVirtualizer.getVirtualItems().map((virtualRow) => {
+                      const memory =
+                        dataModel.displayedMemories[virtualRow.index];
+                      if (!memory) {
+                        return null;
+                      }
+
+                      return (
+                        <div
+                          key={memory.id}
+                          data-index={virtualRow.index}
+                          ref={memoryListVirtualizer.measureElement}
+                          className="absolute left-0 top-0 w-full pb-3"
+                          style={{
+                            transform: `translateY(${
+                              virtualRow.start - memoryListScrollMargin
+                            }px)`,
+                          }}
+                        >
+                          <MemoryCard
+                            memory={memory}
+                            derivedTags={dataModel.getActiveDerivedTags(memory)}
+                            hasLinkedSession={memory.session_id.trim() !== ""}
+                            isSelected={routeState.selected?.id === memory.id}
+                            onClick={() =>
+                              routeState.openMemoryDetail(memory, "list")
+                            }
+                            onDelete={() => setDeleteTarget(memory)}
+                            t={t}
+                            delay={
+                              virtualRow.index <
+                              dataModel.displayedFirstPageSize
+                                ? virtualRow.index * 30
+                                : 0
+                            }
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
                   {dataModel.hasMoreMemories && (
                     <div className="py-4 text-center">
                       <Button

--- a/dashboard/app/src/lib/pixel-farm/use-pixel-farm-npc-dialog-content.test.tsx
+++ b/dashboard/app/src/lib/pixel-farm/use-pixel-farm-npc-dialog-content.test.tsx
@@ -120,6 +120,18 @@ describe("use-pixel-farm-npc-dialog-content", () => {
     await waitFor(() => {
       expect(result.current.catalog.deepInsights.length).toBeGreaterThan(0);
     });
+
+    expect(analysisApi.listDeepAnalysisReports).toHaveBeenCalledWith(
+      "space-1",
+      20,
+      0,
+      expect.any(AbortSignal),
+    );
+    expect(analysisApi.getDeepAnalysisReport).toHaveBeenCalledWith(
+      "space-1",
+      "dar_1",
+      expect.any(AbortSignal),
+    );
   });
 
   it("keeps tips available when no analysis source exists", async () => {

--- a/dashboard/app/src/lib/pixel-farm/use-pixel-farm-npc-dialog-content.ts
+++ b/dashboard/app/src/lib/pixel-farm/use-pixel-farm-npc-dialog-content.ts
@@ -45,7 +45,8 @@ export function usePixelFarmNpcDialogContent(
 
   const reportListQuery = useQuery({
     queryKey: ["space", spaceId, "pixelFarm", "npcDialog", "deepList"],
-    queryFn: () => analysisApi.listDeepAnalysisReports(spaceId, 20, 0),
+    queryFn: ({ signal }) =>
+      analysisApi.listDeepAnalysisReports(spaceId, 20, 0, signal),
     enabled: !!spaceId,
     staleTime: 60_000,
     retry: false,
@@ -65,7 +66,12 @@ export function usePixelFarmNpcDialogContent(
       "deepDetail",
       latestCompletedReport?.id ?? null,
     ],
-    queryFn: () => analysisApi.getDeepAnalysisReport(spaceId, latestCompletedReport!.id),
+    queryFn: ({ signal }) =>
+      analysisApi.getDeepAnalysisReport(
+        spaceId,
+        latestCompletedReport!.id,
+        signal,
+      ),
     enabled: !!spaceId && !!latestCompletedReport,
     staleTime: 60_000,
     retry: false,

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -612,6 +612,7 @@ describe("SpacePage", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("does not compact the overview when an insight memory opens in a sheet", () => {
@@ -705,6 +706,62 @@ describe("SpacePage", () => {
         document.querySelector('[data-mp-event="Dashboard/Detail/DeleteClicked"]'),
       ).toBeNull();
     });
+  });
+
+  it("keeps the memory list DOM bounded as loaded pages grow", async () => {
+    mockedPageMemories = Array.from({ length: 500 }, (_, index) =>
+      createMemory(
+        `mem-virtual-${index}`,
+        `Virtualized memory ${index}`,
+        new Date(FIXED_NOW.getTime() - index * 60_000).toISOString(),
+      ),
+    );
+    mockedSourceMemories = [...mockedPageMemories];
+    renderSpacePage();
+
+    const listTab = screen.getByRole("tab", { name: "Memory List" });
+    listTab.focus();
+    fireEvent.keyDown(listTab, { key: "Enter" });
+
+    await waitFor(() => expect(listTab).toHaveAttribute("data-state", "active"));
+    await waitFor(() => {
+      expect(screen.queryAllByText(/^Virtualized memory \d+$/)).not.toHaveLength(0);
+    });
+
+    expect(screen.queryAllByText(/^Virtualized memory \d+$/).length).toBeLessThan(50);
+  });
+
+  it("recalculates the virtual list offset when its layout resizes", async () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        public constructor(_callback: ResizeObserverCallback) {}
+
+        public readonly observe = observe;
+        public readonly unobserve = vi.fn();
+        public readonly disconnect = disconnect;
+      },
+    );
+
+    const rendered = renderSpacePage();
+    const listTab = screen.getByRole("tab", { name: "Memory List" });
+    listTab.focus();
+    fireEvent.keyDown(listTab, { key: "Enter" });
+
+    await waitFor(() => expect(listTab).toHaveAttribute("data-state", "active"));
+    const layout = screen.getByTestId("memory-list-layout");
+    const rows = screen.getByTestId("memory-list-rows");
+
+    await waitFor(() => {
+      expect(observe).toHaveBeenCalledWith(layout);
+      expect(observe).toHaveBeenCalledWith(rows);
+    });
+
+    rendered.unmount();
+    expect(disconnect).toHaveBeenCalled();
   });
 
   it("filters memories by clicked analysis category without auto-opening detail", async () => {


### PR DESCRIPTION
## What Changed
- Virtualize loaded memory cards and cap list previews at 600 characters.
- Propagate cancellation through Your Memory read queries.
- Recompute virtual offsets on layout changes and isolate source-query signals.

## Why
Long sessions accumulated full-content DOM nodes and kept obsolete network work alive.

## Review Path
- `space-page-layout.tsx`
- `memory-card.tsx`
- Provider, query, and source layers
- `@tanstack/react-virtual`

## Validation
- Focused API, preview, and virtualization tests
- `pnpm typecheck`
- `pnpm build`
- Full suite: 259/276 pass; the remaining 17 `space.test.tsx` failures exactly match the `main` baseline
