### PR TITLE
fix(server): preserve Recall terminal responses

### DIFF
--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -342,10 +342,7 @@ func (s *Server) handleError(ctx context.Context, w http.ResponseWriter, err err
 			attrs = append(attrs, "cluster_id", auth.ClusterID)
 		}
 		s.logger.ErrorContext(ctx, "request deadline exceeded", attrs...)
-		return respond(w, http.StatusGatewayTimeout, map[string]string{
-			"error": "recall request deadline exceeded",
-			"code":  recallServerDeadlineCode,
-		})
+		return respond(w, http.StatusGatewayTimeout, recallServerDeadlinePayload())
 	case errors.As(err, &budgetErr):
 		return respond(w, http.StatusUnprocessableEntity, map[string]string{
 			"error": memoryListBudgetErrorMessage,
@@ -438,8 +435,8 @@ func requestLogger(logger *slog.Logger) func(http.Handler) http.Handler {
 				}
 			}
 			status := ww.Status()
-			if errors.Is(r.Context().Err(), context.Canceled) && errors.Is(context.Cause(r.Context()), context.Canceled) {
-				status = 499
+			if status == 0 && errors.Is(r.Context().Err(), context.Canceled) && errors.Is(context.Cause(r.Context()), context.Canceled) {
+				status = statusClientClosedRequest
 			}
 			level := slog.LevelInfo
 			if status >= 500 {

--- a/server/internal/handler/recall_budget.go
+++ b/server/internal/handler/recall_budget.go
@@ -14,6 +14,7 @@ const (
 	defaultRecallRequestTimeout  = time.Minute
 	defaultRecallResponseReserve = 5 * time.Second
 	recallServerDeadlineCode     = "recall_server_deadline_exceeded"
+	recallServerDeadlineMessage  = "recall request deadline exceeded"
 	recallBranchDeadlineCode     = "recall_branch_deadline_exceeded"
 )
 
@@ -32,7 +33,7 @@ type recallBudgetContext struct {
 type recallServerDeadlineError struct{}
 
 func (*recallServerDeadlineError) Error() string {
-	return "recall request deadline exceeded"
+	return recallServerDeadlineMessage
 }
 
 func (*recallServerDeadlineError) Unwrap() error {
@@ -195,7 +196,7 @@ func (w *recallBudgetResponseWriter) Write(payload []byte) (int, error) {
 }
 
 func (w *recallBudgetResponseWriter) shouldOverride() bool {
-	return w.terminalStatus() != 0
+	return !w.wroteHeader && w.terminalStatus() != 0
 }
 
 func (w *recallBudgetResponseWriter) completeDeadlineResponse() {
@@ -227,16 +228,22 @@ func (w *recallBudgetResponseWriter) writeDeadlineResponse() {
 	}
 	w.wroteHeader = true
 	w.Header().Del("Content-Length")
-	w.Header().Set("Content-Type", "application/json")
-	w.ResponseWriter.WriteHeader(w.overrideStatus)
-	payload := "{\"error\":\"client closed request\"}\n"
+	var err error
 	if w.overrideStatus == http.StatusGatewayTimeout {
-		payload = "{\"code\":\"" + recallServerDeadlineCode + "\",\"error\":\"recall request deadline exceeded\"}\n"
+		err = respond(w.ResponseWriter, w.overrideStatus, recallServerDeadlinePayload())
+	} else {
+		err = respondError(w.ResponseWriter, w.overrideStatus, "client closed request")
 	}
-	_, err := w.ResponseWriter.Write([]byte(payload))
 	w.writeOutcome = "success"
 	if err != nil {
 		w.writeOutcome = "failed"
+	}
+}
+
+func recallServerDeadlinePayload() map[string]string {
+	return map[string]string{
+		"code":  recallServerDeadlineCode,
+		"error": recallServerDeadlineMessage,
 	}
 }
 

--- a/server/internal/handler/recall_budget_test.go
+++ b/server/internal/handler/recall_budget_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/qiffang/mnemos/server/internal/domain"
 	"github.com/qiffang/mnemos/server/internal/metrics"
+	"github.com/qiffang/mnemos/server/internal/middleware"
 )
 
 type failingJSONResponseWriter struct {
@@ -69,9 +70,11 @@ func TestRecallRequestBudgetStartsBeforeGlobalRateLimitMiddleware(t *testing.T) 
 	}
 }
 
-func TestRecallRequestBudgetMapsPreHandlerDeadlineTo504(t *testing.T) {
+func TestRecallRequestBudgetMapsServerDeadlinesToSame504Contract(t *testing.T) {
 	metrics.HTTPRequestsTotal.Reset()
+	var preHandlerLogBuf bytes.Buffer
 	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).WithRecallRequestBudget(120*time.Millisecond, 60*time.Millisecond)
+	srv.logger = slog.New(slog.NewJSONHandler(&preHandlerLogBuf, nil))
 	rateLimit := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			<-r.Context().Done()
@@ -84,22 +87,77 @@ func TestRecallRequestBudgetMapsPreHandlerDeadlineTo504(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 
-	if rr.Code != http.StatusGatewayTimeout {
-		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	preHandlerResponse := assertRecallDeadlineResponse(t, rr)
+	assertRecallHTTPMetric(t, "unmatched", http.StatusGatewayTimeout)
+	assertRecallRequestLog(t, &preHandlerLogBuf, http.StatusGatewayTimeout, "ERROR")
+
+	metrics.HTTPRequestsTotal.Reset()
+	waitForDeadline := func(ctx context.Context) ([]domain.Memory, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
 	}
-	var response map[string]string
-	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
+	memRepo := &testMemoryRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return waitForDeadline(ctx)
+		},
 	}
-	if response["code"] != recallServerDeadlineCode {
-		t.Fatalf("code = %q, want %q", response["code"], recallServerDeadlineCode)
+	sessRepo := &testSessionRepo{
+		keywordSearchHook: func(ctx context.Context, _ string, _ domain.MemoryFilter, _ int) ([]domain.Memory, error) {
+			return waitForDeadline(ctx)
+		},
 	}
-	assertRecallHTTPMetric(t, http.StatusGatewayTimeout)
+	var handlerLogBuf bytes.Buffer
+	srv = newTestServer(memRepo, sessRepo).WithRecallRequestBudget(120*time.Millisecond, 60*time.Millisecond)
+	srv.logger = slog.New(slog.NewJSONHandler(&handlerLogBuf, nil))
+	apiKey := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := middleware.WithAuthContext(r.Context(), &domain.AuthInfo{AgentName: "test-agent"})
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+	handler = srv.Router(identityMiddleware, identityMiddleware, apiKey, identityMiddleware)
+	req = httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project", nil)
+	rr = httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	handlerResponse := assertRecallDeadlineResponse(t, rr)
+	assertRecallHTTPMetric(t, "/v1alpha2/mem9s/memories", http.StatusGatewayTimeout)
+	assertRecallRequestLog(t, &handlerLogBuf, http.StatusGatewayTimeout, "ERROR")
+	if handlerResponse != preHandlerResponse {
+		t.Fatalf("handler response = %#v, want pre-handler response %#v", handlerResponse, preHandlerResponse)
+	}
+}
+
+func TestRecallRequestBudgetRecordsPreHandlerDeadlineWriteFailure(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{}).WithRecallRequestBudget(120*time.Millisecond, 60*time.Millisecond)
+	srv.logger = logger
+	rateLimit := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+			http.Error(w, "rate limit dependency timed out", http.StatusServiceUnavailable)
+		})
+	}
+	handler := srv.Router(identityMiddleware, rateLimit, identityMiddleware, identityMiddleware)
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project", nil)
+	w := &failingJSONResponseWriter{header: make(http.Header)}
+
+	handler.ServeHTTP(w, req)
+
+	if w.status != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504", w.status)
+	}
+	entry := findHandlerLogEntry(t, decodeHandlerLogs(t, &logBuf), "recall request deadline exceeded before handler")
+	assertHandlerLogField(t, entry, "response_write_outcome", "failed")
 }
 
 func TestRecallRequestBudgetMapsPreHandlerClientCancellationTo499(t *testing.T) {
 	metrics.HTTPRequestsTotal.Reset()
+	var logBuf bytes.Buffer
 	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	srv.logger = slog.New(slog.NewJSONHandler(&logBuf, nil))
 	rateLimit := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			<-r.Context().Done()
@@ -118,12 +176,76 @@ func TestRecallRequestBudgetMapsPreHandlerClientCancellationTo499(t *testing.T) 
 	if rr.Code != statusClientClosedRequest {
 		t.Fatalf("status = %d, want 499: %s", rr.Code, rr.Body.String())
 	}
-	assertRecallHTTPMetric(t, statusClientClosedRequest)
+	assertRecallHTTPMetric(t, "unmatched", statusClientClosedRequest)
+	assertRecallRequestLog(t, &logBuf, statusClientClosedRequest, "INFO")
 }
 
