### PR TITLE
fix(runtimeusage): retry transient reservations

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ Runtime usage is disabled by default. When enabled, the server reserves quota be
 
 The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for pending reservation finalization and metering delivery. It is enabled by default when runtime usage is enabled.
 
+Reservation retries require one of these exact responses with `details.retryable: true`: `409 registry_conflict`, `409 operation_in_progress`, `429 reservation_concurrency_limited` with a positive decimal integer-seconds `Retry-After`, or `503 unavailable`. Other response shapes retain their existing status handling. Reservation calls make up to three total attempts. The first retry samples from the base delay through the midpoint, and the second samples from the midpoint through the maximum delay. Admission concurrency responses use the greater of the sampled delay and `Retry-After`.
+
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MNEMO_RUNTIME_USAGE_ENABLED` | No | `false` | Enable runtime usage quota gating and console metering for memory recall/write operations |
@@ -315,6 +317,8 @@ The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for
 | `MNEMO_RUNTIME_USAGE_BASE_URL` | Yes when enabled | — | Runtime usage service base URL. Must be `http` or `https`; query and fragment are rejected |
 | `MNEMO_RUNTIME_USAGE_INTERNAL_SECRET` | Yes when enabled | — | Bearer token for internal runtime usage service calls |
 | `MNEMO_RUNTIME_USAGE_TIMEOUT` | No | `3s` | Timeout for quota reservation and finalization requests |
+| `MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY` | No | `500ms` | Lower bound for Reservation retry jitter. Accepted range: `300ms` through `1s` |
+| `MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY` | No | `1s` | Upper bound for Reservation retry jitter. Accepted range: `600ms` through `2s`; must exceed the base delay |
 | `MNEMO_RUNTIME_USAGE_METERING_TIMEOUT` | No | `5s` | Timeout for console metering event delivery requests |
 | `MNEMO_RUNTIME_USAGE_RESERVATION_TTL` | No | `30m` | Parsed into server config, but currently not sent to reservation requests; changing it does not alter reservation lifetimes |
 | `MNEMO_RUNTIME_USAGE_OPERATION_TTL` | No | `30m` | Parsed into server config, but currently not used to expire runtime usage outbox rows; changing it does not alter outbox lifetimes |

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -189,23 +189,7 @@ func main() {
 		logger.Info("runtime usage metering writer initialized", "enabled", true)
 	}
 	runtimeUsageClient := runtimeusage.NewHTTPClient(cfg.RuntimeUsageBaseURL, cfg.RuntimeUsageInternalSecret, cfg.RuntimeUsageTimeout)
-	runtimeUsageManager := runtimeusage.NewManager(runtimeusage.Config{
-		Enabled:            cfg.RuntimeUsageEnabled,
-		ProviderID:         cfg.RuntimeUsageProviderID,
-		BaseURL:            cfg.RuntimeUsageBaseURL,
-		InternalSecret:     cfg.RuntimeUsageInternalSecret,
-		Timeout:            cfg.RuntimeUsageTimeout,
-		MeteringTimeout:    cfg.RuntimeUsageMeteringTimeout,
-		ReservationTTL:     cfg.RuntimeUsageReservationTTL,
-		OperationTTL:       cfg.RuntimeUsageOperationTTL,
-		FailOpen:           cfg.RuntimeUsageFailOpen,
-		OutboxEnabled:      cfg.RuntimeUsageOutboxEnabled,
-		NoticeTimeout:      cfg.RuntimeUsageNoticeTimeout,
-		NoticeCacheEnabled: cfg.RuntimeUsageNoticeCacheEnabled,
-		NoticeCacheTTL:     cfg.RuntimeUsageNoticeCacheTTL,
-		NoticeStaleTTL:     cfg.RuntimeUsageNoticeStaleTTL,
-		Outbox:             runtimeUsageStore,
-	}, runtimeUsageClient, runtimeUsageMetering, logger)
+	runtimeUsageManager := runtimeusage.NewManager(newRuntimeUsageConfig(cfg, runtimeUsageStore), runtimeUsageClient, runtimeUsageMetering, logger)
 	var runtimeUsageWorkerCancel context.CancelFunc
 	if cfg.RuntimeUsageEnabled && runtimeUsageStore != nil {
 		var runtimeUsageWorkerCtx context.Context
@@ -363,6 +347,28 @@ func main() {
 		os.Exit(1)
 	}
 	logger.Info("server stopped")
+}
+
+func newRuntimeUsageConfig(cfg *config.Config, outbox runtimeusage.OutboxStore) runtimeusage.Config {
+	return runtimeusage.Config{
+		Enabled:                   cfg.RuntimeUsageEnabled,
+		ProviderID:                cfg.RuntimeUsageProviderID,
+		BaseURL:                   cfg.RuntimeUsageBaseURL,
+		InternalSecret:            cfg.RuntimeUsageInternalSecret,
+		Timeout:                   cfg.RuntimeUsageTimeout,
+		MeteringTimeout:           cfg.RuntimeUsageMeteringTimeout,
+		ReservationTTL:            cfg.RuntimeUsageReservationTTL,
+		OperationTTL:              cfg.RuntimeUsageOperationTTL,
+		ReservationRetryBaseDelay: cfg.RuntimeUsageRetryBaseDelay,
+		ReservationRetryMaxDelay:  cfg.RuntimeUsageRetryMaxDelay,
+		FailOpen:                  cfg.RuntimeUsageFailOpen,
+		OutboxEnabled:             cfg.RuntimeUsageOutboxEnabled,
+		NoticeTimeout:             cfg.RuntimeUsageNoticeTimeout,
+		NoticeCacheEnabled:        cfg.RuntimeUsageNoticeCacheEnabled,
+		NoticeCacheTTL:            cfg.RuntimeUsageNoticeCacheTTL,
+		NoticeStaleTTL:            cfg.RuntimeUsageNoticeStaleTTL,
+		Outbox:                    outbox,
+	}
 }
 
 func redactMeteringURLForLog(raw string) string {

--- a/server/cmd/mnemo-server/main_test.go
+++ b/server/cmd/mnemo-server/main_test.go
@@ -1,6 +1,26 @@
 package main
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/config"
+)
+
+func TestNewRuntimeUsageConfigMapsReservationRetryDelays(t *testing.T) {
+	cfg := &config.Config{
+		RuntimeUsageRetryBaseDelay: 450 * time.Millisecond,
+		RuntimeUsageRetryMaxDelay:  1250 * time.Millisecond,
+	}
+
+	got := newRuntimeUsageConfig(cfg, nil)
+	if got.ReservationRetryBaseDelay != cfg.RuntimeUsageRetryBaseDelay {
+		t.Fatalf("ReservationRetryBaseDelay = %v, want %v", got.ReservationRetryBaseDelay, cfg.RuntimeUsageRetryBaseDelay)
+	}
+	if got.ReservationRetryMaxDelay != cfg.RuntimeUsageRetryMaxDelay {
+		t.Fatalf("ReservationRetryMaxDelay = %v, want %v", got.ReservationRetryMaxDelay, cfg.RuntimeUsageRetryMaxDelay)
+	}
+}
 
 func TestRedactMeteringURLForLog(t *testing.T) {
 	cases := []struct {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -171,13 +171,18 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED=false requires MNEMO_RUNTIME_USAGE_FAIL_OPEN=true when runtime usage is enabled")
 		}
 	}
-	runtimeUsageRetryBaseDelay, err := envDurationStrict("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", runtimeusage.DefaultReservationRetryBaseDelay)
-	if err != nil {
-		return nil, err
-	}
-	runtimeUsageRetryMaxDelay, err := envDurationStrict("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY", runtimeusage.DefaultReservationRetryMaxDelay)
-	if err != nil {
-		return nil, err
+	runtimeUsageRetryBaseDelay := runtimeusage.DefaultReservationRetryBaseDelay
+	runtimeUsageRetryMaxDelay := runtimeusage.DefaultReservationRetryMaxDelay
+	if runtimeUsageEnabled {
+		var err error
+		runtimeUsageRetryBaseDelay, err = envDurationStrict("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", runtimeUsageRetryBaseDelay)
+		if err != nil {
+			return nil, err
+		}
+		runtimeUsageRetryMaxDelay, err = envDurationStrict("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY", runtimeUsageRetryMaxDelay)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	env := strings.ToLower(strings.TrimSpace(envOr("MNEMO_ENV", envOr("APP_ENV", "development"))))
@@ -282,22 +287,24 @@ func Load() (*Config, error) {
 	if cfg.RuntimeUsageNoticeStaleTTL < 0 {
 		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL must not be negative")
 	}
-	if cfg.RuntimeUsageRetryBaseDelay < runtimeusage.MinReservationRetryBaseDelay || cfg.RuntimeUsageRetryBaseDelay > runtimeusage.MaxReservationRetryBaseDelay {
-		return nil, fmt.Errorf(
-			"MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY must be between %s and %s",
-			runtimeusage.MinReservationRetryBaseDelay,
-			runtimeusage.MaxReservationRetryBaseDelay,
-		)
-	}
-	if cfg.RuntimeUsageRetryMaxDelay < runtimeusage.MinReservationRetryMaxDelay || cfg.RuntimeUsageRetryMaxDelay > runtimeusage.MaxReservationRetryMaxDelay {
-		return nil, fmt.Errorf(
-			"MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be between %s and %s",
-			runtimeusage.MinReservationRetryMaxDelay,
-			runtimeusage.MaxReservationRetryMaxDelay,
-		)
-	}
-	if cfg.RuntimeUsageRetryMaxDelay <= cfg.RuntimeUsageRetryBaseDelay {
-		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be greater than MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY")
+	if cfg.RuntimeUsageEnabled {
+		if cfg.RuntimeUsageRetryBaseDelay < runtimeusage.MinReservationRetryBaseDelay || cfg.RuntimeUsageRetryBaseDelay > runtimeusage.MaxReservationRetryBaseDelay {
+			return nil, fmt.Errorf(
+				"MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY must be between %s and %s",
+				runtimeusage.MinReservationRetryBaseDelay,
+				runtimeusage.MaxReservationRetryBaseDelay,
+			)
+		}
+		if cfg.RuntimeUsageRetryMaxDelay < runtimeusage.MinReservationRetryMaxDelay || cfg.RuntimeUsageRetryMaxDelay > runtimeusage.MaxReservationRetryMaxDelay {
+			return nil, fmt.Errorf(
+				"MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be between %s and %s",
+				runtimeusage.MinReservationRetryMaxDelay,
+				runtimeusage.MaxReservationRetryMaxDelay,
+			)
+		}
+		if cfg.RuntimeUsageRetryMaxDelay <= cfg.RuntimeUsageRetryBaseDelay {
+			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be greater than MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY")
+		}
 	}
 
 	return cfg, nil

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
 type Config struct {
@@ -82,6 +84,8 @@ type Config struct {
 	RuntimeUsageMeteringTimeout    time.Duration
 	RuntimeUsageReservationTTL     time.Duration
 	RuntimeUsageOperationTTL       time.Duration
+	RuntimeUsageRetryBaseDelay     time.Duration
+	RuntimeUsageRetryMaxDelay      time.Duration
 	RuntimeUsageFailOpen           bool
 	RuntimeUsageOutboxEnabled      bool
 	RuntimeUsageNoticeTimeout      time.Duration
@@ -167,6 +171,14 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_OUTBOX_ENABLED=false requires MNEMO_RUNTIME_USAGE_FAIL_OPEN=true when runtime usage is enabled")
 		}
 	}
+	runtimeUsageRetryBaseDelay, err := envDurationStrict("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", runtimeusage.DefaultReservationRetryBaseDelay)
+	if err != nil {
+		return nil, err
+	}
+	runtimeUsageRetryMaxDelay, err := envDurationStrict("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY", runtimeusage.DefaultReservationRetryMaxDelay)
+	if err != nil {
+		return nil, err
+	}
 
 	env := strings.ToLower(strings.TrimSpace(envOr("MNEMO_ENV", envOr("APP_ENV", "development"))))
 	cfg := &Config{
@@ -214,6 +226,8 @@ func Load() (*Config, error) {
 		RuntimeUsageMeteringTimeout:      envDuration("MNEMO_RUNTIME_USAGE_METERING_TIMEOUT", 5*time.Second),
 		RuntimeUsageReservationTTL:       envDuration("MNEMO_RUNTIME_USAGE_RESERVATION_TTL", 30*time.Minute),
 		RuntimeUsageOperationTTL:         envDuration("MNEMO_RUNTIME_USAGE_OPERATION_TTL", 30*time.Minute),
+		RuntimeUsageRetryBaseDelay:       runtimeUsageRetryBaseDelay,
+		RuntimeUsageRetryMaxDelay:        runtimeUsageRetryMaxDelay,
 		RuntimeUsageFailOpen:             runtimeUsageFailOpen,
 		RuntimeUsageOutboxEnabled:        runtimeUsageOutboxEnabled,
 		RuntimeUsageNoticeTimeout:        envDuration("MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT", time.Second),
@@ -267,6 +281,23 @@ func Load() (*Config, error) {
 	}
 	if cfg.RuntimeUsageNoticeStaleTTL < 0 {
 		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_NOTICE_STALE_TTL must not be negative")
+	}
+	if cfg.RuntimeUsageRetryBaseDelay < runtimeusage.MinReservationRetryBaseDelay || cfg.RuntimeUsageRetryBaseDelay > runtimeusage.MaxReservationRetryBaseDelay {
+		return nil, fmt.Errorf(
+			"MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY must be between %s and %s",
+			runtimeusage.MinReservationRetryBaseDelay,
+			runtimeusage.MaxReservationRetryBaseDelay,
+		)
+	}
+	if cfg.RuntimeUsageRetryMaxDelay < runtimeusage.MinReservationRetryMaxDelay || cfg.RuntimeUsageRetryMaxDelay > runtimeusage.MaxReservationRetryMaxDelay {
+		return nil, fmt.Errorf(
+			"MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be between %s and %s",
+			runtimeusage.MinReservationRetryMaxDelay,
+			runtimeusage.MaxReservationRetryMaxDelay,
+		)
+	}
+	if cfg.RuntimeUsageRetryMaxDelay <= cfg.RuntimeUsageRetryBaseDelay {
+		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be greater than MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY")
 	}
 
 	return cfg, nil
@@ -343,6 +374,30 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 		}
 	}
 	return fallback
+}
+
+func envDurationStrict(key string, fallback time.Duration) (time.Duration, error) {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback, nil
+	}
+	duration, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a valid duration: %w", key, &redactedDurationParseError{cause: err})
+	}
+	return duration, nil
+}
+
+type redactedDurationParseError struct {
+	cause error
+}
+
+func (e *redactedDurationParseError) Error() string {
+	return "invalid duration syntax"
+}
+
+func (e *redactedDurationParseError) Unwrap() error {
+	return e.cause
 }
 
 func parseClusterBlacklist(raw string) map[string]struct{} {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
 func TestConfig_MeteringSurfaceReduced(t *testing.T) {
@@ -371,6 +373,24 @@ func TestLoad_RuntimeUsageReservationRetryConfigRedactsParseInputAndWrapsCause(t
 	}
 	if errors.Unwrap(err) == nil {
 		t.Fatal("duration parse error did not wrap its cause")
+	}
+}
+
+func TestLoad_RuntimeUsageReservationRetryConfigIgnoresValuesWhenDisabled(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "false")
+	t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", "placeholder-base")
+	t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY", "placeholder-maximum")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RuntimeUsageRetryBaseDelay != runtimeusage.DefaultReservationRetryBaseDelay {
+		t.Fatalf("RuntimeUsageRetryBaseDelay = %v, want %v", cfg.RuntimeUsageRetryBaseDelay, runtimeusage.DefaultReservationRetryBaseDelay)
+	}
+	if cfg.RuntimeUsageRetryMaxDelay != runtimeusage.DefaultReservationRetryMaxDelay {
+		t.Fatalf("RuntimeUsageRetryMaxDelay = %v, want %v", cfg.RuntimeUsageRetryMaxDelay, runtimeusage.DefaultReservationRetryMaxDelay)
 	}
 }
 

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -219,6 +220,157 @@ func TestLoad_RuntimeUsageProviderID(t *testing.T) {
 	}
 	if cfg.RuntimeUsageProviderID != "provider-x" {
 		t.Fatalf("RuntimeUsageProviderID = %q, want provider-x", cfg.RuntimeUsageProviderID)
+	}
+}
+
+func TestLoad_RuntimeUsageReservationRetryConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		baseDelay   string
+		maxDelay    string
+		wantBase    time.Duration
+		wantMaximum time.Duration
+	}{
+		{
+			name:        "defaults",
+			wantBase:    500 * time.Millisecond,
+			wantMaximum: time.Second,
+		},
+		{
+			name:        "lower bounds",
+			baseDelay:   "300ms",
+			maxDelay:    "600ms",
+			wantBase:    300 * time.Millisecond,
+			wantMaximum: 600 * time.Millisecond,
+		},
+		{
+			name:        "upper bounds",
+			baseDelay:   "1s",
+			maxDelay:    "2s",
+			wantBase:    time.Second,
+			wantMaximum: 2 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MNEMO_DSN", "test-dsn")
+			t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+			t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+			t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+			if tt.baseDelay != "" {
+				t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", tt.baseDelay)
+			}
+			if tt.maxDelay != "" {
+				t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY", tt.maxDelay)
+			}
+
+			cfg, err := Load()
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.RuntimeUsageRetryBaseDelay != tt.wantBase {
+				t.Fatalf("RuntimeUsageRetryBaseDelay = %v, want %v", cfg.RuntimeUsageRetryBaseDelay, tt.wantBase)
+			}
+			if cfg.RuntimeUsageRetryMaxDelay != tt.wantMaximum {
+				t.Fatalf("RuntimeUsageRetryMaxDelay = %v, want %v", cfg.RuntimeUsageRetryMaxDelay, tt.wantMaximum)
+			}
+		})
+	}
+}
+
+func TestLoad_RuntimeUsageReservationRetryConfigValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseDelay  string
+		maxDelay   string
+		wantSubstr string
+	}{
+		{
+			name:       "base below minimum",
+			baseDelay:  "299ms",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY must be between 300ms and 1s",
+		},
+		{
+			name:       "base above maximum",
+			baseDelay:  "1001ms",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY must be between 300ms and 1s",
+		},
+		{
+			name:       "maximum below minimum",
+			maxDelay:   "599ms",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be between 600ms and 2s",
+		},
+		{
+			name:       "maximum above maximum",
+			maxDelay:   "2001ms",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be between 600ms and 2s",
+		},
+		{
+			name:       "maximum equals base",
+			baseDelay:  "600ms",
+			maxDelay:   "600ms",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be greater than MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY",
+		},
+		{
+			name:       "maximum below base",
+			baseDelay:  "700ms",
+			maxDelay:   "600ms",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be greater than MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY",
+		},
+		{
+			name:       "malformed base",
+			baseDelay:  "soon",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY must be a valid duration",
+		},
+		{
+			name:       "malformed maximum",
+			maxDelay:   "later",
+			wantSubstr: "MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY must be a valid duration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MNEMO_DSN", "test-dsn")
+			t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+			t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+			t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+			if tt.baseDelay != "" {
+				t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", tt.baseDelay)
+			}
+			if tt.maxDelay != "" {
+				t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_MAX_DELAY", tt.maxDelay)
+			}
+
+			_, err := Load()
+			if err == nil {
+				t.Fatal("Load error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("Load error = %v, want %q", err, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestLoad_RuntimeUsageReservationRetryConfigRedactsParseInputAndWrapsCause(t *testing.T) {
+	const rawValue = "private-duration-value"
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RUNTIME_USAGE_ENABLED", "true")
+	t.Setenv("MNEMO_RUNTIME_USAGE_BASE_URL", "https://runtime-usage.example.com")
+	t.Setenv("MNEMO_RUNTIME_USAGE_INTERNAL_SECRET", "secret-value")
+	t.Setenv("MNEMO_RUNTIME_USAGE_RESERVATION_RETRY_BASE_DELAY", rawValue)
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("Load error = nil, want duration parse error")
+	}
+	if strings.Contains(err.Error(), rawValue) {
+		t.Fatal("duration parse error exposed the raw environment value")
+	}
+	if errors.Unwrap(err) == nil {
+		t.Fatal("duration parse error did not wrap its cause")
 	}
 }
 

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -198,6 +198,16 @@ func classifyRuntimeUsageError(err error) (string, int, bool) {
 	if errors.As(err, &denied) {
 		return "quota_denied", status, status == http.StatusTooManyRequests
 	}
+	var reservationFailure interface {
+		ReservationRetryable() bool
+	}
+	if errors.As(err, &reservationFailure) {
+		var conflict *runtimeusage.ConflictError
+		if errors.As(err, &conflict) {
+			return "conflict", status, false
+		}
+		return "unavailable", status, reservationFailure.ReservationRetryable()
+	}
 	var conflict *runtimeusage.ConflictError
 	if errors.As(err, &conflict) {
 		return "conflict", status, true

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -308,6 +308,44 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			wantOperation: "operation-conflict",
 			wantMessage:   "runtime usage conflict",
 		},
+		{
+			name: "exhausted retryable reservation response",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusServiceUnavailable,
+				`{"code":"unavailable","details":{"retryable":true}}`,
+				"",
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-reserve",
+			}, runtimeusage.MeterMemoryRecallRequests),
+			wantStatus:    http.StatusServiceUnavailable,
+			wantClass:     "unavailable",
+			wantRetryable: true,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-reserve",
+			wantMeter:     runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:   "runtime usage unavailable",
+		},
+		{
+			name: "permanent reservation operation conflict",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusConflict,
+				`{"code":"operation_conflict","details":{"retryable":true}}`,
+				"",
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-reserve-conflict",
+			}, runtimeusage.MeterMemoryWriteRequests),
+			wantStatus:    http.StatusBadGateway,
+			wantClass:     "conflict",
+			wantRetryable: false,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-reserve-conflict",
+			wantMeter:     runtimeusage.MeterMemoryWriteRequests,
+			wantMessage:   "runtime usage conflict",
+		},
 	}
 
 	for _, tt := range tests {
@@ -359,6 +397,29 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newRuntimeUsageReservationResponseError(t *testing.T, status int, body, retryAfter string) error {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if retryAfter != "" {
+			w.Header().Set("Retry-After", retryAfter)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	client := runtimeusage.NewHTTPClient(upstream.URL, "test-secret", time.Second)
+	_, err := client.Reserve(context.Background(), runtimeusage.Subject{APIKeySubject: "test-subject"}, "test-operation", runtimeusage.Operation{
+		Meter: runtimeusage.MeterMemoryRecallRequests,
+		Units: 1,
+	})
+	if err == nil {
+		t.Fatal("Reserve error = nil")
+	}
+	return err
 }
 
 func TestLogRuntimeUsageBackgroundFinalizeError(t *testing.T) {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -314,7 +314,6 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 				t,
 				http.StatusServiceUnavailable,
 				`{"code":"unavailable","details":{"retryable":true}}`,
-				"",
 			),
 			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
 				ClusterID: "cluster-reserve",
@@ -333,7 +332,6 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 				t,
 				http.StatusConflict,
 				`{"code":"operation_conflict","details":{"retryable":true}}`,
-				"",
 			),
 			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
 				ClusterID: "cluster-reserve-conflict",
@@ -399,13 +397,10 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 	}
 }
 
-func newRuntimeUsageReservationResponseError(t *testing.T, status int, body, retryAfter string) error {
+func newRuntimeUsageReservationResponseError(t *testing.T, status int, body string) error {
 	t.Helper()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		if retryAfter != "" {
-			w.Header().Set("Retry-After", retryAfter)
-		}
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
 	}))

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -94,6 +94,11 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		return &UnavailableError{Err: err}
 	}
 	defer resp.Body.Close()
+	success := resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices
+	if success && out == nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBodyBytes+1))
+		return nil
+	}
 	respBody, overflow, err := readBoundedResponseBody(resp.Body)
 	if err != nil || overflow {
 		if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
@@ -119,7 +124,7 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	if resp.StatusCode == http.StatusConflict {
 		return newConflictError(resp, respBody)
 	}
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+	if !success {
 		return &UnavailableError{Err: fmt.Errorf("runtime usage service returned status %d", resp.StatusCode)}
 	}
 	if out != nil && len(respBody) > 0 {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -20,6 +20,8 @@ type HTTPClient struct {
 	client         *http.Client
 }
 
+const maxResponseBodyBytes = 1 << 20
+
 func NewHTTPClient(baseURL, internalSecret string, timeout time.Duration) *HTTPClient {
 	if timeout <= 0 {
 		timeout = 3 * time.Second
@@ -92,13 +94,16 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		return &UnavailableError{Err: err}
 	}
 	defer resp.Body.Close()
-	respBody, err := readBoundedResponseBody(resp.Body)
-	if err != nil {
+	respBody, overflow, err := readBoundedResponseBody(resp.Body)
+	if err != nil || overflow {
+		if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
+			return newQuotaDeniedError(resp, nil)
+		}
 		if resp.StatusCode == http.StatusConflict {
 			return newConflictError(resp, nil)
 		}
-		if classifyQuotaStatuses && resp.StatusCode == http.StatusPaymentRequired {
-			return newQuotaDeniedError(resp, nil)
+		if err == nil {
+			err = fmt.Errorf("runtime usage response exceeds %d bytes", maxResponseBodyBytes)
 		}
 		return &UnavailableError{Err: err}
 	}
@@ -183,16 +188,16 @@ func parseRetryAfter(raw string) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
-func readBoundedResponseBody(body io.Reader) ([]byte, error) {
-	const maxResponseBodyBytes = 1 << 20
+func readBoundedResponseBody(body io.Reader) ([]byte, bool, error) {
 	responseBody, err := io.ReadAll(io.LimitReader(body, maxResponseBodyBytes+1))
+	overflow := len(responseBody) > maxResponseBodyBytes
+	if overflow {
+		responseBody = responseBody[:maxResponseBodyBytes]
+	}
 	if err != nil {
-		return nil, fmt.Errorf("runtime usage read response: %w", err)
+		return responseBody, overflow, fmt.Errorf("runtime usage read response: %w", err)
 	}
-	if len(responseBody) > maxResponseBodyBytes {
-		return nil, fmt.Errorf("runtime usage response exceeds %d bytes", maxResponseBodyBytes)
-	}
-	return responseBody, nil
+	return responseBody, overflow, nil
 }
 
 func isRuntimeQuotaDenialResponse(status int, body []byte) bool {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -94,6 +94,9 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	defer resp.Body.Close()
 	respBody, err := readBoundedResponseBody(resp.Body)
 	if err != nil {
+		if classifyQuotaStatuses && resp.StatusCode == http.StatusPaymentRequired {
+			return newQuotaDeniedError(resp, nil)
+		}
 		return &UnavailableError{Err: err}
 	}
 
@@ -103,11 +106,7 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		}
 	}
 	if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
-		return &QuotaDeniedError{
-			StatusCode: resp.StatusCode,
-			Body:       respBody,
-			RetryAfter: strings.TrimSpace(resp.Header.Get("Retry-After")),
-		}
+		return newQuotaDeniedError(resp, respBody)
 	}
 	if resp.StatusCode == http.StatusConflict {
 		return &ConflictError{StatusCode: resp.StatusCode, Body: respBody}
@@ -121,6 +120,14 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		}
 	}
 	return nil
+}
+
+func newQuotaDeniedError(resp *http.Response, body []byte) *QuotaDeniedError {
+	return &QuotaDeniedError{
+		StatusCode: resp.StatusCode,
+		Body:       body,
+		RetryAfter: strings.TrimSpace(resp.Header.Get("Retry-After")),
+	}
 }
 
 func classifyReservationError(status int, body []byte, retryAfterHeader string) *reservationError {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -94,6 +94,9 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	defer resp.Body.Close()
 	respBody, err := readBoundedResponseBody(resp.Body)
 	if err != nil {
+		if resp.StatusCode == http.StatusConflict {
+			return newConflictError(resp, nil)
+		}
 		if classifyQuotaStatuses && resp.StatusCode == http.StatusPaymentRequired {
 			return newQuotaDeniedError(resp, nil)
 		}
@@ -109,7 +112,7 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		return newQuotaDeniedError(resp, respBody)
 	}
 	if resp.StatusCode == http.StatusConflict {
-		return &ConflictError{StatusCode: resp.StatusCode, Body: respBody}
+		return newConflictError(resp, respBody)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return &UnavailableError{Err: fmt.Errorf("runtime usage service returned status %d", resp.StatusCode)}
@@ -128,6 +131,10 @@ func newQuotaDeniedError(resp *http.Response, body []byte) *QuotaDeniedError {
 		Body:       body,
 		RetryAfter: strings.TrimSpace(resp.Header.Get("Retry-After")),
 	}
+}
+
+func newConflictError(resp *http.Response, body []byte) *ConflictError {
+	return &ConflictError{StatusCode: resp.StatusCode, Body: body}
 }
 
 func classifyReservationError(status int, body []byte, retryAfterHeader string) *reservationError {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -91,8 +92,16 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		return &UnavailableError{Err: err}
 	}
 	defer resp.Body.Close()
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	respBody, err := readBoundedResponseBody(resp.Body)
+	if err != nil {
+		return &UnavailableError{Err: err}
+	}
 
+	if classifyQuotaStatuses {
+		if reservationErr := classifyReservationError(resp.StatusCode, respBody, resp.Header.Get("Retry-After")); reservationErr != nil {
+			return reservationErr
+		}
+	}
 	if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
 		return &QuotaDeniedError{
 			StatusCode: resp.StatusCode,
@@ -112,6 +121,59 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		}
 	}
 	return nil
+}
+
+func classifyReservationError(status int, body []byte, retryAfterHeader string) *reservationError {
+	var envelope struct {
+		Code    reservationErrorCode `json:"code"`
+		Details struct {
+			Retryable bool `json:"retryable"`
+		} `json:"details"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil
+	}
+
+	policy, known := envelope.Code.policy()
+	if !known || policy.statusCode != status {
+		return nil
+	}
+
+	retryAfter := parseRetryAfter(retryAfterHeader)
+	retryable := policy.retryable && envelope.Details.Retryable
+	if envelope.Code == reservationErrorCodeConcurrencyLimited {
+		retryable = retryable && retryAfter > 0
+	}
+	return newReservationError(envelope.Code, retryable, retryAfter)
+}
+
+func parseRetryAfter(raw string) time.Duration {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0
+	}
+	for _, digit := range []byte(raw) {
+		if digit < '0' || digit > '9' {
+			return 0
+		}
+	}
+	seconds, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil || seconds == 0 || seconds > uint64((1<<63-1)/time.Second) {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func readBoundedResponseBody(body io.Reader) ([]byte, error) {
+	const maxResponseBodyBytes = 1 << 20
+	responseBody, err := io.ReadAll(io.LimitReader(body, maxResponseBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("runtime usage read response: %w", err)
+	}
+	if len(responseBody) > maxResponseBodyBytes {
+		return nil, fmt.Errorf("runtime usage response exceeds %d bytes", maxResponseBodyBytes)
+	}
+	return responseBody, nil
 }
 
 func isRuntimeQuotaDenialResponse(status int, body []byte) bool {

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -138,13 +138,18 @@ func classifyReservationError(status int, body []byte, retryAfterHeader string) 
 	if !known || policy.statusCode != status {
 		return nil
 	}
+	if envelope.Code == reservationErrorCodeOperationConflict {
+		return newReservationError(envelope.Code, false, 0)
+	}
+	if !policy.retryable || !envelope.Details.Retryable {
+		return nil
+	}
 
 	retryAfter := parseRetryAfter(retryAfterHeader)
-	retryable := policy.retryable && envelope.Details.Retryable
-	if envelope.Code == reservationErrorCodeConcurrencyLimited {
-		retryable = retryable && retryAfter > 0
+	if envelope.Code == reservationErrorCodeConcurrencyLimited && retryAfter == 0 {
+		return nil
 	}
-	return newReservationError(envelope.Code, retryable, retryAfter)
+	return newReservationError(envelope.Code, true, retryAfter)
 }
 
 func parseRetryAfter(raw string) time.Duration {

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -587,6 +587,22 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 		}
 	})
 
+	t.Run("quota denial survives read failure", func(t *testing.T) {
+		client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+		client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusPaymentRequired,
+				Header:     make(http.Header),
+				Body:       failingReadCloser{err: errors.New("quota response read failed")},
+			}, nil
+		})}
+		_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", Operation{Meter: MeterMemoryRecallRequests, Units: 1})
+		var denied *QuotaDeniedError
+		if !errors.As(err, &denied) || denied.Status() != http.StatusPaymentRequired {
+			t.Fatalf("Reserve error = %T, want status-based quota denial", err)
+		}
+	})
+
 	const structuredBody = `{"code":"unavailable","details":{"retryable":true}}`
 	for _, tt := range []struct {
 		name           string
@@ -611,6 +627,17 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("oversized quota denial preserves status classification", func(t *testing.T) {
+		err := reserveErrorForTest(t, http.StatusPaymentRequired, strings.Repeat("x", (1<<20)+1), "")
+		var denied *QuotaDeniedError
+		if !errors.As(err, &denied) || denied.Status() != http.StatusPaymentRequired {
+			t.Fatalf("Reserve error = %T, want status-based quota denial", err)
+		}
+		if len(denied.Body) != 0 {
+			t.Fatal("oversized quota denial retained response body bytes")
+		}
+	})
 
 	t.Run("structured response body is discarded", func(t *testing.T) {
 		const sensitiveMarker = "sensitive-provider-message"

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -388,7 +388,7 @@ func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.
 	tests := []struct {
 		name           string
 		retryAfter     string
-		wantRetryable  bool
+		wantStructured bool
 		wantRetryAfter time.Duration
 	}{
 		{name: "missing"},
@@ -398,7 +398,7 @@ func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.
 		{name: "zero", retryAfter: "0"},
 		{name: "duration overflow", retryAfter: "9223372037"},
 		{name: "integer overflow", retryAfter: "18446744073709551616"},
-		{name: "positive integer seconds", retryAfter: "2", wantRetryable: true, wantRetryAfter: 2 * time.Second},
+		{name: "positive integer seconds", retryAfter: "2", wantStructured: true, wantRetryAfter: 2 * time.Second},
 	}
 
 	for _, tt := range tests {
@@ -417,11 +417,15 @@ func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.
 				Units: 1,
 			})
 			var reservationErr *reservationError
-			if !errors.As(err, &reservationErr) {
-				t.Fatalf("Reserve error = %T, want ReservationError", err)
+			if got := errors.As(err, &reservationErr); got != tt.wantStructured {
+				t.Fatalf("structured reservation classification = %v, want %v", got, tt.wantStructured)
 			}
-			if reservationErr.retryable != tt.wantRetryable {
-				t.Fatalf("Retryable = %v, want %v", reservationErr.retryable, tt.wantRetryable)
+			if !tt.wantStructured {
+				var unavailable *UnavailableError
+				if !errors.As(err, &unavailable) {
+					t.Fatalf("Reserve error = %T, want legacy unavailable fallback", err)
+				}
+				return
 			}
 			if reservationErr.retryAfter != tt.wantRetryAfter {
 				t.Fatalf("RetryAfter = %v, want %v", reservationErr.retryAfter, tt.wantRetryAfter)
@@ -488,10 +492,12 @@ func TestHTTPClientReserveRequiresExactReservationRetryContract(t *testing.T) {
 				body += "}"
 				err := reserveErrorForTest(t, code.status, body, code.retryAfter)
 				var reservationErr *reservationError
-				if got := errors.As(err, &reservationErr); got != detail.wantStructured {
-					t.Fatalf("structured reservation classification = %v, want %v", got, detail.wantStructured)
+				wantStructured := detail.wantStructured && (detail.wantRetryable || code.code == reservationErrorCodeOperationConflict)
+				if got := errors.As(err, &reservationErr); got != wantStructured {
+					t.Fatalf("structured reservation classification = %v, want %v", got, wantStructured)
 				}
-				if !detail.wantStructured {
+				if !wantStructured {
+					assertReservationFallbackForStatus(t, err, code.status)
 					return
 				}
 				wantRetryable := detail.wantRetryable && code.code != reservationErrorCodeOperationConflict

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -19,6 +19,21 @@ func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
 }
 
+type reservationContractCase struct {
+	name       string
+	code       reservationErrorCode
+	status     int
+	retryAfter string
+}
+
+var reservationContractCases = []reservationContractCase{
+	{name: "registry conflict", code: reservationErrorCodeRegistryConflict, status: http.StatusConflict},
+	{name: "operation in progress", code: reservationErrorCodeOperationInProgress, status: http.StatusConflict},
+	{name: "concurrency limited", code: reservationErrorCodeConcurrencyLimited, status: http.StatusTooManyRequests, retryAfter: "1"},
+	{name: "unavailable", code: reservationErrorCodeUnavailable, status: http.StatusServiceUnavailable},
+	{name: "operation conflict", code: reservationErrorCodeOperationConflict, status: http.StatusConflict},
+}
+
 func TestHTTPClientReserveAllowsNullRemainingIncludedUnits(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -337,6 +352,277 @@ func TestHTTPClientReserveTreatsGenericRateLimitAsUnavailable(t *testing.T) {
 	}
 }
 
+func TestHTTPClientReserveClassifiesStructuredReservationErrors(t *testing.T) {
+	for _, tt := range reservationContractCases {
+		t.Run(tt.name, func(t *testing.T) {
+			body := `{"code":"` + string(tt.code) + `","details":{"retryable":true}}`
+			err := reserveErrorForTest(t, tt.status, body, tt.retryAfter)
+			var reservationErr *reservationError
+			if !errors.As(err, &reservationErr) {
+				t.Fatalf("Reserve error = %T, want ReservationError", err)
+			}
+			if reservationErr.code != tt.code {
+				t.Fatalf("Code = %q, want %q", reservationErr.code, tt.code)
+			}
+			wantRetryable := tt.code != reservationErrorCodeOperationConflict
+			if reservationErr.retryable != wantRetryable {
+				t.Fatalf("Retryable = %v, want %v", reservationErr.retryable, wantRetryable)
+			}
+			wantRetryAfter := time.Duration(0)
+			if tt.code == reservationErrorCodeConcurrencyLimited {
+				wantRetryAfter = time.Second
+			}
+			if reservationErr.retryAfter != wantRetryAfter {
+				t.Fatalf("RetryAfter = %v, want %v", reservationErr.retryAfter, wantRetryAfter)
+			}
+			var conflict *ConflictError
+			wantConflict := tt.code == reservationErrorCodeOperationConflict
+			if got := errors.As(err, &conflict); got != wantConflict {
+				t.Fatalf("ConflictError classification = %v, want %v", got, wantConflict)
+			}
+		})
+	}
+}
+
+func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.T) {
+	tests := []struct {
+		name           string
+		retryAfter     string
+		wantRetryable  bool
+		wantRetryAfter time.Duration
+	}{
+		{name: "missing"},
+		{name: "malformed", retryAfter: "soon"},
+		{name: "signed positive", retryAfter: "+2"},
+		{name: "negative", retryAfter: "-2"},
+		{name: "zero", retryAfter: "0"},
+		{name: "duration overflow", retryAfter: "9223372037"},
+		{name: "integer overflow", retryAfter: "18446744073709551616"},
+		{name: "positive integer seconds", retryAfter: "2", wantRetryable: true, wantRetryAfter: 2 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return statusJSONResponse(
+					http.StatusTooManyRequests,
+					`{"code":"reservation_concurrency_limited","message":"admission is busy","details":{"retryable":true}}`,
+					http.Header{"Retry-After": []string{tt.retryAfter}},
+				), nil
+			})}
+
+			_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-concurrency", Operation{
+				Meter: MeterMemoryRecallRequests,
+				Units: 1,
+			})
+			var reservationErr *reservationError
+			if !errors.As(err, &reservationErr) {
+				t.Fatalf("Reserve error = %T, want ReservationError", err)
+			}
+			if reservationErr.retryable != tt.wantRetryable {
+				t.Fatalf("Retryable = %v, want %v", reservationErr.retryable, tt.wantRetryable)
+			}
+			if reservationErr.retryAfter != tt.wantRetryAfter {
+				t.Fatalf("RetryAfter = %v, want %v", reservationErr.retryAfter, tt.wantRetryAfter)
+			}
+		})
+	}
+}
+
+func TestHTTPClientReserveKeepsPermanentStatusesOutsideRetryAllowlist(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "invalid request", status: http.StatusBadRequest, body: `{"code":"invalid_request","message":"invalid","details":{"retryable":false}}`},
+		{name: "unauthenticated", status: http.StatusUnauthorized, body: `{"code":"unauthenticated","message":"authenticate","details":{"retryable":false}}`},
+		{name: "forbidden", status: http.StatusForbidden, body: `{"code":"forbidden","message":"forbidden","details":{"retryable":false}}`},
+		{name: "unavailable code on unaccepted status", status: http.StatusInternalServerError, body: `{"code":"unavailable","message":"try again","details":{"retryable":true}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return statusJSONResponse(tt.status, tt.body, nil), nil
+			})}
+
+			_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-terminal", Operation{
+				Meter: MeterMemoryRecallRequests,
+				Units: 1,
+			})
+			var reservationErr *reservationError
+			if errors.As(err, &reservationErr) {
+				t.Fatalf("Reserve error = %+v, want terminal unavailable classification", reservationErr)
+			}
+			var unavailable *UnavailableError
+			if !errors.As(err, &unavailable) {
+				t.Fatalf("Reserve error = %T, want UnavailableError", err)
+			}
+		})
+	}
+}
+
+func TestHTTPClientReserveRequiresExactReservationRetryContract(t *testing.T) {
+	details := []struct {
+		name           string
+		json           string
+		wantStructured bool
+		wantRetryable  bool
+	}{
+		{name: "true", json: `"details":{"retryable":true}`, wantStructured: true, wantRetryable: true},
+		{name: "false", json: `"details":{"retryable":false}`, wantStructured: true},
+		{name: "missing", wantStructured: true},
+		{name: "non boolean", json: `"details":{"retryable":"true"}`},
+	}
+
+	for _, code := range reservationContractCases {
+		for _, detail := range details {
+			t.Run(code.name+"/"+detail.name, func(t *testing.T) {
+				body := `{"code":"` + string(code.code) + `"`
+				if detail.json != "" {
+					body += "," + detail.json
+				}
+				body += "}"
+				err := reserveErrorForTest(t, code.status, body, code.retryAfter)
+				var reservationErr *reservationError
+				if got := errors.As(err, &reservationErr); got != detail.wantStructured {
+					t.Fatalf("structured reservation classification = %v, want %v", got, detail.wantStructured)
+				}
+				if !detail.wantStructured {
+					return
+				}
+				wantRetryable := detail.wantRetryable && code.code != reservationErrorCodeOperationConflict
+				if reservationErr.retryable != wantRetryable {
+					t.Fatalf("Retryable = %v, want %v", reservationErr.retryable, wantRetryable)
+				}
+			})
+		}
+	}
+}
+
+func TestHTTPClientReserveUsesOnlyExactKnownStatusCodePairs(t *testing.T) {
+	statuses := []int{
+		http.StatusConflict,
+		http.StatusTooManyRequests,
+		http.StatusServiceUnavailable,
+	}
+
+	for _, contract := range reservationContractCases {
+		for _, status := range statuses {
+			t.Run(contract.name+"/"+http.StatusText(status), func(t *testing.T) {
+				body := `{"code":"` + string(contract.code) + `","details":{"retryable":true}}`
+				err := reserveErrorForTest(t, status, body, "1")
+				var reservationErr *reservationError
+				if status == contract.status {
+					if !errors.As(err, &reservationErr) {
+						t.Fatal("exact status/code pair missed structured reservation classification")
+					}
+					if reservationErr.code != contract.code {
+						t.Fatal("exact status/code pair produced the wrong structured classification")
+					}
+					return
+				}
+				if errors.As(err, &reservationErr) {
+					t.Fatal("status/code mismatch received structured reservation classification")
+				}
+				assertReservationFallbackForStatus(t, err, status)
+			})
+		}
+	}
+
+	t.Run("unknown code on conflict", func(t *testing.T) {
+		err := reserveErrorForTest(
+			t,
+			http.StatusConflict,
+			`{"code":"future_retryable","details":{"retryable":true}}`,
+			"",
+		)
+		var reservationErr *reservationError
+		if errors.As(err, &reservationErr) {
+			t.Fatal("unknown code received structured reservation classification")
+		}
+		assertReservationFallbackForStatus(t, err, http.StatusConflict)
+	})
+}
+
+func assertReservationFallbackForStatus(t *testing.T, err error, status int) {
+	t.Helper()
+	if status == http.StatusConflict {
+		var conflict *ConflictError
+		if !errors.As(err, &conflict) || HTTPStatus(err) != http.StatusBadGateway {
+			t.Fatal("generic 409 did not preserve the legacy conflict fallback")
+		}
+		return
+	}
+	var unavailable *UnavailableError
+	if !errors.As(err, &unavailable) || HTTPStatus(err) != http.StatusServiceUnavailable {
+		t.Fatal("generic non-conflict response did not preserve unavailable fallback")
+	}
+}
+
+func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
+	t.Run("read failure", func(t *testing.T) {
+		readErr := errors.New("response read sentinel")
+		client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+		client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+				Header:     make(http.Header),
+				Body:       failingReadCloser{err: readErr},
+			}, nil
+		})}
+		_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", Operation{Meter: MeterMemoryRecallRequests, Units: 1})
+		var unavailable *UnavailableError
+		if !errors.As(err, &unavailable) {
+			t.Fatalf("Reserve error = %T, want UnavailableError", err)
+		}
+		if !errors.Is(err, readErr) {
+			t.Fatal("Reserve error did not preserve the response read failure")
+		}
+	})
+
+	const structuredBody = `{"code":"unavailable","details":{"retryable":true}}`
+	for _, tt := range []struct {
+		name           string
+		size           int
+		wantStructured bool
+	}{
+		{name: "response at limit", size: 1 << 20, wantStructured: true},
+		{name: "response above limit", size: (1 << 20) + 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			body := structuredBody + strings.Repeat(" ", tt.size-len(structuredBody))
+			err := reserveErrorForTest(t, http.StatusServiceUnavailable, body, "")
+			var reservationErr *reservationError
+			if got := errors.As(err, &reservationErr); got != tt.wantStructured {
+				t.Fatalf("structured reservation classification = %v, want %v", got, tt.wantStructured)
+			}
+			if !tt.wantStructured {
+				var unavailable *UnavailableError
+				if !errors.As(err, &unavailable) {
+					t.Fatalf("Reserve error = %T, want UnavailableError", err)
+				}
+			}
+		})
+	}
+
+	t.Run("structured response body is discarded", func(t *testing.T) {
+		const sensitiveMarker = "sensitive-provider-message"
+		err := reserveErrorForTest(
+			t,
+			http.StatusServiceUnavailable,
+			`{"code":"unavailable","message":"`+sensitiveMarker+`","details":{"retryable":true}}`,
+			"",
+		)
+		if strings.Contains(err.Error(), sensitiveMarker) {
+			t.Fatal("structured reservation error retained provider response text")
+		}
+	})
+}
+
 func TestHTTPClientFinalizeReservationTreatsRateLimitAsUnavailable(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -358,6 +644,36 @@ func TestHTTPClientFinalizeReservationTreatsRateLimitAsUnavailable(t *testing.T)
 	if !errors.As(err, &unavailable) {
 		t.Fatalf("FinalizeReservation error = %T, want UnavailableError", err)
 	}
+}
+
+type failingReadCloser struct {
+	err error
+}
+
+func (r failingReadCloser) Read([]byte) (int, error) {
+	return 0, r.err
+}
+
+func (failingReadCloser) Close() error { return nil }
+
+func reserveErrorForTest(t *testing.T, status int, body, retryAfter string) error {
+	t.Helper()
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		if retryAfter != "" {
+			header.Set("Retry-After", retryAfter)
+		}
+		return statusJSONResponse(status, body, header), nil
+	})}
+	_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", Operation{
+		Meter: MeterMemoryRecallRequests,
+		Units: 1,
+	})
+	if err == nil {
+		t.Fatal("Reserve error = nil")
+	}
+	return err
 }
 
 func jsonResponse(body string) *http.Response {

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -421,10 +421,7 @@ func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.
 				t.Fatalf("structured reservation classification = %v, want %v", got, tt.wantStructured)
 			}
 			if !tt.wantStructured {
-				var unavailable *UnavailableError
-				if !errors.As(err, &unavailable) {
-					t.Fatalf("Reserve error = %T, want legacy unavailable fallback", err)
-				}
+				assertReservationFallbackForStatus(t, err, http.StatusTooManyRequests)
 				return
 			}
 			if reservationErr.retryAfter != tt.wantRetryAfter {
@@ -471,14 +468,14 @@ func TestHTTPClientReserveKeepsPermanentStatusesOutsideRetryAllowlist(t *testing
 
 func TestHTTPClientReserveRequiresExactReservationRetryContract(t *testing.T) {
 	details := []struct {
-		name           string
-		json           string
-		wantStructured bool
-		wantRetryable  bool
+		name          string
+		json          string
+		decodable     bool
+		wantRetryable bool
 	}{
-		{name: "true", json: `"details":{"retryable":true}`, wantStructured: true, wantRetryable: true},
-		{name: "false", json: `"details":{"retryable":false}`, wantStructured: true},
-		{name: "missing", wantStructured: true},
+		{name: "true", json: `"details":{"retryable":true}`, decodable: true, wantRetryable: true},
+		{name: "false", json: `"details":{"retryable":false}`, decodable: true},
+		{name: "missing", decodable: true},
 		{name: "non boolean", json: `"details":{"retryable":"true"}`},
 	}
 
@@ -492,7 +489,7 @@ func TestHTTPClientReserveRequiresExactReservationRetryContract(t *testing.T) {
 				body += "}"
 				err := reserveErrorForTest(t, code.status, body, code.retryAfter)
 				var reservationErr *reservationError
-				wantStructured := detail.wantStructured && (detail.wantRetryable || code.code == reservationErrorCodeOperationConflict)
+				wantStructured := detail.decodable && (detail.wantRetryable || code.code == reservationErrorCodeOperationConflict)
 				if got := errors.As(err, &reservationErr); got != wantStructured {
 					t.Fatalf("structured reservation classification = %v, want %v", got, wantStructured)
 				}

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -34,6 +34,12 @@ var reservationContractCases = []reservationContractCase{
 	{name: "operation conflict", code: reservationErrorCodeOperationConflict, status: http.StatusConflict},
 }
 
+const postQuotaRateLimitBody = `{"code":"provider_post_quota_throttled","message":"Post-quota rate limit exceeded.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`
+
+func oversizedResponseWithPrefix(prefix string) string {
+	return prefix + strings.Repeat(" ", (1<<20)+1-len(prefix))
+}
+
 func TestHTTPClientReserveAllowsNullRemainingIncludedUnits(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -654,6 +660,45 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 			t.Fatal("oversized quota denial retained response body bytes")
 		}
 	})
+
+	t.Run("oversized post quota denial preserves quota classification", func(t *testing.T) {
+		body := oversizedResponseWithPrefix(postQuotaRateLimitBody)
+		err := reserveErrorForTest(t, http.StatusTooManyRequests, body, "20")
+		var denied *QuotaDeniedError
+		if !errors.As(err, &denied) || denied.Status() != http.StatusTooManyRequests {
+			t.Fatalf("Reserve error = %T, want status-based post-quota denial", err)
+		}
+		if denied.RetryAfter != "20" {
+			t.Fatalf("RetryAfter = %q, want 20", denied.RetryAfter)
+		}
+		if len(denied.Body) != 0 {
+			t.Fatal("oversized post-quota denial retained response body bytes")
+		}
+	})
+
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{name: "oversized generic rate limit", body: `{"error":"rate limited"}`},
+		{name: "oversized concurrency limit", body: `{"code":"reservation_concurrency_limited","details":{"retryable":true}}`},
+	} {
+		t.Run(tt.name+" stays unavailable", func(t *testing.T) {
+			err := reserveErrorForTest(t, http.StatusTooManyRequests, oversizedResponseWithPrefix(tt.body), "1")
+			var denied *QuotaDeniedError
+			if errors.As(err, &denied) {
+				t.Fatalf("Reserve error = %T, want non-quota unavailable failure", err)
+			}
+			var reservationErr *reservationError
+			if errors.As(err, &reservationErr) {
+				t.Fatalf("Reserve error = %T, want no structured retry classification", err)
+			}
+			var unavailable *UnavailableError
+			if !errors.As(err, &unavailable) {
+				t.Fatalf("Reserve error = %T, want UnavailableError", err)
+			}
+		})
+	}
 
 	t.Run("oversized conflict preserves status classification", func(t *testing.T) {
 		err := reserveErrorForTest(t, http.StatusConflict, strings.Repeat("x", (1<<20)+1), "")

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -37,7 +37,7 @@ var reservationContractCases = []reservationContractCase{
 const postQuotaRateLimitBody = `{"code":"provider_post_quota_throttled","message":"Post-quota rate limit exceeded.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`
 
 func oversizedResponseWithPrefix(prefix string) string {
-	return prefix + strings.Repeat(" ", (1<<20)+1-len(prefix))
+	return prefix + strings.Repeat(" ", maxResponseBodyBytes+1-len(prefix))
 }
 
 type responseBodyCase struct {
@@ -56,7 +56,7 @@ func successfulFinalizeBodyFailureCases() []responseBodyCase {
 		{
 			name: "oversized body",
 			body: func() io.ReadCloser {
-				return io.NopCloser(strings.NewReader(strings.Repeat("x", (1<<20)+1)))
+				return io.NopCloser(strings.NewReader(strings.Repeat("x", maxResponseBodyBytes+1)))
 			},
 		},
 	}
@@ -653,8 +653,8 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 		size           int
 		wantStructured bool
 	}{
-		{name: "response at limit", size: 1 << 20, wantStructured: true},
-		{name: "response above limit", size: (1 << 20) + 1},
+		{name: "response at limit", size: maxResponseBodyBytes, wantStructured: true},
+		{name: "response above limit", size: maxResponseBodyBytes + 1},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			body := structuredBody + strings.Repeat(" ", tt.size-len(structuredBody))
@@ -673,7 +673,7 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 	}
 
 	t.Run("oversized quota denial preserves status classification", func(t *testing.T) {
-		err := reserveErrorForTest(t, http.StatusPaymentRequired, strings.Repeat("x", (1<<20)+1), "")
+		err := reserveErrorForTest(t, http.StatusPaymentRequired, strings.Repeat("x", maxResponseBodyBytes+1), "")
 		var denied *QuotaDeniedError
 		if !errors.As(err, &denied) || denied.Status() != http.StatusPaymentRequired {
 			t.Fatalf("Reserve error = %T, want status-based quota denial", err)
@@ -723,7 +723,7 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 	}
 
 	t.Run("oversized conflict preserves status classification", func(t *testing.T) {
-		err := reserveErrorForTest(t, http.StatusConflict, strings.Repeat("x", (1<<20)+1), "")
+		err := reserveErrorForTest(t, http.StatusConflict, strings.Repeat("x", maxResponseBodyBytes+1), "")
 		var conflict *ConflictError
 		if !errors.As(err, &conflict) {
 			t.Fatalf("Reserve error = %T, want status-based conflict", err)
@@ -792,7 +792,7 @@ func TestHTTPClientFinalizeReservationIgnoresSuccessfulResponseBodies(t *testing
 func TestHTTPClientFinalizeReservationPreservesOversizedConflict(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-		return statusJSONResponse(http.StatusConflict, strings.Repeat("x", (1<<20)+1), nil), nil
+		return statusJSONResponse(http.StatusConflict, strings.Repeat("x", maxResponseBodyBytes+1), nil), nil
 	})}
 
 	err := client.FinalizeReservation(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", ReservationStatusCommitted, reservationCommitReason)

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -40,6 +40,28 @@ func oversizedResponseWithPrefix(prefix string) string {
 	return prefix + strings.Repeat(" ", (1<<20)+1-len(prefix))
 }
 
+type responseBodyCase struct {
+	name string
+	body func() io.ReadCloser
+}
+
+func successfulFinalizeBodyFailureCases() []responseBodyCase {
+	return []responseBodyCase{
+		{
+			name: "read failure",
+			body: func() io.ReadCloser {
+				return failingReadCloser{err: errors.New("finalize response read sentinel")}
+			},
+		},
+		{
+			name: "oversized body",
+			body: func() io.ReadCloser {
+				return io.NopCloser(strings.NewReader(strings.Repeat("x", (1<<20)+1)))
+			},
+		},
+	}
+}
+
 func TestHTTPClientReserveAllowsNullRemainingIncludedUnits(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
@@ -745,6 +767,25 @@ func TestHTTPClientFinalizeReservationTreatsRateLimitAsUnavailable(t *testing.T)
 	var unavailable *UnavailableError
 	if !errors.As(err, &unavailable) {
 		t.Fatalf("FinalizeReservation error = %T, want UnavailableError", err)
+	}
+}
+
+func TestHTTPClientFinalizeReservationIgnoresSuccessfulResponseBodies(t *testing.T) {
+	for _, tt := range successfulFinalizeBodyFailureCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       tt.body(),
+				}, nil
+			})}
+
+			if err := client.FinalizeReservation(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", ReservationStatusCommitted, reservationCommitReason); err != nil {
+				t.Fatalf("FinalizeReservation: %v", err)
+			}
+		})
 	}
 }
 

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -603,6 +603,22 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 		}
 	})
 
