### PR TITLE
fix(server): bound FTS recall candidate paging

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3059,7 +3059,8 @@
           "code": {
             "type": "string",
             "enum": [
-              "recall_branch_deadline_exceeded"
+              "recall_branch_deadline_exceeded",
+              "fts_candidate_budget_exhausted"
             ]
           },
           "branch": {
@@ -3308,7 +3309,7 @@
           },
           "partial": {
             "type": "boolean",
-            "description": "True when Recall preserved completed branches after another branch exhausted the server work budget."
+            "description": "True when Recall preserved accepted results after a branch deadline or FTS candidate budget was exhausted."
           },
           "warnings": {
             "type": "array",

--- a/server/internal/domain/errors.go
+++ b/server/internal/domain/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrNotSupported            = errors.New("not supported")
 	ErrAutoVectorSearchSkipped = errors.New("auto vector search skipped")
 	ErrSchemaIncompatible      = errors.New("schema incompatible")
+	ErrFTSSearchTruncated      = errors.New("fts search truncated")
 )
 
 // ValidationError wraps ErrValidation with a field-level message.

--- a/server/internal/domain/recall_warning.go
+++ b/server/internal/domain/recall_warning.go
@@ -1,0 +1,23 @@
+package domain
+
+import "context"
+
+const RecallWarningFTSCandidateBudgetExhausted = "fts_candidate_budget_exhausted"
+
+type RecallWarning struct {
+	Code   string `json:"code"`
+	Branch string `json:"branch"`
+}
+
+type recallWarningRecorderKey struct{}
+
+func WithRecallWarningRecorder(ctx context.Context, record func(RecallWarning)) context.Context {
+	return context.WithValue(ctx, recallWarningRecorderKey{}, record)
+}
+
+func RecordRecallWarning(ctx context.Context, warning RecallWarning) {
+	record, _ := ctx.Value(recallWarningRecorderKey{}).(func(RecallWarning))
+	if record != nil {
+		record(warning)
+	}
+}

--- a/server/internal/domain/recall_warning.go
+++ b/server/internal/domain/recall_warning.go
@@ -15,9 +15,11 @@ func WithRecallWarningRecorder(ctx context.Context, record func(RecallWarning)) 
 	return context.WithValue(ctx, recallWarningRecorderKey{}, record)
 }
 
