### PR TITLE
fix(dashboard): bound insight worker memory

### DIFF
--- a/dashboard/app/src/lib/memory-insight-background-hooks.test.tsx
+++ b/dashboard/app/src/lib/memory-insight-background-hooks.test.tsx
@@ -1,0 +1,437 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
+  EMPTY_MEMORY_INSIGHT_GRAPH,
+  EMPTY_MEMORY_INSIGHT_RELATION_GRAPH,
+  useBackgroundDerivedSignals,
+  useBackgroundMemoryInsightGraph,
+  useBackgroundMemoryInsightRelationGraph,
+} from "./memory-insight-background";
+import type { LocalDerivedSignalIndex } from "@/lib/memory-derived-signals";
+import type { Memory } from "@/types/memory";
+
+const mocks = vi.hoisted(() => ({
+  buildLocalDerivedSignalIndex: vi.fn(),
+  buildMemoryInsightGraph: vi.fn(),
+  buildMemoryInsightRelationGraph: vi.fn(),
+}));
+
+vi.mock("@/lib/memory-derived-signals", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/memory-derived-signals")>();
+
+  return {
+    ...actual,
+    buildLocalDerivedSignalIndex: mocks.buildLocalDerivedSignalIndex,
+  };
+});
+
+vi.mock("@/lib/memory-insight", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/memory-insight")>();
+
+  return {
+    ...actual,
+    buildMemoryInsightGraph: mocks.buildMemoryInsightGraph,
+  };
+});
+
+vi.mock("@/lib/memory-insight-relations", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/memory-insight-relations")>();
+
+  return {
+    ...actual,
+    buildMemoryInsightRelationGraph: mocks.buildMemoryInsightRelationGraph,
+  };
+});
+
+function createMemories(count: number): Memory[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `mem-${index}`,
+    content: `Memory ${index}`,
+    memory_type: "insight",
+    source: "agent",
+    tags: ["dashboard"],
+    metadata: {},
+    agent_id: "agent-1",
+    session_id: "session-1",
+    state: "active",
+    version: 1,
+    updated_by: "agent-1",
+    created_at: "2026-07-30T00:00:00Z",
+    updated_at: "2026-07-30T00:00:00Z",
+  }));
+}
+
+function createSignalIndex(value: string): LocalDerivedSignalIndex {
+  return {
+    derivedTagsByMemoryId: new Map(),
+    combinedTagsByMemoryId: new Map(),
+    tagStats: [
+      {
+        value,
+        normalizedValue: value,
+        count: 1,
+        origin: "derived",
+      },
+    ],
+    tagSourceByValue: new Map(),
+  };
+}
+
+class FailingWorker {
+  public static instances: FailingWorker[] = [];
+
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+  public onerror: ((event: ErrorEvent) => void) | null = null;
+  public readonly terminate = vi.fn();
+
+  public constructor() {
+    FailingWorker.instances.push(this);
+  }
+
+  public postMessage(): void {
+    queueMicrotask(() => {
+      this.onerror?.({ message: "worker failed" } as ErrorEvent);
+    });
+  }
+}
+
+class PendingWorker {
+  public static instances: PendingWorker[] = [];
+
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+  public onerror: ((event: ErrorEvent) => void) | null = null;
+  public readonly terminate = vi.fn();
+
+  public constructor() {
+    PendingWorker.instances.push(this);
+  }
+
+  public postMessage(): void {}
+}
+
+class ControlledWorker {
+  public static instances: ControlledWorker[] = [];
+
+  public onmessage: ((event: MessageEvent) => void) | null = null;
+  public onerror: ((event: ErrorEvent) => void) | null = null;
+  public readonly terminate = vi.fn(() => {
+    this.onmessage = null;
+    this.onerror = null;
+  });
+  private requestID: number | null = null;
+
+  public constructor() {
+    ControlledWorker.instances.push(this);
+  }
+
+  public postMessage(message: { id?: number }): void {
+    if (typeof message.id === "number") {
+      this.requestID = message.id;
+    }
+  }
+
+  public complete(result: LocalDerivedSignalIndex): void {
+    if (this.requestID === null) {
+      throw new Error("Worker request is missing");
+    }
+
+    this.onmessage?.({
+      data: {
+        id: this.requestID,
+        ok: true,
+        result,
+      },
+    } as MessageEvent);
+  }
+}
+
+class ConstructorFailingWorker {
+  public constructor() {
+    throw new Error("worker unavailable");
+  }
+}
+
+describe("background insight computations", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    ControlledWorker.instances = [];
+    FailingWorker.instances = [];
+    PendingWorker.instances = [];
+  });
+
+  it("returns the stable empty result without scanning memories when disabled", () => {
+    const memories = createMemories(500);
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useBackgroundDerivedSignals({
+          memories,
+          matchMap: new Map(),
+          enabled,
+        }),
+      {
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(result.current).toEqual({
+      data: EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
+      isComputing: false,
+    });
+    expect(result.current.data).toBe(EMPTY_LOCAL_DERIVED_SIGNAL_INDEX);
+    expect(mocks.buildLocalDerivedSignalIndex).not.toHaveBeenCalled();
+
+    rerender({ enabled: false });
+
+    expect(result.current.data).toBe(EMPTY_LOCAL_DERIVED_SIGNAL_INDEX);
+    expect(mocks.buildLocalDerivedSignalIndex).not.toHaveBeenCalled();
+  });
+
+  it("returns the stable empty graph without scanning memories when disabled", () => {
+    const memories = createMemories(500);
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useBackgroundMemoryInsightGraph({
+          cards: [],
+          memories,
+          matchMap: new Map(),
+          enabled,
+        }),
+      {
+        initialProps: { enabled: false },
+      },
+    );
+
+    expect(result.current).toEqual({
+      data: EMPTY_MEMORY_INSIGHT_GRAPH,
+      isComputing: false,
+    });
+    expect(result.current.data).toBe(EMPTY_MEMORY_INSIGHT_GRAPH);
+    expect(mocks.buildMemoryInsightGraph).not.toHaveBeenCalled();
+
+    rerender({ enabled: false });
+
+    expect(result.current.data).toBe(EMPTY_MEMORY_INSIGHT_GRAPH);
+    expect(mocks.buildMemoryInsightGraph).not.toHaveBeenCalled();
+  });
+
+  it("keeps the empty result when the worker fails without scanning memories on the main thread", async () => {
+    vi.stubGlobal("Worker", FailingWorker);
+    const memories = createMemories(80);
+    const matchMap = new Map();
+
+    const { result, unmount } = renderHook(() =>
+      useBackgroundDerivedSignals({
+        memories,
+        matchMap,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        data: EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
+        isComputing: false,
+      });
+    });
+    expect(mocks.buildLocalDerivedSignalIndex).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(FailingWorker.instances).toHaveLength(1);
+    expect(FailingWorker.instances[0]?.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the empty result when worker construction fails", async () => {
+    vi.stubGlobal("Worker", ConstructorFailingWorker);
+    const memories = createMemories(80);
+    const matchMap = new Map();
+
+    const { result } = renderHook(() =>
+      useBackgroundDerivedSignals({
+        memories,
+        matchMap,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        data: EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
+        isComputing: false,
+      });
+    });
+    expect(mocks.buildLocalDerivedSignalIndex).not.toHaveBeenCalled();
+  });
+
+  it("keeps the empty derived result for a large input when Worker is unavailable", () => {
+    vi.stubGlobal("Worker", undefined);
+    const memories = createMemories(80);
+
+    const { result } = renderHook(() =>
+      useBackgroundDerivedSignals({
+        memories,
+        matchMap: new Map(),
+      }),
+    );
+
+    expect(result.current).toEqual({
+      data: EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
+      isComputing: false,
+    });
+    expect(result.current.data).toBe(EMPTY_LOCAL_DERIVED_SIGNAL_INDEX);
+    expect(mocks.buildLocalDerivedSignalIndex).not.toHaveBeenCalled();
+  });
+
+  it("keeps the empty insight graph for a large input when Worker is unavailable", () => {
+    vi.stubGlobal("Worker", undefined);
+    const memories = createMemories(80);
+
+    const { result } = renderHook(() =>
+      useBackgroundMemoryInsightGraph({
+        cards: [],
+        memories,
+        matchMap: new Map(),
+      }),
+    );
+
+    expect(result.current).toEqual({
+      data: EMPTY_MEMORY_INSIGHT_GRAPH,
+      isComputing: false,
+    });
+    expect(result.current.data).toBe(EMPTY_MEMORY_INSIGHT_GRAPH);
+    expect(mocks.buildMemoryInsightGraph).not.toHaveBeenCalled();
+  });
+
+  it("keeps the empty relation graph for a large input when Worker is unavailable", () => {
+    vi.stubGlobal("Worker", undefined);
+    const memories = createMemories(80);
+
+    const { result } = renderHook(() =>
+      useBackgroundMemoryInsightRelationGraph({
+        cards: [],
+        memories,
+        matchMap: new Map(),
+      }),
+    );
+
+    expect(result.current).toEqual({
+      data: EMPTY_MEMORY_INSIGHT_RELATION_GRAPH,
+      isComputing: false,
+    });
+    expect(result.current.data).toBe(EMPTY_MEMORY_INSIGHT_RELATION_GRAPH);
+    expect(mocks.buildMemoryInsightRelationGraph).not.toHaveBeenCalled();
+  });
+
+  it("keeps synchronous computation for small inputs when Worker is unavailable", () => {
+    vi.stubGlobal("Worker", undefined);
+    const memories = createMemories(79);
+    mocks.buildLocalDerivedSignalIndex.mockReturnValueOnce(
+      EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
+    );
+    mocks.buildMemoryInsightGraph.mockReturnValueOnce(
+      EMPTY_MEMORY_INSIGHT_GRAPH,
+    );
+    mocks.buildMemoryInsightRelationGraph.mockReturnValueOnce(
+      EMPTY_MEMORY_INSIGHT_RELATION_GRAPH,
+    );
+
+    renderHook(() =>
+      useBackgroundDerivedSignals({
+        memories,
+        matchMap: new Map(),
+      }),
+    );
+    renderHook(() =>
+      useBackgroundMemoryInsightGraph({
+        cards: [],
+        memories,
+        matchMap: new Map(),
+      }),
+    );
+    renderHook(() =>
+      useBackgroundMemoryInsightRelationGraph({
+        cards: [],
+        memories,
+        matchMap: new Map(),
+      }),
+    );
+
+    expect(mocks.buildLocalDerivedSignalIndex).toHaveBeenCalledOnce();
+    expect(mocks.buildMemoryInsightGraph).toHaveBeenCalledOnce();
+    expect(mocks.buildMemoryInsightRelationGraph).toHaveBeenCalledOnce();
+  });
+
+  it("cancels only the unmounted computation while a concurrent worker completes", async () => {
+    vi.stubGlobal("Worker", ControlledWorker);
+    const memories = createMemories(80);
+    const matchMap = new Map();
+    const first = renderHook(() =>
+      useBackgroundDerivedSignals({
+        memories,
+        matchMap,
+      }),
+    );
+    const second = renderHook(() =>
+      useBackgroundDerivedSignals({
+        memories,
+        matchMap,
+      }),
+    );
+
+    expect(ControlledWorker.instances).toHaveLength(2);
+    const [firstWorker, secondWorker] = ControlledWorker.instances;
+    const firstSnapshot = first.result.current;
+
+    first.unmount();
+
+    expect(firstWorker?.terminate).toHaveBeenCalledOnce();
+    expect(secondWorker?.terminate).not.toHaveBeenCalled();
+
+    act(() => {
+      firstWorker?.complete(createSignalIndex("stale"));
+      secondWorker?.complete(createSignalIndex("current"));
+    });
+
+    await waitFor(() => {
+      expect(second.result.current).toEqual({
+        data: createSignalIndex("current"),
+        isComputing: false,
+      });
+    });
+    expect(first.result.current).toBe(firstSnapshot);
+    expect(secondWorker?.terminate).toHaveBeenCalledOnce();
+
+    second.unmount();
+
+    expect(secondWorker?.terminate).toHaveBeenCalledOnce();
+  });
+
+  it("terminates the previous worker when the memory input switches", () => {
+    vi.stubGlobal("Worker", PendingWorker);
+    const firstMemories = createMemories(80);
+    const secondMemories = createMemories(81);
+    const matchMap = new Map();
+
+    const { rerender, unmount } = renderHook(
+      ({ memories }) =>
+        useBackgroundDerivedSignals({
+          memories,
+          matchMap,
+        }),
+      {
+        initialProps: { memories: firstMemories },
+      },
+    );
+
+    expect(PendingWorker.instances).toHaveLength(1);
+
+    rerender({ memories: secondMemories });
+
+    expect(PendingWorker.instances).toHaveLength(2);
+    expect(PendingWorker.instances[0]?.terminate).toHaveBeenCalledOnce();
+
+    unmount();
+
+    expect(PendingWorker.instances[1]?.terminate).toHaveBeenCalledOnce();
+  });
+});