+	t.Run("conflict survives read failure", func(t *testing.T) {
+		client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+		client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusConflict,
+				Header:     make(http.Header),
+				Body:       failingReadCloser{err: errors.New("conflict response read failed")},
+			}, nil
+		})}
+		_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", Operation{Meter: MeterMemoryRecallRequests, Units: 1})
+		var conflict *ConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("Reserve error = %T, want status-based conflict", err)
+		}
+	})
+
 	const structuredBody = `{"code":"unavailable","details":{"retryable":true}}`
 	for _, tt := range []struct {
 		name           string
@@ -636,6 +652,17 @@ func TestHTTPClientReserveBoundsAndRedactsResponseFailures(t *testing.T) {
 		}
 		if len(denied.Body) != 0 {
 			t.Fatal("oversized quota denial retained response body bytes")
+		}
+	})
+
+	t.Run("oversized conflict preserves status classification", func(t *testing.T) {
+		err := reserveErrorForTest(t, http.StatusConflict, strings.Repeat("x", (1<<20)+1), "")
+		var conflict *ConflictError
+		if !errors.As(err, &conflict) {
+			t.Fatalf("Reserve error = %T, want status-based conflict", err)
+		}
+		if len(conflict.Body) != 0 {
+			t.Fatal("oversized conflict retained response body bytes")
 		}
 	})
 
