### PR TITLE
fix(server): enforce Recall request budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ The `MEM9_SOURCE_TURN_*` variables control how many source turn conversations ar
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `MNEMO_CHAIN_RECALL_STOP_SCORE` | No | `0.8` | Stop querying later Space Chain nodes only when an eligible query has a top normalized confidence at or above this threshold. Raw search `score` values do not trigger chain stop. Must be between `0` and `1` |
+| `MNEMO_RECALL_REQUEST_TIMEOUT` | No | `1m` | Total server-owned Recall request budget, including response assembly and write time |
+| `MNEMO_RECALL_RESPONSE_RESERVE` | No | `5s` | Time reserved inside the Recall request budget for response assembly and write; must be shorter than `MNEMO_RECALL_REQUEST_TIMEOUT` |
 
 #### Provisioning And Pooling
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -349,6 +349,9 @@
           },
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable"
+          },
+          "504": {
+            "$ref": "#/components/responses/RecallGatewayTimeout"
           }
         }
       }
@@ -818,6 +821,9 @@
           },
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable"
+          },
+          "504": {
+            "$ref": "#/components/responses/RecallGatewayTimeout"
           }
         }
       }
@@ -2550,6 +2556,16 @@
           }
         }
       },
+      "RecallGatewayTimeout": {
+        "description": "Recall exhausted its server-owned request budget before the outer HTTP timeout.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/RecallDeadlineError"
+            }
+          }
+        }
+      },
       "NoContent": {
         "description": "No content."
       },
@@ -3033,6 +3049,50 @@
           }
         }
       },