--- a/dashboard/app/src/lib/memory-insight-background.ts
+++ b/dashboard/app/src/lib/memory-insight-background.ts
@@ -108,22 +108,30 @@ export const EMPTY_MEMORY_INSIGHT_RELATION_GRAPH: MemoryInsightRelationGraph = {
   risingEntities: [],
 };
 
-const DEFAULT_DERIVED_SIGNALS_MINIMUM_MEMORY_COUNT = 80;
+const DEFAULT_BACKGROUND_WORKER_MINIMUM_MEMORY_COUNT = 80;
+const EMPTY_WORKER_MEMORIES: InsightWorkerMemory[] = [];
+const EMPTY_ANALYSIS_MATCHES: MemoryAnalysisMatch[] = [];
+const EMPTY_MEMORY_GRAPH_INPUT = {
+  memories: [] as Memory[],
+  matches: EMPTY_ANALYSIS_MATCHES,
+  matchMap: new Map<string, MemoryAnalysisMatch>(),
+};
 
-let backgroundWorker: Worker | null = null;
 let nextRequestID = 1;
-const pendingRequests = new Map<
-  number,
-  {
-    resolve: (value: WorkerResult) => void;
-    reject: (error: Error) => void;
-  }
->();
+
+interface ActiveWorkerTask {
+  cancel: (error?: Error) => void;
+}
+
+interface WorkerTaskHandle<T extends WorkerResult> extends ActiveWorkerTask {
+  promise: Promise<T>;
+}
+
+const activeWorkerTasks = new Set<ActiveWorkerTask>();
 
 function shouldUseBackgroundWorker(): boolean {
   return typeof window !== "undefined" &&
-    typeof Worker !== "undefined" &&
-    import.meta.env.MODE !== "test";
+    typeof Worker !== "undefined";
 }
 
 export function projectInsightWorkerMemory(memory: Memory): InsightWorkerMemory {
@@ -214,87 +222,145 @@ export function shouldUseDerivedSignalsWorker(input: {
   const {
     enabled = true,
     memoryCount,
-    minimumMemoryCount = DEFAULT_DERIVED_SIGNALS_MINIMUM_MEMORY_COUNT,
+    minimumMemoryCount = DEFAULT_BACKGROUND_WORKER_MINIMUM_MEMORY_COUNT,
     workerAvailable = shouldUseBackgroundWorker(),
   } = input;
 
   return enabled && workerAvailable && memoryCount >= minimumMemoryCount;
 }
 
-function getWorker(): Worker {
-  if (backgroundWorker) {
-    return backgroundWorker;
+export function disposeMemoryInsightBackgroundWorker(
+  error = new Error("Background insight worker disposed"),
+): void {
+  for (const task of [...activeWorkerTasks]) {
+    task.cancel(error);
   }
-
-  backgroundWorker = new Worker(
-    new URL("./memory-insight-background.worker.ts", import.meta.url),
-    { type: "module" },
-  );
-  backgroundWorker.onmessage = (event: MessageEvent<WorkerResponse>) => {
-    const response = event.data;
-    const pending = pendingRequests.get(response.id);
-    if (!pending) {
-      return;
-    }
-
-    pendingRequests.delete(response.id);
-    if (response.ok) {
-      pending.resolve(response.result);
-      return;
-    }
-
-    pending.reject(new Error(response.error));
-  };
-
-  backgroundWorker.onerror = (event) => {
-    const error = new Error(event.message || "Background insight worker failed");
-    for (const [id, pending] of pendingRequests.entries()) {
-      pending.reject(error);
-      pendingRequests.delete(id);
-    }
-  };
-
-  return backgroundWorker;
 }
 
 function runWorkerTask<T extends WorkerResult>(
   request: Omit<WorkerRequest, "id">,
-): Promise<T> {
-  const worker = getWorker();
+): WorkerTaskHandle<T> {
   const id = nextRequestID;
   nextRequestID += 1;
+  let worker: Worker | null = null;
+  let handle: WorkerTaskHandle<T> | null = null;
+  let rejectTask: ((error: Error) => void) | null = null;
+  let settled = false;
 
-  return new Promise<T>((resolve, reject) => {
-    pendingRequests.set(id, {
-      resolve: (value) => resolve(value as T),
-      reject,
-    });
-    worker.postMessage({ ...request, id });
+  const terminateWorker = () => {
+    if (worker) {
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.terminate();
+      worker = null;
+    }
+    if (handle) {
+      activeWorkerTasks.delete(handle);
+    }
+  };
+
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectTask = reject;
+    try {
+      worker = new Worker(
+        new URL("./memory-insight-background.worker.ts", import.meta.url),
+        { type: "module" },
+      );
+    } catch (error) {
+      settled = true;
+      reject(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+
+    worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const response = event.data;
+      if (settled || response.id !== id) {
+        return;
+      }
+
+      settled = true;
+      terminateWorker();
+      if (response.ok) {
+        resolve(response.result as T);
+        return;
+      }
+
+      reject(new Error(response.error));
+    };
+    worker.onerror = (event) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      terminateWorker();
+      reject(new Error(event.message || "Background insight worker failed"));
+    };
+
+    try {
+      worker.postMessage({ ...request, id });
+    } catch (error) {
+      settled = true;
+      terminateWorker();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
   });
+
+  handle = {
+    promise,
+    cancel: (
+      error = new Error("Background insight worker task cancelled"),
+    ) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      terminateWorker();
+      rejectTask?.(error);
+    },
+  };
+  if (!settled) {
+    activeWorkerTasks.add(handle);
+  }
+
+  return handle;
 }
 
 function useBackgroundComputation<T extends WorkerResult>({
+  enabled,
   workerEnabled,
+  syncEnabled,
   request,
   computeSync,
   emptyValue,
   deps,
 }: {
+  enabled: boolean;
   workerEnabled: boolean;
+  syncEnabled: boolean;
   request: Omit<WorkerRequest, "id">;
   computeSync: () => T;
   emptyValue: T;
   deps: readonly unknown[];
 }): { data: T; isComputing: boolean } {
   const syncValue = useMemo(
-    () => (workerEnabled ? emptyValue : computeSync()),
-    [computeSync, emptyValue, workerEnabled],
+    () => {
+      if (!enabled || workerEnabled || !syncEnabled) {
+        return emptyValue;
+      }
+
+      return computeSync();
+    },
+    [computeSync, emptyValue, enabled, syncEnabled, workerEnabled],
   );
   const [data, setData] = useState<T>(syncValue);
-  const [isComputing, setIsComputing] = useState(workerEnabled);
+  const [isComputing, setIsComputing] = useState(enabled && workerEnabled);
 
   useEffect(() => {
-    if (!workerEnabled) {
+    if (!enabled || !workerEnabled) {
+      setData(emptyValue);
+      setIsComputing(false);
       return;
     }
 
@@ -308,9 +374,11 @@ function useBackgroundComputation<T extends WorkerResult>({
     }
 
     let cancelled = false;
+    setData(emptyValue);
     setIsComputing(true);
 
-    runWorkerTask<T>(request)
+    const workerTask = runWorkerTask<T>(request);
+    workerTask.promise
       .then((result) => {
         if (cancelled) {
           return;
@@ -327,17 +395,18 @@ function useBackgroundComputation<T extends WorkerResult>({
         }
 
         startTransition(() => {
-          setData(computeSync());
+          setData(emptyValue);
           setIsComputing(false);
         });
       });
 
     return () => {
       cancelled = true;
+      workerTask.cancel();
     };
   }, deps);
 
-  if (!workerEnabled) {
+  if (!enabled || !workerEnabled) {
     return { data: syncValue, isComputing: false };
   }
 
@@ -348,7 +417,7 @@ export function useBackgroundDerivedSignals({
   memories,
   matchMap,
   enabled = true,
-  minimumMemoryCount = DEFAULT_DERIVED_SIGNALS_MINIMUM_MEMORY_COUNT,
+  minimumMemoryCount = DEFAULT_BACKGROUND_WORKER_MINIMUM_MEMORY_COUNT,
 }: {
   memories: Memory[];
   matchMap: Map<string, MemoryAnalysisMatch>;
@@ -360,14 +429,21 @@ export function useBackgroundDerivedSignals({
     memoryCount: memories.length,
     minimumMemoryCount,
   });
-  const matches = useMemo(() => [...matchMap.values()], [matchMap]);
+  const matches = useMemo(
+    () => enabled ? [...matchMap.values()] : EMPTY_ANALYSIS_MATCHES,
+    [enabled, matchMap],
+  );
   const projectedMemories = useMemo(
-    () => memories.map(projectInsightWorkerMemory),
-    [memories],
+    () => enabled
+      ? memories.map(projectInsightWorkerMemory)
+      : EMPTY_WORKER_MEMORIES,
+    [enabled, memories],
   );
 
   return useBackgroundComputation({
+    enabled,
     workerEnabled,
+    syncEnabled: enabled && memories.length < minimumMemoryCount,
     request: {
       type: "derived-signals",
       payload: {
@@ -381,7 +457,7 @@ export function useBackgroundDerivedSignals({
         matchMap,
       }),
     emptyValue: EMPTY_LOCAL_DERIVED_SIGNAL_INDEX,
-    deps: [workerEnabled, projectedMemories, memories, matches, matchMap],
+    deps: [enabled, workerEnabled, projectedMemories, memories, matches, matchMap],
   });
 }
 
@@ -389,19 +465,27 @@ export function useBackgroundMemoryInsightGraph({
   cards,
   memories,
   matchMap,
+  enabled = true,
 }: {
   cards: AnalysisCategoryCard[];
   memories: Memory[];
   matchMap: Map<string, MemoryAnalysisMatch>;
+  enabled?: boolean;
 }): { data: MemoryInsightGraph; isComputing: boolean } {
-  const workerEnabled = shouldUseBackgroundWorker();
+  const workerEnabled = enabled && shouldUseBackgroundWorker();
   const boundedInput = useMemo(
-    () => buildBoundedMemoryInsightGraphInput({ memories, matchMap }),
-    [memories, matchMap],
+    () =>
+      enabled
+        ? buildBoundedMemoryInsightGraphInput({ memories, matchMap })
+        : EMPTY_MEMORY_GRAPH_INPUT,
+    [enabled, memories, matchMap],
   );
 
   return useBackgroundComputation({
+    enabled,
     workerEnabled,
+    syncEnabled: enabled &&
+      memories.length < DEFAULT_BACKGROUND_WORKER_MINIMUM_MEMORY_COUNT,
     request: {
       type: "insight-graph",
       payload: {
@@ -415,9 +499,9 @@ export function useBackgroundMemoryInsightGraph({
         cards,
         memories: boundedInput.memories,
         matchMap: boundedInput.matchMap,
-      }),
+    }),
     emptyValue: EMPTY_MEMORY_INSIGHT_GRAPH,
-    deps: [workerEnabled, cards, boundedInput],
+    deps: [enabled, workerEnabled, cards, boundedInput],
   });
 }
 
@@ -429,6 +513,7 @@ export function useBackgroundMemoryInsightRelationGraph({
   activeTag,
   relationType,
   minimumCoOccurrence,
+  enabled = true,
 }: {
   cards: AnalysisCategoryCard[];
   memories: Memory[];
@@ -437,15 +522,22 @@ export function useBackgroundMemoryInsightRelationGraph({
   activeTag?: string;
   relationType?: MemoryInsightRelationType;
   minimumCoOccurrence?: number;
+  enabled?: boolean;
 }): { data: MemoryInsightRelationGraph; isComputing: boolean } {
-  const workerEnabled = shouldUseBackgroundWorker();
+  const workerEnabled = enabled && shouldUseBackgroundWorker();
   const boundedInput = useMemo(
-    () => buildBoundedMemoryInsightRelationGraphInput({ memories, matchMap }),
-    [memories, matchMap],
+    () =>
+      enabled
+        ? buildBoundedMemoryInsightRelationGraphInput({ memories, matchMap })
+        : EMPTY_MEMORY_GRAPH_INPUT,
+    [enabled, memories, matchMap],
   );
 
   return useBackgroundComputation({
+    enabled,
     workerEnabled,
+    syncEnabled: enabled &&
+      memories.length < DEFAULT_BACKGROUND_WORKER_MINIMUM_MEMORY_COUNT,
     request: {
       type: "relation-graph",
       payload: {
@@ -471,6 +563,7 @@ export function useBackgroundMemoryInsightRelationGraph({
     emptyValue: EMPTY_MEMORY_INSIGHT_RELATION_GRAPH,
     deps: [
       workerEnabled,
+      enabled,
       cards,
       boundedInput,
       activeCategory,

--- a/dashboard/app/src/lib/memory-insight-background.worker.test.ts
+++ b/dashboard/app/src/lib/memory-insight-background.worker.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LocalDerivedSignalIndex } from "@/lib/memory-derived-signals";
+
+const mocks = vi.hoisted(() => ({
+  buildLocalDerivedSignalIndex: vi.fn(),
+}));
+
+vi.mock("@/lib/memory-derived-signals", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/memory-derived-signals")>();
+
+  return {
+    ...actual,
+    buildLocalDerivedSignalIndex: mocks.buildLocalDerivedSignalIndex,
+  };
+});
+
+function createSignalIndex(value: string): LocalDerivedSignalIndex {
+  return {
+    derivedTagsByMemoryId: new Map(),
+    combinedTagsByMemoryId: new Map(),
+    tagStats: [
+      {
+        value,
+        normalizedValue: value,
+        count: 1,
+        origin: "derived",
+      },
+    ],
+    tagSourceByValue: new Map(),
+  };
+}
+
+describe("memory insight worker result cache", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("retains only the current result and releases it on request", async () => {
+    const responses: Array<{ result?: LocalDerivedSignalIndex }> = [];
+    vi.stubGlobal("postMessage", (response: { result?: LocalDerivedSignalIndex }) => {
+      responses.push(response);
+    });
+    mocks.buildLocalDerivedSignalIndex
+      .mockReturnValueOnce(createSignalIndex("first-a"))
+      .mockReturnValueOnce(createSignalIndex("b"))
+      .mockReturnValueOnce(createSignalIndex("second-a"))
+      .mockReturnValueOnce(createSignalIndex("released-a"));
+
+    await import("./memory-insight-background.worker");
+
+    const send = (id: number, memoryID: string) => {
+      self.onmessage?.({
+        data: {
+          id,
+          type: "derived-signals",
+          payload: {
+            memories: [
+              {
+                id: memoryID,
+                content: memoryID,
+                created_at: "2026-07-30T00:00:00Z",
+                updated_at: "2026-07-30T00:00:00Z",
+                tags: [],
+              },
+            ],
+            matches: [],
+          },
+        },
+      } as MessageEvent);
+    };
+
+    send(1, "a");
+    send(2, "b");
+    send(3, "a");
+    self.onmessage?.({
+      data: {
+        type: "release-cache",
+        target: "derived-signals",
+      },
+    } as MessageEvent);
+    send(4, "a");
+
+    expect(mocks.buildLocalDerivedSignalIndex).toHaveBeenCalledTimes(4);
+    expect(
+      responses.flatMap((response) =>
+        response.result ? [response.result.tagStats[0]?.value] : [],
+      ),
+    ).toEqual([
+      "first-a",
+      "b",
+      "second-a",
+      "released-a",
+    ]);
+  });
+});

--- a/dashboard/app/src/lib/memory-insight-background.worker.ts
+++ b/dashboard/app/src/lib/memory-insight-background.worker.ts
@@ -59,6 +59,10 @@ type WorkerRequest =
         relationType?: MemoryInsightRelationType;
         minimumCoOccurrence?: number;
       };
+    }
+  | {
+      type: "release-cache";
+      target: "derived-signals" | "insight-graph" | "relation-graph";
     };
 
 type WorkerResult =
@@ -79,12 +83,28 @@ type WorkerResponse =
     };
 
 const MAX_MEMORY_ANALYSIS_CACHE = 2048;
-const MAX_RESULT_CACHE = 128;
+const MAX_RESULT_CACHE = 1;
 
 const memoryAnalysisCache = new Map<string, MemoryDerivedAnalysis>();
 const derivedSignalCache = new Map<string, LocalDerivedSignalIndex>();
 const insightGraphCache = new Map<string, MemoryInsightGraph>();
 const relationGraphCache = new Map<string, MemoryInsightRelationGraph>();
+
+function releaseResultCache(
+  target: "derived-signals" | "insight-graph" | "relation-graph",
+): void {
+  switch (target) {
+    case "derived-signals":
+      derivedSignalCache.clear();
+      break;
+    case "insight-graph":
+      insightGraphCache.clear();
+      break;
+    case "relation-graph":
+      relationGraphCache.clear();
+      break;
+  }
+}
 
 function stableHash(value: string): string {
   let hash = 2166136261;
@@ -289,6 +309,11 @@ function getOrBuildRelationGraph(
 
 self.onmessage = (event: MessageEvent<WorkerRequest>) => {
   const request = event.data;
+
+  if (request.type === "release-cache") {
+    releaseResultCache(request.target);
+    return;
+  }
 
   try {
     let result: WorkerResult;


### PR DESCRIPTION
## What Changed
- Return stable empty results for disabled and unsafe fallback paths.
- Give each computation an independently cancellable Worker.
- Terminate completed or cancelled Workers and keep result caches at one entry.

## Why
Disabled, failed, and superseded analysis work could still consume main-thread CPU and retain large results.

## Review Path
- `memory-insight-background.ts`
- `memory-insight-background.worker.ts`
- Focused lifecycle tests

## Validation
- 37/37 Worker and related component tests
- `pnpm typecheck`
- Combined-stack production build