@@ -673,6 +700,22 @@ func TestHTTPClientFinalizeReservationTreatsRateLimitAsUnavailable(t *testing.T)
 	var unavailable *UnavailableError
 	if !errors.As(err, &unavailable) {
 		t.Fatalf("FinalizeReservation error = %T, want UnavailableError", err)
+	}
+}
+
+func TestHTTPClientFinalizeReservationPreservesOversizedConflict(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return statusJSONResponse(http.StatusConflict, strings.Repeat("x", (1<<20)+1), nil), nil
+	})}
+
+	err := client.FinalizeReservation(context.Background(), Subject{APIKeySubject: "test-subject"}, "test-operation", ReservationStatusCommitted, reservationCommitReason)
+	var conflict *ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("FinalizeReservation error = %T, want status-based conflict", err)
+	}
+	if len(conflict.Body) != 0 {
+		t.Fatal("oversized finalization conflict retained response body bytes")
 	}
 }
 

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -289,7 +289,7 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 			if reservationErr.code == reservationErrorCodeOperationConflict {
 				return nil, err
 			}
-			if shouldRetryReservation(reservationErr) && attempt+1 < reservationMaxAttempts {
+			if reservationErr.ReservationRetryable() && attempt+1 < reservationMaxAttempts {
 				delay := m.reservationRetryDelay(attempt, reservationErr)
 				if waitErr := m.wait(ctx, delay); waitErr != nil {
 					return nil, &UnavailableError{Err: waitErr}
@@ -316,10 +316,6 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		return lease, nil
 	}
 	return nil, err
-}
-
-func shouldRetryReservation(reservationErr *reservationError) bool {
-	return reservationErr.ReservationRetryable()
 }
 
 func (m *manager) reservationRetryDelay(retry int, reservationErr *reservationError) time.Duration {

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -13,13 +14,25 @@ import (
 	"github.com/qiffang/mnemos/server/internal/metrics"
 )
 
+const (
+	DefaultReservationRetryBaseDelay = 500 * time.Millisecond
+	DefaultReservationRetryMaxDelay  = time.Second
+	MinReservationRetryBaseDelay     = 300 * time.Millisecond
+	MaxReservationRetryBaseDelay     = time.Second
+	MinReservationRetryMaxDelay      = 600 * time.Millisecond
+	MaxReservationRetryMaxDelay      = 2 * time.Second
+	reservationMaxAttempts           = 3
+)
+
 type manager struct {
-	cfg      Config
-	client   QuotaClient
-	metering metering.Writer
-	outbox   OutboxStore
-	logger   *slog.Logger
-	now      func() time.Time
+	cfg          Config
+	client       QuotaClient
+	metering     metering.Writer
+	outbox       OutboxStore
+	logger       *slog.Logger
+	now          func() time.Time
+	wait         func(context.Context, time.Duration) error
+	randomInt64N func(int64) int64
 
 	noticeState *noticeStateCache
 }
@@ -31,13 +44,21 @@ func NewManager(cfg Config, client QuotaClient, writer metering.Writer, logger *
 	if !cfg.Enabled {
 		return noopManager{}
 	}
+	if cfg.ReservationRetryBaseDelay == 0 {
+		cfg.ReservationRetryBaseDelay = DefaultReservationRetryBaseDelay
+	}
+	if cfg.ReservationRetryMaxDelay == 0 {
+		cfg.ReservationRetryMaxDelay = DefaultReservationRetryMaxDelay
+	}
 	manager := &manager{
-		cfg:      cfg,
-		client:   client,
-		metering: writer,
-		outbox:   cfg.Outbox,
-		logger:   logger,
-		now:      time.Now,
+		cfg:          cfg,
+		client:       client,
+		metering:     writer,
+		outbox:       cfg.Outbox,
+		logger:       logger,
+		now:          time.Now,
+		wait:         waitForContext,
+		randomInt64N: rand.Int64N,
 	}
 	manager.noticeState = newNoticeStateCache(cfg, manager.runtimeStateProvider)
 	return manager
@@ -250,30 +271,87 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		Units:       units,
 		Reserved:    true,
 	}
-	_, err = m.client.Reserve(ctx, subject, operationID, Operation{Meter: meter, Units: units})
-	if err != nil {
+	op := Operation{Meter: meter, Units: units}
+	for attempt := 0; attempt < reservationMaxAttempts; attempt++ {
+		_, err = m.client.Reserve(ctx, subject, operationID, op)
+		if err == nil {
+			return lease, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, &UnavailableError{Err: ctxErr}
+		}
 		var denied *QuotaDeniedError
 		if errors.As(err, &denied) {
 			return nil, err
+		}
+		var reservationErr *reservationError
+		if errors.As(err, &reservationErr) {
+			if reservationErr.code == reservationErrorCodeOperationConflict {
+				return nil, err
+			}
+			if shouldRetryReservation(reservationErr) && attempt+1 < reservationMaxAttempts {
+				delay := m.reservationRetryDelay(attempt, reservationErr)
+				if waitErr := m.wait(ctx, delay); waitErr != nil {
+					return nil, &UnavailableError{Err: waitErr}
+				}
+				continue
+			}
+			break
 		}
 		var conflict *ConflictError
 		if errors.As(err, &conflict) {
 			return nil, err
 		}
-		if m.cfg.FailOpen {
-			m.logger.WarnContext(ctx, "runtime usage reserve failed open",
-				"operation_id", operationID,
-				"tenant_id", subject.TenantID,
-				"cluster_id", subject.ClusterID,
-				"meter", meter,
-				"err", err,
-			)
-			lease.Reserved = false
-			return lease, nil
-		}
-		return nil, err
+		break
 	}
-	return lease, nil
+	if m.cfg.FailOpen {
+		m.logger.WarnContext(ctx, "runtime usage reserve failed open",
+			"operation_id", operationID,
+			"tenant_id", subject.TenantID,
+			"cluster_id", subject.ClusterID,
+			"meter", meter,
+			"err", err,
+		)
+		lease.Reserved = false
+		return lease, nil
+	}
+	return nil, err
+}
+
+func shouldRetryReservation(reservationErr *reservationError) bool {
+	return reservationErr.ReservationRetryable()
+}
+
+func (m *manager) reservationRetryDelay(retry int, reservationErr *reservationError) time.Duration {
+	base := m.cfg.ReservationRetryBaseDelay
+	maximum := m.cfg.ReservationRetryMaxDelay
+	midpoint := base + (maximum-base)/2
+	minimum := base
+	upper := midpoint
+	if retry > 0 {
+		minimum = midpoint
+		upper = maximum
+	}
+
+	delay := minimum
+	if width := int64(upper-minimum) + 1; width > 1 {
+		delay += time.Duration(m.randomInt64N(width))
+	}
+	if reservationErr.code == reservationErrorCodeConcurrencyLimited && reservationErr.retryAfter > delay {
+		return reservationErr.retryAfter
+	}
+	return delay
+}
+
+func waitForContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (m *manager) release(ctx context.Context, lease *OperationLease, reason string, detail string) {

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1427,7 +1427,7 @@ func TestManagerOversizedQuotaDenialPreservesFailOpenFence(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		attempts++
-		return statusJSONResponse(http.StatusPaymentRequired, strings.Repeat("x", (1<<20)+1), nil), nil
+		return statusJSONResponse(http.StatusPaymentRequired, strings.Repeat("x", maxResponseBodyBytes+1), nil), nil
 	})}
 	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
 	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {
@@ -1481,7 +1481,7 @@ func TestManagerOversizedConflictPreservesFailOpenFence(t *testing.T) {
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
 	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		attempts++
-		return statusJSONResponse(http.StatusConflict, strings.Repeat("x", (1<<20)+1), nil), nil
+		return statusJSONResponse(http.StatusConflict, strings.Repeat("x", maxResponseBodyBytes+1), nil), nil
 	})}
 	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
 	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -17,6 +19,8 @@ import (
 type fakeQuotaClient struct {
 	mu               sync.Mutex
 	reserveOps       []Operation
+	reserveSubjects  []Subject
+	reserveIDs       []string
 	finalized        []string
 	finalizeSubjects []Subject
 	state            RuntimeState
@@ -25,6 +29,8 @@ type fakeQuotaClient struct {
 	stateErr         error
 	stateDelay       time.Duration
 	reserveErr       error
+	reserveErrs      []error
+	reserveHook      func(context.Context, Subject, string, Operation) (*Reservation, error)
 	finalizeErr      error
 }
 
@@ -44,16 +50,25 @@ func (c *fakeQuotaClient) RuntimeState(_ context.Context, subject Subject) (Runt
 	return c.state, nil
 }
 
-func (c *fakeQuotaClient) Reserve(_ context.Context, _ Subject, operationID string, op Operation) (*Reservation, error) {
+func (c *fakeQuotaClient) Reserve(ctx context.Context, subject Subject, operationID string, op Operation) (*Reservation, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.reserveOps = append(c.reserveOps, op)
+	c.reserveSubjects = append(c.reserveSubjects, subject)
+	c.reserveIDs = append(c.reserveIDs, operationID)
+	if c.reserveHook != nil {
+		return c.reserveHook(ctx, subject, operationID, op)
+	}
+	attempt := len(c.reserveOps) - 1
+	if attempt < len(c.reserveErrs) && c.reserveErrs[attempt] != nil {
+		return nil, c.reserveErrs[attempt]
+	}
 	if c.reserveErr != nil {
 		return nil, c.reserveErr
 	}
 	if c.err != nil {
 		return nil, c.err
 	}
-	c.reserveOps = append(c.reserveOps, op)
 	return &Reservation{OperationID: operationID, Meter: op.Meter, Units: op.Units, Status: "reserved"}, nil
 }
 
@@ -709,6 +724,627 @@ func TestManagerRecallCommitsBeforeMetering(t *testing.T) {
 	}
 }
 
+func TestManagerReservationRetriesKeepStableRequestIdentity(t *testing.T) {
+	tests := []struct {
+		name        string
+		meter       string
+		chooseUpper []bool
+		wantDelays  []time.Duration
+		before      func(Manager, context.Context, Subject) (*OperationLease, error)
+	}{
+		{
+			name:        "recall",
+			meter:       MeterMemoryRecallRequests,
+			chooseUpper: []bool{false, true},
+			wantDelays:  []time.Duration{400 * time.Millisecond, 800 * time.Millisecond},
+			before: func(manager Manager, ctx context.Context, subject Subject) (*OperationLease, error) {
+				return manager.BeforeRecall(ctx, subject)
+			},
+		},
+		{
+			name:        "write",
+			meter:       MeterMemoryWriteRequests,
+			chooseUpper: []bool{true, false},
+			wantDelays:  []time.Duration{600 * time.Millisecond, 600 * time.Millisecond},
+			before: func(manager Manager, ctx context.Context, subject Subject) (*OperationLease, error) {
+				return manager.BeforeMemoryCreate(ctx, subject, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := &fakeQuotaClient{reserveErrs: []error{
+				newReservationError(reservationErrorCodeRegistryConflict, true, 0),
+				newReservationError(reservationErrorCodeUnavailable, true, 0),
+				nil,
+			}}
+			runtimeManager := NewManager(Config{
+				Enabled:                   true,
+				ReservationRetryBaseDelay: 400 * time.Millisecond,
+				ReservationRetryMaxDelay:  800 * time.Millisecond,
+			}, quota, &captureWriter{}, nil)
+			concrete := runtimeManager.(*manager)
+			var delays []time.Duration
+			concrete.wait = func(_ context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				return nil
+			}
+			randomCalls := 0
+			concrete.randomInt64N = func(n int64) int64 {
+				if n != int64(200*time.Millisecond)+1 {
+					t.Fatalf("random range width = %d, want %d", n, int64(200*time.Millisecond)+1)
+				}
+				chooseUpper := tt.chooseUpper[randomCalls]
+				randomCalls++
+				if chooseUpper {
+					return n - 1
+				}
+				return 0
+			}
+
+			subject := Subject{
+				TenantID:      "tenant-a",
+				ClusterID:     "cluster-a",
+				APIKeySubject: "api-key-subject",
+				AgentName:     "Codex",
+			}
+			lease, err := tt.before(runtimeManager, context.Background(), subject)
+			if err != nil {
+				t.Fatalf("Before operation: %v", err)
+			}
+			if lease == nil || !lease.Reserved {
+				t.Fatal("Before operation returned no active reservation")
+			}
+			if len(quota.reserveOps) != 3 {
+				t.Fatalf("Reserve attempts = %d, want 3", len(quota.reserveOps))
+			}
+			for attempt := range quota.reserveOps {
+				if quota.reserveIDs[attempt] != lease.OperationID {
+					t.Fatalf("attempt %d changed the operation ID", attempt+1)
+				}
+				if quota.reserveSubjects[attempt] != subject {
+					t.Fatalf("attempt %d changed the reservation subject", attempt+1)
+				}
+				if quota.reserveOps[attempt] != (Operation{Meter: tt.meter, Units: 1}) {
+					t.Fatalf("attempt %d changed the reservation operation", attempt+1)
+				}
+			}
+			if len(delays) != len(tt.wantDelays) || delays[0] != tt.wantDelays[0] || delays[1] != tt.wantDelays[1] {
+				t.Fatalf("retry delays = %v, want %v", delays, tt.wantDelays)
+			}
+		})
+	}
+}
+
+func TestManagerReservationRetriesKeepStableSerializedHTTPRequest(t *testing.T) {
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", 750*time.Millisecond)
+	var paths []string
+	var subjects []string
+	var bodies []string
+	client.client = &http.Client{
+		Timeout: 750 * time.Millisecond,
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read request body: %v", err)
+			}
+			paths = append(paths, req.URL.Path)
+			subjects = append(subjects, req.Header.Get("X-API-Key"))
+			bodies = append(bodies, string(body))
+			switch len(bodies) {
+			case 1:
+				return statusJSONResponse(
+					http.StatusConflict,
+					`{"code":"registry_conflict","message":"registry changed","details":{"retryable":true}}`,
+					nil,
+				), nil
+			case 2:
+				return statusJSONResponse(
+					http.StatusServiceUnavailable,
+					`{"code":"unavailable","message":"try again","details":{"retryable":true}}`,
+					nil,
+				), nil
+			default:
+				return jsonResponse(`{"status":"reserved"}`), nil
+			}
+		}),
+	}
+	runtimeManager := NewManager(Config{Enabled: true}, client, &captureWriter{}, nil)
+	concrete := runtimeManager.(*manager)
+	concrete.wait = func(context.Context, time.Duration) error { return nil }
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	if err != nil {
+		t.Fatalf("BeforeRecall: %v", err)
+	}
+	if lease == nil || !lease.Reserved {
+		t.Fatal("BeforeRecall returned no active reservation")
+	}
+	if client.client.Timeout != 750*time.Millisecond {
+		t.Fatalf("HTTP timeout = %v, want 750ms", client.client.Timeout)
+	}
+	if len(paths) != reservationMaxAttempts {
+		t.Fatalf("request count = %d, want %d", len(paths), reservationMaxAttempts)
+	}
+	wantPath := "/api/internal/quota/reservations/" + lease.OperationID
+	for attempt := range paths {
+		if paths[attempt] != wantPath {
+			t.Fatalf("attempt %d changed the request path", attempt+1)
+		}
+		if subjects[attempt] != "api-key-subject" {
+			t.Fatalf("attempt %d changed the API key subject", attempt+1)
+		}
+		if bodies[attempt] != bodies[0] {
+			t.Fatalf("attempt %d changed the serialized request body", attempt+1)
+		}
+	}
+	var operation Operation
+	if err := json.Unmarshal([]byte(bodies[0]), &operation); err != nil {
+		t.Fatalf("decode reservation request body: %v", err)
+	}
+	if operation != (Operation{Meter: MeterMemoryRecallRequests, Units: 1}) {
+		t.Fatal("reservation request body has unexpected semantics")
+	}
+}
+
+func TestManagerReservationConcurrencyLimitUsesGreaterDelay(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseDelay  time.Duration
+		maxDelay   time.Duration
+		retryAfter string
+		random     func(int64) int64
+		wantDelay  time.Duration
+	}{
+		{
+			name:       "retry after exceeds jitter",
+			baseDelay:  400 * time.Millisecond,
+			maxDelay:   800 * time.Millisecond,
+			retryAfter: "1",
+			random:     func(int64) int64 { return 0 },
+			wantDelay:  time.Second,
+		},
+		{
+			name:       "jitter exceeds retry after",
+			baseDelay:  time.Second,
+			maxDelay:   2 * time.Second,
+			retryAfter: "1",
+			random:     func(n int64) int64 { return n - 1 },
+			wantDelay:  1500 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attempts := 0
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				attempts++
+				if attempts == 1 {
+					return statusJSONResponse(
+						http.StatusTooManyRequests,
+						`{"code":"reservation_concurrency_limited","details":{"retryable":true}}`,
+						http.Header{"Retry-After": []string{tt.retryAfter}},
+					), nil
+				}
+				return jsonResponse(`{"status":"reserved"}`), nil
+			})}
+			runtimeManager := NewManager(Config{
+				Enabled:                   true,
+				ReservationRetryBaseDelay: tt.baseDelay,
+				ReservationRetryMaxDelay:  tt.maxDelay,
+			}, client, &captureWriter{}, nil)
+			concrete := runtimeManager.(*manager)
+			var delays []time.Duration
+			concrete.wait = func(_ context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				return nil
+			}
+			concrete.randomInt64N = tt.random
+
+			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if err != nil {
+				t.Fatalf("BeforeRecall: %v", err)
+			}
+			if lease == nil || !lease.Reserved {
+				t.Fatal("BeforeRecall returned no active reservation")
+			}
+			if attempts != 2 {
+				t.Fatalf("Reserve attempts = %d, want 2", attempts)
+			}
+			if len(delays) != 1 || delays[0] != tt.wantDelay {
+				t.Fatalf("retry delays = %v, want [%v]", delays, tt.wantDelay)
+			}
+		})
+	}
+}
+
+func TestManagerReservationRetriesEachAllowedCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		code       reservationErrorCode
+		retryAfter time.Duration
+	}{
+		{name: "registry conflict", code: reservationErrorCodeRegistryConflict},
+		{name: "operation in progress", code: reservationErrorCodeOperationInProgress},
+		{name: "reservation concurrency limited", code: reservationErrorCodeConcurrencyLimited, retryAfter: time.Second},
+		{name: "service unavailable", code: reservationErrorCodeUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := &fakeQuotaClient{reserveErrs: []error{
+				newReservationError(tt.code, true, tt.retryAfter),
+				nil,
+			}}
+			runtimeManager := NewManager(Config{Enabled: true}, quota, &captureWriter{}, nil)
+			concrete := runtimeManager.(*manager)
+			concrete.wait = func(context.Context, time.Duration) error { return nil }
+
+			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if err != nil {
+				t.Fatalf("BeforeRecall: %v", err)
+			}
+			if lease == nil || !lease.Reserved {
+				t.Fatal("retryable reservation returned no active lease")
+			}
+			if len(quota.reserveOps) != 2 {
+				t.Fatalf("Reserve attempts = %d, want 2", len(quota.reserveOps))
+			}
+		})
+	}
+}
+
+func TestManagerReservationRetriesStopOnCallerCancellation(t *testing.T) {
+	t.Run("active request", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		entered := make(chan struct{})
+		client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+		client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			close(entered)
+			timer := time.NewTimer(time.Second)
+			defer timer.Stop()
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-timer.C:
+				return nil, errors.New("request context remained active")
+			}
+		})}
+		runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
+		result := make(chan error, 1)
+		go func() {
+			lease, err := runtimeManager.BeforeRecall(ctx, Subject{APIKeySubject: "api-key-subject"})
+			if lease != nil {
+				result <- errors.New("caller cancellation returned a lease")
+				return
+			}
+			result <- err
+		}()
+
+		awaitTestSignal(t, entered)
+		cancel()
+		err := awaitTestError(t, result)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("BeforeRecall error = %v, want context canceled", err)
+		}
+	})
+
+	t.Run("retry delay", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		quota := &fakeQuotaClient{reserveErr: newReservationError(reservationErrorCodeRegistryConflict, true, 0)}
+		runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, quota, &captureWriter{}, nil)
+		concrete := runtimeManager.(*manager)
+		entered := make(chan struct{})
+		concrete.wait = func(ctx context.Context, delay time.Duration) error {
+			close(entered)
+			return waitForContext(ctx, delay)
+		}
+		result := make(chan error, 1)
+		go func() {
+			lease, err := runtimeManager.BeforeRecall(ctx, Subject{APIKeySubject: "api-key-subject"})
+			if lease != nil {
+				result <- errors.New("retry cancellation returned a lease")
+				return
+			}
+			result <- err
+		}()
+
+		awaitTestSignal(t, entered)
+		cancel()
+		err := awaitTestError(t, result)
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("BeforeRecall error = %v, want context canceled", err)
+		}
+		if len(quota.reserveOps) != 1 {
+			t.Fatalf("Reserve attempts = %d, want 1", len(quota.reserveOps))
+		}
+	})
+}
+
+func TestManagerEachReservationAttemptGetsFreshHTTPClientTimeout(t *testing.T) {
+	const attemptTimeout = 25 * time.Millisecond
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", attemptTimeout)
+	var deadlines []time.Time
+	client.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		deadline, ok := req.Context().Deadline()
+		if !ok {
+			return nil, errors.New("request has no deadline")
+		}
+		deadlines = append(deadlines, deadline)
+		if len(deadlines) == 1 {
+			return statusJSONResponse(
+				http.StatusServiceUnavailable,
+				`{"code":"unavailable","details":{"retryable":true}}`,
+				nil,
+			), nil
+		}
+		timer := time.NewTimer(time.Second)
+		defer timer.Stop()
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		case <-timer.C:
+			return nil, errors.New("request deadline was not enforced")
+		}
+	})
+	runtimeManager := NewManager(Config{Enabled: true}, client, &captureWriter{}, nil)
+	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error { return nil }
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("BeforeRecall error = %v, want deadline exceeded", err)
+	}
+	if lease != nil {
+		t.Fatal("timed-out reservation returned a lease")
+	}
+	if len(deadlines) != 2 {
+		t.Fatalf("Reservation attempts = %d, want 2", len(deadlines))
+	}
+	if !deadlines[1].After(deadlines[0]) {
+		t.Fatal("second Reservation attempt did not receive a fresh timeout deadline")
+	}
+}
+
+func TestManagerDefaultReservationRetryJitterRanges(t *testing.T) {
+	runtimeManager := NewManager(Config{Enabled: true}, &fakeQuotaClient{}, &captureWriter{}, nil)
+	concrete := runtimeManager.(*manager)
+	if concrete.cfg.ReservationRetryBaseDelay != DefaultReservationRetryBaseDelay {
+		t.Fatalf("default base delay = %v, want %v", concrete.cfg.ReservationRetryBaseDelay, DefaultReservationRetryBaseDelay)
+	}
+	if concrete.cfg.ReservationRetryMaxDelay != DefaultReservationRetryMaxDelay {
+		t.Fatalf("default maximum delay = %v, want %v", concrete.cfg.ReservationRetryMaxDelay, DefaultReservationRetryMaxDelay)
+	}
+
+	err := newReservationError(reservationErrorCodeUnavailable, true, 0)
+	concrete.randomInt64N = func(int64) int64 { return 0 }
+	if got := concrete.reservationRetryDelay(0, err); got != 500*time.Millisecond {
+		t.Fatalf("first retry lower bound = %v, want 500ms", got)
+	}
+	if got := concrete.reservationRetryDelay(1, err); got != 750*time.Millisecond {
+		t.Fatalf("second retry lower bound = %v, want 750ms", got)
+	}
+	concrete.randomInt64N = func(n int64) int64 { return n - 1 }
+	if got := concrete.reservationRetryDelay(0, err); got != 750*time.Millisecond {
+		t.Fatalf("first retry upper bound = %v, want 750ms", got)
+	}
+	if got := concrete.reservationRetryDelay(1, err); got != time.Second {
+		t.Fatalf("second retry upper bound = %v, want 1s", got)
+	}
+}
+
+func TestManagerConcurrentReservationsRetryWithStableUniqueIdentity(t *testing.T) {
+	const concurrentReservations = 64
+	attemptsByOperation := make(map[string]int)
+	firstSubjects := make(map[string]Subject)
+	firstOperations := make(map[string]Operation)
+	quota := &fakeQuotaClient{}
+	quota.reserveHook = func(_ context.Context, subject Subject, operationID string, op Operation) (*Reservation, error) {
+		attemptsByOperation[operationID]++
+		switch attemptsByOperation[operationID] {
+		case 1:
+			firstSubjects[operationID] = subject
+			firstOperations[operationID] = op
+			return nil, newReservationError(reservationErrorCodeUnavailable, true, 0)
+		case 2:
+			if firstSubjects[operationID] != subject || firstOperations[operationID] != op {
+				return nil, errors.New("Reservation retry changed request identity")
+			}
+			return &Reservation{OperationID: operationID, Meter: op.Meter, Units: op.Units, Status: "reserved"}, nil
+		default:
+			return nil, errors.New("Reservation exceeded two attempts")
+		}
+	}
+	concrete := NewManager(Config{Enabled: true}, quota, &captureWriter{}, nil).(*manager)
+	concrete.wait = func(context.Context, time.Duration) error { return nil }
+	errCh := make(chan error, concurrentReservations)
+	var workers sync.WaitGroup
+	for range concurrentReservations {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			lease, err := concrete.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			if lease == nil || !lease.Reserved {
+				errCh <- errors.New("concurrent Reservation returned no active lease")
+			}
+		}()
+	}
+	workers.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+	if len(attemptsByOperation) != concurrentReservations {
+		t.Fatalf("unique operation IDs = %d, want %d", len(attemptsByOperation), concurrentReservations)
+	}
+	for _, attempts := range attemptsByOperation {
+		if attempts != 2 {
+			t.Fatalf("attempts for one operation = %d, want 2", attempts)
+		}
+	}
+}
+
+func TestManagerRetriedReservationCompletesSuccessLifecycle(t *testing.T) {
+	tests := []struct {
+		name   string
+		before func(Manager, context.Context, Subject) (*OperationLease, error)
+		finish func(Manager, context.Context, *OperationLease) error
+		meter  string
+		event  string
+	}{
+		{
+			name: "recall",
+			before: func(manager Manager, ctx context.Context, subject Subject) (*OperationLease, error) {
+				return manager.BeforeRecall(ctx, subject)
+			},
+			finish: func(manager Manager, ctx context.Context, lease *OperationLease) error {
+				return manager.AfterRecallSuccess(ctx, lease, RecallResult{AgentName: "test-agent"})
+			},
+			meter: MeterMemoryRecallRequests,
+			event: EventTypeMemoryRecall,
+		},
+		{
+			name: "write",
+			before: func(manager Manager, ctx context.Context, subject Subject) (*OperationLease, error) {
+				return manager.BeforeMemoryCreate(ctx, subject, 1)
+			},
+			finish: func(manager Manager, ctx context.Context, lease *OperationLease) error {
+				return manager.AfterMemoryCreateSuccess(ctx, lease, MemoryCreateResult{AgentName: "test-agent", ObjectsAffected: 1})
+			},
+			meter: MeterMemoryWriteRequests,
+			event: EventTypeMemoryCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := &fakeQuotaClient{reserveErrs: []error{
+				newReservationError(reservationErrorCodeUnavailable, true, 0),
+				nil,
+			}}
+			writer := &captureWriter{}
+			outbox := &fakeOutboxStore{}
+			runtimeManager := NewManager(Config{Enabled: true, Outbox: outbox}, quota, writer, nil)
+			runtimeManager.(*manager).wait = func(context.Context, time.Duration) error { return nil }
+
+			lease, err := tt.before(runtimeManager, context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if err != nil {
+				t.Fatalf("Before operation: %v", err)
+			}
+			if err := tt.finish(runtimeManager, context.Background(), lease); err != nil {
+				t.Fatalf("After success: %v", err)
+			}
+			if len(quota.reserveOps) != 2 {
+				t.Fatalf("Reserve attempts = %d, want 2", len(quota.reserveOps))
+			}
+			if len(quota.finalized) != 1 {
+				t.Fatalf("Finalize calls = %d, want 1", len(quota.finalized))
+			}
+			if outbox.commitPending != 1 {
+				t.Fatalf("outbox commit-pending calls = %d, want 1", outbox.commitPending)
+			}
+			if len(writer.events) != 1 {
+				t.Fatalf("metering events = %d, want 1", len(writer.events))
+			}
+			if writer.events[0].Meter != tt.meter || writer.events[0].EventType != tt.event {
+				t.Fatal("success lifecycle recorded unexpected metering semantics")
+			}
+		})
+	}
+}
+
+func TestManagerReservationRetryExhaustionAppliesDeploymentPolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		failOpen bool
+	}{
+		{name: "fail closed"},
+		{name: "fail open", failOpen: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := &fakeQuotaClient{reserveErr: newReservationError(reservationErrorCodeUnavailable, true, 0)}
+			runtimeManager := NewManager(Config{Enabled: true, FailOpen: tt.failOpen}, quota, &captureWriter{}, nil)
+			concrete := runtimeManager.(*manager)
+			var delays []time.Duration
+			concrete.wait = func(_ context.Context, delay time.Duration) error {
+				delays = append(delays, delay)
+				return nil
+			}
+
+			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if tt.failOpen {
+				if err != nil {
+					t.Fatalf("BeforeRecall: %v", err)
+				}
+				if lease == nil || lease.Reserved {
+					t.Fatal("retry exhaustion returned an unexpected fail-open lease state")
+				}
+			} else {
+				var reservationErr *reservationError
+				if !errors.As(err, &reservationErr) {
+					t.Fatalf("BeforeRecall error = %T, want structured reservation error", err)
+				}
+				if lease != nil {
+					t.Fatal("fail-closed retry exhaustion returned a lease")
+				}
+			}
+			if len(quota.reserveOps) != reservationMaxAttempts {
+				t.Fatalf("Reserve attempts = %d, want %d", len(quota.reserveOps), reservationMaxAttempts)
+			}
+			if len(delays) != reservationMaxAttempts-1 {
+				t.Fatalf("retry delays = %d, want %d", len(delays), reservationMaxAttempts-1)
+			}
+		})
+	}
+}
+
+func TestManagerReservationTerminalFailuresUseOneAttempt(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		failOpen bool
+	}{
+		{name: "quota denied", err: &QuotaDeniedError{StatusCode: http.StatusPaymentRequired}},
+		{name: "post quota rate limited", err: &QuotaDeniedError{StatusCode: http.StatusTooManyRequests}},
+		{name: "permanent operation conflict", err: newReservationError(reservationErrorCodeOperationConflict, false, 0)},
+		{name: "permanent operation conflict with fail open", err: newReservationError(reservationErrorCodeOperationConflict, false, 0), failOpen: true},
+		{name: "allowlisted code marked terminal", err: newReservationError(reservationErrorCodeUnavailable, false, 0)},
+		{name: "unknown structured code", err: newReservationError(reservationErrorCode("future_retryable"), true, 0)},
+		{name: "legacy conflict", err: &ConflictError{StatusCode: http.StatusConflict}},
+		{name: "invalid or authentication response", err: &UnavailableError{Err: errString("terminal response")}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quota := &fakeQuotaClient{reserveErr: tt.err}
+			runtimeManager := NewManager(Config{Enabled: true, FailOpen: tt.failOpen}, quota, &captureWriter{}, nil)
+			concrete := runtimeManager.(*manager)
+			concrete.wait = func(context.Context, time.Duration) error {
+				t.Fatal("terminal failure entered retry delay")
+				return nil
+			}
+
+			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if err == nil {
+				t.Fatal("BeforeRecall error = nil")
+			}
+			if lease != nil {
+				t.Fatal("terminal reservation failure returned a lease")
+			}
+			if len(quota.reserveOps) != 1 {
+				t.Fatalf("Reserve attempts = %d, want 1", len(quota.reserveOps))
+			}
+		})
+	}
+}
+
 func TestManagerMemoryDeleteUsesWriteRequestMeter(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}
