### PR TITLE
fix(dashboard): defer full memory source loading

### DIFF
--- a/dashboard/app/src/api/analysis-queries.ts
+++ b/dashboard/app/src/api/analysis-queries.ts
@@ -350,6 +350,7 @@ export function useSpaceAnalysis(input: {
   sourceMemories: Memory[];
   sourceLoading: boolean;
   refreshSource: () => Promise<unknown>;
+  enabled: boolean;
 }): {
   state: SpaceAnalysisState;
   taxonomy: TaxonomyResponse | null;
@@ -375,7 +376,7 @@ export function useSpaceAnalysis(input: {
   const [cards, setCards] = useState<AnalysisCategoryCard[]>([]);
   const [matchesLoading, setMatchesLoading] = useState(false);
   const runRef = useRef(0);
-  const enabled = features.enableAnalysis && !!spaceId;
+  const enabled = features.enableAnalysis && input.enabled && !!spaceId;
 
   const sourceMemories = useMemo(
     () =>

--- a/dashboard/app/src/api/source-memories.test.ts
+++ b/dashboard/app/src/api/source-memories.test.ts
@@ -125,5 +125,120 @@ describe("loadSourceMemories", () => {
 
     expect(api.listMemories).toHaveBeenCalled();
     expect(result).toEqual([freshMemory]);
+    expect(localCache.patchSyncState).toHaveBeenCalledWith(
+      "space-1",
+      expect.objectContaining({
+        hasFullCache: true,
+        incrementalCursor: null,
+      }),
+    );
+  });
+
+  it("stops source sync at the hard budget and keeps the partial cache marked incomplete", async () => {
+    const { sourceMemories, api, localCache } = await importModules();
+    const total = sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.maxRecords + 1;
+
+    vi.mocked(localCache.readSyncState).mockResolvedValue(null);
+    vi.mocked(localCache.readCachedMemories).mockResolvedValue([]);
+    vi.mocked(api.listMemories).mockImplementation(
+      async (_spaceId, params) => {
+        const limit =
+          params.limit ?? sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.pageSize;
+        const offset = params.offset ?? 0;
+
+        return {
+          memories: Array.from({ length: limit }, (_, index) =>
+            createMemory(String(offset + index)),
+          ),
+          total,
+          limit,
+          offset,
+        };
+      },
+    );
+
+    const result = await sourceMemories.loadSourceMemories("space-1");
+
+    expect(api.listMemories).toHaveBeenCalledTimes(
+      sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.maxPages,
+    );
+    expect(result).toHaveLength(
+      sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.maxRecords,
+    );
+    expect(localCache.patchSyncState).toHaveBeenCalledWith(
+      "space-1",
+      expect.objectContaining({
+        hasFullCache: false,
+      }),
+    );
+  });
+
+  it("advances pagination by the number of records returned", async () => {
+    const { sourceMemories, api, localCache } = await importModules();
+
+    vi.mocked(localCache.readSyncState).mockResolvedValue(null);
+    vi.mocked(localCache.readCachedMemories).mockResolvedValue([]);
+    vi.mocked(api.listMemories)
+      .mockResolvedValueOnce({
+        memories: [createMemory("m1"), createMemory("m2")],
+        total: 3,
+        limit: 200,
+        offset: 0,
+      })
+      .mockResolvedValueOnce({
+        memories: [createMemory("m3")],
+        total: 3,
+        limit: 200,
+        offset: 2,
+      });
+
+    const result = await sourceMemories.loadSourceMemories("space-1");
+
+    expect(api.listMemories).toHaveBeenNthCalledWith(2, "space-1", {
+      limit: sourceMemories.SOURCE_MEMORY_SYNC_BUDGET.pageSize,
+      offset: 2,
+    });
+    expect(result).toHaveLength(3);
+    expect(localCache.patchSyncState).toHaveBeenCalledWith(
+      "space-1",
+      expect.objectContaining({
+        hasFullCache: true,
+      }),
+    );
+  });
+});
+
+describe("useSourceMemories", () => {
+  it("does not read cache or issue source requests while disabled", async () => {
+    const { sourceMemories, api, localCache } = await importModules();
+    const React = await import("react");
+    const { renderHook } = await import("@testing-library/react");
+    const { QueryClient, QueryClientProvider } = await import(
+      "@tanstack/react-query"
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    const { result } = renderHook(
+      () => sourceMemories.useSourceMemories("space-1", { enabled: false }),
+      {
+        wrapper: ({ children }) =>
+          React.createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            children,
+          ),
+      },
+    );
+
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(localCache.readCachedMemories).not.toHaveBeenCalled();
+    expect(localCache.readSyncState).not.toHaveBeenCalled();
+    expect(api.listMemories).not.toHaveBeenCalled();
   });
 });

--- a/dashboard/app/src/api/source-memories.ts
+++ b/dashboard/app/src/api/source-memories.ts
@@ -10,7 +10,11 @@ import {
 import { sortMemoriesByCreatedAtDesc } from "@/lib/memory-filters";
 import type { Memory } from "@/types/memory";
 
-const PAGE_SIZE = 200;
+export const SOURCE_MEMORY_SYNC_BUDGET = {
+  pageSize: 200,
+  maxPages: 5,
+  maxRecords: 1_000,
+} as const;
 const activeSyncs = new Map<string, Promise<Memory[]>>();
 
 export function getSourceMemoriesQueryKey(spaceId: string): string[] {
@@ -27,21 +31,41 @@ export async function syncAllMemories(spaceId: string): Promise<Memory[]> {
     const all: Memory[] = [];
     let offset = 0;
     let total = Number.POSITIVE_INFINITY;
+    let pagesFetched = 0;
 
-    while (offset < total) {
+    while (
+      offset < total &&
+      pagesFetched < SOURCE_MEMORY_SYNC_BUDGET.maxPages &&
+      all.length < SOURCE_MEMORY_SYNC_BUDGET.maxRecords
+    ) {
+      const limit = Math.min(
+        SOURCE_MEMORY_SYNC_BUDGET.pageSize,
+        SOURCE_MEMORY_SYNC_BUDGET.maxRecords - all.length,
+      );
       const page = await api.listMemories(spaceId, {
-        limit: PAGE_SIZE,
+        limit,
         offset,
       });
-      all.push(...page.memories);
+      all.push(
+        ...page.memories.slice(
+          0,
+          SOURCE_MEMORY_SYNC_BUDGET.maxRecords - all.length,
+        ),
+      );
       total = page.total;
-      offset += page.limit;
+      pagesFetched += 1;
+      offset += page.memories.length;
+
+      if (page.memories.length === 0) {
+        break;
+      }
     }
 
+    const hasFullCache = all.length >= total;
     await clearCachedMemoriesForSpace(spaceId);
     await upsertCachedMemories(spaceId, all);
     await patchSyncState(spaceId, {
-      hasFullCache: true,
+      hasFullCache,
       lastSyncedAt: new Date().toISOString(),
       incrementalCursor: null,
     });
@@ -75,12 +99,18 @@ export async function loadSourceMemories(spaceId: string): Promise<Memory[]> {
 
 export function useSourceMemories(
   spaceId: string,
-  refreshToken = 0,
+  {
+    enabled = true,
+    refreshToken = 0,
+  }: {
+    enabled?: boolean;
+    refreshToken?: number;
+  } = {},
 ) {
   return useQuery({
     queryKey: [...getSourceMemoriesQueryKey(spaceId), refreshToken],
     queryFn: () => loadSourceMemories(spaceId),
-    enabled: !!spaceId,
+    enabled: enabled && !!spaceId,
     staleTime: 30_000,
     retry: 1,
   });

--- a/dashboard/app/src/components/space/analysis-panel.tsx
+++ b/dashboard/app/src/components/space/analysis-panel.tsx
@@ -170,6 +170,8 @@ export function formatBatchSummary(
 }
 
 export function AnalysisPanel({
+  active = true,
+  onActivate = () => {},
   state,
   sourceCount,
   sourceLoading,
@@ -186,6 +188,8 @@ export function AnalysisPanel({
   onRetry,
   t,
 }: {
+  active?: boolean;
+  onActivate?: () => void;
   state: SpaceAnalysisState;
   sourceCount: number;
   sourceLoading: boolean;
@@ -215,23 +219,43 @@ export function AnalysisPanel({
         </div>
 
         <div className="analysis-scroll-area space-y-4 px-4 py-4 xl:max-h-[calc(100vh-9.5rem)] xl:overflow-y-auto">
-          <AnalysisPanelBody
-            state={state}
-            sourceCount={sourceCount}
-            sourceLoading={sourceLoading}
-            taxonomy={taxonomy}
-            taxonomyUnavailable={taxonomyUnavailable}
-            cards={cards}
-            activeCategory={activeCategory}
-            activeTag={activeTag}
-            tagStats={tagStats}
-            onSelectCategory={onSelectCategory}
-            onSelectTag={onSelectTag}
-            onRefreshMemories={onRefreshMemories}
-            refreshingMemories={refreshingMemories}
-            onRetry={onRetry}
-            t={t}
-          />
+          {!active && (
+            <div className="rounded-lg border border-dashed bg-muted/30 p-3">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {t("analysis.load_description")}
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                className="mt-3 w-full"
+                onClick={onActivate}
+                data-mp-event="Dashboard/Analysis/LoadClicked"
+                data-mp-page-name="space"
+              >
+                <BarChart3 className="size-4" />
+                {t("analysis.load")}
+              </Button>
+            </div>
+          )}
+          {active && (
+            <AnalysisPanelBody
+              state={state}
+              sourceCount={sourceCount}
+              sourceLoading={sourceLoading}
+              taxonomy={taxonomy}
+              taxonomyUnavailable={taxonomyUnavailable}
+              cards={cards}
+              activeCategory={activeCategory}
+              activeTag={activeTag}
+              tagStats={tagStats}
+              onSelectCategory={onSelectCategory}
+              onSelectTag={onSelectTag}
+              onRefreshMemories={onRefreshMemories}
+              refreshingMemories={refreshingMemories}
+              onRetry={onRetry}
+              t={t}
+            />
+          )}
         </div>
       </div>
     </aside>

--- a/dashboard/app/src/components/space/memory-profile-overview.test.tsx
+++ b/dashboard/app/src/components/space/memory-profile-overview.test.tsx
@@ -93,6 +93,32 @@ describe("MemoryProfileOverview", () => {
     expect(useBackgroundMemoryInsightGraph).not.toHaveBeenCalled();
   });
 
+  it("renders the topic radar from the lightweight facet summary while analysis is idle", () => {
+    render(
+      <MemoryProfileOverview
+        spaceId="space-1"
+        stats={{ total: 12, pinned: 3, insight: 9 }}
+        memories={[createMemory()]}
+        cards={[]}
+        snapshot={null}
+        range="all"
+        facetSummary={{
+          topics: [
+            { facet: "plans", count: 8 },
+            { facet: "preferences", count: 4 },
+          ],
+          total: 12,
+        }}
+        loading={false}
+      />,
+    );
+
+    expect(screen.getByRole("img", { name: "plans: 8" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "preferences: 4" }),
+    ).toBeInTheDocument();
+  });
+
   it("calculates companion days for a memory set larger than the function argument limit", () => {
     const recentMemory = {
       ...createMemory(),

--- a/dashboard/app/src/components/space/memory-profile-overview.tsx
+++ b/dashboard/app/src/components/space/memory-profile-overview.tsx
@@ -65,6 +65,17 @@ export function MemoryProfileOverview({ spaceId, stats, memories, cards, snapsho
       ? buildFacetComposition(compositionStats, facetSummary.topics)
       : buildPulseComposition(compositionStats, memories, cards);
   }, [cards, facetSummary, memories, memoryCount, stats]);
+  const radarCards = useMemo(
+    () =>
+      cards.some((card) => card.count > 0)
+        ? cards
+        : composition.inner.map((segment) => ({
+            category: segment.key,
+            count: segment.value,
+            confidence: segment.ratio,
+          })),
+    [cards, composition.inner],
+  );
   const pulse = useMemo(() => {
     if (!stats) {
       return null;
@@ -95,7 +106,7 @@ export function MemoryProfileOverview({ spaceId, stats, memories, cards, snapsho
     </div>
 
     <div className={cn("mt-4", profileGridClass)}>
-      <ProfileCard title={t("memory_profile.topics.title")}><RadarChart cards={cards} /></ProfileCard>
+      <ProfileCard title={t("memory_profile.topics.title")}><RadarChart cards={radarCards} /></ProfileCard>
       <article className="surface-card min-h-[260px] p-5"><MemoryRhythmChart buckets={pulse?.trend.buckets ?? []} maxCount={pulse?.trend.maxCount ?? 0} locale={i18n.language} /></article>
     </div>
 

--- a/dashboard/app/src/components/space/space-page-layout.tsx
+++ b/dashboard/app/src/components/space/space-page-layout.tsx
@@ -49,6 +49,8 @@ interface SpacePageLayoutProps {
   spaceId: string;
   routeState: SpaceRouteState;
   dataModel: SpaceDataModel;
+  analysisActivated: boolean;
+  onActivateAnalysis: () => void;
   t: TFunction;
   addOpen: boolean;
   setAddOpen: Dispatch<SetStateAction<boolean>>;
@@ -78,6 +80,8 @@ export const SpacePageLayout = ({
   spaceId,
   routeState,
   dataModel,
+  analysisActivated,
+  onActivateAnalysis,
   t,
   addOpen,
   setAddOpen,
@@ -264,6 +268,9 @@ export const SpacePageLayout = ({
                 navigateAndScrollToMemoryList(() => routeState.handleEntitySearch(query))
               }
               onTabChange={(nextTab) => {
+                if (nextTab === "insight" || nextTab === "analysis") {
+                  onActivateAnalysis();
+                }
                 setActiveOverviewTab(nextTab);
                 if (nextTab !== activeOverviewTab) {
                   routeState.setSelected(null);
@@ -543,6 +550,8 @@ export const SpacePageLayout = ({
                 onAction={onHandleFarmAction}
               />
               <AnalysisPanel
+                active={analysisActivated}
+                onActivate={onActivateAnalysis}
                 state={dataModel.analysis.state}
                 sourceCount={dataModel.analysis.sourceCount}
                 sourceLoading={dataModel.analysis.sourceLoading}
@@ -553,12 +562,16 @@ export const SpacePageLayout = ({
                 activeTag={routeState.tag}
                 tagStats={dataModel.analysisTagStats}
                 onSelectCategory={(category) =>
-                  navigateAndScrollToMemoryList(() =>
-                    routeState.handleAnalysisCategoryChange(category),
-                  )
+                  navigateAndScrollToMemoryList(() => {
+                    onActivateAnalysis();
+                    routeState.handleAnalysisCategoryChange(category);
+                  })
                 }
                 onSelectTag={(tag) =>
-                  navigateAndScrollToMemoryList(() => routeState.handleTagChange(tag))
+                  navigateAndScrollToMemoryList(() => {
+                    onActivateAnalysis();
+                    routeState.handleTagChange(tag);
+                  })
                 }
                 onRefreshMemories={onRefreshMemories}
                 refreshingMemories={refreshingMemories}
@@ -593,7 +606,12 @@ export const SpacePageLayout = ({
       {!routeState.isDesktopViewport && features.enableAnalysis && (
         <MobileAnalysisSheet
           open={routeState.mobileAnalysisOpen}
-          onOpenChange={routeState.setMobileAnalysisOpen}
+          onOpenChange={(open) => {
+            if (open) {
+              onActivateAnalysis();
+            }
+            routeState.setMobileAnalysisOpen(open);
+          }}
           state={dataModel.analysis.state}
           sourceCount={dataModel.analysis.sourceCount}
           sourceLoading={dataModel.analysis.sourceLoading}

--- a/dashboard/app/src/components/space/use-memory-farm-entry-state.test.ts
+++ b/dashboard/app/src/components/space/use-memory-farm-entry-state.test.ts
@@ -16,11 +16,16 @@ async function importModules() {
 }
 
 describe("resolveMemoryFarmEntryStatus", () => {
-  it("returns ready when the full cache exists and the all-range snapshot is terminal", async () => {
+  it.each([
+    { cacheKind: "full", hasFullCache: true },
+    { cacheKind: "bounded", hasFullCache: false },
+  ])("returns ready when the $cacheKind cache has a terminal all-range snapshot", async ({
+    hasFullCache,
+  }) => {
     const { localCache, memoryFarm } = await importModules();
     vi.mocked(localCache.readSyncState).mockResolvedValue({
       spaceId: "space-1",
-      hasFullCache: true,
+      hasFullCache,
       lastSyncedAt: "2026-03-28T00:00:00Z",
       incrementalCursor: null,
       incrementalTodo: null,

--- a/dashboard/app/src/components/space/use-memory-farm-entry-state.ts
+++ b/dashboard/app/src/components/space/use-memory-farm-entry-state.ts
@@ -20,7 +20,9 @@ export async function resolveMemoryFarmEntryStatus(input: {
   }
 
   const syncState = await readSyncState(input.spaceId);
-  if (!syncState?.hasFullCache) {
+  const sourcePrepared =
+    syncState?.hasFullCache || Boolean(syncState?.lastSyncedAt);
+  if (!sourcePrepared) {
     return "preparing";
   }
 
@@ -55,6 +57,7 @@ export function useMemoryFarmEntryState(
   isSourceMemoriesLoading: boolean,
   currentAnalysisState: SpaceAnalysisState,
   currentRange: string,
+  enabled = true,
 ): MemoryFarmEntryStatus {
   const query = useQuery({
     queryKey: [
@@ -74,7 +77,7 @@ export function useMemoryFarmEntryState(
         currentAnalysisState,
         currentRange,
       }),
-    enabled: !!spaceId,
+    enabled: enabled && !!spaceId,
     initialData: "preparing" as MemoryFarmEntryStatus,
     refetchInterval: (currentQuery) =>
       currentQuery.state.data === "preparing" ? 2000 : false,

--- a/dashboard/app/src/components/space/use-space-data-model.test.tsx
+++ b/dashboard/app/src/components/space/use-space-data-model.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   sourceRefetch: vi.fn(async () => undefined),
   useSpaceAnalysis: vi.fn(),
   useBackgroundDerivedSignals: vi.fn(),
+  useMemoryFarmEntryState: vi.fn((..._args: unknown[]) => "preparing"),
 }));
 
 function createMemory(id: string): Memory {
@@ -71,7 +72,8 @@ vi.mock("@/api/analysis-queries", () => ({
 }));
 
 vi.mock("@/components/space/use-memory-farm-entry-state", () => ({
-  useMemoryFarmEntryState: () => "ready",
+  useMemoryFarmEntryState: (...args: unknown[]) =>
+    mocks.useMemoryFarmEntryState(...args),
 }));
 
 vi.mock("@/lib/memory-insight-background", () => ({
@@ -160,6 +162,178 @@ describe("useSpaceDataModel", () => {
   });
 
   primeMocks();
+
+  it("keeps source loading and analysis idle before a heavy memory surface is activated", () => {
+    renderHook(() =>
+      useSpaceDataModel({
+        spaceId: "space-1",
+        q: undefined,
+        range: "all",
+        facet: undefined,
+        analysisCategory: undefined,
+        tag: undefined,
+        memoryTypeFilter: "pinned,insight",
+        timelineSelection: undefined,
+        importStatusOpen: false,
+        exportOpen: false,
+        isDesktopViewport: true,
+        mobileAnalysisOpen: false,
+        analysisActivated: false,
+        selected: null,
+        localVisibleCount: 50,
+        onSelectedMissing: vi.fn(),
+      }),
+    );
+
+    expect(mocks.useSourceMemories).toHaveBeenCalledWith("space-1", {
+      enabled: false,
+    });
+    expect(mocks.useSpaceAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(mocks.useMemoryFarmEntryState).toHaveBeenCalledWith(
+      "space-1",
+      false,
+      expect.any(Object),
+      "all",
+      false,
+    );
+  });
+
+  it("uses loaded page memories for Profile while the full source stays idle", () => {
+    mocks.useSourceMemories.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      refetch: mocks.sourceRefetch,
+    });
+
+    const { result } = renderHook(() =>
+      useSpaceDataModel({
+        spaceId: "space-1",
+        q: undefined,
+        range: "all",
+        facet: undefined,
+        analysisCategory: undefined,
+        tag: undefined,
+        memoryTypeFilter: "pinned,insight",
+        timelineSelection: undefined,
+        importStatusOpen: false,
+        exportOpen: false,
+        isDesktopViewport: true,
+        mobileAnalysisOpen: false,
+        analysisActivated: false,
+        selected: null,
+        localVisibleCount: 50,
+        onSelectedMissing: vi.fn(),
+      }),
+    );
+
+    expect(mocks.useSourceMemories).toHaveBeenCalledWith("space-1", {
+      enabled: false,
+    });
+    expect(result.current.pulseMemories).toEqual(SOURCE_MEMORIES);
+  });
+
+  it("keeps the Profile sample independent from main-list filters", () => {
+    const filteredMemory = createMemory("filtered");
+    mocks.useMemories.mockImplementation(
+      (
+        _spaceId: string,
+        params: {
+          q?: string;
+          facet?: string;
+          memory_type?: string;
+        },
+      ) => {
+        const memories =
+          params.q || params.facet || params.memory_type === "pinned"
+            ? [filteredMemory]
+            : SOURCE_MEMORIES;
+        return {
+          data: {
+            pages: [
+              {
+                memories,
+                total: memories.length,
+                limit: 50,
+                offset: 0,
+              },
+            ],
+          },
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+          isFetchingNextPage: false,
+          isLoading: false,
+          isFetching: false,
+        };
+      },
+    );
+    mocks.useSourceMemories.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      refetch: mocks.sourceRefetch,
+    });
+
+    const { result } = renderHook(() =>
+      useSpaceDataModel({
+        spaceId: "space-1",
+        q: "filtered",
+        range: "30d",
+        facet: "plans",
+        analysisCategory: undefined,
+        tag: undefined,
+        memoryTypeFilter: "pinned",
+        timelineSelection: undefined,
+        importStatusOpen: false,
+        exportOpen: false,
+        isDesktopViewport: true,
+        mobileAnalysisOpen: false,
+        analysisActivated: false,
+        selected: null,
+        localVisibleCount: 50,
+        onSelectedMissing: vi.fn(),
+      }),
+    );
+
+    expect(result.current.memories).toEqual([filteredMemory]);
+    expect(result.current.pulseMemories).toEqual(SOURCE_MEMORIES);
+    expect(mocks.useMemories).toHaveBeenNthCalledWith(2, "space-1", {
+      range: "30d",
+      memory_type: "pinned,insight",
+    });
+  });
+
+  it("activates analysis and the full source for a direct tag route", () => {
+    renderHook(() =>
+      useSpaceDataModel({
+        spaceId: "space-1",
+        q: undefined,
+        range: "all",
+        facet: undefined,
+        analysisCategory: undefined,
+        tag: "dashboard",
+        memoryTypeFilter: "pinned,insight",
+        timelineSelection: undefined,
+        importStatusOpen: false,
+        exportOpen: false,
+        isDesktopViewport: true,
+        mobileAnalysisOpen: false,
+        analysisActivated: false,
+        selected: null,
+        localVisibleCount: 50,
+        onSelectedMissing: vi.fn(),
+      }),
+    );
+
+    expect(mocks.useSourceMemories).toHaveBeenCalledWith("space-1", {
+      enabled: true,
+    });
+    expect(mocks.useSpaceAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true }),
+    );
+  });
 
   it("keeps source memories under a single owner and passes shared source state into useSpaceAnalysis", () => {
     renderHook(() =>

--- a/dashboard/app/src/components/space/use-space-data-model.ts
+++ b/dashboard/app/src/components/space/use-space-data-model.ts
@@ -90,11 +90,17 @@ export function useSpaceDataModel(input: {
   exportOpen: boolean;
   isDesktopViewport: boolean;
   mobileAnalysisOpen: boolean;
+  analysisActivated?: boolean;
   selected: Memory | null;
   localVisibleCount: number;
   onSelectedMissing: () => void;
 }): SpaceDataModel {
   const { spaceId } = input;
+  const analysisActivated =
+    !!input.tag ||
+    (input.analysisActivated ??
+      (input.mobileAnalysisOpen || !!input.analysisCategory));
+  const analysisEnabled = features.enableAnalysis && analysisActivated;
   const { data: stats } = useStats(spaceId, input.range);
   const { data: totalStatsQuery } = useStats(
     spaceId,
@@ -114,7 +120,13 @@ export function useSpaceDataModel(input: {
     range: input.range,
     facet: input.facet,
   });
-  const sourceQuery = useSourceMemories(spaceId);
+  const { data: profileMemData } = useMemories(spaceId, {
+    range: input.range,
+    memory_type: "pinned,insight",
+  });
+  const sourceQuery = useSourceMemories(spaceId, {
+    enabled: analysisEnabled,
+  });
   const refreshSource = useCallback(
     () => sourceQuery.refetch(),
     [sourceQuery],
@@ -131,12 +143,14 @@ export function useSpaceDataModel(input: {
     sourceMemories: allMemories,
     sourceLoading: sourceQuery.isLoading || sourceQuery.isFetching,
     refreshSource,
+    enabled: analysisEnabled,
   });
   const farmEntryStatus = useMemoryFarmEntryState(
     spaceId,
     sourceQuery.isLoading || sourceQuery.isFetching,
     analysis.state,
     input.range,
+    analysisEnabled,
   );
   const { data: topicData } = useTopicSummary(
     spaceId,
@@ -146,6 +160,8 @@ export function useSpaceDataModel(input: {
   const { data: importTaskData } = useImportTasks(spaceId, input.importStatusOpen);
 
   const memories = memData?.pages.flatMap((page) => page.memories) ?? [];
+  const profileSampleMemories =
+    profileMemData?.pages.flatMap((page) => page.memories) ?? EMPTY_MEMORIES;
   const firstPageSize = memData?.pages[0]?.memories.length ?? 0;
   const rangeScopedMemories = useMemo(
     () => filterMemoriesForView(allMemories, { range: input.range }),
@@ -171,7 +187,7 @@ export function useSpaceDataModel(input: {
     () => createTagResolver(listSignalIndex),
     [listSignalIndex],
   );
-  const analysisSignalsEnabled = features.enableAnalysis &&
+  const analysisSignalsEnabled = analysisEnabled &&
     (input.isDesktopViewport || input.mobileAnalysisOpen);
   const { data: analysisRangeSignalIndex } = useBackgroundDerivedSignals({
     memories: rangeScopedMemories,
@@ -213,7 +229,7 @@ export function useSpaceDataModel(input: {
   const { data: analysisCategorySignalIndex } = useBackgroundDerivedSignals({
     memories: analysisCategoryScopeMemories,
     matchMap: analysis.matchMap,
-    enabled: !!input.analysisCategory,
+    enabled: analysisEnabled && !!input.analysisCategory,
   });
   const analysisCategoryTagResolver = useMemo<MemoryTagResolver>(
     () => createTagResolver(analysisCategorySignalIndex),
@@ -370,7 +386,10 @@ export function useSpaceDataModel(input: {
   return {
     stats,
     totalStats,
-    pulseMemories: rangeScopedMemories,
+    pulseMemories:
+      sourceQuery.data === undefined
+        ? profileSampleMemories
+        : rangeScopedMemories,
     analysis,
     sourceQuery,
     farmEntryStatus,

--- a/dashboard/app/src/i18n/locales/en.json
+++ b/dashboard/app/src/i18n/locales/en.json
@@ -240,6 +240,8 @@
   "analysis": {
     "title": "Analysis Summary",
     "open": "Summary",
+    "load": "Load analysis",
+    "load_description": "Load memories to start Analysis Summary and Memory Insight. Large spaces use a bounded working set for responsive browsing.",
     "taxonomy_version": "Taxonomy {{version}}",
     "taxonomy_fallback": "Using fallback labels",
     "taxonomy_warning": "Taxonomy is unavailable right now. Showing local fallback labels.",

--- a/dashboard/app/src/i18n/locales/zh-CN.json
+++ b/dashboard/app/src/i18n/locales/zh-CN.json
@@ -240,6 +240,8 @@
   "analysis": {
     "title": "分析摘要",
     "open": "摘要",
+    "load": "加载分析",
+    "load_description": "按需加载记忆以开始分析摘要和记忆洞察；大空间使用有界工作集保持页面流畅。",
     "taxonomy_version": "分类版本 {{version}}",
     "taxonomy_fallback": "使用默认分类标签",
     "taxonomy_warning": "分类定义暂不可用，当前展示为本地兜底标签。",

--- a/dashboard/app/src/pages/space.test.tsx
+++ b/dashboard/app/src/pages/space.test.tsx
@@ -473,8 +473,8 @@ vi.mock("@/api/queries", () => ({
 
 vi.mock("@/api/source-memories", () => ({
   getSourceMemoriesQueryKey: (spaceId: string) => ["space", spaceId, "sourceMemories"],
-  useSourceMemories: (_spaceId: string) => {
-    mocks.useSourceMemories(_spaceId);
+  useSourceMemories: (_spaceId: string, options?: { enabled?: boolean }) => {
+    mocks.useSourceMemories(_spaceId, options);
     return {
       data: mockedSourceMemories,
       isLoading: false,
@@ -624,6 +624,38 @@ describe("SpacePage", () => {
     expect(shouldCompactMemoryOverview(selected, true, "sheet")).toBe(false);
     expect(shouldCompactMemoryOverview(selected, true, "panel")).toBe(true);
     expect(shouldCompactMemoryOverview(selected, false, "sheet")).toBe(false);
+  });
+
+  it("keeps the full source idle on Profile and enables it after entering Memory Insight", async () => {
+    renderSpacePage();
+
+    expect(mocks.useSourceMemories).toHaveBeenLastCalledWith("space-1", {
+      enabled: false,
+    });
+
+    const insightTab = screen.getByRole("tab", { name: "Memory Insight" });
+    insightTab.focus();
+    fireEvent.keyDown(insightTab, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(mocks.useSourceMemories).toHaveBeenLastCalledWith("space-1", {
+        enabled: true,
+      }),
+    );
+  });
+
+  it("enables the full source from the explicit Analysis Summary action", async () => {
+    renderSpacePage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Load analysis" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.useSourceMemories).toHaveBeenLastCalledWith("space-1", {
+        enabled: true,
+      }),
+    );
   });
 
   it("opens an insight memory detail sheet from the Memory Insight tab", async () => {
@@ -1156,6 +1188,7 @@ describe("SpacePage", () => {
   it("does not pass tag state to the useMemories API query", async () => {
     renderSpacePage();
 
+    fireEvent.click(screen.getByRole("button", { name: "Load analysis" }));
     const tagButton = within(screen.getByTestId("analysis-facets-tags"))
       .getByRole("button", { name: /launch/i });
     fireEvent.click(tagButton);
@@ -1173,6 +1206,7 @@ describe("SpacePage", () => {
   it("keeps tag state when leaving analysis mode", async () => {
     renderSpacePage();
 
+    fireEvent.click(screen.getByRole("button", { name: "Load analysis" }));
     fireEvent.click(getAnalysisCategoryButton("activity"));
 
     await waitFor(() => {

--- a/dashboard/app/src/pages/space.tsx
+++ b/dashboard/app/src/pages/space.tsx
@@ -28,6 +28,9 @@ export function SpacePage() {
   const [importStatusOpen, setImportStatusOpen] = useState(false);
   const [refreshingMemories, setRefreshingMemories] = useState(false);
   const [farmPrepOpen, setFarmPrepOpen] = useState(false);
+  const [analysisActivated, setAnalysisActivated] = useState(
+    () => !!routeState.analysisCategory,
+  );
   const dataModel = useSpaceDataModel({
     spaceId,
     q: routeState.search.q,
@@ -41,6 +44,7 @@ export function SpacePage() {
     exportOpen,
     isDesktopViewport: routeState.isDesktopViewport,
     mobileAnalysisOpen: routeState.mobileAnalysisOpen,
+    analysisActivated,
     selected: routeState.selected,
     localVisibleCount: routeState.localVisibleCount,
     onSelectedMissing: () => routeState.setSelected(null),
@@ -171,6 +175,7 @@ export function SpacePage() {
       return;
     }
 
+    setAnalysisActivated(true);
     setFarmPrepOpen(true);
   };
 
@@ -179,6 +184,8 @@ export function SpacePage() {
       spaceId={spaceId}
       routeState={routeState}
       dataModel={dataModel}
+      analysisActivated={analysisActivated}
+      onActivateAnalysis={() => setAnalysisActivated(true)}
       t={t}
       addOpen={addOpen}
       setAddOpen={setAddOpen}


### PR DESCRIPTION
## What Changed
- Keep full source and analysis idle on Profile.
- Keep Profile summaries populated from paged memories and facet aggregates.
- Activate them from Insight, explicit Analysis, mobile Analysis, tag routes, and Farm flows.
- Cap synchronization at 5 pages / 1,000 records and treat completed bounded data as Farm-ready.

## Why
The default view previously loaded and analyzed the entire space before those features were used.

## Review Path
- `source-memories.ts`
- `use-space-data-model.ts`
- `analysis-queries.ts`
- `analysis-panel.tsx`

## Validation
- 27/27 source, data-model, and panel tests
- Focused page activation and tag-state tests
- `pnpm typecheck`