-func assertRecallHTTPMetric(t *testing.T, status int) {
+func TestRecallRequestBudgetPreservesCommitted500AfterClientCancellation(t *testing.T) {
+	metrics.HTTPRequestsTotal.Reset()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+	srv := newTestServer(&testMemoryRepo{}, &testSessionRepo{})
+	srv.logger = logger
+
+	req := httptest.NewRequest(http.MethodGet, "/v1alpha2/mem9s/memories?q=project", nil)
+	ctx, cancel := context.WithCancel(req.Context())
+	req = req.WithContext(ctx)
+	rateLimit := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			respondError(w, http.StatusInternalServerError, "dependency failed")
+			cancel()
+		})
+	}
+	handler := srv.Router(identityMiddleware, rateLimit, identityMiddleware, identityMiddleware)
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500: %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Body.String(); got != "{\"error\":\"dependency failed\"}\n" {
+		t.Fatalf("body = %q, want committed 500 response", got)
+	}
+	assertRecallHTTPMetric(t, "unmatched", http.StatusInternalServerError)
+	entries := decodeHandlerLogs(t, &logBuf)
+	for _, entry := range entries {
+		if entry["msg"] == "recall request canceled before handler" {
+			t.Fatal("logged synthetic 499 after response was committed")
+		}
+	}
+	entry := findHandlerLogEntry(t, entries, "handle request done")
+	assertHandlerLogField(t, entry, "status", float64(http.StatusInternalServerError))
+	assertHandlerLogField(t, entry, "level", "ERROR")
+}
+
+func assertRecallDeadlineResponse(t *testing.T, rr *httptest.ResponseRecorder) [2]string {
 	t.Helper()
-	counter, err := metrics.HTTPRequestsTotal.GetMetricWithLabelValues(http.MethodGet, "unmatched", strconv.Itoa(status))
+	if rr.Code != http.StatusGatewayTimeout {
+		t.Fatalf("status = %d, want 504: %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+	var response map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response) != 2 {
+		t.Fatalf("response = %#v, want code and error", response)
+	}
+	if response["code"] != recallServerDeadlineCode {
+		t.Fatalf("code = %q, want %q", response["code"], recallServerDeadlineCode)
+	}
+	if response["error"] != recallServerDeadlineMessage {
+		t.Fatalf("error = %q, want %q", response["error"], recallServerDeadlineMessage)
+	}
+	return [2]string{response["code"], response["error"]}
+}
+
+func assertRecallHTTPMetric(t *testing.T, route string, status int) {
+	t.Helper()
+	counter, err := metrics.HTTPRequestsTotal.GetMetricWithLabelValues(http.MethodGet, route, strconv.Itoa(status))
 	if err != nil {
 		t.Fatalf("get HTTP request metric: %v", err)
 	}
@@ -138,6 +260,13 @@ func assertRecallHTTPMetric(t *testing.T, status int) {
 	if pb.Counter == nil || pb.Counter.GetValue() != 1 {
 		t.Fatalf("HTTP %d request metric = %#v, want 1", status, pb.Counter)
 	}
+}
+
+func assertRecallRequestLog(t *testing.T, logBuf *bytes.Buffer, status int, level string) {
+	t.Helper()
+	entry := findHandlerLogEntry(t, decodeHandlerLogs(t, logBuf), "handle request done")
+	assertHandlerLogField(t, entry, "status", float64(status))
+	assertHandlerLogField(t, entry, "level", level)
 }
 
 func TestRecallRequestBudgetMiddlewareSkipsKeywordSearch(t *testing.T) {


### PR DESCRIPTION
## Summary

- preserve an already committed response status and body when caller cancellation races with completion
- synthesize 499 only before another response is committed, keeping the client response, request log, and HTTP metric consistent
- share one Recall server-deadline payload across pre-handler and handler-reached 504 paths
- preserve deadline defaults and response-write outcome observability

## Impact

This changes Recall terminal-response classification and observability only. It introduces no schema, migration, configuration, Runtime Usage contract, or OpenAPI changes. The one-minute request budget and five-second response reserve remain unchanged.

## Verification

- `GOENV=off make vet`
- `GOENV=off make test`
- focused Recall terminal-response race tests repeated 10 times
- Standards and Spec reviews passed after addressing the committed-body cancellation race

Closes #447
Follow-up to #445