@@ -1052,4 +1688,24 @@ func assertFallbackMeter(t *testing.T, state RuntimeState, meter string, budgetT
 		return
 	}
 	t.Fatalf("meter %s missing from %+v", meter, state.Meters)
+}
+
+func awaitTestSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for test rendezvous")
+	}
+}
+
+func awaitTestError(t *testing.T, result <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for operation result")
+		return nil
+	}
 }

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1345,6 +1345,36 @@ func TestManagerReservationTerminalFailuresUseOneAttempt(t *testing.T) {
 	}
 }
 
+func TestManagerNonRetryableReservationConflictPreservesFailOpenFence(t *testing.T) {
+	attempts := 0
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return statusJSONResponse(
+			http.StatusConflict,
+			`{"code":"registry_conflict","details":{"retryable":false}}`,
+			nil,
+		), nil
+	})}
+	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
+	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {
+		t.Fatal("non-retryable conflict entered retry delay")
+		return nil
+	}
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	var conflict *ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("BeforeRecall error = %T, want legacy conflict", err)
+	}
+	if lease != nil {
+		t.Fatal("fail-open reservation conflict returned a lease")
+	}
+	if attempts != 1 {
+		t.Fatalf("Reservation attempts = %d, want 1", attempts)
+	}
+}
+
 func TestManagerMemoryDeleteUsesWriteRequestMeter(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1259,6 +1259,52 @@ func TestManagerRetriedReservationCompletesSuccessLifecycle(t *testing.T) {
 	}
 }
 
