### PR TITLE
fix(dashboard): bound memory export buffering

### DIFF
--- a/dashboard/app/src/api/provider-http.test.ts
+++ b/dashboard/app/src/api/provider-http.test.ts
@@ -8,8 +8,18 @@ vi.mock("./local-cache", () => ({
   upsertCachedMemories: vi.fn().mockResolvedValue(undefined),
 }));
 
+function readBlob(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => resolve(String(reader.result)));
+    reader.addEventListener("error", () => reject(reader.error));
+    reader.readAsText(blob);
+  });
+}
+
 describe("httpProvider", () => {
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -217,10 +227,20 @@ describe("httpProvider", () => {
     expect(result).toEqual({ messages: [] });
   });
 
-  it("exports more than 3000 pinned and insight memories", async () => {
+  it("exports large Unicode pages as Blob chunks without caching pages", async () => {
+    const NativeBlob = globalThis.Blob;
+    const constructedParts: BlobPart[][] = [];
+    class RecordingBlob extends NativeBlob {
+      constructor(parts: BlobPart[] = [], options?: BlobPropertyBag) {
+        super(parts, options);
+        constructedParts.push(parts);
+      }
+    }
+    vi.stubGlobal("Blob", RecordingBlob);
+
     const memories = Array.from({ length: 3001 }, (_, index) => ({
       id: `mem-${index}`,
-      content: `memory ${index}`,
+      content: `memory ${index} 中文记忆 🧠`,
       memory_type: index % 2 === 0 ? "pinned" : "insight",
       source: "agent",
       tags: [],
@@ -265,12 +285,26 @@ describe("httpProvider", () => {
         );
       });
 
-    const result = await httpProvider.exportMemories("space-1");
+    vi.mocked(upsertCachedMemories).mockClear();
 
+    const blob = await httpProvider.exportMemories("space-1");
+    const result = JSON.parse(await readBlob(blob)) as {
+      memories: Array<{ memory_type: string }>;
+    };
+
+    expect(blob.type).toBe("application/json");
     expect(result.memories).toHaveLength(3001);
+    expect(result.memories[3000]).toEqual(
+      expect.objectContaining({ content: "memory 3000 中文记忆 🧠" }),
+    );
     expect(new Set(result.memories.map((memory) => memory.memory_type))).toEqual(
       new Set(["pinned", "insight"]),
     );
+    const finalParts = constructedParts[constructedParts.length - 1] ?? [];
+    expect(
+      finalParts.filter((part) => part instanceof NativeBlob),
+    ).toHaveLength(16);
+    expect(upsertCachedMemories).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(16);
     for (const [url] of fetchMock.mock.calls) {
       expect(
@@ -279,5 +313,26 @@ describe("httpProvider", () => {
         ),
       ).toBe("pinned,insight");
     }
+  });
+
+  it("rejects an export when pagination stops before the declared total", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          memories: [],
+          total: 1,
+          limit: 200,
+          offset: 0,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await expect(httpProvider.exportMemories("space-1")).rejects.toThrow(
+      "Memory export ended before all records were received.",
+    );
   });
 });

--- a/dashboard/app/src/api/provider-http.ts
+++ b/dashboard/app/src/api/provider-http.ts
@@ -6,7 +6,7 @@ import type {
   MemoryCreateInput,
   MemoryUpdateInput,
   MemoryStats,
-  MemoryExportFile,
+  MemoryExportEntry,
   SessionMessage,
   SessionMessageListParams,
   SessionMessageListResponse,
@@ -83,6 +83,44 @@ function normalizeMemoryListResponse(
     total: response.total ?? 0,
     limit: response.limit ?? 0,
     offset: response.offset ?? 0,
+  };
+}
+
+async function listMemoriesPage(
+  apiKey: string,
+  params: MemoryListParams,
+  cacheResult: boolean,
+): Promise<MemoryListResponse> {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set("q", params.q);
+  if (params.tags?.length) qs.set("tags", params.tags.join(","));
+  if (params.memory_type) qs.set("memory_type", params.memory_type);
+  if (params.facet) qs.set("facet", params.facet);
+  if (params.updated_from) qs.set("updated_from", params.updated_from);
+  if (params.updated_to) qs.set("updated_to", params.updated_to);
+  qs.set("limit", String(params.limit ?? 50));
+  qs.set("offset", String(params.offset ?? 0));
+
+  const response = await request<MemoryListResponse>(
+    apiKey,
+    `/memories?${qs}`,
+  );
+  const normalized = normalizeMemoryListResponse(response);
+  if (cacheResult) {
+    void upsertCachedMemories(apiKey, normalized.memories);
+  }
+  return normalized;
+}
+
+function toExportEntry(memory: Memory): MemoryExportEntry {
+  return {
+    content: memory.content,
+    source: memory.source,
+    tags: memory.tags,
+    metadata: memory.metadata,
+    memory_type: memory.memory_type,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
   };
 }
 
@@ -201,22 +239,7 @@ export const httpProvider: DashboardProvider = {
     apiKey: string,
     params: MemoryListParams = {},
   ): Promise<MemoryListResponse> {
-    const qs = new URLSearchParams();
-    if (params.q) qs.set("q", params.q);
-    if (params.tags?.length) qs.set("tags", params.tags.join(","));
-    if (params.memory_type) qs.set("memory_type", params.memory_type);
-    if (params.facet) qs.set("facet", params.facet);
-    if (params.updated_from) qs.set("updated_from", params.updated_from);
-    if (params.updated_to) qs.set("updated_to", params.updated_to);
-    qs.set("limit", String(params.limit ?? 50));
-    qs.set("offset", String(params.offset ?? 0));
-    const response = await request<MemoryListResponse>(
-      apiKey,
-      `/memories?${qs}`,
-    );
-    const normalized = normalizeMemoryListResponse(response);
-    void upsertCachedMemories(apiKey, normalized.memories);
-    return normalized;
+    return listMemoriesPage(apiKey, params, true);
   },
 
   async listSessionMessages(
@@ -344,38 +367,51 @@ export const httpProvider: DashboardProvider = {
     await removeCachedMemory(apiKey, memoryId);
   },
 
-  async exportMemories(apiKey: string): Promise<MemoryExportFile> {
+  async exportMemories(apiKey: string): Promise<Blob> {
     const PAGE = 200;
-    const allMemories: Memory[] = [];
-    let offset = 0;
-    let total = Infinity;
-
-    while (offset < total) {
-      const page = await this.listMemories(apiKey, {
-        memory_type: "pinned,insight",
-        limit: PAGE,
-        offset,
-      });
-      allMemories.push(...page.memories);
-      total = page.total;
-      offset += PAGE;
-    }
-
-    return {
+    const header = JSON.stringify({
       schema_version: "mem9.memory_export.v1",
       exported_at: new Date().toISOString(),
       source_space_id: apiKey,
       agent_id: AGENT_ID,
-      memories: allMemories.map((m) => ({
-        content: m.content,
-        source: m.source,
-        tags: m.tags,
-        metadata: m.metadata,
-        memory_type: m.memory_type,
-        created_at: m.created_at,
-        updated_at: m.updated_at,
-      })),
-    };
+    });
+    const parts: BlobPart[] = [header.slice(0, -1), ',"memories":['];
+    let offset = 0;
+    let total = Infinity;
+    let hasMemories = false;
+
+    while (offset < total) {
+      const page = await listMemoriesPage(
+        apiKey,
+        {
+          memory_type: "pinned,insight",
+          limit: PAGE,
+          offset,
+        },
+        false,
+      );
+      total = page.total;
+      if (page.memories.length === 0) {
+        break;
+      }
+
+      const pageJSON = page.memories
+        .map((memory) => JSON.stringify(toExportEntry(memory)))
+        .join(",");
+      if (hasMemories) {
+        parts.push(",");
+      }
+      parts.push(new Blob([pageJSON], { type: "application/json" }));
+      hasMemories = true;
+      offset += page.memories.length;
+    }
+
+    if (offset < total) {
+      throw new Error("Memory export ended before all records were received.");
+    }
+
+    parts.push("]}");
+    return new Blob(parts, { type: "application/json" });
   },
 
   async importMemories(apiKey: string, file: File): Promise<ImportTask> {

--- a/dashboard/app/src/api/provider-mock.ts
+++ b/dashboard/app/src/api/provider-mock.ts
@@ -315,9 +315,9 @@ export const mockProvider: DashboardProvider = {
     await removeCachedMemory(apiKey, memoryId);
   },
 
-  async exportMemories(apiKey: string): Promise<MemoryExportFile> {
+  async exportMemories(apiKey: string): Promise<Blob> {
     await delay(500);
-    return {
+    const exportFile: MemoryExportFile = {
       schema_version: "mem9.memory_export.v1",
       exported_at: new Date().toISOString(),
       source_space_id: apiKey,
@@ -332,6 +332,9 @@ export const mockProvider: DashboardProvider = {
         updated_at: m.updated_at,
       })),
     };
+    return new Blob([JSON.stringify(exportFile)], {
+      type: "application/json",
+    });
   },
 
   async importMemories(

--- a/dashboard/app/src/api/provider.ts
+++ b/dashboard/app/src/api/provider.ts
@@ -5,7 +5,6 @@ import type {
   MemoryCreateInput,
   MemoryUpdateInput,
   MemoryStats,
-  MemoryExportFile,
   SessionMessageListParams,
   SessionMessageListResponse,
   SpaceInfo,
@@ -34,7 +33,7 @@ export interface DashboardProvider {
     version?: number,
   ): Promise<Memory>;
   deleteMemory(apiKey: string, memoryId: string): Promise<void>;
-  exportMemories(apiKey: string): Promise<MemoryExportFile>;
+  exportMemories(apiKey: string): Promise<Blob>;
   importMemories(apiKey: string, file: File): Promise<ImportTask>;
   getImportTask(apiKey: string, taskId: string): Promise<ImportTask>;
   listImportTasks(apiKey: string): Promise<ImportTaskList>;

--- a/dashboard/app/src/api/queries.test.ts
+++ b/dashboard/app/src/api/queries.test.ts
@@ -3,7 +3,10 @@ import type { Memory, SessionMessage } from "@/types/memory";
 
 const mocks = vi.hoisted(() => ({
   useQuery: vi.fn((options: unknown) => options),
+  useMutation: vi.fn((options: unknown) => options),
+  invalidateQueries: vi.fn(),
   listSessionMessages: vi.fn(),
+  exportMemories: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", async () => {
@@ -14,12 +17,17 @@ vi.mock("@tanstack/react-query", async () => {
   return {
     ...actual,
     useQuery: (options: unknown) => mocks.useQuery(options),
+    useMutation: (options: unknown) => mocks.useMutation(options),
+    useQueryClient: () => ({
+      invalidateQueries: mocks.invalidateQueries,
+    }),
   };
 });
 
 vi.mock("./client", () => ({
   api: {
     listSessionMessages: (...args: unknown[]) => mocks.listSessionMessages(...args),
+    exportMemories: (...args: unknown[]) => mocks.exportMemories(...args),
   },
 }));
 
@@ -156,5 +164,29 @@ describe("useSelectedSessionMessages", () => {
       retry: 1,
       queryKey: ["space", "space-1", "sessionMessages", ""],
     });
+  });
+});
+
+describe("useExportMemories", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it("exports without invalidating read-only space queries", async () => {
+    const blob = new Blob(["{}"], { type: "application/json" });
+    mocks.exportMemories.mockResolvedValue(blob);
+
+    const { useExportMemories } = await importQueriesModule();
+    const options = useExportMemories("space-1") as unknown as {
+      mutationFn: () => Promise<Blob>;
+      onSuccess?: () => void;
+    };
+
+    await expect(options.mutationFn()).resolves.toBe(blob);
+    options.onSuccess?.();
+
+    expect(mocks.exportMemories).toHaveBeenCalledWith("space-1");
+    expect(mocks.invalidateQueries).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/app/src/api/queries.ts
+++ b/dashboard/app/src/api/queries.ts
@@ -224,12 +224,8 @@ export function useUpdateMemory(spaceId: string) {
 }
 
 export function useExportMemories(spaceId: string) {
-  const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.exportMemories(spaceId),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["space", spaceId] });
-    },
   });
 }
 

--- a/dashboard/app/src/pages/space.tsx
+++ b/dashboard/app/src/pages/space.tsx
@@ -143,10 +143,7 @@ export function SpacePage() {
 
   const handleExport = async () => {
     try {
-      const exportFile = await dataModel.exportMutation.mutateAsync();
-      const blob = new Blob([JSON.stringify(exportFile, null, 2)], {
-        type: "application/json",
-      });
+      const blob = await dataModel.exportMutation.mutateAsync();
       const url = URL.createObjectURL(blob);
       const anchor = document.createElement("a");
       anchor.href = url;


### PR DESCRIPTION
## What Changed
- Build exports from per-page Blob chunks.
- Skip query-cache writes during export.
- Preserve query state and reject incomplete pagination.

## Why
Large exports previously held multiple full-space representations and refreshed unrelated queries.

## Review Path
- `provider-http.ts`
- `provider.ts`
- `queries.ts`
- `space.tsx`

## Validation
- 13/13 provider and query tests
- `pnpm typecheck`
- Combined-stack production build