-func RecordRecallWarning(ctx context.Context, warning RecallWarning) {
+func RecordRecallWarning(ctx context.Context, warning RecallWarning) bool {
 	record, _ := ctx.Value(recallWarningRecorderKey{}).(func(RecallWarning))
-	if record != nil {
-		record(warning)
+	if record == nil {
+		return false
 	}
+	record(warning)
+	return true
 }

--- a/server/internal/domain/recall_warning_test.go
+++ b/server/internal/domain/recall_warning_test.go
@@ -15,7 +15,9 @@ func TestRecordRecallWarningUsesContextRecorder(t *testing.T) {
 		got = append(got, warning)
 	})
 
-	RecordRecallWarning(ctx, want)
+	if !RecordRecallWarning(ctx, want) {
+		t.Fatal("RecordRecallWarning() = false, want true")
+	}
 
 	if len(got) != 1 || got[0] != want {
 		t.Fatalf("warnings = %+v, want [%+v]", got, want)
@@ -23,8 +25,10 @@ func TestRecordRecallWarningUsesContextRecorder(t *testing.T) {
 }
 
 func TestRecordRecallWarningWithoutRecorderIsNoOp(t *testing.T) {
-	RecordRecallWarning(context.Background(), RecallWarning{
+	if RecordRecallWarning(context.Background(), RecallWarning{
 		Code:   RecallWarningFTSCandidateBudgetExhausted,
 		Branch: string(TypePinned),
-	})
+	}) {
+		t.Fatal("RecordRecallWarning() = true, want false")
+	}
 }

--- a/server/internal/domain/recall_warning_test.go
+++ b/server/internal/domain/recall_warning_test.go
@@ -1,0 +1,30 @@
+package domain
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRecordRecallWarningUsesContextRecorder(t *testing.T) {
+	want := RecallWarning{
+		Code:   RecallWarningFTSCandidateBudgetExhausted,
+		Branch: string(TypeInsight),
+	}
+	var got []RecallWarning
+	ctx := WithRecallWarningRecorder(context.Background(), func(warning RecallWarning) {
+		got = append(got, warning)
+	})
+
+	RecordRecallWarning(ctx, want)
+
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("warnings = %+v, want [%+v]", got, want)
+	}
+}
+
+func TestRecordRecallWarningWithoutRecorderIsNoOp(t *testing.T) {
+	RecordRecallWarning(context.Background(), RecallWarning{
+		Code:   RecallWarningFTSCandidateBudgetExhausted,
+		Branch: string(TypePinned),
+	})
+}

--- a/server/internal/handler/memory_list_observability.go
+++ b/server/internal/handler/memory_list_observability.go
@@ -127,7 +127,10 @@ func memoryListTypeLabel(memoryType string) string {
 }
 
 func withMemoryListObservation(ctx context.Context, observation *memoryListObservation) context.Context {
-	return context.WithValue(ctx, memoryListObservationContextKey{}, observation)
+	ctx = context.WithValue(ctx, memoryListObservationContextKey{}, observation)
+	return domain.WithRecallWarningRecorder(ctx, func(warning domain.RecallWarning) {
+		observation.recordRecallPartial([]recallWarning{warning})
+	})
 }
 
 func memoryListObservationFromContext(ctx context.Context) *memoryListObservation {

--- a/server/internal/handler/memory_list_observability_test.go
+++ b/server/internal/handler/memory_list_observability_test.go
@@ -49,6 +49,24 @@ func TestMemoryListMode(t *testing.T) {
 	}
 }
 
+func TestMemoryListObservationRecordsRepositoryRecallWarning(t *testing.T) {
+	observation := newMemoryListObservation(nil, nil, domain.MemoryFilter{Query: "term"}, false)
+	ctx := withMemoryListObservation(context.Background(), observation)
+
+	domain.RecordRecallWarning(ctx, domain.RecallWarning{
+		Code:   domain.RecallWarningFTSCandidateBudgetExhausted,
+		Branch: string(domain.TypeInsight),
+	})
+
+	partial, warnings := observation.recallResponseMetadata()
+	if !partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(warnings) != 1 || warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted || warnings[0].Branch != string(domain.TypeInsight) {
+		t.Fatalf("warnings = %+v, want insight FTS candidate budget warning", warnings)
+	}
+}
+
 func TestListMemories_RecordsMemoryListMetrics(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/server/internal/handler/openapi_contract_test.go
+++ b/server/internal/handler/openapi_contract_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/reqid"
 )
 
@@ -124,6 +125,15 @@ func TestOpenAPIRecallRequestBudgetContract(t *testing.T) {
 	items := objectValue(t, warnings, "items")
 	if items["$ref"] != "#/components/schemas/RecallWarning" {
 		t.Fatalf("MemoryListResponse.warnings items = %#v", items["$ref"])
+	}
+	warning := objectValue(t, schemas, "RecallWarning")
+	warningProperties := objectValue(t, warning, "properties")
+	warningCode := objectValue(t, warningProperties, "code")
+	codeEnum := stringSlice(t, warningCode["enum"])
+	for _, code := range []string{recallBranchDeadlineCode, domain.RecallWarningFTSCandidateBudgetExhausted} {
+		if !containsString(codeEnum, code) {
+			t.Fatalf("RecallWarning.code enum = %#v, missing %q", codeEnum, code)
+		}
 	}
 }
 

--- a/server/internal/handler/recall_budget.go
+++ b/server/internal/handler/recall_budget.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
 const (
@@ -39,10 +41,7 @@ func (*recallServerDeadlineError) Unwrap() error {
 	return context.DeadlineExceeded
 }
 
-type recallWarning struct {
-	Code   string `json:"code"`
-	Branch string `json:"branch"`
-}
+type recallWarning = domain.RecallWarning
 
 func newRecallRequestBudget(parent context.Context, total, responseReserve time.Duration) (context.Context, context.Context, context.CancelFunc) {
 	totalCtx, cancelTotal := newRecallTotalBudget(parent, total, responseReserve)

--- a/server/internal/handler/recall_budget_test.go
+++ b/server/internal/handler/recall_budget_test.go
@@ -279,6 +279,50 @@ func TestListMemories_RecallDeadlinePreservesCompletedBranches(t *testing.T) {
 	}
 }
 
+func TestListMemories_FTSCandidateBudgetPreservesAcceptedResults(t *testing.T) {
+	now := time.Now()
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, filter domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			if filter.MemoryType != string(domain.TypeInsight) {
+				return nil, nil
+			}
+			domain.RecordRecallWarning(ctx, domain.RecallWarning{
+				Code:   domain.RecallWarningFTSCandidateBudgetExhausted,
+				Branch: string(domain.TypeInsight),
+			})
+			return []domain.Memory{{
+				ID:         "insight-1",
+				Content:    "project-1234",
+				MemoryType: domain.TypeInsight,
+				State:      domain.StateActive,
+				UpdatedAt:  now,
+			}}, nil
+		},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{})
+	req := makeRequest(t, http.MethodGet, "/memories?q="+url.QueryEscape("project-1234"), nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rr.Code, rr.Body.String())
+	}
+	var response listResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !response.Partial {
+		t.Fatal("partial = false, want true")
+	}
+	if len(response.Memories) != 1 || response.Memories[0].ID != "insight-1" {
+		t.Fatalf("memories = %+v, want accepted insight result", response.Memories)
+	}
+	if len(response.Warnings) != 1 || response.Warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted || response.Warnings[0].Branch != string(domain.TypeInsight) {
+		t.Fatalf("warnings = %+v, want insight FTS candidate budget warning", response.Warnings)
+	}
+}
+
 func TestDefaultConfidenceRecallSearch_PropagatesBranchDeadlineToRepositories(t *testing.T) {
 	deadlines := make(chan time.Time, 16)
 	recordDeadline := func(ctx context.Context) ([]domain.Memory, error) {

--- a/server/internal/repository/tidb/fts_paging.go
+++ b/server/internal/repository/tidb/fts_paging.go
@@ -251,19 +251,11 @@ func logFTSSearchStats(ctx context.Context, message, resource, clusterID string,
 	)
 }
 
-func recordFTSCandidateBudgetWarning(ctx context.Context, stats ftsSearchStats, branch string) {
+func ftsCandidateBudgetError(stats ftsSearchStats) error {
 	switch stats.stopReason {
 	case ftsStopCandidateLimit, ftsStopPageLimit, ftsStopElapsedLimit:
-		domain.RecordRecallWarning(ctx, domain.RecallWarning{
-			Code:   domain.RecallWarningFTSCandidateBudgetExhausted,
-			Branch: branch,
-		})
+		return domain.ErrFTSSearchTruncated
+	default:
+		return nil
 	}
-}
-
-func memoryFTSRecallBranch(memoryType string) string {
-	if memoryType == string(domain.TypeInsight) {
-		return string(domain.TypeInsight)
-	}
-	return string(domain.TypePinned)
 }

--- a/server/internal/repository/tidb/fts_paging.go
+++ b/server/internal/repository/tidb/fts_paging.go
@@ -1,0 +1,269 @@
+package tidb
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+const (
+	// TiDB keeps text-search Top-K bounded when FTS is the only predicate.
+	// Business filters run in a second ID-hydration query, so candidate pages
+	// start at the requested result count and expand only from observed yield.
+	maxFTSCandidatePageSize   = 2000
+	maxFTSTotalCandidates     = 10000
+	maxFTSCandidatePages      = 8
+	maxFTSCandidateMultiplier = 256
+	maxFTSPageGrowth          = 4
+	maxFTSPagingElapsed       = 5 * time.Second
+
+	ftsPageSizeInitial   = "requested_results"
+	ftsPageSizePassRatio = "observed_pass_ratio"
+	ftsPageSizeZeroPass  = "zero_pass_growth"
+
+	ftsStopRequestedLimit  = "requested_results"
+	ftsStopSourceExhausted = "source_exhausted"
+	ftsStopCandidateLimit  = "candidate_limit"
+	ftsStopPageLimit       = "page_limit"
+	ftsStopElapsedLimit    = "elapsed_limit"
+	ftsStopRepeatedPage    = "repeated_page"
+	ftsStopError           = "error"
+)
+
+type ftsCandidatePager struct {
+	requested           int
+	totalCandidateLimit int
+	startedAt           time.Time
+	currentPageSize     int
+	pages               int
+	candidates          int
+	uniqueCandidates    int
+	accepted            int
+	maxPageSize         int
+	lastPageSizeReason  string
+	maxPageSizeReason   string
+	repeatedCandidates  int
+}
+
+func newFTSCandidatePager(requested int, startedAt time.Time) *ftsCandidatePager {
+	totalCandidateLimit := maxFTSTotalCandidates
+	if requested > 0 && requested <= maxFTSTotalCandidates/maxFTSCandidateMultiplier {
+		totalCandidateLimit = requested * maxFTSCandidateMultiplier
+	}
+	return &ftsCandidatePager{
+		requested:           requested,
+		totalCandidateLimit: totalCandidateLimit,
+		startedAt:           startedAt,
+	}
+}
+
+func (p *ftsCandidatePager) nextPage(now time.Time) (int, string, string) {
+	switch {
+	case p.requested <= 0 || p.accepted >= p.requested:
+		return 0, "", ftsStopRequestedLimit
+	case !now.Before(p.startedAt.Add(maxFTSPagingElapsed)):
+		return 0, "", ftsStopElapsedLimit
+	case p.candidates >= p.totalCandidateLimit:
+		return 0, "", ftsStopCandidateLimit
+	case p.pages >= maxFTSCandidatePages:
+		return 0, "", ftsStopPageLimit
+	}
+
+	remainingCandidates := p.totalCandidateLimit - p.candidates
+	pageSize := p.requested
+	sizeReason := ftsPageSizeInitial
+	if p.pages > 0 {
+		remainingResults := p.requested - p.accepted
+		if p.accepted == 0 {
+			pageSize = p.currentPageSize * 2
+			sizeReason = ftsPageSizeZeroPass
+		} else {
+			pageSize = (remainingResults*p.uniqueCandidates + p.accepted - 1) / p.accepted
+			growthLimit := p.currentPageSize * maxFTSPageGrowth
+			if pageSize > growthLimit {
+				pageSize = growthLimit
+			}
+			sizeReason = ftsPageSizePassRatio
+		}
+	}
+	pageSize = min(pageSize, maxFTSCandidatePageSize, remainingCandidates)
+	p.lastPageSizeReason = sizeReason
+	return pageSize, sizeReason, ""
+}
+
+func (p *ftsCandidatePager) recordPage(pageSize, candidates, uniqueCandidates, accepted int) {
+	p.currentPageSize = pageSize
+	p.pages++
+	p.candidates += candidates
+	p.uniqueCandidates += uniqueCandidates
+	p.accepted += accepted
+	p.repeatedCandidates += candidates - uniqueCandidates
+	if pageSize > p.maxPageSize {
+		p.maxPageSize = pageSize
+		p.maxPageSizeReason = p.lastPageSizeReason
+	}
+}
+
+type ftsSearchStats struct {
+	requested          int
+	candidates         int
+	accepted           int
+	pages              int
+	maxPageSize        int
+	maxPageSizeReason  string
+	repeatedCandidates int
+	stopReason         string
+	passRatio          float64
+}
+
+func (p *ftsCandidatePager) stats(stopReason string) ftsSearchStats {
+	passRatio := 0.0
+	if p.uniqueCandidates > 0 {
+		passRatio = float64(p.accepted) / float64(p.uniqueCandidates)
+	}
+	return ftsSearchStats{
+		requested:          p.requested,
+		candidates:         p.candidates,
+		accepted:           p.accepted,
+		pages:              p.pages,
+		maxPageSize:        p.maxPageSize,
+		maxPageSizeReason:  p.maxPageSizeReason,
+		repeatedCandidates: p.repeatedCandidates,
+		stopReason:         stopReason,
+		passRatio:          passRatio,
+	}
+}
+
+func runAdaptiveFTSSearch[T any](
+	ctx context.Context,
+	requested int,
+	candidateID func(T) string,
+	fetchCandidates func(context.Context, int, int) ([]T, error),
+	fetchFiltered func(context.Context, []T) ([]domain.Memory, error),
+) ([]domain.Memory, ftsSearchStats, error) {
+	startedAt := time.Now()
+	pager := newFTSCandidatePager(requested, startedAt)
+	if requested <= 0 {
+		return nil, pager.stats(ftsStopRequestedLimit), nil
+	}
+
+	pagingCtx, cancel := context.WithTimeout(ctx, maxFTSPagingElapsed)
+	defer cancel()
+
+	filtered := make([]domain.Memory, 0, min(requested, maxFTSTotalCandidates))
+	seenCandidates := make(map[string]struct{})
+	seenResults := make(map[string]struct{})
+	offset := 0
+
+	for {
+		pageSize, _, stopReason := pager.nextPage(time.Now())
+		if stopReason != "" {
+			return filtered, pager.stats(stopReason), nil
+		}
+
+		candidates, err := fetchCandidates(pagingCtx, pageSize, offset)
+		if err != nil {
+			if ctx.Err() != nil {
+				return filtered, pager.stats(ftsStopError), err
+			}
+			if pagingCtx.Err() != nil {
+				return filtered, pager.stats(ftsStopElapsedLimit), nil
+			}
+			return filtered, pager.stats(ftsStopError), err
+		}
+
+		newCandidates := make([]T, 0, len(candidates))
+		for _, candidate := range candidates {
+			id := candidateID(candidate)
+			if _, seen := seenCandidates[id]; seen {
+				continue
+			}
+			seenCandidates[id] = struct{}{}
+			newCandidates = append(newCandidates, candidate)
+		}
+
+		if len(candidates) == 0 {
+			pager.recordPage(pageSize, 0, 0, 0)
+			return filtered, pager.stats(ftsStopSourceExhausted), nil
+		}
+		if len(newCandidates) == 0 {
+			pager.recordPage(pageSize, len(candidates), 0, 0)
+			return filtered, pager.stats(ftsStopRepeatedPage), nil
+		}
+
+		page, err := fetchFiltered(pagingCtx, newCandidates)
+		if err != nil {
+			pager.recordPage(pageSize, len(candidates), len(newCandidates), 0)
+			if ctx.Err() != nil {
+				return filtered, pager.stats(ftsStopError), err
+			}
+			if pagingCtx.Err() != nil {
+				return filtered, pager.stats(ftsStopElapsedLimit), nil
+			}
+			return filtered, pager.stats(ftsStopError), err
+		}
+
+		accepted := 0
+		for _, memory := range page {
+			if len(filtered) >= requested {
+				break
+			}
+			if _, seen := seenResults[memory.ID]; seen {
+				continue
+			}
+			seenResults[memory.ID] = struct{}{}
+			filtered = append(filtered, memory)
+			accepted++
+		}
+		pager.recordPage(pageSize, len(candidates), len(newCandidates), accepted)
+		offset += len(candidates)
+
+		switch {
+		case len(filtered) >= requested:
+			return filtered, pager.stats(ftsStopRequestedLimit), nil
+		case len(candidates) < pageSize:
+			return filtered, pager.stats(ftsStopSourceExhausted), nil
+		case pagingCtx.Err() != nil:
+			if ctx.Err() != nil {
+				return filtered, pager.stats(ftsStopError), ctx.Err()
+			}
+			return filtered, pager.stats(ftsStopElapsedLimit), nil
+		}
+	}
+}
+
+func logFTSSearchStats(ctx context.Context, message, resource, clusterID string, duration time.Duration, stats ftsSearchStats) {
+	slog.InfoContext(ctx, message,
+		"cluster_id", clusterID,
+		"resource", resource,
+		"requested_results", stats.requested,
+		"candidates", stats.candidates,
+		"accepted", stats.accepted,
+		"pages", stats.pages,
+		"pass_ratio", stats.passRatio,
+		"duration_ms", duration.Milliseconds(),
+		"stop_reason", stats.stopReason,
+		"max_page_size", stats.maxPageSize,
+		"max_page_size_reason", stats.maxPageSizeReason,
+		"repeated_candidates", stats.repeatedCandidates,
+	)
+}
+
+func recordFTSCandidateBudgetWarning(ctx context.Context, stats ftsSearchStats, branch string) {
+	switch stats.stopReason {
+	case ftsStopCandidateLimit, ftsStopPageLimit, ftsStopElapsedLimit:
+		domain.RecordRecallWarning(ctx, domain.RecallWarning{
+			Code:   domain.RecallWarningFTSCandidateBudgetExhausted,
+			Branch: branch,
+		})
+	}
+}
+
+func memoryFTSRecallBranch(memoryType string) string {
+	if memoryType == string(domain.TypeInsight) {
+		return string(domain.TypeInsight)
+	}
+	return string(domain.TypePinned)
+}

--- a/server/internal/repository/tidb/fts_paging_test.go
+++ b/server/internal/repository/tidb/fts_paging_test.go
@@ -1,0 +1,208 @@
+package tidb
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestFTSCandidatePagerUsesObservedPassRatio(t *testing.T) {
+	startedAt := time.Now()
+	pager := newFTSCandidatePager(10, startedAt)
+
+	pageSize, sizeReason, stopReason := pager.nextPage(startedAt)
+	if pageSize != 10 || sizeReason != ftsPageSizeInitial || stopReason != "" {
+		t.Fatalf("initial page = (%d, %q, %q), want (10, %q, empty)", pageSize, sizeReason, stopReason, ftsPageSizeInitial)
+	}
+	pager.recordPage(pageSize, pageSize, pageSize, 2)
+
+	pageSize, sizeReason, stopReason = pager.nextPage(startedAt)
+	if pageSize != 40 || sizeReason != ftsPageSizePassRatio || stopReason != "" {
+		t.Fatalf("adaptive page = (%d, %q, %q), want (40, %q, empty)", pageSize, sizeReason, stopReason, ftsPageSizePassRatio)
+	}
+}
+
+func TestFTSCandidatePagerGrowsGraduallyWithNoAcceptedCandidates(t *testing.T) {
+	startedAt := time.Now()
+	pager := newFTSCandidatePager(10, startedAt)
+
+	pageSize, _, _ := pager.nextPage(startedAt)
+	pager.recordPage(pageSize, pageSize, pageSize, 0)
+
+	pageSize, sizeReason, stopReason := pager.nextPage(startedAt)
+	if pageSize != 20 || sizeReason != ftsPageSizeZeroPass || stopReason != "" {
+		t.Fatalf("zero-pass page = (%d, %q, %q), want (20, %q, empty)", pageSize, sizeReason, stopReason, ftsPageSizeZeroPass)
+	}
+}
+
+func TestFTSCandidatePagerStopsAtTotalCandidateBudget(t *testing.T) {
+	startedAt := time.Now()
+	pager := newFTSCandidatePager(600, startedAt)
+	wantPageSizes := []int{600, 1200, 2000, 2000, 2000, 2000, 200}
+
+	for page, want := range wantPageSizes {
+		pageSize, _, stopReason := pager.nextPage(startedAt)
+		if stopReason != "" || pageSize != want {
+			t.Fatalf("page %d = (%d, %q), want (%d, empty)", page, pageSize, stopReason, want)
+		}
+		pager.recordPage(pageSize, pageSize, pageSize, 0)
+	}
+
+	pageSize, _, stopReason := pager.nextPage(startedAt)
+	if pageSize != 0 || stopReason != ftsStopCandidateLimit {
+		t.Fatalf("after candidate budget = (%d, %q), want (0, %q)", pageSize, stopReason, ftsStopCandidateLimit)
+	}
+}
+
+func TestFTSCandidatePagerStopsAtPageBudget(t *testing.T) {
+	startedAt := time.Now()
+	pager := newFTSCandidatePager(1, startedAt)
+	wantPageSizes := []int{1, 2, 4, 8, 16, 32, 64, 128}
+
+	for page, want := range wantPageSizes {
+		pageSize, _, stopReason := pager.nextPage(startedAt)
+		if stopReason != "" || pageSize != want {
+			t.Fatalf("page %d = (%d, %q), want (%d, empty)", page, pageSize, stopReason, want)
+		}
+		pager.recordPage(pageSize, pageSize, pageSize, 0)
+	}
+
+	pageSize, _, stopReason := pager.nextPage(startedAt)
+	if pageSize != 0 || stopReason != ftsStopPageLimit {
+		t.Fatalf("after page budget = (%d, %q), want (0, %q)", pageSize, stopReason, ftsStopPageLimit)
+	}
+}
+
+func TestFTSCandidatePagerStopsAtElapsedBudget(t *testing.T) {
+	startedAt := time.Now()
+	pager := newFTSCandidatePager(10, startedAt)
+
+	pageSize, _, _ := pager.nextPage(startedAt)
+	pager.recordPage(pageSize, pageSize, pageSize, 0)
+
+	pageSize, _, stopReason := pager.nextPage(startedAt.Add(maxFTSPagingElapsed))
+	if pageSize != 0 || stopReason != ftsStopElapsedLimit {
+		t.Fatalf("after elapsed budget = (%d, %q), want (0, %q)", pageSize, stopReason, ftsStopElapsedLimit)
+	}
+}
+
+func TestAdaptiveFTSSearchPreservesAcceptedResultsAtPageBudget(t *testing.T) {
+	type candidate struct{ id string }
+	var warnings []domain.RecallWarning
+	ctx := domain.WithRecallWarningRecorder(context.Background(), func(warning domain.RecallWarning) {
+		warnings = append(warnings, warning)
+	})
+
+	results, stats, err := runAdaptiveFTSSearch(
+		ctx,
+		2,
+		func(candidate candidate) string { return candidate.id },
+		func(_ context.Context, pageSize, offset int) ([]candidate, error) {
+			page := make([]candidate, pageSize)
+			for i := range page {
+				page[i].id = fmt.Sprintf("candidate-%d", offset+i)
+			}
+			return page, nil
+		},
+		func(_ context.Context, candidates []candidate) ([]domain.Memory, error) {
+			if candidates[0].id == "candidate-0" {
+				return []domain.Memory{{ID: candidates[0].id}}, nil
+			}
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("runAdaptiveFTSSearch: %v", err)
+	}
+	recordFTSCandidateBudgetWarning(ctx, stats, string(domain.TypeInsight))
+	if len(results) != 1 || results[0].ID != "candidate-0" {
+		t.Fatalf("results = %+v, want accepted candidate-0", results)
+	}
+	if stats.stopReason != ftsStopPageLimit {
+		t.Fatalf("stop reason = %q, want %q", stats.stopReason, ftsStopPageLimit)
+	}
+	if len(warnings) != 1 || warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted {
+		t.Fatalf("warnings = %+v, want FTS candidate budget warning", warnings)
+	}
+}
+
+func TestAdaptiveFTSSearchPropagatesCallerCancellation(t *testing.T) {
+	type candidate struct{ id string }
+	ctx, cancel := context.WithCancel(context.Background())
+	page := 0
+
+	results, stats, err := runAdaptiveFTSSearch(
+		ctx,
+		2,
+		func(candidate candidate) string { return candidate.id },
+		func(_ context.Context, pageSize, offset int) ([]candidate, error) {
+			if page > 0 {
+				cancel()
+				return nil, context.Canceled
+			}
+			page++
+			return []candidate{{id: "candidate-0"}, {id: "candidate-1"}}, nil
+		},
+		func(_ context.Context, candidates []candidate) ([]domain.Memory, error) {
+			return []domain.Memory{{ID: candidates[0].id}}, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if len(results) != 1 || results[0].ID != "candidate-0" {
+		t.Fatalf("results = %+v, want accepted candidate-0", results)
+	}
+	if stats.stopReason != ftsStopError {
+		t.Fatalf("stop reason = %q, want %q", stats.stopReason, ftsStopError)
+	}
+}
+
+func TestLogFTSSearchStatsIncludesAdaptivePagingFields(t *testing.T) {
+	previousLogger := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previousLogger) })
+	var logBuf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logBuf, nil)))
+
+	logFTSSearchStats(context.Background(), "fts search done", "memory", "cluster-1", 1250*time.Millisecond, ftsSearchStats{
+		requested:          10,
+		candidates:         40,
+		accepted:           4,
+		pages:              3,
+		maxPageSize:        20,
+		maxPageSizeReason:  ftsPageSizePassRatio,
+		repeatedCandidates: 2,
+		stopReason:         ftsStopCandidateLimit,
+		passRatio:          0.1,
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(bytes.TrimSpace(logBuf.Bytes()), &entry); err != nil {
+		t.Fatalf("decode FTS stats log: %v; log = %s", err, logBuf.String())
+	}
+	want := map[string]any{
+		"resource":             "memory",
+		"requested_results":    float64(10),
+		"candidates":           float64(40),
+		"accepted":             float64(4),
+		"pages":                float64(3),
+		"pass_ratio":           0.1,
+		"duration_ms":          float64(1250),
+		"stop_reason":          ftsStopCandidateLimit,
+		"max_page_size":        float64(20),
+		"max_page_size_reason": ftsPageSizePassRatio,
+		"repeated_candidates":  float64(2),
+	}
+	for key, wantValue := range want {
+		if got := entry[key]; got != wantValue {
+			t.Fatalf("%s = %#v, want %#v", key, got, wantValue)
+		}
+	}
+}

--- a/server/internal/repository/tidb/fts_paging_test.go
+++ b/server/internal/repository/tidb/fts_paging_test.go
@@ -95,13 +95,9 @@ func TestFTSCandidatePagerStopsAtElapsedBudget(t *testing.T) {
 
 func TestAdaptiveFTSSearchPreservesAcceptedResultsAtPageBudget(t *testing.T) {
 	type candidate struct{ id string }
-	var warnings []domain.RecallWarning
-	ctx := domain.WithRecallWarningRecorder(context.Background(), func(warning domain.RecallWarning) {
-		warnings = append(warnings, warning)
-	})
 
 	results, stats, err := runAdaptiveFTSSearch(
-		ctx,
+		context.Background(),
 		2,
 		func(candidate candidate) string { return candidate.id },
 		func(_ context.Context, pageSize, offset int) ([]candidate, error) {
@@ -121,15 +117,14 @@ func TestAdaptiveFTSSearchPreservesAcceptedResultsAtPageBudget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runAdaptiveFTSSearch: %v", err)
 	}
-	recordFTSCandidateBudgetWarning(ctx, stats, string(domain.TypeInsight))
 	if len(results) != 1 || results[0].ID != "candidate-0" {
 		t.Fatalf("results = %+v, want accepted candidate-0", results)
 	}
 	if stats.stopReason != ftsStopPageLimit {
 		t.Fatalf("stop reason = %q, want %q", stats.stopReason, ftsStopPageLimit)
 	}
-	if len(warnings) != 1 || warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted {
-		t.Fatalf("warnings = %+v, want FTS candidate budget warning", warnings)
+	if budgetErr := ftsCandidateBudgetError(stats); !errors.Is(budgetErr, domain.ErrFTSSearchTruncated) {
+		t.Fatalf("budget error = %v, want ErrFTSSearchTruncated", budgetErr)
 	}
 }
 

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -435,7 +435,8 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	initialCandidateLimit := 2
 	firstPageArgs := append(ftsCandidateArgs("m-page-0", initialCandidateLimit), "active", "agent-1", `"tag-a"`)
-	secondPageArgs := append(ftsCandidateArgs("m-page-1", maxFTSCandidatePageLimit), "active", "agent-1", `"tag-a"`)
+	secondCandidateLimit := 2
+	secondPageArgs := append(ftsCandidateArgs("m-page-1", secondCandidateLimit), "active", "agent-1", `"tag-a"`)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
 			mustContain: []string{
@@ -484,10 +485,10 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"agent_id = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, initialCandidateLimit},
+			wantArgs: []any{secondCandidateLimit, initialCandidateLimit},
 			rows: &generatedFTSCandidateRows{
 				prefix: "m-page-1",
-				count:  maxFTSCandidatePageLimit,
+				count:  secondCandidateLimit,
 			},
 		},
 		{
@@ -527,8 +528,8 @@ func TestMemoryFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	if results[0].Score == nil || *results[0].Score != 1 {
 		t.Fatalf("results[0].Score = %v, want 1", results[0].Score)
 	}
-	if results[1].Score == nil || *results[1].Score != 10000 {
-		t.Fatalf("results[1].Score = %v, want 10000", results[1].Score)
+	if results[1].Score == nil || *results[1].Score != 2 {
+		t.Fatalf("results[1].Score = %v, want 2", results[1].Score)
 	}
 }
 
@@ -536,7 +537,8 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	initialCandidateLimit := 2
 	firstPageArgs := append(ftsCandidateArgs("s-page-0", initialCandidateLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
-	secondPageArgs := append(ftsCandidateArgs("s-page-1", maxFTSCandidatePageLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
+	secondCandidateLimit := 2
+	secondPageArgs := append(ftsCandidateArgs("s-page-1", secondCandidateLimit), "active", "agent-1", "sess-1", "chat", `"tag-a"`)
 	db := newScriptedTestDB(t, []*queryExpectation{
 		{
 			mustContain: []string{
@@ -590,10 +592,10 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 				"source = ?",
 				"JSON_CONTAINS(tags, ?)",
 			},
-			wantArgs: []any{maxFTSCandidatePageLimit, initialCandidateLimit},
+			wantArgs: []any{secondCandidateLimit, initialCandidateLimit},
 			rows: &generatedFTSCandidateRows{
 				prefix: "s-page-1",
-				count:  maxFTSCandidatePageLimit,
+				count:  secondCandidateLimit,
 			},
 		},
 		{
@@ -636,8 +638,8 @@ func TestSessionFTSSearch_PagesPureFTSBeforePostFilter(t *testing.T) {
 	if results[0].Score == nil || *results[0].Score != 1 {
 		t.Fatalf("results[0].Score = %v, want 1", results[0].Score)
 	}
-	if results[1].Score == nil || *results[1].Score != 10000 {
-		t.Fatalf("results[1].Score = %v, want 10000", results[1].Score)
+	if results[1].Score == nil || *results[1].Score != 2 {
+		t.Fatalf("results[1].Score = %v, want 2", results[1].Score)
 	}
 }
 
@@ -692,6 +694,54 @@ func TestMemoryFTSSearch_StopsAfterRequestedLimitPageWhenFull(t *testing.T) {
 	}
 	if len(results) != 2 {
 		t.Fatalf("len(results) = %d, want 2", len(results))
+	}
+}
+
+func TestMemoryFTSSearch_StopsWhenCandidatePageRepeats(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	firstPageArgs := append(ftsCandidateArgs("m-repeat", 2), "active")
+	db := newScriptedTestDB(t, []*queryExpectation{
+		{
+			wantArgs: []any{2, 0},
+			rows: &generatedFTSCandidateRows{
+				prefix: "m-repeat",
+				count:  2,
+			},
+		},
+		{
+			mustContain: []string{
+				"SELECT " + searchColumns + " FROM memories",
+				"WHERE id IN (",
+				"AND state = ?",
+			},
+			wantArgs: firstPageArgs,
+			rows: &scriptedRows{
+				columns: memorySearchColumns(),
+				values: [][]driver.Value{
+					memorySearchRow("m-repeat-0000", "match one", "agent-1", "session-1", "active", []byte(`[]`), now),
+				},
+			},
+		},
+		{
+			wantArgs: []any{2, 2},
+			rows: &scriptedRows{
+				columns: []string{"id", "fts_score"},
+				values: [][]driver.Value{
+					{"m-repeat-0000", float64(2)},
+					{"m-repeat-0001", float64(1)},
+				},
+			},
+		},
+	})
+	defer db.Close()
+
+	repo := NewMemoryRepo(db, "", true, "cluster-1")
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{State: "active"}, 2)
+	if err != nil {
+		t.Fatalf("FTSSearch: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != "m-repeat-0000" {
+		t.Fatalf("results = %+v, want only m-repeat-0000", results)
 	}
 }
 
@@ -750,43 +800,13 @@ func TestSessionFTSSearch_StopsAfterRequestedLimitPageWhenFull(t *testing.T) {
 	}
 }
 
-func TestMemoryFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
-	initialCandidateLimit := 1
-	initialCandidateArgs := ftsCandidateArgs("m-cap-initial", initialCandidateLimit)
-	expectations := make([]*queryExpectation, 0, 2+maxFTSFallbackPages*2)
-	expectations = append(expectations, &queryExpectation{
-		mustContain: []string{
-			"SELECT id, fts_match_word('golang', content) AS fts_score",
-			"FROM memories",
-			"WHERE fts_match_word('golang', content)",
-			"ORDER BY fts_match_word('golang', content) DESC, id",
-			"LIMIT ? OFFSET ?",
-		},
-		mustNotContain: []string{
-			"state = ?",
-		},
-		wantArgs: []any{initialCandidateLimit, 0},
-		rows: &generatedFTSCandidateRows{
-			prefix: "m-cap-initial",
-			count:  initialCandidateLimit,
-		},
-	}, &queryExpectation{
-		mustContain: []string{
-			"SELECT " + searchColumns + " FROM memories",
-			"WHERE id IN (",
-			"AND state = ?",
-		},
-		mustNotContain: []string{"fts_match_word("},
-		wantArgs:       append(initialCandidateArgs, "active"),
-		rows: &scriptedRows{
-			columns: memorySearchColumns(),
-		},
-	})
-	for page := 0; page < maxFTSFallbackPages; page++ {
+func TestMemoryFTSSearch_StopsAtPageBudget(t *testing.T) {
+	pageSizes := []int{1, 2, 4, 8, 16, 32, 64, 128}
+	expectations := make([]*queryExpectation, 0, len(pageSizes)*2)
+	offset := 0
+	for page, pageSize := range pageSizes {
 		prefix := fmt.Sprintf("m-cap-%02d", page)
-		candidateArgs := ftsCandidateArgs(prefix, maxFTSCandidatePageLimit)
-		postFilterArgs := append(candidateArgs, "active")
-		offset := initialCandidateLimit + page*maxFTSCandidatePageLimit
+		candidateArgs := ftsCandidateArgs(prefix, pageSize)
 		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
@@ -795,13 +815,11 @@ func TestMemoryFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 				"ORDER BY fts_match_word('golang', content) DESC, id",
 				"LIMIT ? OFFSET ?",
 			},
-			mustNotContain: []string{
-				"state = ?",
-			},
-			wantArgs: []any{maxFTSCandidatePageLimit, offset},
+			mustNotContain: []string{"state = ?"},
+			wantArgs:       []any{pageSize, offset},
 			rows: &generatedFTSCandidateRows{
 				prefix: prefix,
-				count:  maxFTSCandidatePageLimit,
+				count:  pageSize,
 			},
 		}, &queryExpectation{
 			mustContain: []string{
@@ -810,65 +828,42 @@ func TestMemoryFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 				"AND state = ?",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       postFilterArgs,
+			wantArgs:       append(candidateArgs, "active"),
 			rows: &scriptedRows{
 				columns: memorySearchColumns(),
 			},
 		})
+		offset += pageSize
 	}
 	db := newScriptedTestDB(t, expectations)
 	defer db.Close()
 
 	repo := NewMemoryRepo(db, "", true, "cluster-1")
-	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
+	var warnings []domain.RecallWarning
+	ctx := domain.WithRecallWarningRecorder(context.Background(), func(warning domain.RecallWarning) {
+		warnings = append(warnings, warning)
+	})
+	results, err := repo.FTSSearch(ctx, "golang", domain.MemoryFilter{
 		State: "active",
-	}, initialCandidateLimit)
+	}, 1)
 	if err != nil {
 		t.Fatalf("FTSSearch: %v", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("len(results) = %d, want 0", len(results))
 	}
+	if len(warnings) != 1 || warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted || warnings[0].Branch != string(domain.TypePinned) {
+		t.Fatalf("warnings = %+v, want pinned FTS candidate budget warning", warnings)
+	}
 }
 
-func TestSessionFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
-	initialCandidateLimit := 1
-	initialCandidateArgs := ftsCandidateArgs("s-cap-initial", initialCandidateLimit)
-	expectations := make([]*queryExpectation, 0, 2+maxFTSFallbackPages*2)
-	expectations = append(expectations, &queryExpectation{
-		mustContain: []string{
-			"SELECT id, fts_match_word('golang', content) AS fts_score",
-			"FROM sessions",
-			"WHERE fts_match_word('golang', content)",
-			"ORDER BY fts_match_word('golang', content) DESC, id",
-			"LIMIT ? OFFSET ?",
-		},
-		mustNotContain: []string{
-			"state = ?",
-		},
-		wantArgs: []any{initialCandidateLimit, 0},
-		rows: &generatedFTSCandidateRows{
-			prefix: "s-cap-initial",
-			count:  initialCandidateLimit,
-		},
-	}, &queryExpectation{
-		mustContain: []string{
-			"SELECT id, session_id, agent_id, app_id, source, seq, role, content, content_type, tags, state, created_at",
-			"FROM sessions",
-			"WHERE id IN (",
-			"AND state = ?",
-		},
-		mustNotContain: []string{"fts_match_word("},
-		wantArgs:       append(initialCandidateArgs, "active"),
-		rows: &scriptedRows{
-			columns: sessionColumns(),
-		},
-	})
-	for page := 0; page < maxFTSFallbackPages; page++ {
+func TestSessionFTSSearch_StopsAtPageBudget(t *testing.T) {
+	pageSizes := []int{1, 2, 4, 8, 16, 32, 64, 128}
+	expectations := make([]*queryExpectation, 0, len(pageSizes)*2)
+	offset := 0
+	for page, pageSize := range pageSizes {
 		prefix := fmt.Sprintf("s-cap-%02d", page)
-		candidateArgs := ftsCandidateArgs(prefix, maxFTSCandidatePageLimit)
-		postFilterArgs := append(candidateArgs, "active")
-		offset := initialCandidateLimit + page*maxFTSCandidatePageLimit
+		candidateArgs := ftsCandidateArgs(prefix, pageSize)
 		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
@@ -877,13 +872,11 @@ func TestSessionFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 				"ORDER BY fts_match_word('golang', content) DESC, id",
 				"LIMIT ? OFFSET ?",
 			},
-			mustNotContain: []string{
-				"state = ?",
-			},
-			wantArgs: []any{maxFTSCandidatePageLimit, offset},
+			mustNotContain: []string{"state = ?"},
+			wantArgs:       []any{pageSize, offset},
 			rows: &generatedFTSCandidateRows{
 				prefix: prefix,
-				count:  maxFTSCandidatePageLimit,
+				count:  pageSize,
 			},
 		}, &queryExpectation{
 			mustContain: []string{
@@ -893,11 +886,12 @@ func TestSessionFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 				"AND state = ?",
 			},
 			mustNotContain: []string{"fts_match_word("},
-			wantArgs:       postFilterArgs,
+			wantArgs:       append(candidateArgs, "active"),
 			rows: &scriptedRows{
 				columns: sessionColumns(),
 			},
 		})
+		offset += pageSize
 	}
 	db := newScriptedTestDB(t, expectations)
 	defer db.Close()
@@ -905,7 +899,7 @@ func TestSessionFTSSearch_StopsAtCandidatePageLimit(t *testing.T) {
 	repo := NewSessionRepo(db, "", true, "cluster-1")
 	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
 		State: "active",
-	}, initialCandidateLimit)
+	}, 1)
 	if err != nil {
 		t.Fatalf("FTSSearch: %v", err)
 	}

--- a/server/internal/repository/tidb/fts_test.go
+++ b/server/internal/repository/tidb/fts_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -801,12 +802,19 @@ func TestSessionFTSSearch_StopsAfterRequestedLimitPageWhenFull(t *testing.T) {
 }
 
 func TestMemoryFTSSearch_StopsAtPageBudget(t *testing.T) {
-	pageSizes := []int{1, 2, 4, 8, 16, 32, 64, 128}
+	now := time.Now().UTC().Truncate(time.Second)
+	pageSizes := []int{2, 2, 4, 8, 16, 32, 64, 128}
 	expectations := make([]*queryExpectation, 0, len(pageSizes)*2)
 	offset := 0
 	for page, pageSize := range pageSizes {
 		prefix := fmt.Sprintf("m-cap-%02d", page)
 		candidateArgs := ftsCandidateArgs(prefix, pageSize)
+		var filteredRows [][]driver.Value
+		if page == 0 {
+			filteredRows = [][]driver.Value{
+				memorySearchRow("m-cap-00-0000", "match one", "agent-1", "session-1", "active", []byte(`[]`), now),
+			}
+		}
 		expectations = append(expectations, &queryExpectation{
 			mustContain: []string{
 				"SELECT id, fts_match_word('golang', content) AS fts_score",
@@ -831,6 +839,7 @@ func TestMemoryFTSSearch_StopsAtPageBudget(t *testing.T) {
 			wantArgs:       append(candidateArgs, "active"),
 			rows: &scriptedRows{
 				columns: memorySearchColumns(),
+				values:  filteredRows,
 			},
 		})
 		offset += pageSize
@@ -839,21 +848,14 @@ func TestMemoryFTSSearch_StopsAtPageBudget(t *testing.T) {
 	defer db.Close()
 
 	repo := NewMemoryRepo(db, "", true, "cluster-1")
-	var warnings []domain.RecallWarning
-	ctx := domain.WithRecallWarningRecorder(context.Background(), func(warning domain.RecallWarning) {
-		warnings = append(warnings, warning)
-	})
-	results, err := repo.FTSSearch(ctx, "golang", domain.MemoryFilter{
+	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
 		State: "active",
-	}, 1)
-	if err != nil {
-		t.Fatalf("FTSSearch: %v", err)
+	}, 2)
+	if !errors.Is(err, domain.ErrFTSSearchTruncated) {
+		t.Fatalf("FTSSearch error = %v, want ErrFTSSearchTruncated", err)
 	}
-	if len(results) != 0 {
-		t.Fatalf("len(results) = %d, want 0", len(results))
-	}
-	if len(warnings) != 1 || warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted || warnings[0].Branch != string(domain.TypePinned) {
-		t.Fatalf("warnings = %+v, want pinned FTS candidate budget warning", warnings)
+	if len(results) != 1 || results[0].ID != "m-cap-00-0000" {
+		t.Fatalf("results = %+v, want preserved m-cap-00-0000", results)
 	}
 }
 
@@ -900,8 +902,8 @@ func TestSessionFTSSearch_StopsAtPageBudget(t *testing.T) {
 	results, err := repo.FTSSearch(context.Background(), "golang", domain.MemoryFilter{
 		State: "active",
 	}, 1)
-	if err != nil {
-		t.Fatalf("FTSSearch: %v", err)
+	if !errors.Is(err, domain.ErrFTSSearchTruncated) {
+		t.Fatalf("FTSSearch error = %v, want ErrFTSSearchTruncated", err)
 	}
 	if len(results) != 0 {
 		t.Fatalf("len(results) = %d, want 0", len(results))

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -805,10 +805,13 @@ func ftsSafeLiteral(s string) string {
 func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	start := time.Now()
 	memories, stats, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
-	if err != nil {
+	if err != nil && !errors.Is(err, domain.ErrFTSSearchTruncated) {
 		stats.stopReason = ftsStopError
 	}
 	logFTSSearchStats(ctx, "fts search done", "memory", r.clusterID, time.Since(start), stats)
+	if errors.Is(err, domain.ErrFTSSearchTruncated) {
+		return memories, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
+	}
 	if err != nil {
 		logSearchError(ctx, "fts search failed", "memory", "fts", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
@@ -836,7 +839,9 @@ func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, 
 			return r.fetchFilteredFTSMemories(ctx, candidates, where, args)
 		},
 	)
-	recordFTSCandidateBudgetWarning(ctx, stats, memoryFTSRecallBranch(f.MemoryType))
+	if err == nil {
+		err = ftsCandidateBudgetError(stats)
+	}
 	return memories, stats, err
 }
 

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -38,12 +38,7 @@ func (r *MemoryRepo) FTSAvailable() bool { return r.ftsAvailable.Load() }
 const (
 	allColumns               = `id, content, source, tags, metadata, embedding, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
 	searchColumns            = `id, content, source, tags, metadata, memory_type, agent_id, session_id, app_id, state, version, updated_by, created_at, updated_at, superseded_by`
-	maxFTSCandidatePageLimit = 10000
-	maxFTSFallbackPages      = 30
 	allTypeListSlowThreshold = 2 * time.Second
-	// TiDB Cloud FTS is only safe with fts_match_word as the only WHERE predicate,
-	// so wider recall uses bounded pure-FTS pages followed by post-filtering.
-	maxFTSFallbackCandidateLimit = maxFTSCandidatePageLimit * maxFTSFallbackPages
 )
 
 func (r *MemoryRepo) Create(ctx context.Context, m *domain.Memory) error {
@@ -809,12 +804,15 @@ func ftsSafeLiteral(s string) string {
 // SQL string literal after escaping via ftsSafeLiteral.
 func (r *MemoryRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	start := time.Now()
-	memories, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
+	memories, stats, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
+	if err != nil {
+		stats.stopReason = ftsStopError
+	}
+	logFTSSearchStats(ctx, "fts search done", "memory", r.clusterID, time.Since(start), stats)
 	if err != nil {
 		logSearchError(ctx, "fts search failed", "memory", "fts", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
-	slog.DebugContext(ctx, "fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
 	return memories, nil
 }
 
@@ -823,70 +821,23 @@ type memoryFTSCandidate struct {
 	score float64
 }
 
-func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
-	if limit <= 0 {
-		return nil, nil
-	}
-
+func (r *MemoryRepo) ftsSearchWithPostFilter(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, ftsSearchStats, error) {
 	conds, args := r.buildFilterConds(f)
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
-
-	filtered := make([]domain.Memory, 0, min(limit, maxFTSFallbackCandidateLimit))
-	initialCandidateLimit := min(limit, maxFTSCandidatePageLimit)
-	candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, initialCandidateLimit, 0)
-	if err != nil {
-		return nil, err
-	}
-	exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSMemories)
-	if err != nil {
-		return nil, err
-	}
-	if len(filtered) >= limit {
-		return filtered[:limit], nil
-	}
-	if exhausted || len(candidates) < initialCandidateLimit {
-		return filtered, nil
-	}
-
-	offset := initialCandidateLimit
-	for page := 0; page < maxFTSFallbackPages; page++ {
-		candidates, err := r.fetchMemoryFTSCandidates(ctx, safeQ, maxFTSCandidatePageLimit, offset)
-		if err != nil {
-			return nil, err
-		}
-		exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSMemories)
-		if err != nil {
-			return nil, err
-		}
-		if len(filtered) >= limit {
-			return filtered[:limit], nil
-		}
-		if exhausted || len(candidates) < maxFTSCandidatePageLimit {
-			return filtered, nil
-		}
-		offset += maxFTSCandidatePageLimit
-	}
-	return filtered, nil
-}
-
-func appendFilteredFTSPage[T any](
-	ctx context.Context,
-	candidates []T,
-	where string,
-	args []any,
-	filtered *[]domain.Memory,
-	fetchFiltered func(context.Context, []T, string, []any) ([]domain.Memory, error),
-) (bool, error) {
-	if len(candidates) == 0 {
-		return true, nil
-	}
-	page, err := fetchFiltered(ctx, candidates, where, args)
-	if err != nil {
-		return false, err
-	}
-	*filtered = append(*filtered, page...)
-	return false, nil
+	memories, stats, err := runAdaptiveFTSSearch(
+		ctx,
+		limit,
+		func(candidate memoryFTSCandidate) string { return candidate.id },
+		func(ctx context.Context, pageSize, offset int) ([]memoryFTSCandidate, error) {
+			return r.fetchMemoryFTSCandidates(ctx, safeQ, pageSize, offset)
+		},
+		func(ctx context.Context, candidates []memoryFTSCandidate) ([]domain.Memory, error) {
+			return r.fetchFilteredFTSMemories(ctx, candidates, where, args)
+		},
+	)
+	recordFTSCandidateBudgetWarning(ctx, stats, memoryFTSRecallBranch(f.MemoryType))
+	return memories, stats, err
 }
 
 func (r *MemoryRepo) fetchMemoryFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]memoryFTSCandidate, error) {

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -399,10 +399,13 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	start := time.Now()
 	memories, stats, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
-	if err != nil {
+	if err != nil && !errors.Is(err, domain.ErrFTSSearchTruncated) {
 		stats.stopReason = ftsStopError
 	}
 	logFTSSearchStats(ctx, "sessions fts search done", "session", r.clusterID, time.Since(start), stats)
+	if errors.Is(err, domain.ErrFTSSearchTruncated) {
+		return memories, fmt.Errorf("sessions fts search: cluster_id=%s: %w", r.clusterID, err)
+	}
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
@@ -433,7 +436,9 @@ func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string,
 			return r.fetchFilteredFTSSessions(ctx, candidates, where, args)
 		},
 	)
-	recordFTSCandidateBudgetWarning(ctx, stats, string(domain.TypeSession))
+	if err == nil {
+		err = ftsCandidateBudgetError(stats)
+	}
 	return memories, stats, err
 }
 

--- a/server/internal/repository/tidb/sessions.go
+++ b/server/internal/repository/tidb/sessions.go
@@ -398,7 +398,11 @@ func (r *SessionRepo) VectorSearch(ctx context.Context, queryVec []float32, f do
 
 func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
 	start := time.Now()
-	memories, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
+	memories, stats, err := r.ftsSearchWithPostFilter(ctx, query, f, limit)
+	if err != nil {
+		stats.stopReason = ftsStopError
+	}
+	logFTSSearchStats(ctx, "sessions fts search done", "session", r.clusterID, time.Since(start), stats)
 	if err != nil {
 		if internaltenant.IsTableNotFoundError(err) {
 			return nil, nil
@@ -406,7 +410,6 @@ func (r *SessionRepo) FTSSearch(ctx context.Context, query string, f domain.Memo
 		logSearchError(ctx, "sessions fts search failed", "session", "fts", r.clusterID, time.Since(start), err)
 		return nil, fmt.Errorf("sessions fts search: cluster_id=%s: %w", r.clusterID, err)
 	}
-	slog.DebugContext(ctx, "sessions fts search done", "cluster_id", r.clusterID, "duration_ms", time.Since(start).Milliseconds(), "count", len(memories))
 	return memories, nil
 }
 
@@ -415,51 +418,23 @@ type sessionFTSCandidate struct {
 	score float64
 }
 
-func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, error) {
-	if limit <= 0 {
-		return nil, nil
-	}
-
+func (r *SessionRepo) ftsSearchWithPostFilter(ctx context.Context, query string, f domain.MemoryFilter, limit int) ([]domain.Memory, ftsSearchStats, error) {
 	conds, args := r.buildSessionFilterConds(f)
 	where := strings.Join(conds, " AND ")
 	safeQ := ftsSafeLiteral(query)
-
-	filtered := make([]domain.Memory, 0, min(limit, maxFTSFallbackCandidateLimit))
-	initialCandidateLimit := min(limit, maxFTSCandidatePageLimit)
-	candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, initialCandidateLimit, 0)
-	if err != nil {
-		return nil, err
-	}
-	exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSSessions)
-	if err != nil {
-		return nil, err
-	}
-	if len(filtered) >= limit {
-		return filtered[:limit], nil
-	}
-	if exhausted || len(candidates) < initialCandidateLimit {
-		return filtered, nil
-	}
-
-	offset := initialCandidateLimit
-	for page := 0; page < maxFTSFallbackPages; page++ {
-		candidates, err := r.fetchSessionFTSCandidates(ctx, safeQ, maxFTSCandidatePageLimit, offset)
-		if err != nil {
-			return nil, err
-		}
-		exhausted, err := appendFilteredFTSPage(ctx, candidates, where, args, &filtered, r.fetchFilteredFTSSessions)
-		if err != nil {
-			return nil, err
-		}
-		if len(filtered) >= limit {
-			return filtered[:limit], nil
-		}
-		if exhausted || len(candidates) < maxFTSCandidatePageLimit {
-			return filtered, nil
-		}
-		offset += maxFTSCandidatePageLimit
-	}
-	return filtered, nil
+	memories, stats, err := runAdaptiveFTSSearch(
+		ctx,
+		limit,
+		func(candidate sessionFTSCandidate) string { return candidate.id },
+		func(ctx context.Context, pageSize, offset int) ([]sessionFTSCandidate, error) {
+			return r.fetchSessionFTSCandidates(ctx, safeQ, pageSize, offset)
+		},
+		func(ctx context.Context, candidates []sessionFTSCandidate) ([]domain.Memory, error) {
+			return r.fetchFilteredFTSSessions(ctx, candidates, where, args)
+		},
+	)
+	recordFTSCandidateBudgetWarning(ctx, stats, string(domain.TypeSession))
+	return memories, stats, err
 }
 
 func (r *SessionRepo) fetchSessionFTSCandidates(ctx context.Context, safeQ string, limit, offset int) ([]sessionFTSCandidate, error) {

--- a/server/internal/service/fts_search.go
+++ b/server/internal/service/fts_search.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func resolveFTSSearchResult(ctx context.Context, results []domain.Memory, err error, branch string) ([]domain.Memory, error) {
+	if !errors.Is(err, domain.ErrFTSSearchTruncated) {
+		return results, err
+	}
+	recorded := domain.RecordRecallWarning(ctx, domain.RecallWarning{
+		Code:   domain.RecallWarningFTSCandidateBudgetExhausted,
+		Branch: branch,
+	})
+	if !recorded {
+		return results, err
+	}
+	return results, nil
+}
+
+func memoryFTSRecallBranch(memoryType string) string {
+	if memoryType == string(domain.TypeInsight) {
+		return string(domain.TypeInsight)
+	}
+	return string(domain.TypePinned)
+}
+
+func (s *MemoryService) repositoryFTSSearch(ctx context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	results, err := s.memories.FTSSearch(ctx, query, filter, limit)
+	return resolveFTSSearchResult(ctx, results, err, memoryFTSRecallBranch(filter.MemoryType))
+}
+
+func (s *SessionService) repositoryFTSSearch(ctx context.Context, query string, filter domain.MemoryFilter, limit int) ([]domain.Memory, error) {
+	results, err := s.sessions.FTSSearch(ctx, query, filter, limit)
+	return resolveFTSSearchResult(ctx, results, err, string(domain.TypeSession))
+}

--- a/server/internal/service/fts_search_test.go
+++ b/server/internal/service/fts_search_test.go
@@ -1,0 +1,40 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+)
+
+func TestResolveFTSSearchResultAcceptsTruncationForRecall(t *testing.T) {
+	want := []domain.Memory{{ID: "memory-1"}}
+	var warnings []domain.RecallWarning
+	ctx := domain.WithRecallWarningRecorder(context.Background(), func(warning domain.RecallWarning) {
+		warnings = append(warnings, warning)
+	})
+
+	got, err := resolveFTSSearchResult(ctx, want, domain.ErrFTSSearchTruncated, string(domain.TypeInsight))
+	if err != nil {
+		t.Fatalf("resolveFTSSearchResult() error = %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "memory-1" {
+		t.Fatalf("results = %+v, want memory-1", got)
+	}
+	if len(warnings) != 1 || warnings[0].Code != domain.RecallWarningFTSCandidateBudgetExhausted || warnings[0].Branch != string(domain.TypeInsight) {
+		t.Fatalf("warnings = %+v, want insight FTS candidate budget warning", warnings)
+	}
+}
+
+func TestResolveFTSSearchResultPropagatesTruncationWithoutRecall(t *testing.T) {
+	want := []domain.Memory{{ID: "memory-1"}}
+
+	got, err := resolveFTSSearchResult(context.Background(), want, domain.ErrFTSSearchTruncated, string(domain.TypeInsight))
+	if !errors.Is(err, domain.ErrFTSSearchTruncated) {
+		t.Fatalf("resolveFTSSearchResult() error = %v, want ErrFTSSearchTruncated", err)
+	}
+	if len(got) != 1 || got[0].ID != "memory-1" {
+		t.Fatalf("results = %+v, want memory-1", got)
+	}
+}

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -1528,6 +1528,7 @@ type existingMemoryCandidate struct {
 type factSearchResult struct {
 	attempts   int
 	candidates []existingMemoryCandidate
+	fatalErr   error
 	successes  int
 }
 
@@ -1597,6 +1598,9 @@ func (s *IngestService) gatherExistingMemories(ctx context.Context, agentID, app
 
 	var searchAttempts, searchSuccesses int
 	for _, searchResult := range searchResults {
+		if searchResult.fatalErr != nil {
+			return nil, fmt.Errorf("existing memory FTS search incomplete: %w", searchResult.fatalErr)
+		}
 		searchAttempts += searchResult.attempts
 		searchSuccesses += searchResult.successes
 		addUnseen(searchResult.candidates)
@@ -1644,6 +1648,9 @@ func (s *IngestService) searchExistingMemoriesForFact(
 			kwMatches, kwErr = s.memories.KeywordSearch(ctx, fact, filter, perFactLimit)
 		}
 		if kwErr != nil {
+			if errors.Is(kwErr, domain.ErrFTSSearchTruncated) {
+				result.fatalErr = kwErr
+			}
 			slog.Warn("gatherExistingMemories: keyword/FTS search failed for fact, skipping", "fact_len", len(fact), "err", kwErr)
 			return result
 		}
@@ -1699,6 +1706,9 @@ func (s *IngestService) searchExistingMemoriesForFact(
 		kwMatches, kwErr = s.memories.KeywordSearch(ctx, fact, filter, perFactLimit)
 	}
 	if kwErr != nil {
+		if errors.Is(kwErr, domain.ErrFTSSearchTruncated) {
+			result.fatalErr = kwErr
+		}
 		slog.Warn("gatherExistingMemories: keyword/FTS search failed for fact, skipping", "fact_len", len(fact), "err", kwErr)
 	} else {
 		result.successes++

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -2984,6 +2984,29 @@ func TestGatherExistingMemoriesPartialLegFailureContinues(t *testing.T) {
 	}
 }
 
+func TestGatherExistingMemoriesFTSTruncationReturnsError(t *testing.T) {
+	t.Parallel()
+
+	highScore := 0.8
+	memRepo := &memoryRepoMock{
+		ftsAvail: true,
+		ftsErr:   domain.ErrFTSSearchTruncated,
+		vectorResults: []domain.Memory{
+			{ID: "vec-1", Content: "from vector", MemoryType: domain.TypeInsight, State: domain.StateActive, Score: &highScore},
+		},
+	}
+
+	svc := NewIngestService(memRepo, nil, nil, "auto-model", ModeSmart)
+
+	result, err := svc.gatherExistingMemories(context.Background(), "agent-1", "", []string{"test fact"})
+	if !errors.Is(err, domain.ErrFTSSearchTruncated) {
+		t.Fatalf("gatherExistingMemories() error = %v, want ErrFTSSearchTruncated", err)
+	}
+	if result != nil {
+		t.Fatalf("result = %+v, want nil", result)
+	}
+}
+
 // TestGatherExistingMemoriesFTSOnlyTotalOutage verifies the no-vector path
 // also detects total outage when all keyword/FTS searches fail.
 func TestGatherExistingMemoriesFTSOnlyTotalOutage(t *testing.T) {

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -319,7 +319,7 @@ func (s *MemoryService) ftsOnlySearch(ctx context.Context, filter domain.MemoryF
 	}
 	fetchLimit := limit * 3
 
-	ftsResults, err := s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
+	ftsResults, err := s.repositoryFTSSearch(ctx, filter.Query, filter, fetchLimit)
 	if err != nil {
 		return nil, 0, fmt.Errorf("FTS search: %w", err)
 	}
@@ -501,7 +501,7 @@ func (s *MemoryService) ftsOnlyCandidates(ctx context.Context, filter domain.Mem
 	limit := normalizeRecallLimit(filter.Limit, 10)
 	fetchLimit := limit * normalizeRecallFetchMultiplier(opts.FetchMultiplier, 3)
 
-	ftsResults, err := s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
+	ftsResults, err := s.repositoryFTSSearch(ctx, filter.Query, filter, fetchLimit)
 	if err != nil {
 		return nil, fmt.Errorf("FTS search: %w", err)
 	}
@@ -570,7 +570,7 @@ func (s *MemoryService) hybridSearch(ctx context.Context, filter domain.MemoryFi
 	var kwResults []domain.Memory
 	if s.memories.FTSAvailable() {
 		var kwErr error
-		kwResults, kwErr = s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
+		kwResults, kwErr = s.repositoryFTSSearch(ctx, filter.Query, filter, fetchLimit)
 		if kwErr != nil {
 			return nil, 0, fmt.Errorf("FTS search: %w", kwErr)
 		}
@@ -619,7 +619,7 @@ func (s *MemoryService) hybridCandidates(ctx context.Context, filter domain.Memo
 
 	var kwResults []domain.Memory
 	if s.memories.FTSAvailable() {
-		kwResults, err = s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
+		kwResults, err = s.repositoryFTSSearch(ctx, filter.Query, filter, fetchLimit)
 		if err != nil {
 			return nil, fmt.Errorf("FTS search: %w", err)
 		}
@@ -674,7 +674,7 @@ func (s *MemoryService) autoHybridSearch(ctx context.Context, filter domain.Memo
 	var kwResults []domain.Memory
 	if s.memories.FTSAvailable() {
 		var kwErr error
-		kwResults, kwErr = s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
+		kwResults, kwErr = s.repositoryFTSSearch(ctx, filter.Query, filter, fetchLimit)
 		if kwErr != nil {
 			return nil, 0, fmt.Errorf("FTS search: %w", kwErr)
 		}
@@ -747,7 +747,7 @@ func (s *MemoryService) autoHybridCandidates(
 	var kwResults []domain.Memory
 	keywordStart := time.Now()
 	if s.memories.FTSAvailable() {
-		kwResults, err = s.memories.FTSSearch(ctx, filter.Query, filter, fetchLimit)
+		kwResults, err = s.repositoryFTSSearch(ctx, filter.Query, filter, fetchLimit)
 		if err != nil {
 			return nil, fmt.Errorf("FTS search: %w", err)
 		}

--- a/server/internal/service/session.go
+++ b/server/internal/service/session.go
@@ -305,7 +305,7 @@ func (s *SessionService) hybridCandidates(
 }
 
 func (s *SessionService) ftsSearch(ctx context.Context, f domain.MemoryFilter, limit, fetchLimit int) ([]domain.Memory, error) {
-	results, err := s.sessions.FTSSearch(ctx, f.Query, f, fetchLimit)
+	results, err := s.repositoryFTSSearch(ctx, f.Query, f, fetchLimit)
 	if err != nil {
 		return nil, fmt.Errorf("session fts search: %w", err)
 	}
@@ -314,7 +314,7 @@ func (s *SessionService) ftsSearch(ctx context.Context, f domain.MemoryFilter, l
 }
 
 func (s *SessionService) ftsCandidates(ctx context.Context, f domain.MemoryFilter, sourcePool RecallSourcePool, opts RecallCandidateOptions, fetchLimit int) ([]RecallCandidate, error) {
-	results, err := s.sessions.FTSSearch(ctx, f.Query, f, fetchLimit)
+	results, err := s.repositoryFTSSearch(ctx, f.Query, f, fetchLimit)
 	if err != nil {
 		return nil, fmt.Errorf("session fts search: %w", err)
 	}
@@ -348,7 +348,7 @@ func (s *SessionService) keywordCandidates(ctx context.Context, f domain.MemoryF
 
 func (s *SessionService) ftsOrKeyword(ctx context.Context, f domain.MemoryFilter, fetchLimit int) ([]domain.Memory, error) {
 	if s.sessions.FTSAvailable() {
-		r, err := s.sessions.FTSSearch(ctx, f.Query, f, fetchLimit)
+		r, err := s.repositoryFTSSearch(ctx, f.Query, f, fetchLimit)
 		if err != nil {
 			return nil, fmt.Errorf("session fts search: %w", err)
 		}


### PR DESCRIPTION
## What Changed
- Full-text Recall sizes candidate pages from requested results and observed post-filter yield.
- Candidate paging stops at per-page, total-candidate, page-count, and elapsed-time budgets while preserving accepted results.
- Recall responses and structured logs expose partial-budget and paging outcomes.
- Budget exhaustion is explicit to generic FTS callers; Recall keeps accepted results as partial, and Ingest stops reconciliation before duplicate writes.

## Why
- The previous fallback requested 10,000 candidates per page even for small result requests.
- TiDB Cloud 8.5.3 keeps bounded `textSearch topK` for pure FTS; adding business predicates moves them into a TiFlash `Selection` and removes Top-K pushdown from text search.

## Review Path
1. Start with `server/internal/repository/tidb/fts_paging.go` for adaptive sizing, hard budgets, deduplication, and paging stats.
2. Check `memory.go` and `sessions.go` for the shared pager adapters, explicit truncation signal, and preserved pure-FTS query shape.
3. Check `server/internal/service/fts_search.go` and `ingest.go` for Recall partial handling and Ingest completeness enforcement.
4. Check `domain/recall_warning.go`, handler observation, and `docs/api/openapi.json` for partial-response propagation.
5. Finish with the repository, service, handler, and contract tests.

## Validation
- `make test`
- `make vet`
- TiDB Cloud Zero `8.5.3-serverless`: `EXPLAIN ANALYZE` retained `textSearch top5` for the pure candidate query; the filtered query added a TiFlash `Selection` and lost Top-K pushdown at the text-search node.

Closes #443