+func TestManagerSuccessfulFinalizeBodyFailuresDoNotQueueRetry(t *testing.T) {
+	for _, tt := range successfulFinalizeBodyFailureCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			reserveCalls := 0
+			finalizeCalls := 0
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				switch req.Method {
+				case http.MethodPut:
+					reserveCalls++
+					return jsonResponse(`{"status":"reserved"}`), nil
+				case http.MethodPatch:
+					finalizeCalls++
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     make(http.Header),
+						Body:       tt.body(),
+					}, nil
+				default:
+					return nil, errors.New("unexpected runtime usage method")
+				}
+			})}
+			writer := &captureWriter{}
+			outbox := &fakeOutboxStore{}
+			runtimeManager := NewManager(Config{Enabled: true, Outbox: outbox}, client, writer, nil)
+
+			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if err != nil {
+				t.Fatalf("BeforeRecall: %v", err)
+			}
+			if err := runtimeManager.AfterRecallSuccess(context.Background(), lease, RecallResult{AgentName: "test-agent"}); err != nil {
+				t.Fatalf("AfterRecallSuccess: %v", err)
+			}
+			if reserveCalls != 1 || finalizeCalls != 1 {
+				t.Fatalf("runtime usage calls = reserve %d, finalize %d; want 1 each", reserveCalls, finalizeCalls)
+			}
+			if outbox.commitPending != 1 || outbox.retryable != 0 {
+				t.Fatalf("outbox calls = commit pending %d, retryable %d; want 1, 0", outbox.commitPending, outbox.retryable)
+			}
+			if len(writer.events) != 1 {
+				t.Fatalf("metering events = %d, want 1", len(writer.events))
+			}
+		})
+	}
+}
+
 func TestManagerReservationRetryExhaustionAppliesDeploymentPolicy(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1375,6 +1375,32 @@ func TestManagerNonRetryableReservationConflictPreservesFailOpenFence(t *testing
 	}
 }
 