+      "RecallWarning": {
+        "type": "object",
+        "required": [
+          "code",
+          "branch"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "recall_branch_deadline_exceeded"
+            ]
+          },
+          "branch": {
+            "type": "string",
+            "enum": [
+              "pinned",
+              "insight",
+              "session"
+            ]
+          }
+        }
+      },
+      "RecallDeadlineError": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ErrorResponse"
+          },
+          {
+            "type": "object",
+            "required": [
+              "code"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "enum": [
+                  "recall_server_deadline_exceeded"
+                ]
+              }
+            }
+          }
+        ]
+      },
       "LocalRateLimitError": {
         "allOf": [
           {
@@ -3245,6 +3305,16 @@
           "offset": {
             "type": "integer",
             "minimum": 0
+          },
+          "partial": {
+            "type": "boolean",
+            "description": "True when Recall preserved completed branches after another branch exhausted the server work budget."
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RecallWarning"
+            }
           },
           "message": {
             "type": "string",

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -285,7 +285,8 @@ func main() {
 		WithRuntimeUsage(runtimeUsageManager).
 		WithWebhookService(webhookSvc).
 		WithActivityTracker(activityTracker).
-		WithDisableSessionSave(cfg.DisableSessionSave)
+		WithDisableSessionSave(cfg.DisableSessionSave).
+		WithRecallRequestBudget(cfg.RecallRequestTimeout, cfg.RecallResponseReserve)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW, middleware.CORS(cfg.CORSAllowedOrigins))
 
 	httpSrv := &http.Server{

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -52,6 +52,8 @@ type Config struct {
 	TenantPoolIdleTimeout    time.Duration
 	TenantPoolTotalLimit     int
 	ChainRecallStopScore     float64
+	RecallRequestTimeout     time.Duration
+	RecallResponseReserve    time.Duration
 
 	// TiDB Cloud Pool configuration
 	TiDBCloudAPIURL                  string
@@ -184,6 +186,14 @@ func Load() (*Config, error) {
 			return nil, err
 		}
 	}
+	recallRequestTimeout, err := envDurationStrict("MNEMO_RECALL_REQUEST_TIMEOUT", time.Minute)
+	if err != nil {
+		return nil, err
+	}
+	recallResponseReserve, err := envDurationStrict("MNEMO_RECALL_RESPONSE_RESERVE", 5*time.Second)
+	if err != nil {
+		return nil, err
+	}
 
 	env := strings.ToLower(strings.TrimSpace(envOr("MNEMO_ENV", envOr("APP_ENV", "development"))))
 	cfg := &Config{
@@ -217,6 +227,8 @@ func Load() (*Config, error) {
 		TenantPoolIdleTimeout:            envDuration("MNEMO_TENANT_POOL_IDLE_TIMEOUT", 10*time.Minute),
 		TenantPoolTotalLimit:             envInt("MNEMO_TENANT_POOL_TOTAL_LIMIT", 200),
 		ChainRecallStopScore:             envFloat("MNEMO_CHAIN_RECALL_STOP_SCORE", 0.8),
+		RecallRequestTimeout:             recallRequestTimeout,
+		RecallResponseReserve:            recallResponseReserve,
 		UploadDir:                        envOr("MNEMO_UPLOAD_DIR", "./uploads"),
 		FTSEnabled:                       envBool("MNEMO_FTS_ENABLED", false),
 		WorkerConcurrency:                envInt("MNEMO_WORKER_CONCURRENCY", 5),
@@ -277,6 +289,15 @@ func Load() (*Config, error) {
 	}
 	if cfg.ChainRecallStopScore < 0 || cfg.ChainRecallStopScore > 1 {
 		return nil, fmt.Errorf("MNEMO_CHAIN_RECALL_STOP_SCORE must be between 0 and 1")
+	}
+	if cfg.RecallRequestTimeout <= 0 {
+		return nil, fmt.Errorf("MNEMO_RECALL_REQUEST_TIMEOUT must be positive")
+	}
+	if cfg.RecallResponseReserve < 0 {
+		return nil, fmt.Errorf("MNEMO_RECALL_RESPONSE_RESERVE must not be negative")
+	}
+	if cfg.RecallResponseReserve >= cfg.RecallRequestTimeout {
+		return nil, fmt.Errorf("MNEMO_RECALL_RESPONSE_RESERVE must be less than MNEMO_RECALL_REQUEST_TIMEOUT")
 	}
 	if cfg.RuntimeUsageNoticeTimeout <= 0 {
 		return nil, fmt.Errorf("MNEMO_RUNTIME_USAGE_NOTICE_TIMEOUT must be positive")

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -38,6 +38,73 @@ func TestLoad_ChainRecallStopScoreDefaultsToHighConfidence(t *testing.T) {
 	}
 }
 
+func TestLoad_RecallRequestBudgetDefaults(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RecallRequestTimeout != time.Minute {
+		t.Fatalf("RecallRequestTimeout = %v, want 1m", cfg.RecallRequestTimeout)
+	}
+	if cfg.RecallResponseReserve != 5*time.Second {
+		t.Fatalf("RecallResponseReserve = %v, want 5s", cfg.RecallResponseReserve)
+	}
+}
+
+func TestLoad_RecallRequestBudgetOverrides(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_RECALL_REQUEST_TIMEOUT", "90s")
+	t.Setenv("MNEMO_RECALL_RESPONSE_RESERVE", "8s")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.RecallRequestTimeout != 90*time.Second {
+		t.Fatalf("RecallRequestTimeout = %v, want 90s", cfg.RecallRequestTimeout)
+	}
+	if cfg.RecallResponseReserve != 8*time.Second {
+		t.Fatalf("RecallResponseReserve = %v, want 8s", cfg.RecallResponseReserve)
+	}
+}
+
+func TestLoad_RecallRequestBudgetValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		timeout    string
+		reserve    string
+		wantSubstr string
+	}{
+		{name: "timeout must be positive", timeout: "0", wantSubstr: "MNEMO_RECALL_REQUEST_TIMEOUT must be positive"},
+		{name: "reserve must not be negative", reserve: "-1s", wantSubstr: "MNEMO_RECALL_RESPONSE_RESERVE must not be negative"},
+		{name: "reserve must be less than timeout", timeout: "5s", reserve: "5s", wantSubstr: "MNEMO_RECALL_RESPONSE_RESERVE must be less than MNEMO_RECALL_REQUEST_TIMEOUT"},
+		{name: "timeout must be a duration", timeout: "5seconds", wantSubstr: "MNEMO_RECALL_REQUEST_TIMEOUT must be a valid duration"},
+		{name: "reserve must be a duration", reserve: "soon", wantSubstr: "MNEMO_RECALL_RESPONSE_RESERVE must be a valid duration"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("MNEMO_DSN", "test-dsn")
+			if tt.timeout != "" {
+				t.Setenv("MNEMO_RECALL_REQUEST_TIMEOUT", tt.timeout)
+			}
+			if tt.reserve != "" {
+				t.Setenv("MNEMO_RECALL_RESPONSE_RESERVE", tt.reserve)
+			}
+
+			_, err := Load()
+			if err == nil {
+				t.Fatal("Load error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("Load error = %v, want %q", err, tt.wantSubstr)
+			}
+		})
+	}
+}
+
 func TestLoad_DisableSessionSave(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_DISABLE_SESSION_SAVE", "true")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -30,25 +30,27 @@ import (
 
 // Server holds the HTTP handlers and their dependencies.
 type Server struct {
-	tenant               *service.TenantService
-	chains               *service.SpaceChainService
-	uploadTasks          repository.UploadTaskRepo
-	uploadDir            string
-	embedder             *embed.Embedder
-	llmClient            *llm.Client
-	autoModel            string
-	ftsEnabled           bool
-	ingestMode           service.IngestMode
-	dbBackend            string
-	logger               *slog.Logger
-	metering             metering.Writer
-	runtimeUsage         runtimeusage.Manager
-	webhooks             *webhook.Service
-	activity             *service.ActivityTracker
-	startedAt            time.Time
-	svcCache             sync.Map
-	chainRecallStopScore float64
-	disableSessionSave   bool
+	tenant                *service.TenantService
+	chains                *service.SpaceChainService
+	uploadTasks           repository.UploadTaskRepo
+	uploadDir             string
+	embedder              *embed.Embedder
+	llmClient             *llm.Client
+	autoModel             string
+	ftsEnabled            bool
+	ingestMode            service.IngestMode
+	dbBackend             string
+	logger                *slog.Logger
+	metering              metering.Writer
+	runtimeUsage          runtimeusage.Manager
+	webhooks              *webhook.Service
+	activity              *service.ActivityTracker
+	startedAt             time.Time
+	svcCache              sync.Map
+	chainRecallStopScore  float64
+	disableSessionSave    bool
+	recallRequestTimeout  time.Duration
+	recallResponseReserve time.Duration
 }
 
 // NewServer creates a new HTTP handler server.
@@ -65,18 +67,20 @@ func NewServer(
 	logger *slog.Logger,
 ) *Server {
 	return &Server{
-		tenant:               tenantSvc,
-		uploadTasks:          uploadTasks,
-		uploadDir:            uploadDir,
-		embedder:             embedder,
-		llmClient:            llmClient,
-		autoModel:            autoModel,
-		ftsEnabled:           ftsEnabled,
-		ingestMode:           ingestMode,
-		dbBackend:            dbBackend,
-		logger:               logger,
-		startedAt:            time.Now().UTC(),
-		chainRecallStopScore: 0.8,
+		tenant:                tenantSvc,
+		uploadTasks:           uploadTasks,
+		uploadDir:             uploadDir,
+		embedder:              embedder,
+		llmClient:             llmClient,
+		autoModel:             autoModel,
+		ftsEnabled:            ftsEnabled,
+		ingestMode:            ingestMode,
+		dbBackend:             dbBackend,
+		logger:                logger,
+		startedAt:             time.Now().UTC(),
+		chainRecallStopScore:  0.8,
+		recallRequestTimeout:  defaultRecallRequestTimeout,
+		recallResponseReserve: defaultRecallResponseReserve,
 	}
 }
 
@@ -110,6 +114,12 @@ func (s *Server) WithActivityTracker(tracker *service.ActivityTracker) *Server {
 
 func (s *Server) WithDisableSessionSave(disabled bool) *Server {
 	s.disableSessionSave = disabled
+	return s
+}
+
+func (s *Server) WithRecallRequestBudget(timeout, responseReserve time.Duration) *Server {
+	s.recallRequestTimeout = timeout
+	s.recallResponseReserve = responseReserve
 	return s
 }
 
@@ -195,9 +205,10 @@ func (s *Server) Router(
 	// Global middleware.
 	r.Use(reqid.Middleware)
 	r.Use(requestLogger(s.logger))
+	r.Use(metrics.Middleware)
+	r.Use(s.recallRequestBudgetMiddleware)
 	r.Use(chimw.Recoverer)
 	r.Use(corsMW)
-	r.Use(metrics.Middleware)
 	r.Use(rateLimitMW)
 
 	// Health check.
@@ -297,46 +308,77 @@ func (s *Server) Router(
 }
 
 // respond writes a JSON response.
-func respond(w http.ResponseWriter, status int, data any) {
+func respond(w http.ResponseWriter, status int, data any) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if data != nil {
 		if err := json.NewEncoder(w).Encode(data); err != nil {
-			slog.Error("failed to encode response", "err", err)
+			slog.Warn("failed to encode response", "err", err)
+			return err
 		}
 	}
+	return nil
 }
 
 // respondError writes a JSON error response.
-func respondError(w http.ResponseWriter, status int, msg string) {
-	respond(w, status, map[string]string{"error": msg})
+func respondError(w http.ResponseWriter, status int, msg string) error {
+	return respond(w, status, map[string]string{"error": msg})
 }
 
 // handleError maps domain errors to HTTP status codes.
-func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err error) {
+func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err error) error {
 	var budgetErr *memoryListBudgetExceededError
 	switch {
+	case isRecallServerDeadline(err):
+		attrs := []any{
+			"error_role", "final",
+			"error_class", "server_deadline_exceeded",
+			"error_source", "server_budget",
+			"retryable", true,
+			"http_status", http.StatusGatewayTimeout,
+			"err", err,
+		}
+		if auth := middleware.AuthFromContext(ctx); auth != nil && auth.ClusterID != "" {
+			attrs = append(attrs, "cluster_id", auth.ClusterID)
+		}
+		s.logger.ErrorContext(ctx, "request deadline exceeded", attrs...)
+		return respond(w, http.StatusGatewayTimeout, map[string]string{
+			"error": "recall request deadline exceeded",
+			"code":  recallServerDeadlineCode,
+		})
 	case errors.As(err, &budgetErr):
-		respond(w, http.StatusUnprocessableEntity, map[string]string{
+		return respond(w, http.StatusUnprocessableEntity, map[string]string{
 			"error": memoryListBudgetErrorMessage,
 			"code":  memoryListBudgetErrorCode,
 		})
 	case errors.Is(err, domain.ErrNotFound):
-		respondError(w, http.StatusNotFound, err.Error())
+		return respondError(w, http.StatusNotFound, err.Error())
 	case errors.Is(err, domain.ErrWriteConflict):
-		respondError(w, http.StatusServiceUnavailable, err.Error())
+		return respondError(w, http.StatusServiceUnavailable, err.Error())
 	case errors.Is(err, domain.ErrConflict):
-		respondError(w, http.StatusConflict, err.Error())
+		return respondError(w, http.StatusConflict, err.Error())
 	case errors.Is(err, domain.ErrDuplicateKey):
-		respondError(w, http.StatusConflict, "duplicate key: "+err.Error())
+		return respondError(w, http.StatusConflict, "duplicate key: "+err.Error())
 	case errors.Is(err, domain.ErrValidation):
-		respondError(w, http.StatusBadRequest, err.Error())
+		return respondError(w, http.StatusBadRequest, err.Error())
 	case errors.Is(err, domain.ErrNotSupported):
-		respondError(w, http.StatusNotImplemented, err.Error())
+		return respondError(w, http.StatusNotImplemented, err.Error())
 	case errors.Is(err, domain.ErrSchemaIncompatible):
-		respondError(w, http.StatusConflict, err.Error())
+		return respondError(w, http.StatusConflict, err.Error())
 	default:
 		classification := classifyInternalError(err)
+		status := http.StatusInternalServerError
+		responseMessage := "internal server error"
+		logMessage := "internal error"
+		logLevel := slog.LevelError
+		clientCanceled := isClientCanceledRequest(ctx, err)
+		if clientCanceled {
+			classification.class, classification.source, classification.retryable = clientCanceledClassification()
+			status = statusClientClosedRequest
+			responseMessage = "client closed request"
+			logMessage = "request canceled"
+			logLevel = slog.LevelInfo
+		}
 		attrs := []slog.Attr{
 			slog.String("error_role", "final"),
 			slog.String("error_class", classification.class),
@@ -350,11 +392,14 @@ func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err err
 		if classification.upstreamStatus != 0 {
 			attrs = append(attrs, slog.Int("upstream_status", classification.upstreamStatus))
 		}
+		if clientCanceled {
+			attrs = append(attrs, slog.Int("http_status", statusClientClosedRequest))
+		}
 		if auth := middleware.AuthFromContext(ctx); auth != nil && auth.ClusterID != "" {
 			attrs = append(attrs, slog.String("cluster_id", auth.ClusterID))
 		}
-		s.logger.LogAttrs(ctx, slog.LevelError, "internal error", attrs...)
-		respondError(w, http.StatusInternalServerError, "internal server error")
+		s.logger.LogAttrs(ctx, logLevel, logMessage, attrs...)
+		return respondError(w, status, responseMessage)
 	}
 }
 
@@ -392,8 +437,12 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 					path = pattern
 				}
 			}
+			status := ww.Status()
+			if errors.Is(r.Context().Err(), context.Canceled) && errors.Is(context.Cause(r.Context()), context.Canceled) {
+				status = 499
+			}
 			level := slog.LevelInfo
-			if ww.Status() >= 500 {
+			if status >= 500 {
 				level = slog.LevelError
 			}
 			logger.Log(
@@ -402,7 +451,7 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 				"handle request done",
 				"method", r.Method,
 				"path", path,
-				"status", ww.Status(),
+				"status", status,
 				"duration_ms", time.Since(start).Milliseconds(),
 			)
 		})

--- a/server/internal/handler/internal_error.go
+++ b/server/internal/handler/internal_error.go
@@ -18,12 +18,24 @@ var tidbCloudInferenceStatusPattern = regexp.MustCompile(
 	`(?i)\btidb cloud inference:\s*(?:status code|status|http status|http)\s*:?\s*([1-5][0-9]{2})\b`,
 )
 
+const statusClientClosedRequest = 499
+
 type internalErrorClassification struct {
 	class          string
 	source         string
 	retryable      bool
 	dbErrorCode    uint16
 	upstreamStatus int
+}
+
+func isClientCanceledRequest(ctx context.Context, err error) bool {
+	return ctx != nil &&
+		errors.Is(ctx.Err(), context.Canceled) &&
+		errors.Is(err, context.Canceled)
+}
+
+func clientCanceledClassification() (class, source string, retryable bool) {
+	return "client_canceled", "request_context", false
 }
 
 func classifyInternalError(err error) internalErrorClassification {

--- a/server/internal/handler/internal_error_test.go
+++ b/server/internal/handler/internal_error_test.go
@@ -166,6 +166,77 @@ func TestHandleError_LogsStructuredIncidentClassification(t *testing.T) {
 	}
 }
 
+func TestHandleError_MapsCanceledRequestTo499(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
+	srv := &Server{logger: logger}
+	recorder := httptest.NewRecorder()
+	err := fmt.Errorf("recall failed: %w", context.Canceled)
+	handler := requestLogger(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := middleware.WithAuthContext(
+			r.Context(),
+			&domain.AuthInfo{ClusterID: "cluster-canceled"},
+		)
+		srv.handleError(ctx, w, err)
+	}))
+	request := httptest.NewRequest(http.MethodGet, "/memories", nil)
+	requestCtx, cancel := context.WithCancel(reqid.NewContext(request.Context(), "request-canceled"))
+	cancel()
+	request = request.WithContext(requestCtx)
+
+	handler.ServeHTTP(recorder, request)
+
+	if recorder.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want %d", recorder.Code, statusClientClosedRequest)
+	}
+	if got := recorder.Body.String(); got != "{\"error\":\"client closed request\"}\n" {
+		t.Fatalf("body = %q, want client closed request response", got)
+	}
+
+	entries := decodeHandlerLogs(t, &logBuf)
+	entry := findHandlerLogEntry(t, entries, "request canceled")
+	assertHandlerLogField(t, entry, "level", "INFO")
+	assertHandlerLogField(t, entry, "request_id", "request-canceled")
+	assertHandlerLogField(t, entry, "cluster_id", "cluster-canceled")
+	assertHandlerLogField(t, entry, "error_role", "final")
+	assertHandlerLogField(t, entry, "error_class", "client_canceled")
+	assertHandlerLogField(t, entry, "error_source", "request_context")
+	assertHandlerLogField(t, entry, "retryable", false)
+	assertHandlerLogField(t, entry, "http_status", float64(statusClientClosedRequest))
+	assertHandlerLogField(t, entry, "err", err.Error())
+
+	requestEntry := findHandlerLogEntry(t, entries, "handle request done")
+	assertHandlerLogField(t, requestEntry, "level", "INFO")
+	assertHandlerLogField(t, requestEntry, "request_id", "request-canceled")
+	assertHandlerLogField(t, requestEntry, "status", float64(statusClientClosedRequest))
+}
+
+func TestHandleError_PreservesInternalErrorWhenOnlyRequestContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+	srv := &Server{logger: logger}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	recorder := httptest.NewRecorder()
+	err := errors.New("database query failed")
+
+	srv.handleError(ctx, recorder, err)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	entry := findHandlerLogEntry(t, decodeHandlerLogs(t, &logBuf), "internal error")
+	assertHandlerLogField(t, entry, "level", "ERROR")
+	assertHandlerLogField(t, entry, "error_class", "unknown")
+	if got, ok := entry["http_status"]; ok {
+		t.Fatalf("http_status = %#v, want field omitted", got)
+	}
+}
+
 func assertHandlerLogField(t *testing.T, entry map[string]any, key string, want any) {
 	t.Helper()
 	if got := entry[key]; got != want {

--- a/server/internal/handler/memory.go
+++ b/server/internal/handler/memory.go
@@ -716,6 +716,8 @@ type listResponse struct {
 	Total        int                        `json:"total"`
 	Limit        int                        `json:"limit"`
 	Offset       int                        `json:"offset"`
+	Partial      bool                       `json:"partial,omitempty"`
+	Warnings     []recallWarning            `json:"warnings,omitempty"`
 	Message      string                     `json:"message,omitempty"`
 	RuntimeState *runtimeusage.RuntimeState `json:"runtimeState,omitempty"`
 }
@@ -817,33 +819,36 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	)
 	listObservation := newMemoryListObservation(s.logger, auth, filter, contentKeywordSearch)
 	listObservation.startedAt = requestStartedAt
-	listCtx := withMemoryListObservation(r.Context(), listObservation)
+	requestCtx := r.Context()
+	listCtx := withMemoryListObservation(requestCtx, listObservation)
+	cancelRecallBudget := func() {}
 	defer func() {
-		listObservation.finish(r.Context(), err, len(memories), total)
+		listObservation.finish(requestCtx, err, len(memories), total)
+		cancelRecallBudget()
 	}()
 
 	appIDFilter, err := parseAppIDFilter(q)
 	if err != nil {
-		s.handleError(r.Context(), w, err)
+		listObservation.recordResponseWrite(s.handleError(r.Context(), w, err))
 		return
 	}
 	filter.AppID = appIDFilter
 
 	createdAfter, err := parseTimeParam(q.Get("created_after"), "created_after")
 	if err != nil {
-		s.handleError(r.Context(), w, err)
+		listObservation.recordResponseWrite(s.handleError(r.Context(), w, err))
 		return
 	}
 	createdBefore, err := parseTimeParam(q.Get("created_before"), "created_before")
 	if err != nil {
-		s.handleError(r.Context(), w, err)
+		listObservation.recordResponseWrite(s.handleError(r.Context(), w, err))
 		return
 	}
 	if createdAfter != nil && createdBefore != nil && createdAfter.After(*createdBefore) {
 		err = &domain.ValidationError{
 			Field: "created_after", Message: "must not be after created_before",
 		}
-		s.handleError(r.Context(), w, err)
+		listObservation.recordResponseWrite(s.handleError(r.Context(), w, err))
 		return
 	}
 	// The created_at window is consumed only by the session pool. Reject
@@ -854,7 +859,7 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		err = &domain.ValidationError{
 			Field: "created_after", Message: "time-range filter requires memory_type=session",
 		}
-		s.handleError(r.Context(), w, err)
+		listObservation.recordResponseWrite(s.handleError(r.Context(), w, err))
 		return
 	}
 	filter.CreatedAfter = createdAfter
@@ -863,24 +868,53 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	var recallLease *runtimeusage.OperationLease
 	recallFinalized := false
 	recallSearch := filter.Query != "" && !contentKeywordSearch
+	if recallSearch {
+		if budget, ok := recallBudgetFromContext(r.Context()); ok {
+			budget.handlerReached.Store(true)
+			listObservation.startedAt = budget.startedAt
+			requestCtx, cancelRecallBudget = newRecallHandlerContext(r.Context(), budget)
+			listCtx = r.Context()
+			listObservation.configureRecallBudget(budget.total, budget.responseReserve)
+		} else {
+			requestCtx, listCtx, cancelRecallBudget = newRecallRequestBudget(r.Context(), s.recallRequestTimeout, s.recallResponseReserve)
+			listObservation.configureRecallBudget(s.recallRequestTimeout, s.recallResponseReserve)
+		}
+		listCtx = withMemoryListObservation(listCtx, listObservation)
+	}
+	responseCtx := withMemoryListObservation(requestCtx, listObservation)
+	cancelResponse := func() {}
+	clearWriteDeadline := func() {}
+	if recallSearch {
+		var responseBaseCtx context.Context
+		responseBaseCtx, cancelResponse = newRecallResponseContext(requestCtx)
+		responseCtx = withMemoryListObservation(responseBaseCtx, listObservation)
+		clearWriteDeadline = setRecallResponseWriteDeadline(w, requestCtx)
+	}
+	defer cancelResponse()
+	defer clearWriteDeadline()
 	var recallMetric *memoryRecallMetric
 	if recallSearch {
 		metric := newMemoryRecallMetric(auth, filter)
 		recallMetric = &metric
 		defer func() {
-			recallMetric.observe(r.Context(), err)
+			recallMetric.observe(requestCtx, err)
 		}()
 	}
 
 	if s.runtimeUsageEnabled() && recallSearch {
-		recallLease, err = s.runtimeUsage.BeforeRecall(r.Context(), subjectFromAuth(auth))
+		recallLease, err = s.runtimeUsage.BeforeRecall(listCtx, subjectFromAuth(auth))
 		if err != nil {
-			s.handleRuntimeUsageError(r.Context(), w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryRecallRequests))
+			if deadlineErr := recallServerDeadlineFromContext(listCtx); deadlineErr != nil && recallBranchCanceled(err) {
+				err = deadlineErr
+				listObservation.recordResponseWrite(s.handleError(responseCtx, w, err))
+			} else {
+				listObservation.recordResponseWrite(s.handleRuntimeUsageError(responseCtx, w, err, runtimeUsageReserveErrorDetails(auth, runtimeusage.MeterMemoryRecallRequests)))
+			}
 			return
 		}
 		defer func() {
 			if !recallFinalized {
-				s.afterRuntimeUsageRecallFailure(r.Context(), recallLease, context.Canceled)
+				s.afterRuntimeUsageRecallFailure(responseCtx, recallLease, context.Canceled)
 			}
 		}()
 	}
@@ -914,16 +948,21 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	listObservation.queryDuration = time.Since(queryStartedAt)
+	if err != nil && recallSearch {
+		if serverDeadlineErr := recallServerDeadlineFromContext(listCtx); serverDeadlineErr != nil && recallBranchCanceled(err) {
+			err = serverDeadlineErr
+		}
+	}
 	if err == nil {
 		listObservation.recordDirectList(auth, filter, contentKeywordSearch, len(memories))
 	}
 
 	if err != nil {
 		if s.runtimeUsageEnabled() && recallLease != nil {
-			s.afterRuntimeUsageRecallFailure(r.Context(), recallLease, err)
+			s.afterRuntimeUsageRecallFailure(responseCtx, recallLease, err)
 			recallFinalized = true
 		}
-		s.handleError(r.Context(), w, err)
+		listObservation.recordResponseWrite(s.handleError(responseCtx, w, err))
 		return
 	}
 
@@ -936,7 +975,7 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	// untouched, so memory/fact recall is unaffected.
 	if !auth.IsChain() {
 		overlayStartedAt := time.Now()
-		memories = s.resolveServices(auth).session.ApplySessionOverlay(listCtx, memories)
+		memories = s.resolveServices(auth).session.ApplySessionOverlay(responseCtx, memories)
 		listObservation.overlayDuration = time.Since(overlayStartedAt)
 	}
 	if !contentKeywordSearch && rawQuery != "" && classifyRecallQueryShape(rawQuery) == recallQueryShapeTime {
@@ -946,34 +985,61 @@ func (s *Server) listMemories(w http.ResponseWriter, r *http.Request) {
 	}
 	if recallSearch {
 		if s.runtimeUsageEnabled() && recallLease != nil {
-			if finalizeErr := withRuntimeUsagePostSuccessContext(r.Context(), func(ctx context.Context) error {
-				return s.runtimeUsage.AfterRecallSuccess(ctx, recallLease, runtimeusage.RecallResult{
-					MemoryIDs: memoryIDs(memories),
-					AgentName: auth.AgentName,
-				})
-			}); finalizeErr != nil {
-				recallFinalized = true
+			finalizeErr := s.finalizeRuntimeUsageRecallSuccess(responseCtx, recallLease, runtimeusage.RecallResult{
+				MemoryIDs: memoryIDs(memories),
+				AgentName: auth.AgentName,
+			})
+			recallFinalized = true
+			if finalizeErr != nil {
 				err = finalizeErr
-				s.handleRuntimeUsageError(r.Context(), w, finalizeErr, runtimeUsageFinalizeErrorDetails(recallLease))
+				if isRecallServerDeadline(finalizeErr) {
+					listObservation.recordResponseWrite(s.handleError(responseCtx, w, finalizeErr))
+				} else {
+					listObservation.recordResponseWrite(s.handleRuntimeUsageError(responseCtx, w, finalizeErr, runtimeUsageFinalizeErrorDetails(recallLease)))
+				}
 				return
 			}
-			recallFinalized = true
 		}
 		s.recordRecallMetering(auth)
+	}
+	if recallSearch && responseCtx.Err() != nil {
+		if serverDeadlineErr := recallServerDeadlineFromContext(responseCtx); serverDeadlineErr != nil {
+			err = serverDeadlineErr
+		} else {
+			err = responseCtx.Err()
+		}
+		listObservation.recordResponseWrite(s.handleError(responseCtx, w, err))
+		return
 	}
 
 	notice := runtimeResponseNotice{}
 	if recallSearch {
-		notice = s.runtimeResponseNotice(r.Context(), auth)
+		notice = s.runtimeResponseNotice(responseCtx, auth)
+		if responseCtx.Err() != nil {
+			if serverDeadlineErr := recallServerDeadlineFromContext(responseCtx); serverDeadlineErr != nil {
+				err = serverDeadlineErr
+			} else {
+				err = responseCtx.Err()
+			}
+			listObservation.recordResponseWrite(s.handleError(responseCtx, w, err))
+			return
+		}
 	}
-	respond(w, http.StatusOK, listResponse{
+	partial, warnings := listObservation.recallResponseMetadata()
+	writeErr := respond(w, http.StatusOK, listResponse{
 		Memories:     memories,
 		Total:        total,
 		Limit:        limit,
 		Offset:       offset,
+		Partial:      partial,
+		Warnings:     warnings,
 		Message:      notice.Message,
 		RuntimeState: runtimeNoticeState(notice),
 	})
+	listObservation.recordResponseWrite(writeErr)
+	if writeErr != nil && responseCtx.Err() != nil {
+		err = responseCtx.Err()
+	}
 }
 
 func isContentKeywordSearch(q url.Values) bool {

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/service"
 )
 
 const memoryListSlowRequestThreshold = 2 * time.Second
@@ -17,29 +20,40 @@ const memoryListSlowRequestThreshold = 2 * time.Second
 type memoryListObservationContextKey struct{}
 
 type memoryListObservation struct {
-	mu                   sync.Mutex
-	logger               *slog.Logger
-	clusterID            string
-	mode                 string
-	memoryType           string
-	scanAll              bool
-	limit                int
-	offset               int
-	startedAt            time.Time
-	queryDuration        time.Duration
-	overlayDuration      time.Duration
-	mergeDuration        time.Duration
-	memoryQueryDuration  time.Duration
-	sessionQueryDuration time.Duration
-	memoryPages          int
-	memoryRows           int
-	sessionPages         int
-	sessionRows          int
-	allTypePages         int
-	allTypeRows          int
-	chainPages           int
-	chainRows            int
-	chainQueryDuration   time.Duration
+	mu                    sync.Mutex
+	logger                *slog.Logger
+	clusterID             string
+	mode                  string
+	memoryType            string
+	scanAll               bool
+	limit                 int
+	offset                int
+	startedAt             time.Time
+	queryDuration         time.Duration
+	overlayDuration       time.Duration
+	mergeDuration         time.Duration
+	memoryQueryDuration   time.Duration
+	sessionQueryDuration  time.Duration
+	memoryPages           int
+	memoryRows            int
+	sessionPages          int
+	sessionRows           int
+	allTypePages          int
+	allTypeRows           int
+	chainPages            int
+	chainRows             int
+	chainQueryDuration    time.Duration
+	recallBudget          time.Duration
+	responseReserve       time.Duration
+	pinnedRecallDuration  time.Duration
+	insightRecallDuration time.Duration
+	sessionRecallDuration time.Duration
+	pinnedRecallOutcome   string
+	insightRecallOutcome  string
+	sessionRecallOutcome  string
+	recallPartial         bool
+	recallWarnings        []recallWarning
+	responseWriteOutcome  string
 }
 
 func newMemoryListObservation(
@@ -56,14 +70,15 @@ func newMemoryListObservation(
 		clusterID = auth.ClusterID
 	}
 	return &memoryListObservation{
-		logger:     logger,
-		clusterID:  clusterID,
-		mode:       memoryListMode(auth, filter, contentKeywordSearch),
-		memoryType: memoryListTypeLabel(filter.MemoryType),
-		scanAll:    filter.ScanAll,
-		limit:      filter.Limit,
-		offset:     filter.Offset,
-		startedAt:  time.Now(),
+		logger:               logger,
+		clusterID:            clusterID,
+		mode:                 memoryListMode(auth, filter, contentKeywordSearch),
+		memoryType:           memoryListTypeLabel(filter.MemoryType),
+		scanAll:              filter.ScanAll,
+		limit:                filter.Limit,
+		offset:               filter.Offset,
+		startedAt:            time.Now(),
+		responseWriteOutcome: "not_attempted",
 	}
 }
 
@@ -146,6 +161,71 @@ func (o *memoryListObservation) recordMerge(duration time.Duration) {
 	o.mergeDuration += duration
 }
 
+func (o *memoryListObservation) configureRecallBudget(total, responseReserve time.Duration) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.recallBudget = total
+	o.responseReserve = responseReserve
+}
+
+func (o *memoryListObservation) recordRecallBranches(branches [3]recallBranchResult) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	for _, branch := range branches {
+		switch branch.name {
+		case string(service.RecallSourcePinned):
+			o.pinnedRecallDuration = branch.duration
+			o.pinnedRecallOutcome = recallBranchOutcome(branch.err)
+		case string(service.RecallSourceInsight):
+			o.insightRecallDuration = branch.duration
+			o.insightRecallOutcome = recallBranchOutcome(branch.err)
+		case string(service.RecallSourceSession):
+			o.sessionRecallDuration = branch.duration
+			o.sessionRecallOutcome = recallBranchOutcome(branch.err)
+		}
+	}
+}
+
+func (o *memoryListObservation) recordRecallPartial(warnings []recallWarning) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.recallPartial = true
+	for _, warning := range warnings {
+		seen := false
+		for _, existing := range o.recallWarnings {
+			if existing == warning {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			o.recallWarnings = append(o.recallWarnings, warning)
+		}
+	}
+}
+
+func (o *memoryListObservation) recallResponseMetadata() (bool, []recallWarning) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	warnings := append([]recallWarning(nil), o.recallWarnings...)
+	sort.Slice(warnings, func(i, j int) bool {
+		if warnings[i].Branch != warnings[j].Branch {
+			return warnings[i].Branch < warnings[j].Branch
+		}
+		return warnings[i].Code < warnings[j].Code
+	})
+	return o.recallPartial, warnings
+}
+
+func (o *memoryListObservation) recordResponseWrite(err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.responseWriteOutcome = "success"
+	if err != nil {
+		o.responseWriteOutcome = "failed"
+	}
+}
+
 func (o *memoryListObservation) recordDirectList(auth *domain.AuthInfo, filter domain.MemoryFilter, contentKeywordSearch bool, rows int) {
 	if auth != nil && auth.IsChain() {
 		return
@@ -173,10 +253,11 @@ func (o *memoryListObservation) recordDirectList(auth *domain.AuthInfo, filter d
 func (o *memoryListObservation) finish(ctx context.Context, err error, returned, total int) {
 	duration := time.Since(o.startedAt)
 	status := memoryListStatus(ctx, err)
+	clientCanceled := isClientCanceledRequest(ctx, err)
 	metrics.MemoryListRequestsTotal.WithLabelValues(o.mode, status).Inc()
 	metrics.MemoryListDuration.WithLabelValues(o.mode, status).Observe(duration.Seconds())
 
-	if status == "ok" && duration < memoryListSlowRequestThreshold {
+	if status == "ok" && duration < memoryListSlowRequestThreshold && o.recallBudget == 0 {
 		return
 	}
 
@@ -185,6 +266,14 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 	if pages == 0 && o.chainPages > 0 {
 		pages = o.chainPages
 		rows = o.chainRows
+	}
+	outcome := status
+	cancelOrigin := memoryListCancelOrigin(ctx, err)
+	cancelCause := memoryListCancelCause(ctx, err)
+	if o.recallPartial {
+		outcome = "partial"
+		cancelOrigin = "server_deadline"
+		cancelCause = "server_budget_exhausted"
 	}
 	attrs := []slog.Attr{
 		slog.String("cluster_id", o.clusterID),
@@ -212,8 +301,23 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 		slog.Int64("merge_ms", o.mergeDuration.Milliseconds()),
 		slog.Int64("overlay_ms", o.overlayDuration.Milliseconds()),
 		slog.Int64("duration_ms", duration.Milliseconds()),
-		slog.String("outcome", status),
-		slog.String("cancel_origin", memoryListCancelOrigin(ctx, err)),
+		slog.String("outcome", outcome),
+		slog.String("cancel_origin", cancelOrigin),
+		slog.String("cancel_cause", cancelCause),
+	}
+	if o.recallBudget > 0 {
+		attrs = append(attrs,
+			slog.Int64("budget_ms", o.recallBudget.Milliseconds()),
+			slog.Int64("response_reserve_ms", o.responseReserve.Milliseconds()),
+			slog.String("pinned_outcome", o.pinnedRecallOutcome),
+			slog.Int64("pinned_ms", o.pinnedRecallDuration.Milliseconds()),
+			slog.String("insight_outcome", o.insightRecallOutcome),
+			slog.Int64("insight_ms", o.insightRecallDuration.Milliseconds()),
+			slog.String("session_outcome", o.sessionRecallOutcome),
+			slog.Int64("session_ms", o.sessionRecallDuration.Milliseconds()),
+			slog.Bool("partial", o.recallPartial),
+			slog.String("response_write_outcome", o.responseWriteOutcome),
+		)
 	}
 	var budgetErr *memoryListBudgetExceededError
 	if errors.As(err, &budgetErr) {
@@ -223,6 +327,21 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 			slog.String("error_class", "budget_exceeded"),
 			slog.String("error_source", "server_budget"),
 			slog.Bool("retryable", false),
+		)
+	} else if clientCanceled {
+		class, source, retryable := clientCanceledClassification()
+		attrs = append(attrs,
+			slog.String("error_class", class),
+			slog.String("error_source", source),
+			slog.Bool("retryable", retryable),
+			slog.Int("http_status", statusClientClosedRequest),
+		)
+	} else if isRecallServerDeadline(err) {
+		attrs = append(attrs,
+			slog.String("error_class", "server_deadline_exceeded"),
+			slog.String("error_source", "server_budget"),
+			slog.Bool("retryable", true),
+			slog.Int("http_status", http.StatusGatewayTimeout),
 		)
 	} else if status != "ok" {
 		cause := err
@@ -238,10 +357,17 @@ func (o *memoryListObservation) finish(ctx context.Context, err error, returned,
 	}
 
 	message := "memory list completed"
-	level := slog.LevelWarn
-	if status != "ok" {
+	level := slog.LevelInfo
+	if clientCanceled {
+		message = "memory list canceled"
+		level = slog.LevelInfo
+	} else if o.recallPartial {
+		level = slog.LevelWarn
+	} else if status != "ok" {
 		message = "memory list failed"
 		level = slog.LevelError
+	} else if duration >= memoryListSlowRequestThreshold {
+		level = slog.LevelWarn
 	}
 	o.logger.LogAttrs(ctx, level, message, attrs...)
 }
@@ -255,6 +381,9 @@ func memoryListStatus(ctx context.Context, err error) string {
 }
 
 func memoryListCancelOrigin(ctx context.Context, err error) string {
+	if isRecallServerDeadline(err) {
+		return "server_deadline"
+	}
 	if ctx != nil {
 		switch {
 		case errors.Is(ctx.Err(), context.DeadlineExceeded):
@@ -265,6 +394,25 @@ func memoryListCancelOrigin(ctx context.Context, err error) string {
 	}
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return "downstream"
+	}
+	return "none"
+}
+
+func memoryListCancelCause(ctx context.Context, err error) string {
+	if isRecallServerDeadline(err) {
+		return "server_budget_exhausted"
+	}
+	if isClientCanceledRequest(ctx, err) {
+		return "client_disconnect"
+	}
+	if ctx != nil && errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "request_deadline"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "downstream_deadline"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "downstream_cancellation"
 	}
 	return "none"
 }

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -253,18 +253,22 @@ func TestListChainMemories_RecordsNodeWork(t *testing.T) {
 
 func TestListMemories_LogsFailureAndCancellationOrigin(t *testing.T) {
 	tests := []struct {
-		name       string
-		listErr    error
-		cancel     bool
-		deadline   bool
-		wantStatus string
-		wantOrigin string
+		name           string
+		listErr        error
+		cancel         bool
+		deadline       bool
+		wantStatus     string
+		wantOrigin     string
+		wantMessage    string
+		wantLevel      string
+		wantErrorClass string
+		wantHTTPStatus int
 	}{
-		{name: "dependency failure", listErr: errors.New("database unavailable"), wantStatus: "error", wantOrigin: "none"},
-		{name: "dependency cancellation", listErr: context.Canceled, wantStatus: "canceled", wantOrigin: "downstream"},
-		{name: "dependency timeout", listErr: context.DeadlineExceeded, wantStatus: "timeout", wantOrigin: "downstream"},
-		{name: "client cancellation", listErr: context.Canceled, cancel: true, wantStatus: "canceled", wantOrigin: "client"},
-		{name: "request deadline", listErr: context.DeadlineExceeded, deadline: true, wantStatus: "timeout", wantOrigin: "deadline"},
+		{name: "dependency failure", listErr: errors.New("database unavailable"), wantStatus: "error", wantOrigin: "none", wantMessage: "memory list failed", wantLevel: "ERROR", wantErrorClass: "unknown", wantHTTPStatus: http.StatusInternalServerError},
+		{name: "dependency cancellation", listErr: context.Canceled, wantStatus: "canceled", wantOrigin: "downstream", wantMessage: "memory list failed", wantLevel: "ERROR", wantErrorClass: "context_canceled", wantHTTPStatus: http.StatusInternalServerError},
+		{name: "dependency timeout", listErr: context.DeadlineExceeded, wantStatus: "timeout", wantOrigin: "downstream", wantMessage: "memory list failed", wantLevel: "ERROR", wantErrorClass: "context_deadline_exceeded", wantHTTPStatus: http.StatusInternalServerError},
+		{name: "client cancellation", listErr: context.Canceled, cancel: true, wantStatus: "canceled", wantOrigin: "client", wantMessage: "memory list canceled", wantLevel: "INFO", wantErrorClass: "client_canceled", wantHTTPStatus: statusClientClosedRequest},
+		{name: "request deadline", listErr: context.DeadlineExceeded, deadline: true, wantStatus: "timeout", wantOrigin: "deadline", wantMessage: "memory list failed", wantLevel: "ERROR", wantErrorClass: "context_deadline_exceeded", wantHTTPStatus: http.StatusInternalServerError},
 	}
 
 	for _, tt := range tests {
@@ -292,12 +296,17 @@ func TestListMemories_LogsFailureAndCancellationOrigin(t *testing.T) {
 
 			srv.listMemories(rr, req)
 
-			entry := findMemoryListLogEntry(t, &logBuf, "memory list failed")
+			if rr.Code != tt.wantHTTPStatus {
+				t.Fatalf("status = %d, want %d", rr.Code, tt.wantHTTPStatus)
+			}
+			entry := findMemoryListLogEntry(t, &logBuf, tt.wantMessage)
+			assertMemoryListLogField(t, entry, "level", tt.wantLevel)
 			assertMemoryListLogField(t, entry, "request_id", "request-list-failure")
 			assertMemoryListLogField(t, entry, "cluster_id", "cluster-list-failure")
 			assertMemoryListLogField(t, entry, "mode", "all_types_list")
 			assertMemoryListLogField(t, entry, "outcome", tt.wantStatus)
 			assertMemoryListLogField(t, entry, "cancel_origin", tt.wantOrigin)
+			assertMemoryListLogField(t, entry, "error_class", tt.wantErrorClass)
 		})
 	}
 }

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -448,6 +448,9 @@ type captureRuntimeUsageManager struct {
 	beforeRecallSubjects     []runtimeusage.Subject
 	recallResults            []runtimeusage.RecallResult
 	recallSuccessContextErrs []error
+	afterRecallSuccessHook   func(context.Context) error
+	afterRecallFailureHook   func(context.Context)
+	noticeStateHook          func(context.Context) error
 	beforeCreateSubjects     []runtimeusage.Subject
 	createResults            []runtimeusage.MemoryCreateResult
 	createSuccessContextErrs []error
@@ -472,11 +475,16 @@ func (m *captureRuntimeUsageManager) RuntimeState(_ context.Context, subject run
 	}
 	return runtimeusage.RuntimeUsageDisabledState(), nil
 }
-func (m *captureRuntimeUsageManager) RuntimeStateForNotice(_ context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
+func (m *captureRuntimeUsageManager) RuntimeStateForNotice(ctx context.Context, subject runtimeusage.Subject) (runtimeusage.RuntimeState, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.noticeStateCalls++
 	m.noticeStateSubjects = append(m.noticeStateSubjects, subject)
+	if m.noticeStateHook != nil {
+		if err := m.noticeStateHook(ctx); err != nil {
+			return runtimeusage.RuntimeState{}, err
+		}
+	}
 	if m.runtimeStateErr != nil {
 		return runtimeusage.RuntimeState{}, m.runtimeStateErr
 	}
@@ -494,9 +502,15 @@ func (m *captureRuntimeUsageManager) AfterRecallSuccess(ctx context.Context, _ *
 	m.afterRecallSuccessCalls++
 	m.recallResults = append(m.recallResults, result)
 	m.recallSuccessContextErrs = append(m.recallSuccessContextErrs, ctx.Err())
+	if m.afterRecallSuccessHook != nil {
+		return m.afterRecallSuccessHook(ctx)
+	}
 	return nil
 }
-func (m *captureRuntimeUsageManager) AfterRecallFailure(context.Context, *runtimeusage.OperationLease, error) {
+func (m *captureRuntimeUsageManager) AfterRecallFailure(ctx context.Context, _ *runtimeusage.OperationLease, _ error) {
+	if m.afterRecallFailureHook != nil {
+		m.afterRecallFailureHook(ctx)
+	}
 }
 func (m *captureRuntimeUsageManager) BeforeMemoryCreate(_ context.Context, subject runtimeusage.Subject, _ int64) (*runtimeusage.OperationLease, error) {
 	m.mu.Lock()
@@ -3361,9 +3375,10 @@ func TestBulkCreateMemories_ChainRuntimeUsageUsesResolvedNodeSubject(t *testing.
 	}
 }
 
-func TestListMemories_RuntimeUsageRecallFinalizationIgnoresRequestCancellation(t *testing.T) {
+func TestListMemories_RuntimeUsageRecallHandsOffFinalizationBeforeReturning499ForCanceledRequest(t *testing.T) {
 	now := time.Now()
 	var cancelRequest context.CancelFunc
+	finalized := make(chan struct{})
 	memRepo := &testMemoryRepo{
 		keywordSearchHook: func(_ context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
 			cancelRequest()
@@ -3372,7 +3387,13 @@ func TestListMemories_RuntimeUsageRecallFinalizationIgnoresRequestCancellation(t
 			}, nil
 		},
 	}
-	runtimeUsage := &captureRuntimeUsageManager{enabled: true}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled: true,
+		afterRecallSuccessHook: func(context.Context) error {
+			close(finalized)
+			return nil
+		},
+	}
 	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
 
 	req := makeTenantRequest(t, http.MethodGet, "/memories?q=what%20company%20does%20john%20like&memory_type=pinned&limit=10", nil)
@@ -3387,8 +3408,13 @@ func TestListMemories_RuntimeUsageRecallFinalizationIgnoresRequestCancellation(t
 	if ctx.Err() != context.Canceled {
 		t.Fatal("request context was not canceled during recall")
 	}
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	if rr.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want 499: %s", rr.Code, rr.Body.String())
+	}
+	select {
+	case <-finalized:
+	case <-time.After(time.Second):
+		t.Fatal("Recall finalization was not handed off")
 	}
 	if runtimeUsage.afterRecallSuccessCalls != 1 {
 		t.Fatalf("AfterRecallSuccess calls = %d, want 1", runtimeUsage.afterRecallSuccessCalls)

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -88,6 +88,45 @@ func TestOpenAPIMemoryListBudgetResponse(t *testing.T) {
 	}
 }
 
+func TestOpenAPIRecallRequestBudgetContract(t *testing.T) {
+	openapi := loadOpenAPI(t)
+	for _, path := range []string{
+		"/v1alpha1/mem9s/{tenantID}/memories",
+		"/v1alpha2/mem9s/memories",
+	} {
+		responses := operationResponses(t, openapi, path, "get")
+		assertResponseRef(t, responses, "504", "#/components/responses/RecallGatewayTimeout")
+	}
+
+	components := objectValue(t, openapi, "components")
+	responses := objectValue(t, components, "responses")
+	schemas := objectValue(t, components, "schemas")
+	response := objectValue(t, responses, "RecallGatewayTimeout")
+	content := objectValue(t, response, "content")
+	jsonContent := objectValue(t, content, "application/json")
+	schema := objectValue(t, jsonContent, "schema")
+	if schema["$ref"] != "#/components/schemas/RecallDeadlineError" {
+		t.Fatalf("recall timeout schema = %#v", schema["$ref"])
+	}
+
+	deadlineError := objectValue(t, schemas, "RecallDeadlineError")
+	allOf := objectSlice(t, deadlineError["allOf"])
+	if !containsRef(allOf, "#/components/schemas/ErrorResponse") || !allOfRequiresProperty(allOf, "code") {
+		t.Fatalf("RecallDeadlineError contract = %#v", allOf)
+	}
+
+	list := objectValue(t, schemas, "MemoryListResponse")
+	properties := objectValue(t, list, "properties")
+	if _, ok := properties["partial"]; !ok {
+		t.Fatal("MemoryListResponse.partial missing")
+	}
+	warnings := objectValue(t, properties, "warnings")
+	items := objectValue(t, warnings, "items")
+	if items["$ref"] != "#/components/schemas/RecallWarning" {
+		t.Fatalf("MemoryListResponse.warnings items = %#v", items["$ref"])
+	}
+}
+
 func TestOpenAPIRuntimeQuotaSchemas(t *testing.T) {
 	openapi := loadOpenAPI(t)
 	components := objectValue(t, openapi, "components")

--- a/server/internal/handler/recall.go
+++ b/server/internal/handler/recall.go
@@ -10,11 +10,11 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 
 	"github.com/go-sql-driver/mysql"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/service"
@@ -187,46 +187,90 @@ func (s *Server) defaultConfidenceRecallSearch(
 		sessionResult     = recallBranchResult{name: string(service.RecallSourceSession)}
 	)
 
-	group, groupCtx := errgroup.WithContext(ctx)
-	group.Go(func() error {
+	groupCtx, cancelGroup := context.WithCancelCause(ctx)
+	defer cancelGroup(nil)
+	var group sync.WaitGroup
+	group.Add(3)
+	go func() {
+		defer group.Done()
+		branchCtx, cancelBranch := newRecallBranchContext(groupCtx)
+		defer cancelBranch()
 		branchStart := time.Now()
-		candidates, err := svc.memory.SearchCandidates(groupCtx, pinnedFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
+		candidates, err := svc.memory.SearchCandidates(branchCtx, pinnedFilter, service.RecallSourcePinned, recallCandidateOptions(profile.shape, false))
+		err = normalizeRecallBranchError(branchCtx, err)
 		pinnedResult.duration = time.Since(branchStart)
 		pinnedResult.err = err
 		if err != nil {
-			return err
+			if !recallBranchCanceled(err) {
+				cancelGroup(err)
+			}
+			return
 		}
 		pinnedCandidates = candidates
-		return nil
-	})
-	group.Go(func() error {
+	}()
+	go func() {
+		defer group.Done()
+		branchCtx, cancelBranch := newRecallBranchContext(groupCtx)
+		defer cancelBranch()
 		branchStart := time.Now()
-		candidates, err := svc.memory.SearchCandidates(groupCtx, insightFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
+		candidates, err := svc.memory.SearchCandidates(branchCtx, insightFilter, service.RecallSourceInsight, recallCandidateOptions(profile.shape, true))
+		err = normalizeRecallBranchError(branchCtx, err)
 		insightResult.duration = time.Since(branchStart)
 		insightResult.err = err
 		if err != nil {
-			return err
+			if !recallBranchCanceled(err) {
+				cancelGroup(err)
+			}
+			return
 		}
 		insightCandidates = candidates
-		return nil
-	})
-	group.Go(func() error {
+	}()
+	go func() {
+		defer group.Done()
+		branchCtx, cancelBranch := newRecallBranchContext(groupCtx)
+		defer cancelBranch()
 		branchStart := time.Now()
-		candidates, err := svc.session.SearchCandidates(groupCtx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
+		candidates, err := svc.session.SearchCandidates(branchCtx, sessionFilter, service.RecallSourceSession, recallCandidateOptions(profile.shape, false))
+		err = normalizeRecallBranchError(branchCtx, err)
 		sessionResult.duration = time.Since(branchStart)
 		sessionResult.err = err
 		if err != nil {
-			return err
+			if !recallBranchCanceled(err) {
+				cancelGroup(err)
+			}
+			return
 		}
 		sessionCandidates = candidates
-		return nil
-	})
-	if err := group.Wait(); err != nil {
-		s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, err, [3]recallBranchResult{
-			pinnedResult,
-			insightResult,
-			sessionResult,
-		})
+	}()
+	group.Wait()
+	branches := [3]recallBranchResult{pinnedResult, insightResult, sessionResult}
+	var partialWarnings []recallWarning
+	if observation := memoryListObservationFromContext(ctx); observation != nil {
+		observation.recordRecallBranches(branches)
+	}
+
+	if primaryErr := recallGenuineFailure(branches); primaryErr != nil {
+		s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, primaryErr, branches)
+		return nil, 0, primaryErr
+	} else if serverDeadlineErr := recallServerDeadlineFailure(ctx, branches); serverDeadlineErr != nil {
+		if cancellationErr := recallNonServerCancellationFailure(branches); cancellationErr != nil {
+			s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, cancellationErr, branches)
+			return nil, 0, cancellationErr
+		}
+		partialWarnings = recallDeadlineWarnings(branches)
+		if len(partialWarnings) > 0 && recallHasSuccessfulBranch(branches) {
+			if observation := memoryListObservationFromContext(ctx); observation != nil {
+				observation.recordRecallPartial(partialWarnings)
+			}
+		} else {
+			s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, serverDeadlineErr, branches)
+			return nil, 0, serverDeadlineErr
+		}
+	} else if ctx.Err() != nil {
+		s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, ctx.Err(), branches)
+		return nil, 0, ctx.Err()
+	} else if err := recallCancellationFailure(branches); err != nil {
+		s.logConfidenceRecallFailure(ctx, auth.ClusterID, start, err, branches)
 		return nil, 0, err
 	}
 
@@ -240,7 +284,17 @@ func (s *Server) defaultConfidenceRecallSearch(
 	selectionDuration := time.Since(selectionStart)
 
 	memories := append(pinned, mixed...)
-	slog.InfoContext(ctx, "confidence recall search",
+	logger := s.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	message := "confidence recall search"
+	level := slog.LevelInfo
+	if len(partialWarnings) > 0 {
+		message = "confidence recall search partial"
+		level = slog.LevelWarn
+	}
+	attrs := []any{
 		"cluster_id", auth.ClusterID,
 		"query_len", len(filter.Query),
 		"shape", recallQueryShapeLabel(profile.shape),
@@ -261,10 +315,82 @@ func (s *Server) defaultConfidenceRecallSearch(
 		"pinned_ms", pinnedResult.duration.Milliseconds(),
 		"insight_ms", insightResult.duration.Milliseconds(),
 		"session_ms", sessionResult.duration.Milliseconds(),
+		"pinned_outcome", recallBranchOutcome(pinnedResult.err),
+		"insight_outcome", recallBranchOutcome(insightResult.err),
+		"session_outcome", recallBranchOutcome(sessionResult.err),
+		"partial", len(partialWarnings) > 0,
 		"selection_ms", selectionDuration.Milliseconds(),
 		"total_ms", time.Since(start).Milliseconds(),
-	)
+	}
+	if budget, ok := recallBudgetFromContext(ctx); ok {
+		attrs = append(attrs,
+			"budget_ms", budget.total.Milliseconds(),
+			"response_reserve_ms", budget.responseReserve.Milliseconds(),
+		)
+	}
+	logger.Log(ctx, level, message, attrs...)
 	return memories, len(memories), nil
+}
+
+func recallServerDeadlineFailure(ctx context.Context, branches [3]recallBranchResult) error {
+	if err := recallServerDeadlineFromContext(ctx); err != nil {
+		return err
+	}
+	for _, branch := range branches {
+		if isRecallServerDeadline(branch.err) {
+			return branch.err
+		}
+	}
+	return nil
+}
+
+func recallGenuineFailure(branches [3]recallBranchResult) error {
+	for _, branch := range branches {
+		if branch.err != nil && !recallBranchCanceled(branch.err) {
+			return branch.err
+		}
+	}
+	return nil
+}
+
+func recallCancellationFailure(branches [3]recallBranchResult) error {
+	for _, branch := range branches {
+		if branch.err != nil {
+			return branch.err
+		}
+	}
+	return nil
+}
+
+func recallNonServerCancellationFailure(branches [3]recallBranchResult) error {
+	for _, branch := range branches {
+		if branch.err != nil && recallBranchCanceled(branch.err) && !isRecallServerDeadline(branch.err) {
+			return branch.err
+		}
+	}
+	return nil
+}
+
+func recallHasSuccessfulBranch(branches [3]recallBranchResult) bool {
+	for _, branch := range branches {
+		if branch.err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func recallDeadlineWarnings(branches [3]recallBranchResult) []recallWarning {
+	warnings := make([]recallWarning, 0, len(branches))
+	for _, branch := range branches {
+		if isRecallServerDeadline(branch.err) {
+			warnings = append(warnings, recallWarning{
+				Code:   recallBranchDeadlineCode,
+				Branch: branch.name,
+			})
+		}
+	}
+	return warnings
 }
 
 func (s *Server) logConfidenceRecallFailure(
@@ -280,6 +406,9 @@ func (s *Server) logConfidenceRecallFailure(
 	if ctxErr := ctx.Err(); ctxErr != nil && recallBranchCanceled(primaryErr) {
 		primaryBranch = "request"
 		primaryCause = ctxErr
+		if serverDeadlineErr := recallServerDeadlineFromContext(ctx); serverDeadlineErr != nil {
+			primaryCause = serverDeadlineErr
+		}
 		switch {
 		case errors.Is(ctxErr, context.DeadlineExceeded):
 			cancelOrigin = "deadline"
@@ -290,6 +419,15 @@ func (s *Server) logConfidenceRecallFailure(
 		cancelOrigin = "sibling_failure"
 	}
 	classification := classifyRecallError(primaryCause)
+	clientCanceled := cancelOrigin == "client" && isClientCanceledRequest(ctx, primaryCause)
+	if clientCanceled {
+		classification.class, classification.source, classification.retryable = clientCanceledClassification()
+	} else if isRecallServerDeadline(primaryCause) {
+		classification.class = "server_deadline_exceeded"
+		classification.source = "server_budget"
+		classification.retryable = true
+		cancelOrigin = "server_deadline"
+	}
 
 	logger := s.logger
 	if logger == nil {
@@ -304,6 +442,7 @@ func (s *Server) logConfidenceRecallFailure(
 		slog.Bool("primary_retryable", classification.retryable),
 		slog.Any("canceled_branches", recallCanceledBranches(primaryBranch, branches)),
 		slog.String("cancel_origin", cancelOrigin),
+		slog.String("cancel_cause", recallCancelCause(ctx, primaryCause, cancelOrigin)),
 		slog.String("pinned_outcome", recallBranchOutcome(branches[0].err)),
 		slog.Int64("pinned_ms", branches[0].duration.Milliseconds()),
 		slog.String("insight_outcome", recallBranchOutcome(branches[1].err)),
@@ -316,7 +455,46 @@ func (s *Server) logConfidenceRecallFailure(
 	if classification.upstreamStatus != 0 {
 		attrs = append(attrs, slog.Int("primary_upstream_status", classification.upstreamStatus))
 	}
-	logger.LogAttrs(ctx, slog.LevelError, "confidence recall search failed", attrs...)
+	if budget, ok := recallBudgetFromContext(ctx); ok {
+		attrs = append(attrs,
+			slog.Int64("budget_ms", budget.total.Milliseconds()),
+			slog.Int64("response_reserve_ms", budget.responseReserve.Milliseconds()),
+		)
+	}
+	message := "confidence recall search failed"
+	level := slog.LevelError
+	if clientCanceled {
+		attrs = append(attrs, slog.Int("http_status", statusClientClosedRequest))
+		message = "confidence recall search canceled"
+		level = slog.LevelInfo
+	} else if isRecallServerDeadline(primaryCause) {
+		attrs = append(attrs, slog.Int("http_status", http.StatusGatewayTimeout))
+		message = "confidence recall search deadline exceeded"
+	}
+	logger.LogAttrs(ctx, level, message, attrs...)
+}
+
+func recallCancelCause(ctx context.Context, err error, origin string) string {
+	switch origin {
+	case "server_deadline":
+		return "server_budget_exhausted"
+	case "client":
+		return "client_disconnect"
+	case "deadline":
+		return "request_deadline"
+	case "sibling_failure":
+		return "branch_failure"
+	}
+	if isClientCanceledRequest(ctx, err) {
+		return "client_disconnect"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "downstream_deadline"
+	}
+	if errors.Is(err, context.Canceled) {
+		return "downstream_cancellation"
+	}
+	return "none"
 }
 
 func recallPrimaryBranch(primaryErr error, branches [3]recallBranchResult) string {

--- a/server/internal/handler/recall_budget.go
+++ b/server/internal/handler/recall_budget.go
@@ -1,0 +1,303 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultRecallRequestTimeout  = time.Minute
+	defaultRecallResponseReserve = 5 * time.Second
+	recallServerDeadlineCode     = "recall_server_deadline_exceeded"
+	recallBranchDeadlineCode     = "recall_branch_deadline_exceeded"
+)
+
+type recallBudgetContextKey struct{}
+
+type recallBudgetContext struct {
+	total           time.Duration
+	responseReserve time.Duration
+	startedAt       time.Time
+	totalDeadline   time.Time
+	workDeadline    time.Time
+	totalContext    context.Context
+	handlerReached  atomic.Bool
+}
+
+type recallServerDeadlineError struct{}
+
+func (*recallServerDeadlineError) Error() string {
+	return "recall request deadline exceeded"
+}
+
+func (*recallServerDeadlineError) Unwrap() error {
+	return context.DeadlineExceeded
+}
+
+type recallWarning struct {
+	Code   string `json:"code"`
+	Branch string `json:"branch"`
+}
+
+func newRecallRequestBudget(parent context.Context, total, responseReserve time.Duration) (context.Context, context.Context, context.CancelFunc) {
+	totalCtx, cancelTotal := newRecallTotalBudget(parent, total, responseReserve)
+	workCtx, cancelWork := newRecallWorkContext(totalCtx)
+	return totalCtx, workCtx, func() {
+		cancelWork()
+		cancelTotal()
+	}
+}
+
+func newRecallTotalBudget(parent context.Context, total, responseReserve time.Duration) (context.Context, context.CancelFunc) {
+	startedAt := time.Now()
+	totalCtx, cancel := context.WithTimeoutCause(parent, total, &recallServerDeadlineError{})
+	totalDeadline, _ := totalCtx.Deadline()
+	budget := &recallBudgetContext{
+		total:           total,
+		responseReserve: responseReserve,
+		startedAt:       startedAt,
+		totalDeadline:   totalDeadline,
+		workDeadline:    totalDeadline.Add(-responseReserve),
+	}
+	ctx := context.WithValue(totalCtx, recallBudgetContextKey{}, budget)
+	budget.totalContext = ctx
+	return ctx, cancel
+}
+
+func newRecallWorkContext(parent context.Context) (context.Context, context.CancelFunc) {
+	budget, ok := recallBudgetFromContext(parent)
+	if !ok {
+		return context.WithCancel(parent)
+	}
+	return context.WithDeadlineCause(parent, budget.workDeadline, &recallServerDeadlineError{})
+}
+
+func newRecallResponseContext(parent context.Context) (context.Context, context.CancelFunc) {
+	budget, ok := recallBudgetFromContext(parent)
+	if !ok {
+		return context.WithCancel(parent)
+	}
+	writeReserve := budget.responseReserve / 2
+	return context.WithDeadlineCause(parent, budget.totalDeadline.Add(-writeReserve), &recallServerDeadlineError{})
+}
+
+func newRecallHandlerContext(handlerCtx context.Context, budget *recallBudgetContext) (context.Context, context.CancelFunc) {
+	if budget == nil {
+		return context.WithCancel(handlerCtx)
+	}
+	ctx, cancel := context.WithDeadlineCause(context.WithoutCancel(handlerCtx), budget.totalDeadline, &recallServerDeadlineError{})
+	stop := context.AfterFunc(budget.totalContext, func() {
+		if errors.Is(context.Cause(budget.totalContext), context.Canceled) {
+			cancel()
+		}
+	})
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
+
+func (s *Server) recallRequestBudgetMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !isRecallHTTPRequest(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		totalCtx, cancelTotal := newRecallTotalBudget(r.Context(), s.recallRequestTimeout, s.recallResponseReserve)
+		defer cancelTotal()
+		workCtx, cancelWork := newRecallWorkContext(totalCtx)
+		defer cancelWork()
+		budget, _ := recallBudgetFromContext(totalCtx)
+		writer := &recallBudgetResponseWriter{ResponseWriter: w, workCtx: workCtx, budget: budget}
+		clearWriteDeadline := setRecallResponseWriteDeadline(w, totalCtx)
+		defer clearWriteDeadline()
+		next.ServeHTTP(writer, r.WithContext(workCtx))
+		writer.completeDeadlineResponse()
+		if writer.overrideStatus != 0 {
+			logger := s.logger
+			if logger == nil {
+				logger = slog.Default()
+			}
+			level := slog.LevelError
+			message := "recall request deadline exceeded before handler"
+			errorClass := "server_deadline_exceeded"
+			errorSource := "server_budget"
+			cancelOrigin := "server_deadline"
+			cancelCause := "server_budget_exhausted"
+			retryable := true
+			if writer.overrideStatus == statusClientClosedRequest {
+				level = slog.LevelInfo
+				message = "recall request canceled before handler"
+				errorClass = "client_canceled"
+				errorSource = "request_context"
+				cancelOrigin = "client"
+				cancelCause = "client_disconnect"
+				retryable = false
+			}
+			logger.Log(totalCtx, level, message,
+				"error_role", "final",
+				"error_class", errorClass,
+				"error_source", errorSource,
+				"retryable", retryable,
+				"http_status", writer.overrideStatus,
+				"cancel_origin", cancelOrigin,
+				"cancel_cause", cancelCause,
+				"budget_ms", budget.total.Milliseconds(),
+				"response_reserve_ms", budget.responseReserve.Milliseconds(),
+				"response_write_outcome", writer.writeOutcome,
+			)
+		}
+	})
+}
+
+type recallBudgetResponseWriter struct {
+	http.ResponseWriter
+	workCtx        context.Context
+	budget         *recallBudgetContext
+	wroteHeader    bool
+	overrideStatus int
+	writeOutcome   string
+}
+
+func (w *recallBudgetResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *recallBudgetResponseWriter) WriteHeader(status int) {
+	if w.shouldOverride() {
+		w.writeDeadlineResponse()
+		return
+	}
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *recallBudgetResponseWriter) Write(payload []byte) (int, error) {
+	if w.shouldOverride() {
+		w.writeDeadlineResponse()
+		return len(payload), nil
+	}
+	if w.overrideStatus != 0 {
+		return len(payload), nil
+	}
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(payload)
+}
+
+func (w *recallBudgetResponseWriter) shouldOverride() bool {
+	return w.terminalStatus() != 0
+}
+
+func (w *recallBudgetResponseWriter) completeDeadlineResponse() {
+	if w.shouldOverride() && w.overrideStatus == 0 {
+		w.writeDeadlineResponse()
+	}
+}
+
+func (w *recallBudgetResponseWriter) terminalStatus() int {
+	if w.budget == nil || w.budget.handlerReached.Load() {
+		return 0
+	}
+	if isRecallServerDeadline(recallServerDeadlineFromContext(w.workCtx)) {
+		return http.StatusGatewayTimeout
+	}
+	if errors.Is(w.workCtx.Err(), context.Canceled) && errors.Is(context.Cause(w.workCtx), context.Canceled) {
+		return statusClientClosedRequest
+	}
+	return 0
+}
+
+func (w *recallBudgetResponseWriter) writeDeadlineResponse() {
+	if w.overrideStatus != 0 {
+		return
+	}
+	w.overrideStatus = w.terminalStatus()
+	if w.overrideStatus == 0 {
+		return
+	}
+	w.wroteHeader = true
+	w.Header().Del("Content-Length")
+	w.Header().Set("Content-Type", "application/json")
+	w.ResponseWriter.WriteHeader(w.overrideStatus)
+	payload := "{\"error\":\"client closed request\"}\n"
+	if w.overrideStatus == http.StatusGatewayTimeout {
+		payload = "{\"code\":\"" + recallServerDeadlineCode + "\",\"error\":\"recall request deadline exceeded\"}\n"
+	}
+	_, err := w.ResponseWriter.Write([]byte(payload))
+	w.writeOutcome = "success"
+	if err != nil {
+		w.writeOutcome = "failed"
+	}
+}
+
+func isRecallHTTPRequest(r *http.Request) bool {
+	if r == nil || r.Method != http.MethodGet || strings.TrimSpace(r.URL.Query().Get("q")) == "" || isContentKeywordSearch(r.URL.Query()) {
+		return false
+	}
+	path := strings.TrimSuffix(r.URL.Path, "/")
+	if path == "/v1alpha2/mem9s/memories" {
+		return true
+	}
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	return len(parts) == 4 && parts[0] == "v1alpha1" && parts[1] == "mem9s" && parts[2] != "" && parts[3] == "memories"
+}
+
+func setRecallResponseWriteDeadline(w http.ResponseWriter, ctx context.Context) func() {
+	budget, ok := recallBudgetFromContext(ctx)
+	if !ok {
+		return func() {}
+	}
+	controller := http.NewResponseController(w)
+	if err := controller.SetWriteDeadline(budget.totalDeadline); err != nil {
+		return func() {}
+	}
+	return func() {
+		_ = controller.SetWriteDeadline(time.Time{})
+	}
+}
+
+func newRecallBranchContext(parent context.Context) (context.Context, context.CancelFunc) {
+	budget, ok := recallBudgetFromContext(parent)
+	if !ok {
+		return context.WithCancel(parent)
+	}
+	return context.WithDeadlineCause(parent, budget.workDeadline, &recallServerDeadlineError{})
+}
+
+func recallBudgetFromContext(ctx context.Context) (*recallBudgetContext, bool) {
+	budget, ok := ctx.Value(recallBudgetContextKey{}).(*recallBudgetContext)
+	return budget, ok
+}
+
+func recallServerDeadlineFromContext(ctx context.Context) error {
+	var deadlineErr *recallServerDeadlineError
+	if errors.As(context.Cause(ctx), &deadlineErr) {
+		return deadlineErr
+	}
+	return nil
+}
+
+func isRecallServerDeadline(err error) bool {
+	var deadlineErr *recallServerDeadlineError
+	return errors.As(err, &deadlineErr)
+}
+
+func normalizeRecallBranchError(ctx context.Context, err error) error {
+	if err == nil || !recallBranchCanceled(err) {
+		return err
+	}
+	if serverDeadlineErr := recallServerDeadlineFromContext(ctx); serverDeadlineErr != nil {
+		return serverDeadlineErr
+	}
+	return err
+}

--- a/server/internal/handler/recall_budget_test.go
+++ b/server/internal/handler/recall_budget_test.go
@@ -1,0 +1,574 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
+)
+
+type failingJSONResponseWriter struct {
+	header http.Header
+	status int
+}
+
+type deadlineResponseWriter struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+}
+
+func (w *deadlineResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	w.deadlines = append(w.deadlines, deadline)
+	return nil
+}
+
+func identityMiddleware(next http.Handler) http.Handler {
+	return next
+}
+
+func TestRecallRequestBudgetStartsBeforeGlobalRateLimitMiddleware(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).WithRecallRequestBudget(time.Minute, 5*time.Second)
+	var budget *recallBudgetContext
+	var found bool
+	rateLimit := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			budget, found = recallBudgetFromContext(r.Context())
+			w.WriteHeader(http.StatusNoContent)
+		})
+	}
+	handler := srv.Router(identityMiddleware, rateLimit, identityMiddleware, identityMiddleware)
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rr.Code)
+	}
+	if !found {
+		t.Fatal("Recall budget missing in global rate-limit middleware")
+	}
+	if budget == nil || budget.total != time.Minute || budget.responseReserve != 5*time.Second {
+		t.Fatalf("budget = %+v, want total=1m reserve=5s", budget)
+	}
+	if got := budget.workDeadline.Sub(budget.startedAt); got < 54*time.Second || got > 56*time.Second {
+		t.Fatalf("work deadline offset = %s, want approximately 55s", got)
+	}
+}
+
+func TestRecallRequestBudgetMapsPreHandlerDeadlineTo504(t *testing.T) {
+	metrics.HTTPRequestsTotal.Reset()
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).WithRecallRequestBudget(120*time.Millisecond, 60*time.Millisecond)
+	rateLimit := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+			http.Error(w, "rate limit dependency timed out", http.StatusServiceUnavailable)
+		})
+	}
+	handler := srv.Router(identityMiddleware, rateLimit, identityMiddleware, identityMiddleware)
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project", nil)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	}
+	var response map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["code"] != recallServerDeadlineCode {
+		t.Fatalf("code = %q, want %q", response["code"], recallServerDeadlineCode)
+	}
+	assertRecallHTTPMetric(t, http.StatusGatewayTimeout)
+}
+
+func TestRecallRequestBudgetMapsPreHandlerClientCancellationTo499(t *testing.T) {
+	metrics.HTTPRequestsTotal.Reset()
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	rateLimit := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+			http.Error(w, "dependency canceled", http.StatusServiceUnavailable)
+		})
+	}
+	handler := srv.Router(identityMiddleware, rateLimit, identityMiddleware, identityMiddleware)
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	cancel()
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want 499: %s", rr.Code, rr.Body.String())
+	}
+	assertRecallHTTPMetric(t, statusClientClosedRequest)
+}
+
+func assertRecallHTTPMetric(t *testing.T, status int) {
+	t.Helper()
+	counter, err := metrics.HTTPRequestsTotal.GetMetricWithLabelValues(http.MethodGet, "unmatched", strconv.Itoa(status))
+	if err != nil {
+		t.Fatalf("get HTTP request metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("HTTP request metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write HTTP request metric: %v", err)
+	}
+	if pb.Counter == nil || pb.Counter.GetValue() != 1 {
+		t.Fatalf("HTTP %d request metric = %#v, want 1", status, pb.Counter)
+	}
+}
+
+func TestRecallRequestBudgetMiddlewareSkipsKeywordSearch(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	var found bool
+	handler := srv.recallRequestBudgetMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, found = recallBudgetFromContext(r.Context())
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project&search_mode=keyword", nil)
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if found {
+		t.Fatal("keyword search received Recall budget")
+	}
+}
+
+func (w *failingJSONResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingJSONResponseWriter) WriteHeader(status int) {
+	w.status = status
+}
+
+func (*failingJSONResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("client connection closed")
+}
+
+func TestListMemories_RecallServerDeadlineReturns504(t *testing.T) {
+	var logBuf bytes.Buffer
+	var mu sync.Mutex
+	canceledBranches := 0
+	waitForDeadline := func(ctx context.Context) ([]domain.Memory, error) {
+		<-ctx.Done()
+		mu.Lock()
+		canceledBranches++
+		mu.Unlock()
+		return nil, ctx.Err()
+	}
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return waitForDeadline(ctx)
+		},
+	}
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return waitForDeadline(ctx)
+		},
+	}
+	srv := newTestServer(memRepo, sessRepo).WithRecallRequestBudget(500*time.Millisecond, 400*time.Millisecond)
+	srv.logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	rr := httptest.NewRecorder()
+	startedAt := time.Now()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	}
+	var response map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response["code"] != recallServerDeadlineCode {
+		t.Fatalf("code = %q, want %q", response["code"], recallServerDeadlineCode)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 350*time.Millisecond {
+		t.Fatalf("elapsed = %s, want response before total request budget", elapsed)
+	}
+	mu.Lock()
+	gotCanceled := canceledBranches
+	mu.Unlock()
+	if gotCanceled != 3 {
+		t.Fatalf("canceled branches = %d, want 3", gotCanceled)
+	}
+	entry := findMemoryListLogEntry(t, &logBuf, "memory list failed")
+	assertMemoryListLogField(t, entry, "budget_ms", float64(500))
+	assertMemoryListLogField(t, entry, "response_reserve_ms", float64(400))
+	assertMemoryListLogField(t, entry, "cancel_origin", "server_deadline")
+	assertMemoryListLogField(t, entry, "cancel_cause", "server_budget_exhausted")
+	assertMemoryListLogField(t, entry, "response_write_outcome", "success")
+	assertMemoryListLogField(t, entry, "pinned_outcome", "deadline_exceeded")
+	assertMemoryListLogField(t, entry, "insight_outcome", "deadline_exceeded")
+	assertMemoryListLogField(t, entry, "session_outcome", "deadline_exceeded")
+}
+
+func TestListMemories_RecallDeadlinePreservesCompletedBranches(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			if filter.MemoryType == string(domain.TypeInsight) {
+				return []domain.Memory{{
+					ID:         "insight-1",
+					Content:    "project-1234",
+					MemoryType: domain.TypeInsight,
+					State:      domain.StateActive,
+					UpdatedAt:  now,
+				}}, nil
+			}
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	srv := newTestServer(memRepo, sessRepo).WithRecallRequestBudget(100*time.Millisecond, 50*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("project-1234"), nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var response listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(response.Memories) != 1 || response.Memories[0].ID != "insight-1" {
+		t.Fatalf("memories = %+v, want completed insight branch", response.Memories)
+	}
+	if len(response.Warnings) != 2 {
+		t.Fatalf("warnings = %+v, want two deadline warnings", response.Warnings)
+	}
+	for _, warning := range response.Warnings {
+		if warning.Code != recallBranchDeadlineCode {
+			t.Fatalf("warning code = %q, want %q", warning.Code, recallBranchDeadlineCode)
+		}
+	}
+}
+
+func TestDefaultConfidenceRecallSearch_PropagatesBranchDeadlineToRepositories(t *testing.T) {
+	deadlines := make(chan time.Time, 16)
+	recordDeadline := func(ctx context.Context) ([]domain.Memory, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			return nil, errors.New("branch deadline missing")
+		}
+		deadlines <- deadline
+		return nil, nil
+	}
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return recordDeadline(ctx)
+		},
+	}
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return recordDeadline(ctx)
+		},
+	}
+	srv := newTestServer(memRepo, sessRepo).WithRecallRequestBudget(time.Second, 250*time.Millisecond)
+	requestCtx, workCtx, cancel := newRecallRequestBudget(context.Background(), srv.recallRequestTimeout, srv.recallResponseReserve)
+	defer cancel()
+	_ = requestCtx
+
+	_, _, err := srv.defaultConfidenceRecallSearch(workCtx, &domain.AuthInfo{}, srv.resolveServices(&domain.AuthInfo{}), domain.MemoryFilter{
+		Query: "what happened",
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("defaultConfidenceRecallSearch: %v", err)
+	}
+	first := <-deadlines
+	for range 2 {
+		if got := <-deadlines; got.Sub(first).Abs() > 5*time.Millisecond {
+			t.Fatalf("branch deadlines differ: first=%s got=%s", first, got)
+		}
+	}
+}
+
+func TestNewRecallRequestBudget_ReservesResponseTimeInsideParentDeadline(t *testing.T) {
+	parent, cancelParent := context.WithTimeout(context.Background(), time.Second)
+	defer cancelParent()
+	parentDeadline, _ := parent.Deadline()
+
+	_, workCtx, cancelBudget := newRecallRequestBudget(parent, 2*time.Second, 200*time.Millisecond)
+	defer cancelBudget()
+	workDeadline, ok := workCtx.Deadline()
+	if !ok {
+		t.Fatal("work deadline missing")
+	}
+	reserve := parentDeadline.Sub(workDeadline)
+	if reserve < 190*time.Millisecond || reserve > 210*time.Millisecond {
+		t.Fatalf("response reserve = %s, want approximately 200ms", reserve)
+	}
+}
+
+func TestListMemories_RecallDependencyFailureRemains500(t *testing.T) {
+	dependencyErr := errors.New("database unavailable")
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(_ context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			if filter.MemoryType == string(domain.TypePinned) {
+				return nil, dependencyErr
+			}
+			return nil, nil
+		},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestListMemories_SinglePoolRecallServerDeadlineReturns504(t *testing.T) {
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRecallRequestBudget(100*time.Millisecond, 50*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened")+"&memory_type=insight", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestListMemories_RecallCompletionRecordsResponseWriteFailure(t *testing.T) {
+	var logBuf bytes.Buffer
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	srv.logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	w := &failingJSONResponseWriter{header: make(http.Header)}
+
+	srv.listMemories(w, req)
+
+	if w.status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.status)
+	}
+	entry := findMemoryListLogEntry(t, &logBuf, "memory list completed")
+	assertMemoryListLogField(t, entry, "level", "INFO")
+	assertMemoryListLogField(t, entry, "response_write_outcome", "failed")
+}
+
+func TestListMemories_RecallSetsTotalResponseWriteDeadline(t *testing.T) {
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).WithRecallRequestBudget(time.Second, 200*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	w := &deadlineResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	startedAt := time.Now()
+
+	srv.listMemories(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if len(w.deadlines) != 2 {
+		t.Fatalf("write deadline calls = %d, want set and clear", len(w.deadlines))
+	}
+	if got := w.deadlines[0].Sub(startedAt); got < 900*time.Millisecond || got > 1100*time.Millisecond {
+		t.Fatalf("write deadline offset = %s, want approximately 1s", got)
+	}
+	if !w.deadlines[1].IsZero() {
+		t.Fatalf("cleared write deadline = %s, want zero", w.deadlines[1])
+	}
+}
+
+func TestListMemories_RecallRuntimeFinalizationUsesResponseBudget(t *testing.T) {
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled: true,
+		afterRecallSuccessHook: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).
+		WithRuntimeUsage(runtimeUsage).
+		WithRecallRequestBudget(160*time.Millisecond, 80*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	rr := httptest.NewRecorder()
+	startedAt := time.Now()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 150*time.Millisecond {
+		t.Fatalf("elapsed = %s, want response before total budget", elapsed)
+	}
+}
+
+func TestListMemories_RecallRuntimeNoticeUsesResponseBudget(t *testing.T) {
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled:    true,
+		providerID: runtimeNoticeProviderID,
+		noticeStateHook: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).
+		WithRuntimeUsage(runtimeUsage).
+		WithRecallRequestBudget(160*time.Millisecond, 80*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	rr := httptest.NewRecorder()
+	startedAt := time.Now()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 150*time.Millisecond {
+		t.Fatalf("elapsed = %s, want response before total budget", elapsed)
+	}
+}
+
+func TestListMemories_ClientCancellationDuringRuntimeFinalizationReturnsImmediately(t *testing.T) {
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled: true,
+		afterRecallSuccessHook: func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			close(finished)
+			return ctx.Err()
+		},
+	}
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).
+		WithRuntimeUsage(runtimeUsage).
+		WithRecallRequestBudget(300*time.Millisecond, 100*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened"), nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		srv.listMemories(rr, req)
+		close(done)
+	}()
+
+	<-started
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("handler did not return promptly after client cancellation")
+	}
+	if rr.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want 499: %s", rr.Code, rr.Body.String())
+	}
+	select {
+	case <-finished:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("background finalization did not stop at its deadline")
+	}
+}
+
+func TestListMemories_ClientCancellationDoesNotWaitForRuntimeFailureFinalization(t *testing.T) {
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled: true,
+		afterRecallFailureHook: func(ctx context.Context) {
+			close(started)
+			<-ctx.Done()
+			close(finished)
+		},
+	}
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).
+		WithRuntimeUsage(runtimeUsage).
+		WithRecallRequestBudget(300*time.Millisecond, 100*time.Millisecond)
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("what happened")+"&memory_type=insight", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		srv.listMemories(rr, req)
+		close(done)
+	}()
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("handler waited for Recall failure finalization")
+	}
+	if rr.Code != statusClientClosedRequest {
+		t.Fatalf("status = %d, want 499: %s", rr.Code, rr.Body.String())
+	}
+	select {
+	case <-started:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("Recall failure finalization was not handed off")
+	}
+	select {
+	case <-finished:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("Recall failure finalization did not stop at its deadline")
+	}
+}
+
+func TestRecallDeadlineWarningsExcludeDownstreamCancellation(t *testing.T) {
+	branches := [3]recallBranchResult{
+		{name: "pinned", err: &recallServerDeadlineError{}},
+		{name: "insight", err: context.Canceled},
+		{name: "session"},
+	}
+	warnings := recallDeadlineWarnings(branches)
+	if len(warnings) != 1 || warnings[0].Branch != "pinned" {
+		t.Fatalf("warnings = %+v, want only pinned server deadline", warnings)
+	}
+	if err := recallNonServerCancellationFailure(branches); !errors.Is(err, context.Canceled) {
+		t.Fatalf("non-server cancellation = %v, want context.Canceled", err)
+	}
+}