+func TestManagerOversizedQuotaDenialPreservesFailOpenFence(t *testing.T) {
+	attempts := 0
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return statusJSONResponse(http.StatusPaymentRequired, strings.Repeat("x", (1<<20)+1), nil), nil
+	})}
+	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
+	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {
+		t.Fatal("quota denial entered retry delay")
+		return nil
+	}
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	var denied *QuotaDeniedError
+	if !errors.As(err, &denied) || denied.Status() != http.StatusPaymentRequired {
+		t.Fatalf("BeforeRecall error = %T, want quota denial", err)
+	}
+	if lease != nil {
+		t.Fatal("fail-open quota denial returned a lease")
+	}
+	if attempts != 1 {
+		t.Fatalf("Reservation attempts = %d, want 1", attempts)
+	}
+}
+
 func TestManagerMemoryDeleteUsesWriteRequestMeter(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1401,6 +1401,32 @@ func TestManagerOversizedQuotaDenialPreservesFailOpenFence(t *testing.T) {
 	}
 }
 
+func TestManagerOversizedConflictPreservesFailOpenFence(t *testing.T) {
+	attempts := 0
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return statusJSONResponse(http.StatusConflict, strings.Repeat("x", (1<<20)+1), nil), nil
+	})}
+	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
+	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {
+		t.Fatal("conflict entered retry delay")
+		return nil
+	}
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	var conflict *ConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("BeforeRecall error = %T, want conflict", err)
+	}
+	if lease != nil {
+		t.Fatal("fail-open conflict returned a lease")
+	}
+	if attempts != 1 {
+		t.Fatalf("Reservation attempts = %d, want 1", attempts)
+	}
+}
+
 func TestManagerMemoryDeleteUsesWriteRequestMeter(t *testing.T) {
 	quota := &fakeQuotaClient{}
 	writer := &captureWriter{}

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -1395,6 +1396,34 @@ func TestManagerOversizedQuotaDenialPreservesFailOpenFence(t *testing.T) {
 	}
 	if lease != nil {
 		t.Fatal("fail-open quota denial returned a lease")
+	}
+	if attempts != 1 {
+		t.Fatalf("Reservation attempts = %d, want 1", attempts)
+	}
+}
+
+func TestManagerOversizedPostQuotaDenialPreservesFailOpenFence(t *testing.T) {
+	attempts := 0
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		body := oversizedResponseWithPrefix(postQuotaRateLimitBody)
+		return statusJSONResponse(http.StatusTooManyRequests, body, http.Header{"Retry-After": []string{"20"}}), nil
+	})}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, logger)
+	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {
+		t.Fatal("post-quota denial entered retry delay")
+		return nil
+	}
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	var denied *QuotaDeniedError
+	if !errors.As(err, &denied) || denied.Status() != http.StatusTooManyRequests {
+		t.Fatalf("BeforeRecall error = %T, want post-quota denial", err)
+	}
+	if lease != nil {
+		t.Fatal("fail-open post-quota denial returned a lease")
 	}
 	if attempts != 1 {
 		t.Fatalf("Reservation attempts = %d, want 1", attempts)

--- a/server/internal/runtimeusage/reservation_error.go
+++ b/server/internal/runtimeusage/reservation_error.go
@@ -1,0 +1,80 @@
+package runtimeusage
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type reservationErrorCode string
+
+const (
+	reservationErrorCodeRegistryConflict    reservationErrorCode = "registry_conflict"
+	reservationErrorCodeOperationInProgress reservationErrorCode = "operation_in_progress"
+	reservationErrorCodeConcurrencyLimited  reservationErrorCode = "reservation_concurrency_limited"
+	reservationErrorCodeUnavailable         reservationErrorCode = "unavailable"
+	reservationErrorCodeOperationConflict   reservationErrorCode = "operation_conflict"
+)
+
+type reservationErrorPolicy struct {
+	statusCode int
+	retryable  bool
+}
+
+func (c reservationErrorCode) policy() (reservationErrorPolicy, bool) {
+	switch c {
+	case reservationErrorCodeRegistryConflict, reservationErrorCodeOperationInProgress:
+		return reservationErrorPolicy{statusCode: http.StatusConflict, retryable: true}, true
+	case reservationErrorCodeConcurrencyLimited:
+		return reservationErrorPolicy{statusCode: http.StatusTooManyRequests, retryable: true}, true
+	case reservationErrorCodeUnavailable:
+		return reservationErrorPolicy{statusCode: http.StatusServiceUnavailable, retryable: true}, true
+	case reservationErrorCodeOperationConflict:
+		return reservationErrorPolicy{statusCode: http.StatusConflict}, true
+	default:
+		return reservationErrorPolicy{}, false
+	}
+}
+
+type reservationError struct {
+	code       reservationErrorCode
+	retryable  bool
+	retryAfter time.Duration
+	cause      error
+}
+
+func newReservationError(code reservationErrorCode, retryable bool, retryAfter time.Duration) *reservationError {
+	var cause error = &UnavailableError{}
+	if code == reservationErrorCodeOperationConflict {
+		policy, _ := code.policy()
+		cause = &ConflictError{StatusCode: policy.statusCode}
+	}
+	return &reservationError{
+		code:       code,
+		retryable:  retryable,
+		retryAfter: retryAfter,
+		cause:      cause,
+	}
+}
+
+func (e *reservationError) Error() string {
+	if e == nil {
+		return "runtime usage reservation failed"
+	}
+	return fmt.Sprintf("runtime usage reservation failed: %s", e.code)
+}
+
+func (e *reservationError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *reservationError) ReservationRetryable() bool {
+	if e == nil || !e.retryable {
+		return false
+	}
+	policy, known := e.code.policy()
+	return known && policy.retryable
+}

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -62,21 +62,23 @@ const (
 )
 
 type Config struct {
-	Enabled            bool
-	ProviderID         string
-	BaseURL            string
-	InternalSecret     string
-	Timeout            time.Duration
-	MeteringTimeout    time.Duration
-	ReservationTTL     time.Duration
-	OperationTTL       time.Duration
-	FailOpen           bool
-	OutboxEnabled      bool
-	NoticeTimeout      time.Duration
-	NoticeCacheEnabled bool
-	NoticeCacheTTL     time.Duration
-	NoticeStaleTTL     time.Duration
-	Outbox             OutboxStore
+	Enabled                   bool
+	ProviderID                string
+	BaseURL                   string
+	InternalSecret            string
+	Timeout                   time.Duration
+	MeteringTimeout           time.Duration
+	ReservationTTL            time.Duration
+	OperationTTL              time.Duration
+	ReservationRetryBaseDelay time.Duration
+	ReservationRetryMaxDelay  time.Duration
+	FailOpen                  bool
+	OutboxEnabled             bool
+	NoticeTimeout             time.Duration
+	NoticeCacheEnabled        bool
+	NoticeCacheTTL            time.Duration
+	NoticeStaleTTL            time.Duration
+	Outbox                    OutboxStore
 }
 
 type Subject struct {


### PR DESCRIPTION
## Summary

- classify the exact structured Reservation responses that can participate in bounded retries
- retry Reservation calls up to three total attempts with stable request identity, cancellation-aware jitter, and `Retry-After` handling
- add validated retry-delay configuration, runtime error classification, documentation, and comprehensive race-tested coverage

## Contract

- retries require an exact allowed status/code pair and `details.retryable: true`
- `reservation_concurrency_limited` also requires a positive decimal integer-seconds `Retry-After`
- `operation_conflict` remains terminal
- quota denial, post-quota rate limiting, Finalize, Metering, outbox, and fail-policy behavior remain intact

## Verification

- `make test` (full server suite with race detector)
- `make vet`
- live database integration tests were outside this change's required scope and were not run

Closes #440
Part of #439