--- a/server/internal/handler/recall_failure_log_test.go
+++ b/server/internal/handler/recall_failure_log_test.go
@@ -78,13 +78,16 @@ func TestDefaultConfidenceRecallSearch_LogsPrimaryFailureAndSiblingCancellation(
 
 func TestDefaultConfidenceRecallSearch_LogsRequestCancellationOrigin(t *testing.T) {
 	tests := []struct {
-		name          string
-		newContext    func(context.Context) (context.Context, context.CancelFunc)
-		wantErr       error
-		wantClass     string
-		wantOrigin    string
-		wantOutcome   string
-		wantRetryable bool
+		name           string
+		newContext     func(context.Context) (context.Context, context.CancelFunc)
+		wantErr        error
+		wantClass      string
+		wantOrigin     string
+		wantOutcome    string
+		wantRetryable  bool
+		wantMessage    string
+		wantLevel      string
+		wantHTTPStatus float64
 	}{
 		{
 			name: "client cancellation",
@@ -93,10 +96,13 @@ func TestDefaultConfidenceRecallSearch_LogsRequestCancellationOrigin(t *testing.
 				cancel()
 				return ctx, cancel
 			},
-			wantErr:     context.Canceled,
-			wantClass:   "context_canceled",
-			wantOrigin:  "client",
-			wantOutcome: "canceled",
+			wantErr:        context.Canceled,
+			wantClass:      "client_canceled",
+			wantOrigin:     "client",
+			wantOutcome:    "canceled",
+			wantMessage:    "confidence recall search canceled",
+			wantLevel:      "INFO",
+			wantHTTPStatus: statusClientClosedRequest,
 		},
 		{
 			name: "request deadline",
@@ -108,6 +114,8 @@ func TestDefaultConfidenceRecallSearch_LogsRequestCancellationOrigin(t *testing.
 			wantOrigin:    "deadline",
 			wantOutcome:   "deadline_exceeded",
 			wantRetryable: true,
+			wantMessage:   "confidence recall search failed",
+			wantLevel:     "ERROR",
 		},
 	}
 
@@ -133,6 +141,8 @@ func TestDefaultConfidenceRecallSearch_LogsRequestCancellationOrigin(t *testing.
 			}
 
 			entry := decodeRecallFailureLog(t, logBuf)
+			assertRecallLogField(t, entry, "msg", tt.wantMessage)
+			assertRecallLogField(t, entry, "level", tt.wantLevel)
 			assertRecallLogField(t, entry, "request_id", "request-context")
 			assertRecallLogField(t, entry, "primary_branch", "request")
 			assertRecallLogField(t, entry, "primary_error_class", tt.wantClass)
@@ -142,6 +152,11 @@ func TestDefaultConfidenceRecallSearch_LogsRequestCancellationOrigin(t *testing.
 			assertRecallLogField(t, entry, "pinned_outcome", tt.wantOutcome)
 			assertRecallLogField(t, entry, "insight_outcome", tt.wantOutcome)
 			assertRecallLogField(t, entry, "session_outcome", tt.wantOutcome)
+			if tt.wantHTTPStatus != 0 {
+				assertRecallLogField(t, entry, "http_status", tt.wantHTTPStatus)
+			} else if got, ok := entry["http_status"]; ok {
+				t.Fatalf("http_status = %#v, want field omitted", got)
+			}
 			assertRecallLogStrings(t, entry, "canceled_branches", []string{"pinned", "insight", "session"})
 			assertRecallLogDurations(t, entry)
 		})

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -121,7 +121,7 @@ func withRuntimeUsagePostFailureContext(parent context.Context, run func(context
 }
 
 func (s *Server) afterRuntimeUsageRecallFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
-	ctx, cancel := runtimeUsagePostRequestContext(parent)
+	ctx, cancel, _ := runtimeUsageRecallFinalizeContext(parent)
 	go func() {
 		defer cancel()
 		s.runtimeUsage.AfterRecallFailure(ctx, lease, cause)
@@ -147,11 +147,7 @@ func (s *Server) afterRuntimeUsageMemoryDeleteFailure(parent context.Context, le
 }
 
 func runtimeUsagePostRequestContext(parent context.Context) (context.Context, context.CancelFunc) {
-	deadline := time.Now().Add(runtimeUsagePostRequestTimeout)
-	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(deadline) {
-		deadline = parentDeadline
-	}
-	return context.WithDeadline(context.WithoutCancel(parent), deadline)
+	return context.WithTimeout(context.WithoutCancel(parent), runtimeUsagePostRequestTimeout)
 }
 
 func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -50,6 +50,70 @@ func withRuntimeUsagePostSuccessContext(parent context.Context, run func(context
 	return run(ctx)
 }
 
+func (s *Server) finalizeRuntimeUsageRecallSuccess(
+	parent context.Context,
+	lease *runtimeusage.OperationLease,
+	result runtimeusage.RecallResult,
+) error {
+	ctx, cancel, budgetLimited := runtimeUsageRecallFinalizeContext(parent)
+	done := make(chan error, 1)
+	go func() {
+		done <- s.runtimeUsage.AfterRecallSuccess(ctx, lease, result)
+	}()
+	finishInBackground := func() {
+		go func() {
+			err := <-done
+			cancel()
+			if err != nil {
+				s.logRuntimeUsageBackgroundFinalizeError(
+					context.WithoutCancel(parent),
+					err,
+					runtimeUsageFinalizeErrorDetails(lease),
+				)
+			}
+		}()
+	}
+	select {
+	case err := <-done:
+		cancel()
+		if budgetLimited {
+			if deadlineErr := recallServerDeadlineFromContext(ctx); deadlineErr != nil {
+				return deadlineErr
+			}
+		}
+		return err
+	case <-parent.Done():
+		finishInBackground()
+		if deadlineErr := recallServerDeadlineFromContext(parent); deadlineErr != nil {
+			return deadlineErr
+		}
+		return nil
+	case <-ctx.Done():
+		finishInBackground()
+		if budgetLimited {
+			if deadlineErr := recallServerDeadlineFromContext(ctx); deadlineErr != nil {
+				return deadlineErr
+			}
+		}
+		return ctx.Err()
+	}
+}
+
+func runtimeUsageRecallFinalizeContext(parent context.Context) (context.Context, context.CancelFunc, bool) {
+	deadline := time.Now().Add(runtimeUsagePostRequestTimeout)
+	budgetLimited := false
+	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(deadline) {
+		deadline = parentDeadline
+		budgetLimited = true
+	}
+	cause := error(context.DeadlineExceeded)
+	if budgetLimited {
+		cause = &recallServerDeadlineError{}
+	}
+	ctx, cancel := context.WithDeadlineCause(context.WithoutCancel(parent), deadline, cause)
+	return ctx, cancel, budgetLimited
+}
+
 func withRuntimeUsagePostFailureContext(parent context.Context, run func(context.Context)) {
 	ctx, cancel := runtimeUsagePostRequestContext(parent)
 	defer cancel()
@@ -57,9 +121,11 @@ func withRuntimeUsagePostFailureContext(parent context.Context, run func(context
 }
 
 func (s *Server) afterRuntimeUsageRecallFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
-	withRuntimeUsagePostFailureContext(parent, func(ctx context.Context) {
+	ctx, cancel := runtimeUsagePostRequestContext(parent)
+	go func() {
+		defer cancel()
 		s.runtimeUsage.AfterRecallFailure(ctx, lease, cause)
-	})
+	}()
 }
 
 func (s *Server) afterRuntimeUsageMemoryCreateFailure(parent context.Context, lease *runtimeusage.OperationLease, cause error) {
@@ -81,7 +147,11 @@ func (s *Server) afterRuntimeUsageMemoryDeleteFailure(parent context.Context, le
 }
 
 func runtimeUsagePostRequestContext(parent context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(parent), runtimeUsagePostRequestTimeout)
+	deadline := time.Now().Add(runtimeUsagePostRequestTimeout)
+	if parentDeadline, ok := parent.Deadline(); ok && parentDeadline.Before(deadline) {
+		deadline = parentDeadline
+	}
+	return context.WithDeadline(context.WithoutCancel(parent), deadline)
 }
 
 func subjectFromAuth(auth *domain.AuthInfo) runtimeusage.Subject {
@@ -127,7 +197,7 @@ func (s *Server) handleRuntimeUsageError(
 	w http.ResponseWriter,
 	err error,
 	details runtimeUsageErrorDetails,
-) {
+) error {
 	s.logRuntimeUsageError(ctx, err, details, runtimeUsageRoleClientResponse)
 
 	var denied *runtimeusage.QuotaDeniedError
@@ -139,15 +209,14 @@ func (s *Server) handleRuntimeUsageError(
 			w.Header().Set("Retry-After", denied.RetryAfter)
 		}
 		w.WriteHeader(status)
-		_, _ = w.Write(body)
-		return
+		_, writeErr := w.Write(body)
+		return writeErr
 	}
 	status := runtimeusage.HTTPStatus(err)
 	if status == http.StatusBadGateway {
-		respondError(w, status, "runtime usage conflict")
-		return
+		return respondError(w, status, "runtime usage conflict")
 	}
-	respondError(w, status, "runtime usage unavailable")
+	return respondError(w, status, "runtime usage unavailable")
 }
 
 func (s *Server) logRuntimeUsageBackgroundFinalizeError(ctx context.Context, err error, details runtimeUsageErrorDetails) {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -474,6 +474,34 @@ func TestRuntimeUsagePostRequestContextPreservesValuesAndBoundsLifetime(t *testi
 	}
 }
 
+func TestRuntimeUsagePostRequestContextGetsIndependentWindowAfterParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithDeadline(
+		reqid.NewContext(context.Background(), "request-expired"),
+		time.Now().Add(-time.Second),
+	)
+	defer cancelParent()
+
+	ctx, cancel := runtimeUsagePostRequestContext(parent)
+	defer cancel()
+
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("detached context error = %v, want nil", err)
+	}
+	if got := reqid.FromContext(ctx); got != "request-expired" {
+		t.Fatalf("request_id = %q, want request-expired", got)
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("detached context deadline is missing")
+	}
+	remaining := time.Until(deadline)
+	if remaining < runtimeUsagePostRequestTimeout-time.Second || remaining > runtimeUsagePostRequestTimeout {
+		t.Fatalf("detached context remaining timeout = %s, want approximately %s", remaining, runtimeUsagePostRequestTimeout)
+	}
+}
+
 func decodeSingleRuntimeUsageLog(t *testing.T, buf *bytes.Buffer) map[string]any {
 	t.Helper()
 	lines := bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n"))


### PR DESCRIPTION
## What Changed
- Give Recall a one-minute server-owned request budget with a five-second response reserve and bounded branch contexts.
- Classify caller cancellation as synthetic 499 and server budget exhaustion as stable 504.
- Preserve completed branches through `partial` responses with bounded warning codes.
- Record budget, branch outcomes, cancellation cause, and response-write outcome; document the API contract.

## Review Path
1. Start with `server/internal/handler/recall_budget.go` and configuration wiring.
2. Review terminal mapping and runtime-usage handoff in the memory handler.
3. Review parallel branch completion and partial-result handling.
4. Finish with observability, OpenAPI, and regression tests.

## Validation
- `GOCACHE=/private/tmp/mem9-go-cache make vet`
- `GOCACHE=/private/tmp/mem9-go-cache make test`
- `git diff --check upstream/main...HEAD`

## Deployment Note
Caller and proxy timeouts must exceed 60 seconds for clients to receive the server-owned 504 response. Earlier caller deadlines still cancel database work promptly and are recorded as 499.

Closes #444