### PR TITLE
fix(runtimeusage): adapt reservation errors to revised contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Runtime usage is disabled by default. When enabled, the server reserves quota be
 
 The runtime usage outbox uses the control-plane `runtime_usage_outbox` table for pending reservation finalization and metering delivery. It is enabled by default when runtime usage is enabled.
 
-Reservation retries require one of these exact responses with `details.retryable: true`: `409 registry_conflict`, `409 operation_in_progress`, `429 reservation_concurrency_limited` with a positive decimal integer-seconds `Retry-After`, or `503 unavailable`. Other response shapes retain their existing status handling. Reservation calls make up to three total attempts. The first retry samples from the base delay through the midpoint, and the second samples from the midpoint through the maximum delay. Admission concurrency responses use the greater of the sampled delay and `Retry-After`.
+Reservation retries require one of these exact responses with `details.retryable: true`: `409 registry_conflict`; `429 operation_in_progress`, `429 registry_busy`, or `429 reservation_concurrency_limited` with a positive decimal integer-seconds `Retry-After`; or `503 unavailable`. Reservation calls make up to three total attempts. The first retry samples from the base delay through the midpoint, and the second samples from the midpoint through the maximum delay. Retryable 429 responses use the greater of the sampled delay and `Retry-After`. After fail-closed handling stops, recognized or unknown 429 responses remain 429, while exhausted 409/503 responses, terminal `409 operation_conflict`, and unknown 409 responses become 503.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|

--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -40,6 +40,7 @@ type testMemoryRepo struct {
 	bulkCreateHook        func(context.Context)
 	updateCalls           []*domain.Memory
 	vectorSearchResults   []domain.Memory
+	searchCalls           int
 	keywordSearchResults  []domain.Memory
 	keywordSearchHook     func(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error)
 	lastKeywordQuery      string
@@ -162,10 +163,16 @@ func (m *testMemoryRepo) BulkCreate(ctx context.Context, _ []*domain.Memory) err
 	return nil
 }
 func (m *testMemoryRepo) VectorSearch(context.Context, []float32, domain.MemoryFilter, int) ([]domain.Memory, error) {
+	m.mu.Lock()
+	m.searchCalls++
+	m.mu.Unlock()
 	return append([]domain.Memory(nil), m.vectorSearchResults...), nil
 }
 
 func (m *testMemoryRepo) AutoVectorSearch(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
+	m.mu.Lock()
+	m.searchCalls++
+	m.mu.Unlock()
 	return append([]domain.Memory(nil), m.vectorSearchResults...), nil
 }
 
@@ -184,6 +191,9 @@ func (m *testMemoryRepo) KeywordSearch(ctx context.Context, query string, filter
 }
 
 func (m *testMemoryRepo) FTSSearch(context.Context, string, domain.MemoryFilter, int) ([]domain.Memory, error) {
+	m.mu.Lock()
+	m.searchCalls++
+	m.mu.Unlock()
 	return nil, nil
 }
 func (m *testMemoryRepo) FTSAvailable() bool { return false }
@@ -445,6 +455,7 @@ type captureRuntimeUsageManager struct {
 	noticeStateSubjects      []runtimeusage.Subject
 	afterCreateSuccessErr    error
 	beforeCreateErrByTenant  map[string]error
+	beforeRecallErr          error
 	beforeRecallSubjects     []runtimeusage.Subject
 	recallResults            []runtimeusage.RecallResult
 	recallSuccessContextErrs []error
@@ -496,6 +507,9 @@ func (m *captureRuntimeUsageManager) RuntimeStateForNotice(ctx context.Context, 
 func (m *captureRuntimeUsageManager) BeforeRecall(_ context.Context, subject runtimeusage.Subject) (*runtimeusage.OperationLease, error) {
 	m.beforeRecallCalls++
 	m.beforeRecallSubjects = append(m.beforeRecallSubjects, subject)
+	if m.beforeRecallErr != nil {
+		return nil, m.beforeRecallErr
+	}
 	return &runtimeusage.OperationLease{OperationID: "op-recall", Reserved: true}, nil
 }
 func (m *captureRuntimeUsageManager) AfterRecallSuccess(ctx context.Context, _ *runtimeusage.OperationLease, result runtimeusage.RecallResult) error {
@@ -2258,6 +2272,69 @@ func TestCreateMemory_RuntimeUsageAllowsPinnedKnownDelta(t *testing.T) {
 	}
 	if memRepo.bulkCreateCalls != 1 {
 		t.Fatalf("bulk create calls = %d, want 1", memRepo.bulkCreateCalls)
+	}
+}
+
+func TestCreateMemory_RuntimeUsageReserveRateLimitStopsTenantWrite(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled: true,
+		beforeCreateErrByTenant: map[string]error{
+			"tenant-a": newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusTooManyRequests,
+				`{"code":"registry_busy","details":{"retryable":true}}`,
+				"1",
+			),
+		},
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+	req := makeTenantRequest(t, http.MethodPost, "/memories", map[string]any{
+		"content":     "must not be written",
+		"memory_type": "pinned",
+	})
+	rr := httptest.NewRecorder()
+
+	srv.createMemory(rr, req)
+
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("Retry-After") != "1" {
+		t.Fatalf("Retry-After = %q, want 1", rr.Header().Get("Retry-After"))
+	}
+	if memRepo.bulkCreateCalls != 0 || len(memRepo.createCalls) != 0 {
+		t.Fatalf("tenant writes = bulk:%d create:%d, want 0", memRepo.bulkCreateCalls, len(memRepo.createCalls))
+	}
+	if runtimeUsage.afterCreateSuccessCalls != 0 || runtimeUsage.afterCreateFailureCalls != 0 {
+		t.Fatalf("runtime finalization calls = success:%d failure:%d, want 0/0", runtimeUsage.afterCreateSuccessCalls, runtimeUsage.afterCreateFailureCalls)
+	}
+}
+
+func TestListMemories_RuntimeUsageReserveConflictStopsTenantRecall(t *testing.T) {
+	memRepo := &testMemoryRepo{}
+	runtimeUsage := &captureRuntimeUsageManager{
+		enabled: true,
+		beforeRecallErr: newRuntimeUsageReservationResponseError(
+			t,
+			http.StatusConflict,
+			`{"code":"registry_conflict","details":{"retryable":true}}`,
+		),
+	}
+	srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+	req := makeTenantRequest(t, http.MethodGet, "/memories?q=must-not-run", nil)
+	rr := httptest.NewRecorder()
+
+	srv.listMemories(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503: %s", rr.Code, rr.Body.String())
+	}
+	if memRepo.searchCalls != 0 || memRepo.listCalls != 0 || memRepo.allTypeListCalls != 0 {
+		t.Fatalf("tenant recall calls = search:%d list:%d all:%d, want 0", memRepo.searchCalls, memRepo.listCalls, memRepo.allTypeListCalls)
+	}
+	if runtimeUsage.afterRecallSuccessCalls != 0 {
+		t.Fatalf("AfterRecallSuccess calls = %d, want 0", runtimeUsage.afterRecallSuccessCalls)
 	}
 }
 

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
-	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
@@ -197,7 +195,6 @@ func (s *Server) handleRuntimeUsageError(
 	details runtimeUsageErrorDetails,
 ) error {
 	s.logRuntimeUsageError(ctx, err, details, runtimeUsageRoleClientResponse)
-	recordRuntimeUsageReservationFailure(err)
 
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
@@ -222,21 +219,6 @@ func (s *Server) handleRuntimeUsageError(
 		return respondError(w, status, "runtime usage conflict")
 	}
 	return respondError(w, status, "runtime usage unavailable")
-}
-
-func recordRuntimeUsageReservationFailure(err error) {
-	failure, ok := runtimeusage.ReservationFailureDetails(err)
-	if !ok {
-		return
-	}
-	metrics.RuntimeUsageReservationFailuresTotal.WithLabelValues(
-		strconv.Itoa(failure.UpstreamStatus),
-		failure.Code,
-		failure.RetryDecision,
-		strconv.Itoa(failure.AttemptCount),
-		failure.ExhaustionReason,
-		strconv.Itoa(runtimeusage.HTTPStatus(err)),
-	).Inc()
 }
 
 func (s *Server) logRuntimeUsageBackgroundFinalizeError(ctx context.Context, err error, details runtimeUsageErrorDetails) {

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -7,9 +7,11 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
 
@@ -195,6 +197,7 @@ func (s *Server) handleRuntimeUsageError(
 	details runtimeUsageErrorDetails,
 ) error {
 	s.logRuntimeUsageError(ctx, err, details, runtimeUsageRoleClientResponse)
+	recordRuntimeUsageReservationFailure(err)
 
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
@@ -209,10 +212,31 @@ func (s *Server) handleRuntimeUsageError(
 		return writeErr
 	}
 	status := runtimeusage.HTTPStatus(err)
+	if reservationFailure, ok := runtimeusage.ReservationFailureDetails(err); ok && status == http.StatusTooManyRequests {
+		if reservationFailure.RetryAfter != "" {
+			w.Header().Set("Retry-After", reservationFailure.RetryAfter)
+		}
+		return respondError(w, status, "runtime usage rate limited")
+	}
 	if status == http.StatusBadGateway {
 		return respondError(w, status, "runtime usage conflict")
 	}
 	return respondError(w, status, "runtime usage unavailable")
+}
+
+func recordRuntimeUsageReservationFailure(err error) {
+	failure, ok := runtimeusage.ReservationFailureDetails(err)
+	if !ok {
+		return
+	}
+	metrics.RuntimeUsageReservationFailuresTotal.WithLabelValues(
+		strconv.Itoa(failure.UpstreamStatus),
+		failure.Code,
+		failure.RetryDecision,
+		strconv.Itoa(failure.AttemptCount),
+		failure.ExhaustionReason,
+		strconv.Itoa(runtimeusage.HTTPStatus(err)),
+	).Inc()
 }
 
 func (s *Server) logRuntimeUsageBackgroundFinalizeError(ctx context.Context, err error, details runtimeUsageErrorDetails) {
@@ -245,6 +269,17 @@ func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details ru
 	if details.operationID != "" {
 		attrs = append(attrs, "operation_id", details.operationID)
 	}
+	if reservationFailure, ok := runtimeusage.ReservationFailureDetails(err); ok {
+		attrs = append(attrs,
+			"upstream_status", reservationFailure.UpstreamStatus,
+			"error_code", reservationFailure.Code,
+			"attempt_count", reservationFailure.AttemptCount,
+			"retry_decision", reservationFailure.RetryDecision,
+		)
+		if reservationFailure.ExhaustionReason != "" {
+			attrs = append(attrs, "exhaustion_reason", reservationFailure.ExhaustionReason)
+		}
+	}
 
 	logger := s.logger
 	if logger == nil {
@@ -263,15 +298,15 @@ func classifyRuntimeUsageError(err error) (string, int, bool) {
 	if errors.As(err, &denied) {
 		return "quota_denied", status, status == http.StatusTooManyRequests
 	}
-	var reservationFailure interface {
-		ReservationRetryable() bool
-	}
-	if errors.As(err, &reservationFailure) {
-		var conflict *runtimeusage.ConflictError
-		if errors.As(err, &conflict) {
-			return "conflict", status, false
+	if reservationFailure, ok := runtimeusage.ReservationFailureDetails(err); ok {
+		switch reservationFailure.UpstreamStatus {
+		case http.StatusTooManyRequests:
+			return "rate_limited", status, reservationFailure.Retryable
+		case http.StatusConflict:
+			return "conflict", status, reservationFailure.Retryable
+		default:
+			return "unavailable", status, reservationFailure.Retryable
 		}
-		return "unavailable", status, reservationFailure.ReservationRetryable()
 	}
 	var conflict *runtimeusage.ConflictError
 	if errors.As(err, &conflict) {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -8,13 +8,10 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
-	dto "github.com/prometheus/client_model/go"
 	"github.com/qiffang/mnemos/server/internal/domain"
-	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/reqid"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
@@ -364,6 +361,31 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			wantExhaustionReason: "unrecognized_contract",
 		},
 		{
+			name: "exhausted retryable reservation rate limit",
+			err: newExhaustedRuntimeUsageReservationResponseError(
+				t,
+				http.StatusTooManyRequests,
+				`{"code":"registry_busy","details":{"retryable":true}}`,
+				"1",
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-exhausted-rate-limit",
+			}, runtimeusage.MeterMemoryWriteRequests),
+			wantStatus:           http.StatusTooManyRequests,
+			wantClass:            "rate_limited",
+			wantRetryable:        true,
+			wantStage:            runtimeUsageStageReserve,
+			wantClusterID:        "cluster-exhausted-rate-limit",
+			wantMeter:            runtimeusage.MeterMemoryWriteRequests,
+			wantMessage:          "runtime usage rate limited",
+			wantRetryAfter:       "1",
+			wantUpstreamStatus:   http.StatusTooManyRequests,
+			wantErrorCode:        "registry_busy",
+			wantAttemptCount:     3,
+			wantRetryDecision:    "exhausted",
+			wantExhaustionReason: "max_attempts",
+		},
+		{
 			name: "exhausted retryable reservation response",
 			err: newExhaustedRuntimeUsageReservationResponseError(
 				t,
@@ -441,17 +463,8 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			server := &Server{logger: logger}
 			recorder := httptest.NewRecorder()
 			ctx := reqid.NewContext(context.Background(), "request-runtime-usage")
-			metricBefore := float64(0)
-			if tt.wantUpstreamStatus != 0 {
-				metricBefore = runtimeUsageReservationFailureMetric(t, tt)
-			}
 
 			server.handleRuntimeUsageError(ctx, recorder, tt.err, tt.details)
-			if tt.wantUpstreamStatus != 0 {
-				if metricAfter := runtimeUsageReservationFailureMetric(t, tt); metricAfter != metricBefore+1 {
-					t.Fatalf("reservation failure metric = %v, want %v", metricAfter, metricBefore+1)
-				}
-			}
 
 			if recorder.Code != tt.wantStatus {
 				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
@@ -505,48 +518,6 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 	}
 }
 
-func runtimeUsageReservationFailureMetric(t *testing.T, tt struct {
-	name                 string
-	err                  error
-	details              runtimeUsageErrorDetails
-	wantStatus           int
-	wantClass            string
-	wantRetryable        bool
-	wantStage            string
-	wantClusterID        string
-	wantMeter            string
-	wantOperation        string
-	wantMessage          string
-	wantRetryAfter       string
-	wantUpstreamStatus   int
-	wantErrorCode        string
-	wantAttemptCount     int
-	wantRetryDecision    string
-	wantExhaustionReason string
-}) float64 {
-	t.Helper()
-	counter, err := metrics.RuntimeUsageReservationFailuresTotal.GetMetricWithLabelValues(
-		strconv.Itoa(tt.wantUpstreamStatus),
-		tt.wantErrorCode,
-		tt.wantRetryDecision,
-		strconv.Itoa(tt.wantAttemptCount),
-		tt.wantExhaustionReason,
-		strconv.Itoa(tt.wantStatus),
-	)
-	if err != nil {
-		t.Fatalf("get runtime usage reservation failure metric: %v", err)
-	}
-	metric, ok := counter.(interface{ Write(*dto.Metric) error })
-	if !ok {
-		t.Fatal("runtime usage reservation failure metric does not implement Write")
-	}
-	var pb dto.Metric
-	if err := metric.Write(&pb); err != nil {
-		t.Fatalf("write runtime usage reservation failure metric: %v", err)
-	}
-	return pb.GetCounter().GetValue()
-}
-
 func newRuntimeUsageReservationResponseError(t *testing.T, status int, body string, retryAfter ...string) error {
 	t.Helper()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -570,10 +541,15 @@ func newRuntimeUsageReservationResponseError(t *testing.T, status int, body stri
 	return err
 }
 
-func newExhaustedRuntimeUsageReservationResponseError(t *testing.T, status int, body string) error {
+func newExhaustedRuntimeUsageReservationResponseError(t *testing.T, status int, body string, retryAfter ...string) error {
 	t.Helper()
+	attempts := 0
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts++
 		w.Header().Set("Content-Type", "application/json")
+		if len(retryAfter) > 0 {
+			w.Header().Set("Retry-After", retryAfter[0])
+		}
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
 	}))
@@ -588,6 +564,9 @@ func newExhaustedRuntimeUsageReservationResponseError(t *testing.T, status int, 
 	lease, err := manager.BeforeRecall(context.Background(), runtimeusage.Subject{APIKeySubject: "test-subject"})
 	if err == nil || lease != nil {
 		t.Fatalf("BeforeRecall = (%v, %v), want exhausted failure", lease, err)
+	}
+	if attempts != 3 {
+		t.Fatalf("Reserve attempts = %d, want 3", attempts)
 	}
 	return err
 }

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -8,10 +8,14 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/reqid"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
@@ -256,6 +260,26 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			wantRetryable:  true,
 			wantStage:      runtimeUsageStageReserve,
 			wantClusterID:  "cluster-reserve",
+			wantMeter:      runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:    "Post-quota rate limit exceeded.",
+			wantRetryAfter: "20",
+		},
+		{
+			name: "quota shape takes precedence over reservation code",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusTooManyRequests,
+				`{"code":"registry_busy","message":"Post-quota rate limit exceeded.","details":{"retryable":true,"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`,
+				"20",
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-overlapping-quota",
+			}, runtimeusage.MeterMemoryRecallRequests),
+			wantStatus:     http.StatusTooManyRequests,
+			wantClass:      "quota_denied",
+			wantRetryable:  true,
+			wantStage:      runtimeUsageStageReserve,
+			wantClusterID:  "cluster-overlapping-quota",
 			wantMeter:      runtimeusage.MeterMemoryRecallRequests,
 			wantMessage:    "Post-quota rate limit exceeded.",
 			wantRetryAfter: "20",
@@ -518,6 +542,64 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 	}
 }
 
+func TestRuntimeUsageFailuresRecordFinalHTTPStatusMetrics(t *testing.T) {
+	tests := []struct {
+		name           string
+		route          string
+		err            error
+		wantStatus     int
+		wantRetryAfter string
+	}{
+		{
+			name:  "rate limited",
+			route: "/test/runtime-usage/rate-limited",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusTooManyRequests,
+				`{"code":"registry_busy","details":{"retryable":true}}`,
+				"1",
+			),
+			wantStatus:     http.StatusTooManyRequests,
+			wantRetryAfter: "1",
+		},
+		{
+			name:  "unavailable",
+			route: "/test/runtime-usage/unavailable",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusConflict,
+				`{"code":"operation_conflict","details":{"retryable":false}}`,
+			),
+			wantStatus: http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := runtimeUsageHTTPMetricValue(t, tt.route, tt.wantStatus)
+			server := &Server{logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))}
+			router := chi.NewRouter()
+			router.Use(metrics.Middleware)
+			router.Get(tt.route, func(w http.ResponseWriter, r *http.Request) {
+				_ = server.handleRuntimeUsageError(r.Context(), w, tt.err, runtimeUsageErrorDetails{stage: runtimeUsageStageReserve})
+			})
+
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, tt.route, nil))
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if got := recorder.Header().Get("Retry-After"); got != tt.wantRetryAfter {
+				t.Fatalf("Retry-After = %q, want %q", got, tt.wantRetryAfter)
+			}
+			if after := runtimeUsageHTTPMetricValue(t, tt.route, tt.wantStatus); after != before+1 {
+				t.Fatalf("HTTP request metric = %v, want %v", after, before+1)
+			}
+		})
+	}
+}
+
 func newRuntimeUsageReservationResponseError(t *testing.T, status int, body string, retryAfter ...string) error {
 	t.Helper()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -674,6 +756,23 @@ func assertRuntimeUsageLogField(t *testing.T, entry map[string]any, field string
 	if got := entry[field]; got != want {
 		t.Fatalf("%s = %v, want %v; log = %#v", field, got, want, entry)
 	}
+}
+
+func runtimeUsageHTTPMetricValue(t *testing.T, route string, status int) float64 {
+	t.Helper()
+	counter, err := metrics.HTTPRequestsTotal.GetMetricWithLabelValues(http.MethodGet, route, strconv.Itoa(status))
+	if err != nil {
+		t.Fatalf("get HTTP request metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("HTTP request metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write HTTP request metric: %v", err)
+	}
+	return pb.GetCounter().GetValue()
 }
 
 func decodeRuntimeQuotaErrorBody(t *testing.T, body []byte) map[string]any {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -8,10 +8,13 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/metrics"
 	"github.com/qiffang/mnemos/server/internal/reqid"
 	"github.com/qiffang/mnemos/server/internal/runtimeusage"
 )
@@ -217,21 +220,24 @@ func TestNormalizeRuntimeQuotaErrorBodyUsesStatusMessageFallbackWithDetails(t *t
 }
 
 func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
-		name           string
-		err            error
-		details        runtimeUsageErrorDetails
-		wantStatus     int
-		wantClass      string
-		wantRetryable  bool
-		wantStage      string
-		wantClusterID  string
-		wantMeter      string
-		wantOperation  string
-		wantMessage    string
-		wantRetryAfter string
+		name                 string
+		err                  error
+		details              runtimeUsageErrorDetails
+		wantStatus           int
+		wantClass            string
+		wantRetryable        bool
+		wantStage            string
+		wantClusterID        string
+		wantMeter            string
+		wantOperation        string
+		wantMessage          string
+		wantRetryAfter       string
+		wantUpstreamStatus   int
+		wantErrorCode        string
+		wantAttemptCount     int
+		wantRetryDecision    string
+		wantExhaustionReason string
 	}{
 		{
 			name: "quota rate limit during reserve",
@@ -309,8 +315,57 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			wantMessage:   "runtime usage conflict",
 		},
 		{
-			name: "exhausted retryable reservation response",
+			name: "reservation rate limit",
 			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusTooManyRequests,
+				`{"code":"registry_busy","details":{"retryable":true}}`,
+				"1",
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-reserve-rate-limit",
+			}, runtimeusage.MeterMemoryRecallRequests),
+			wantStatus:         http.StatusTooManyRequests,
+			wantClass:          "rate_limited",
+			wantRetryable:      true,
+			wantStage:          runtimeUsageStageReserve,
+			wantClusterID:      "cluster-reserve-rate-limit",
+			wantMeter:          runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:        "runtime usage rate limited",
+			wantRetryAfter:     "1",
+			wantUpstreamStatus: http.StatusTooManyRequests,
+			wantErrorCode:      "registry_busy",
+			wantAttemptCount:   1,
+			wantRetryDecision:  "retryable",
+		},
+		{
+			name: "unknown reservation rate limit",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusTooManyRequests,
+				`{"code":"future_rate_limit","details":{"retryable":true}}`,
+				"2",
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-unknown-rate-limit",
+			}, runtimeusage.MeterMemoryWriteRequests),
+			wantStatus:           http.StatusTooManyRequests,
+			wantClass:            "rate_limited",
+			wantRetryable:        false,
+			wantStage:            runtimeUsageStageReserve,
+			wantClusterID:        "cluster-unknown-rate-limit",
+			wantMeter:            runtimeusage.MeterMemoryWriteRequests,
+			wantMessage:          "runtime usage rate limited",
+			wantRetryAfter:       "2",
+			wantUpstreamStatus:   http.StatusTooManyRequests,
+			wantErrorCode:        "unknown",
+			wantAttemptCount:     1,
+			wantRetryDecision:    "terminal",
+			wantExhaustionReason: "unrecognized_contract",
+		},
+		{
+			name: "exhausted retryable reservation response",
+			err: newExhaustedRuntimeUsageReservationResponseError(
 				t,
 				http.StatusServiceUnavailable,
 				`{"code":"unavailable","details":{"retryable":true}}`,
@@ -318,13 +373,18 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
 				ClusterID: "cluster-reserve",
 			}, runtimeusage.MeterMemoryRecallRequests),
-			wantStatus:    http.StatusServiceUnavailable,
-			wantClass:     "unavailable",
-			wantRetryable: true,
-			wantStage:     runtimeUsageStageReserve,
-			wantClusterID: "cluster-reserve",
-			wantMeter:     runtimeusage.MeterMemoryRecallRequests,
-			wantMessage:   "runtime usage unavailable",
+			wantStatus:           http.StatusServiceUnavailable,
+			wantClass:            "unavailable",
+			wantRetryable:        true,
+			wantStage:            runtimeUsageStageReserve,
+			wantClusterID:        "cluster-reserve",
+			wantMeter:            runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:          "runtime usage unavailable",
+			wantUpstreamStatus:   http.StatusServiceUnavailable,
+			wantErrorCode:        "unavailable",
+			wantAttemptCount:     3,
+			wantRetryDecision:    "exhausted",
+			wantExhaustionReason: "max_attempts",
 		},
 		{
 			name: "permanent reservation operation conflict",
@@ -336,27 +396,62 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
 				ClusterID: "cluster-reserve-conflict",
 			}, runtimeusage.MeterMemoryWriteRequests),
-			wantStatus:    http.StatusBadGateway,
-			wantClass:     "conflict",
-			wantRetryable: false,
-			wantStage:     runtimeUsageStageReserve,
-			wantClusterID: "cluster-reserve-conflict",
-			wantMeter:     runtimeusage.MeterMemoryWriteRequests,
-			wantMessage:   "runtime usage conflict",
+			wantStatus:           http.StatusServiceUnavailable,
+			wantClass:            "conflict",
+			wantRetryable:        false,
+			wantStage:            runtimeUsageStageReserve,
+			wantClusterID:        "cluster-reserve-conflict",
+			wantMeter:            runtimeusage.MeterMemoryWriteRequests,
+			wantMessage:          "runtime usage unavailable",
+			wantUpstreamStatus:   http.StatusConflict,
+			wantErrorCode:        "operation_conflict",
+			wantAttemptCount:     1,
+			wantRetryDecision:    "terminal",
+			wantExhaustionReason: "contract_not_retryable",
+		},
+		{
+			name: "unknown reservation conflict",
+			err: newRuntimeUsageReservationResponseError(
+				t,
+				http.StatusConflict,
+				`{"code":"future_conflict","details":{"retryable":true}}`,
+			),
+			details: runtimeUsageReserveErrorDetails(&domain.AuthInfo{
+				ClusterID: "cluster-unknown-conflict",
+			}, runtimeusage.MeterMemoryRecallRequests),
+			wantStatus:           http.StatusServiceUnavailable,
+			wantClass:            "conflict",
+			wantRetryable:        false,
+			wantStage:            runtimeUsageStageReserve,
+			wantClusterID:        "cluster-unknown-conflict",
+			wantMeter:            runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:          "runtime usage unavailable",
+			wantUpstreamStatus:   http.StatusConflict,
+			wantErrorCode:        "unknown",
+			wantAttemptCount:     1,
+			wantRetryDecision:    "terminal",
+			wantExhaustionReason: "unrecognized_contract",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			var logBuf bytes.Buffer
 			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
 			server := &Server{logger: logger}
 			recorder := httptest.NewRecorder()
 			ctx := reqid.NewContext(context.Background(), "request-runtime-usage")
+			metricBefore := float64(0)
+			if tt.wantUpstreamStatus != 0 {
+				metricBefore = runtimeUsageReservationFailureMetric(t, tt)
+			}
 
 			server.handleRuntimeUsageError(ctx, recorder, tt.err, tt.details)
+			if tt.wantUpstreamStatus != 0 {
+				if metricAfter := runtimeUsageReservationFailureMetric(t, tt); metricAfter != metricBefore+1 {
+					t.Fatalf("reservation failure metric = %v, want %v", metricAfter, metricBefore+1)
+				}
+			}
 
 			if recorder.Code != tt.wantStatus {
 				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)
@@ -381,6 +476,19 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 				t.Fatalf("mapped_status = %v, want field omitted", entry["mapped_status"])
 			}
 			assertRuntimeUsageLogField(t, entry, "retryable", tt.wantRetryable)
+			if tt.wantUpstreamStatus != 0 {
+				assertRuntimeUsageLogField(t, entry, "upstream_status", float64(tt.wantUpstreamStatus))
+				assertRuntimeUsageLogField(t, entry, "error_code", tt.wantErrorCode)
+				assertRuntimeUsageLogField(t, entry, "attempt_count", float64(tt.wantAttemptCount))
+				assertRuntimeUsageLogField(t, entry, "retry_decision", tt.wantRetryDecision)
+				if tt.wantExhaustionReason == "" {
+					if _, ok := entry["exhaustion_reason"]; ok {
+						t.Fatalf("exhaustion_reason = %v, want field omitted", entry["exhaustion_reason"])
+					}
+				} else {
+					assertRuntimeUsageLogField(t, entry, "exhaustion_reason", tt.wantExhaustionReason)
+				}
+			}
 			assertRuntimeUsageLogField(t, entry, "cluster_id", tt.wantClusterID)
 			assertRuntimeUsageLogField(t, entry, "meter", tt.wantMeter)
 			if tt.wantOperation == "" {
@@ -397,10 +505,55 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 	}
 }
 
-func newRuntimeUsageReservationResponseError(t *testing.T, status int, body string) error {
+func runtimeUsageReservationFailureMetric(t *testing.T, tt struct {
+	name                 string
+	err                  error
+	details              runtimeUsageErrorDetails
+	wantStatus           int
+	wantClass            string
+	wantRetryable        bool
+	wantStage            string
+	wantClusterID        string
+	wantMeter            string
+	wantOperation        string
+	wantMessage          string
+	wantRetryAfter       string
+	wantUpstreamStatus   int
+	wantErrorCode        string
+	wantAttemptCount     int
+	wantRetryDecision    string
+	wantExhaustionReason string
+}) float64 {
+	t.Helper()
+	counter, err := metrics.RuntimeUsageReservationFailuresTotal.GetMetricWithLabelValues(
+		strconv.Itoa(tt.wantUpstreamStatus),
+		tt.wantErrorCode,
+		tt.wantRetryDecision,
+		strconv.Itoa(tt.wantAttemptCount),
+		tt.wantExhaustionReason,
+		strconv.Itoa(tt.wantStatus),
+	)
+	if err != nil {
+		t.Fatalf("get runtime usage reservation failure metric: %v", err)
+	}
+	metric, ok := counter.(interface{ Write(*dto.Metric) error })
+	if !ok {
+		t.Fatal("runtime usage reservation failure metric does not implement Write")
+	}
+	var pb dto.Metric
+	if err := metric.Write(&pb); err != nil {
+		t.Fatalf("write runtime usage reservation failure metric: %v", err)
+	}
+	return pb.GetCounter().GetValue()
+}
+
+func newRuntimeUsageReservationResponseError(t *testing.T, status int, body string, retryAfter ...string) error {
 	t.Helper()
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if len(retryAfter) > 0 {
+			w.Header().Set("Retry-After", retryAfter[0])
+		}
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(body))
 	}))
@@ -413,6 +566,28 @@ func newRuntimeUsageReservationResponseError(t *testing.T, status int, body stri
 	})
 	if err == nil {
 		t.Fatal("Reserve error = nil")
+	}
+	return err
+}
+
+func newExhaustedRuntimeUsageReservationResponseError(t *testing.T, status int, body string) error {
+	t.Helper()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	client := runtimeusage.NewHTTPClient(upstream.URL, "test-secret", time.Second)
+	manager := runtimeusage.NewManager(runtimeusage.Config{
+		Enabled:                   true,
+		ReservationRetryBaseDelay: time.Nanosecond,
+		ReservationRetryMaxDelay:  time.Nanosecond,
+	}, client, nil, slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+	lease, err := manager.BeforeRecall(context.Background(), runtimeusage.Subject{APIKeySubject: "test-subject"})
+	if err == nil || lease != nil {
+		t.Fatalf("BeforeRecall = (%v, %v), want exhausted failure", lease, err)
 	}
 	return err
 }

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -272,17 +272,6 @@ var (
 		[]string{"phase"},
 	)
 
-	// RuntimeUsageReservationFailuresTotal counts fail-closed Reservation
-	// responses using bounded provider-contract and public-mapping labels.
-	RuntimeUsageReservationFailuresTotal = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "mnemo",
-			Name:      "runtime_usage_reservation_failures_total",
-			Help:      "Fail-closed runtime usage Reservation failures by bounded contract outcome.",
-		},
-		[]string{"upstream_status", "error_code", "retry_decision", "attempt_count", "exhaustion_reason", "public_status"},
-	)
-
 	// RuntimeUsageMeteringDeliveryFailedTotal counts runtime usage service
 	// metering events that reached a terminal failed state.
 	RuntimeUsageMeteringDeliveryFailedTotal = promauto.NewCounterVec(

--- a/server/internal/metrics/metrics.go
+++ b/server/internal/metrics/metrics.go
@@ -272,6 +272,17 @@ var (
 		[]string{"phase"},
 	)
 
+	// RuntimeUsageReservationFailuresTotal counts fail-closed Reservation
+	// responses using bounded provider-contract and public-mapping labels.
+	RuntimeUsageReservationFailuresTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "mnemo",
+			Name:      "runtime_usage_reservation_failures_total",
+			Help:      "Fail-closed runtime usage Reservation failures by bounded contract outcome.",
+		},
+		[]string{"upstream_status", "error_code", "retry_decision", "attempt_count", "exhaustion_reason", "public_status"},
+	)
+
 	// RuntimeUsageMeteringDeliveryFailedTotal counts runtime usage service
 	// metering events that reached a terminal failed state.
 	RuntimeUsageMeteringDeliveryFailedTotal = promauto.NewCounterVec(

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -118,15 +118,15 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		return &UnavailableError{Err: err}
 	}
 
-	if classifyQuotaStatuses {
-		if reservationErr := classifyReservationError(resp.StatusCode, respBody, resp.Header.Get("Retry-After")); reservationErr != nil {
-			return reservationErr
-		}
-	}
+	// Quota detail shape is a fail-closed product denial even when a provider
+	// also supplies a code that overlaps the Reservation retry contract.
 	if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
 		return newQuotaDeniedError(resp, respBody)
 	}
 	if classifyQuotaStatuses {
+		if reservationErr := classifyReservationError(resp.StatusCode, respBody, resp.Header.Get("Retry-After")); reservationErr != nil {
+			return reservationErr
+		}
 		if reservationErr := newUnknownReservationResponseError(resp); reservationErr != nil {
 			return reservationErr
 		}

--- a/server/internal/runtimeusage/client.go
+++ b/server/internal/runtimeusage/client.go
@@ -104,6 +104,11 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
 			return newQuotaDeniedError(resp, nil)
 		}
+		if classifyQuotaStatuses {
+			if reservationErr := newUnknownReservationResponseError(resp); reservationErr != nil {
+				return reservationErr
+			}
+		}
 		if resp.StatusCode == http.StatusConflict {
 			return newConflictError(resp, nil)
 		}
@@ -121,6 +126,11 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 	if classifyQuotaStatuses && isRuntimeQuotaDenialResponse(resp.StatusCode, respBody) {
 		return newQuotaDeniedError(resp, respBody)
 	}
+	if classifyQuotaStatuses {
+		if reservationErr := newUnknownReservationResponseError(resp); reservationErr != nil {
+			return reservationErr
+		}
+	}
 	if resp.StatusCode == http.StatusConflict {
 		return newConflictError(resp, respBody)
 	}
@@ -133,6 +143,24 @@ func (c *HTTPClient) doJSON(ctx context.Context, method, path string, subject Su
 		}
 	}
 	return nil
+}
+
+func newUnknownReservationResponseError(resp *http.Response) error {
+	if resp == nil {
+		return nil
+	}
+	switch resp.StatusCode {
+	case http.StatusConflict:
+		return newReservationStatusError(resp.StatusCode, 0, newConflictError(resp, nil))
+	case http.StatusTooManyRequests:
+		return newReservationStatusError(
+			resp.StatusCode,
+			parseRetryAfter(resp.Header.Get("Retry-After")),
+			&UnavailableError{Err: fmt.Errorf("runtime usage service returned status %d", resp.StatusCode)},
+		)
+	default:
+		return nil
+	}
 }
 
 func newQuotaDeniedError(resp *http.Response, body []byte) *QuotaDeniedError {
@@ -170,7 +198,7 @@ func classifyReservationError(status int, body []byte, retryAfterHeader string) 
 	}
 
 	retryAfter := parseRetryAfter(retryAfterHeader)
-	if envelope.Code == reservationErrorCodeConcurrencyLimited && retryAfter == 0 {
+	if policy.statusCode == http.StatusTooManyRequests && retryAfter == 0 {
 		return nil
 	}
 	return newReservationError(envelope.Code, true, retryAfter)

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -28,7 +28,8 @@ type reservationContractCase struct {
 
 var reservationContractCases = []reservationContractCase{
 	{name: "registry conflict", code: reservationErrorCodeRegistryConflict, status: http.StatusConflict},
-	{name: "operation in progress", code: reservationErrorCodeOperationInProgress, status: http.StatusConflict},
+	{name: "operation in progress", code: reservationErrorCodeOperationInProgress, status: http.StatusTooManyRequests, retryAfter: "1"},
+	{name: "registry busy", code: reservationErrorCodeRegistryBusy, status: http.StatusTooManyRequests, retryAfter: "1"},
 	{name: "concurrency limited", code: reservationErrorCodeConcurrencyLimited, status: http.StatusTooManyRequests, retryAfter: "1"},
 	{name: "unavailable", code: reservationErrorCodeUnavailable, status: http.StatusServiceUnavailable},
 	{name: "operation conflict", code: reservationErrorCodeOperationConflict, status: http.StatusConflict},
@@ -329,7 +330,7 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 	}
 }
 
-func TestHTTPClientReserveTreatsGenericRateLimitAsUnavailable(t *testing.T) {
+func TestHTTPClientReserveMapsGenericRateLimitToPublicRateLimit(t *testing.T) {
 	tests := []struct {
 		name   string
 		body   string
@@ -376,6 +377,9 @@ func TestHTTPClientReserveTreatsGenericRateLimitAsUnavailable(t *testing.T) {
 			if !errors.As(err, &unavailable) {
 				t.Fatalf("Reserve error = %T, want UnavailableError", err)
 			}
+			if got := HTTPStatus(err); got != http.StatusTooManyRequests {
+				t.Fatalf("HTTPStatus = %d, want %d", got, http.StatusTooManyRequests)
+			}
 		})
 	}
 }
@@ -397,7 +401,7 @@ func TestHTTPClientReserveClassifiesStructuredReservationErrors(t *testing.T) {
 				t.Fatalf("Retryable = %v, want %v", reservationErr.retryable, wantRetryable)
 			}
 			wantRetryAfter := time.Duration(0)
-			if tt.code == reservationErrorCodeConcurrencyLimited {
+			if tt.status == http.StatusTooManyRequests {
 				wantRetryAfter = time.Second
 			}
 			if reservationErr.retryAfter != wantRetryAfter {
@@ -408,11 +412,18 @@ func TestHTTPClientReserveClassifiesStructuredReservationErrors(t *testing.T) {
 			if got := errors.As(err, &conflict); got != wantConflict {
 				t.Fatalf("ConflictError classification = %v, want %v", got, wantConflict)
 			}
+			wantStatus := http.StatusServiceUnavailable
+			if tt.status == http.StatusTooManyRequests {
+				wantStatus = http.StatusTooManyRequests
+			}
+			if got := HTTPStatus(err); got != wantStatus {
+				t.Fatalf("HTTPStatus = %d, want %d", got, wantStatus)
+			}
 		})
 	}
 }
 
-func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.T) {
+func TestHTTPClientReserveRetryableRateLimitsRequirePositiveRetryAfter(t *testing.T) {
 	tests := []struct {
 		name           string
 		retryAfter     string
@@ -429,33 +440,39 @@ func TestHTTPClientReserveConcurrencyLimitRequiresPositiveRetryAfter(t *testing.
 		{name: "positive integer seconds", retryAfter: "2", wantStructured: true, wantRetryAfter: 2 * time.Second},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
-			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
-				return statusJSONResponse(
-					http.StatusTooManyRequests,
-					`{"code":"reservation_concurrency_limited","message":"admission is busy","details":{"retryable":true}}`,
-					http.Header{"Retry-After": []string{tt.retryAfter}},
-				), nil
-			})}
+	for _, code := range []reservationErrorCode{
+		reservationErrorCodeOperationInProgress,
+		reservationErrorCodeRegistryBusy,
+		reservationErrorCodeConcurrencyLimited,
+	} {
+		for _, tt := range tests {
+			t.Run(string(code)+"/"+tt.name, func(t *testing.T) {
+				client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+				client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					return statusJSONResponse(
+						http.StatusTooManyRequests,
+						`{"code":"`+string(code)+`","message":"admission is busy","details":{"retryable":true}}`,
+						http.Header{"Retry-After": []string{tt.retryAfter}},
+					), nil
+				})}
 
-			_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-concurrency", Operation{
-				Meter: MeterMemoryRecallRequests,
-				Units: 1,
+				_, err := client.Reserve(context.Background(), Subject{APIKeySubject: "api-key-subject"}, "op-concurrency", Operation{
+					Meter: MeterMemoryRecallRequests,
+					Units: 1,
+				})
+				var reservationErr *reservationError
+				if got := errors.As(err, &reservationErr); got != tt.wantStructured {
+					t.Fatalf("structured reservation classification = %v, want %v", got, tt.wantStructured)
+				}
+				if !tt.wantStructured {
+					assertReservationFallbackForStatus(t, err, http.StatusTooManyRequests)
+					return
+				}
+				if reservationErr.retryAfter != tt.wantRetryAfter {
+					t.Fatalf("RetryAfter = %v, want %v", reservationErr.retryAfter, tt.wantRetryAfter)
+				}
 			})
-			var reservationErr *reservationError
-			if got := errors.As(err, &reservationErr); got != tt.wantStructured {
-				t.Fatalf("structured reservation classification = %v, want %v", got, tt.wantStructured)
-			}
-			if !tt.wantStructured {
-				assertReservationFallbackForStatus(t, err, http.StatusTooManyRequests)
-				return
-			}
-			if reservationErr.retryAfter != tt.wantRetryAfter {
-				t.Fatalf("RetryAfter = %v, want %v", reservationErr.retryAfter, tt.wantRetryAfter)
-			}
-		})
+		}
 	}
 }
 
@@ -583,13 +600,17 @@ func assertReservationFallbackForStatus(t *testing.T, err error, status int) {
 	t.Helper()
 	if status == http.StatusConflict {
 		var conflict *ConflictError
-		if !errors.As(err, &conflict) || HTTPStatus(err) != http.StatusBadGateway {
-			t.Fatal("generic 409 did not preserve the legacy conflict fallback")
+		if !errors.As(err, &conflict) || HTTPStatus(err) != http.StatusServiceUnavailable {
+			t.Fatal("generic 409 did not map to a public service-unavailable response")
 		}
 		return
 	}
 	var unavailable *UnavailableError
-	if !errors.As(err, &unavailable) || HTTPStatus(err) != http.StatusServiceUnavailable {
+	wantStatus := http.StatusServiceUnavailable
+	if status == http.StatusTooManyRequests {
+		wantStatus = http.StatusTooManyRequests
+	}
+	if !errors.As(err, &unavailable) || HTTPStatus(err) != wantStatus {
 		t.Fatal("generic non-conflict response did not preserve unavailable fallback")
 	}
 }

--- a/server/internal/runtimeusage/client_test.go
+++ b/server/internal/runtimeusage/client_test.go
@@ -36,6 +36,7 @@ var reservationContractCases = []reservationContractCase{
 }
 
 const postQuotaRateLimitBody = `{"code":"provider_post_quota_throttled","message":"Post-quota rate limit exceeded.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`
+const overlappingReservationQuotaBody = `{"code":"registry_busy","message":"Post-quota rate limit exceeded.","details":{"retryable":true,"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`
 
 func oversizedResponseWithPrefix(prefix string) string {
 	return prefix + strings.Repeat(" ", maxResponseBodyBytes+1-len(prefix))
@@ -295,6 +296,12 @@ func TestHTTPClientReserveClassifiesQuotaStatuses(t *testing.T) {
 			name:       "post quota rate limit",
 			status:     http.StatusTooManyRequests,
 			body:       `{"code":"provider_post_quota_throttled","message":"Post-quota rate limit exceeded.","details":{"meter":"memory_recall_requests","quotaGateResult":{"outcome":"rateLimited","mode":"postQuota","reason":"postQuotaRateLimitExceeded"}}}`,
+			retryAfter: "20",
+		},
+		{
+			name:       "quota shape takes precedence over reservation code",
+			status:     http.StatusTooManyRequests,
+			body:       overlappingReservationQuotaBody,
 			retryAfter: "20",
 		},
 	}

--- a/server/internal/runtimeusage/manager.go
+++ b/server/internal/runtimeusage/manager.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"net/http"
 	"strings"
 	"time"
 
@@ -287,6 +288,7 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 		var reservationErr *reservationError
 		if errors.As(err, &reservationErr) {
 			if reservationErr.code == reservationErrorCodeOperationConflict {
+				err = withFinalReservationDecision(err, attempt+1, reservationRetryDecisionTerminal, reservationExhaustionContractNotRetryable)
 				return nil, err
 			}
 			if reservationErr.ReservationRetryable() && attempt+1 < reservationMaxAttempts {
@@ -296,12 +298,19 @@ func (m *manager) reserve(ctx context.Context, subject Subject, meter string, un
 				}
 				continue
 			}
+			if reservationErr.ReservationRetryable() {
+				err = withFinalReservationDecision(err, attempt+1, reservationRetryDecisionExhausted, reservationExhaustionMaxAttempts)
+			} else {
+				err = withFinalReservationDecision(err, attempt+1, reservationRetryDecisionTerminal, reservationExhaustionContractNotRetryable)
+			}
 			break
 		}
 		var conflict *ConflictError
 		if errors.As(err, &conflict) {
+			err = withFinalReservationDecision(err, attempt+1, reservationRetryDecisionTerminal, reservationExhaustionUnrecognizedContract)
 			return nil, err
 		}
+		err = withFinalReservationDecision(err, attempt+1, reservationRetryDecisionTerminal, reservationExhaustionUnrecognizedContract)
 		break
 	}
 	if m.cfg.FailOpen {
@@ -333,7 +342,7 @@ func (m *manager) reservationRetryDelay(retry int, reservationErr *reservationEr
 	if width := int64(upper-minimum) + 1; width > 1 {
 		delay += time.Duration(m.randomInt64N(width))
 	}
-	if reservationErr.code == reservationErrorCodeConcurrencyLimited && reservationErr.retryAfter > delay {
+	if reservationErr.upstreamStatus == http.StatusTooManyRequests && reservationErr.retryAfter > delay {
 		return reservationErr.retryAfter
 	}
 	return delay

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -1606,6 +1606,36 @@ func TestManagerOversizedPostQuotaDenialPreservesFailOpenFence(t *testing.T) {
 	}
 }
 
+func TestManagerQuotaShapeTakesPrecedenceOverReservationCode(t *testing.T) {
+	attempts := 0
+	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+	client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		attempts++
+		return statusJSONResponse(
+			http.StatusTooManyRequests,
+			overlappingReservationQuotaBody,
+			http.Header{"Retry-After": []string{"20"}},
+		), nil
+	})}
+	runtimeManager := NewManager(Config{Enabled: true, FailOpen: true}, client, &captureWriter{}, nil)
+	runtimeManager.(*manager).wait = func(context.Context, time.Duration) error {
+		t.Fatal("quota denial entered retry delay")
+		return nil
+	}
+
+	lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+	var denied *QuotaDeniedError
+	if !errors.As(err, &denied) || denied.Status() != http.StatusTooManyRequests {
+		t.Fatalf("BeforeRecall error = %T, want post-quota denial", err)
+	}
+	if lease != nil {
+		t.Fatal("fail-open quota denial returned a lease")
+	}
+	if attempts != 1 {
+		t.Fatalf("Reservation attempts = %d, want 1", attempts)
+	}
+}
+
 func TestManagerOversizedConflictPreservesFailOpenFence(t *testing.T) {
 	attempts := 0
 	client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)

--- a/server/internal/runtimeusage/manager_test.go
+++ b/server/internal/runtimeusage/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -889,7 +890,7 @@ func TestManagerReservationRetriesKeepStableSerializedHTTPRequest(t *testing.T) 
 	}
 }
 
-func TestManagerReservationConcurrencyLimitUsesGreaterDelay(t *testing.T) {
+func TestManagerReservationRateLimitsUseGreaterDelay(t *testing.T) {
 	tests := []struct {
 		name       string
 		baseDelay  time.Duration
@@ -916,72 +917,83 @@ func TestManagerReservationConcurrencyLimitUsesGreaterDelay(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
+	for _, code := range []reservationErrorCode{
+		reservationErrorCodeOperationInProgress,
+		reservationErrorCodeRegistryBusy,
+		reservationErrorCodeConcurrencyLimited,
+	} {
+		for _, tt := range tests {
+			t.Run(string(code)+"/"+tt.name, func(t *testing.T) {
+				attempts := 0
+				client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+				client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+					attempts++
+					if attempts == 1 {
+						return statusJSONResponse(
+							http.StatusTooManyRequests,
+							`{"code":"`+string(code)+`","details":{"retryable":true}}`,
+							http.Header{"Retry-After": []string{tt.retryAfter}},
+						), nil
+					}
+					return jsonResponse(`{"status":"reserved"}`), nil
+				})}
+				runtimeManager := NewManager(Config{
+					Enabled:                   true,
+					ReservationRetryBaseDelay: tt.baseDelay,
+					ReservationRetryMaxDelay:  tt.maxDelay,
+				}, client, &captureWriter{}, nil)
+				concrete := runtimeManager.(*manager)
+				var delays []time.Duration
+				concrete.wait = func(_ context.Context, delay time.Duration) error {
+					delays = append(delays, delay)
+					return nil
+				}
+				concrete.randomInt64N = tt.random
+
+				lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+				if err != nil {
+					t.Fatalf("BeforeRecall: %v", err)
+				}
+				if lease == nil || !lease.Reserved {
+					t.Fatal("BeforeRecall returned no active reservation")
+				}
+				if attempts != 2 {
+					t.Fatalf("Reserve attempts = %d, want 2", attempts)
+				}
+				if len(delays) != 1 || delays[0] != tt.wantDelay {
+					t.Fatalf("retry delays = %v, want [%v]", delays, tt.wantDelay)
+				}
+			})
+		}
+	}
+}
+
+func TestManagerReservationRetriesEachAllowedCode(t *testing.T) {
+	for _, tt := range reservationContractCases {
+		contractPolicy, _ := tt.code.policy()
+		if !contractPolicy.retryable {
+			continue
+		}
 		t.Run(tt.name, func(t *testing.T) {
 			attempts := 0
-			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
-			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				attempts++
 				if attempts == 1 {
-					return statusJSONResponse(
-						http.StatusTooManyRequests,
-						`{"code":"reservation_concurrency_limited","details":{"retryable":true}}`,
-						http.Header{"Retry-After": []string{tt.retryAfter}},
-					), nil
+					writeReservationContractError(w, tt)
+					return
 				}
-				return jsonResponse(`{"status":"reserved"}`), nil
-			})}
-			runtimeManager := NewManager(Config{
-				Enabled:                   true,
-				ReservationRetryBaseDelay: tt.baseDelay,
-				ReservationRetryMaxDelay:  tt.maxDelay,
-			}, client, &captureWriter{}, nil)
+				_, _ = io.WriteString(w, `{"status":"reserved"}`)
+			}))
+			defer provider.Close()
+
+			client := NewHTTPClient(provider.URL, "secret", time.Second)
+			runtimeManager := NewManager(Config{Enabled: true}, client, &captureWriter{}, nil)
 			concrete := runtimeManager.(*manager)
 			var delays []time.Duration
 			concrete.wait = func(_ context.Context, delay time.Duration) error {
 				delays = append(delays, delay)
 				return nil
 			}
-			concrete.randomInt64N = tt.random
-
-			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
-			if err != nil {
-				t.Fatalf("BeforeRecall: %v", err)
-			}
-			if lease == nil || !lease.Reserved {
-				t.Fatal("BeforeRecall returned no active reservation")
-			}
-			if attempts != 2 {
-				t.Fatalf("Reserve attempts = %d, want 2", attempts)
-			}
-			if len(delays) != 1 || delays[0] != tt.wantDelay {
-				t.Fatalf("retry delays = %v, want [%v]", delays, tt.wantDelay)
-			}
-		})
-	}
-}
-
-func TestManagerReservationRetriesEachAllowedCode(t *testing.T) {
-	tests := []struct {
-		name       string
-		code       reservationErrorCode
-		retryAfter time.Duration
-	}{
-		{name: "registry conflict", code: reservationErrorCodeRegistryConflict},
-		{name: "operation in progress", code: reservationErrorCodeOperationInProgress},
-		{name: "reservation concurrency limited", code: reservationErrorCodeConcurrencyLimited, retryAfter: time.Second},
-		{name: "service unavailable", code: reservationErrorCodeUnavailable},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			quota := &fakeQuotaClient{reserveErrs: []error{
-				newReservationError(tt.code, true, tt.retryAfter),
-				nil,
-			}}
-			runtimeManager := NewManager(Config{Enabled: true}, quota, &captureWriter{}, nil)
-			concrete := runtimeManager.(*manager)
-			concrete.wait = func(context.Context, time.Duration) error { return nil }
 
 			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
 			if err != nil {
@@ -990,8 +1002,11 @@ func TestManagerReservationRetriesEachAllowedCode(t *testing.T) {
 			if lease == nil || !lease.Reserved {
 				t.Fatal("retryable reservation returned no active lease")
 			}
-			if len(quota.reserveOps) != 2 {
-				t.Fatalf("Reserve attempts = %d, want 2", len(quota.reserveOps))
+			if attempts != 2 {
+				t.Fatalf("Reserve attempts = %d, want 2", attempts)
+			}
+			if len(delays) != 1 {
+				t.Fatalf("retry delays = %d, want 1", len(delays))
 			}
 		})
 	}
@@ -1132,6 +1147,12 @@ func TestManagerDefaultReservationRetryJitterRanges(t *testing.T) {
 	}
 	if got := concrete.reservationRetryDelay(1, err); got != time.Second {
 		t.Fatalf("second retry upper bound = %v, want 1s", got)
+	}
+
+	conflictWithRetryAfter := newReservationError(reservationErrorCodeRegistryConflict, true, time.Hour)
+	concrete.randomInt64N = func(int64) int64 { return 0 }
+	if got := concrete.reservationRetryDelay(0, conflictWithRetryAfter); got != 500*time.Millisecond {
+		t.Fatalf("registry conflict retry delay = %v, want jitter-only 500ms", got)
 	}
 }
 
@@ -1306,7 +1327,7 @@ func TestManagerSuccessfulFinalizeBodyFailuresDoNotQueueRetry(t *testing.T) {
 }
 
 func TestManagerReservationRetryExhaustionAppliesDeploymentPolicy(t *testing.T) {
-	tests := []struct {
+	policies := []struct {
 		name     string
 		failOpen bool
 	}{
@@ -1314,39 +1335,148 @@ func TestManagerReservationRetryExhaustionAppliesDeploymentPolicy(t *testing.T) 
 		{name: "fail open", failOpen: true},
 	}
 
+	for _, contract := range reservationContractCases {
+		contractPolicy, _ := contract.code.policy()
+		if !contractPolicy.retryable {
+			continue
+		}
+		for _, policy := range policies {
+			t.Run(contract.name+"/"+policy.name, func(t *testing.T) {
+				attempts := 0
+				provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					attempts++
+					writeReservationContractError(w, contract)
+				}))
+				defer provider.Close()
+
+				client := NewHTTPClient(provider.URL, "secret", time.Second)
+				runtimeManager := NewManager(Config{Enabled: true, FailOpen: policy.failOpen}, client, &captureWriter{}, nil)
+				concrete := runtimeManager.(*manager)
+				var delays []time.Duration
+				concrete.wait = func(_ context.Context, delay time.Duration) error {
+					delays = append(delays, delay)
+					return nil
+				}
+
+				lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+				if policy.failOpen {
+					if err != nil {
+						t.Fatalf("BeforeRecall: %v", err)
+					}
+					if lease == nil || lease.Reserved {
+						t.Fatal("retry exhaustion returned an unexpected fail-open lease state")
+					}
+				} else {
+					var reservationErr *reservationError
+					if !errors.As(err, &reservationErr) {
+						t.Fatalf("BeforeRecall error = %T, want structured reservation error", err)
+					}
+					if lease != nil {
+						t.Fatal("fail-closed retry exhaustion returned a lease")
+					}
+					wantStatus := http.StatusServiceUnavailable
+					if contract.status == http.StatusTooManyRequests {
+						wantStatus = http.StatusTooManyRequests
+					}
+					if got := HTTPStatus(err); got != wantStatus {
+						t.Fatalf("HTTPStatus = %d, want %d", got, wantStatus)
+					}
+					details, ok := ReservationFailureDetails(err)
+					if !ok || details.UpstreamStatus != contract.status || details.Code != string(contract.code) || !details.Retryable || details.AttemptCount != reservationMaxAttempts || details.RetryDecision != string(reservationRetryDecisionExhausted) || details.ExhaustionReason != string(reservationExhaustionMaxAttempts) {
+						t.Fatalf("ReservationFailureDetails = %+v, %v", details, ok)
+					}
+				}
+				if attempts != reservationMaxAttempts {
+					t.Fatalf("Reserve attempts = %d, want %d", attempts, reservationMaxAttempts)
+				}
+				if len(delays) != reservationMaxAttempts-1 {
+					t.Fatalf("retry delays = %d, want %d", len(delays), reservationMaxAttempts-1)
+				}
+			})
+		}
+	}
+}
+
+func writeReservationContractError(w http.ResponseWriter, contract reservationContractCase) {
+	w.Header().Set("Content-Type", "application/json")
+	if contract.retryAfter != "" {
+		w.Header().Set("Retry-After", contract.retryAfter)
+	}
+	w.WriteHeader(contract.status)
+	_, _ = io.WriteString(w, `{"code":"`+string(contract.code)+`","details":{"retryable":true}}`)
+}
+
+func TestManagerUnknownReservationResponsesDoNotRetry(t *testing.T) {
+	tests := []struct {
+		name             string
+		status           int
+		body             string
+		retryAfter       string
+		failOpen         bool
+		wantPublicStatus int
+		wantFailOpen     bool
+	}{
+		{
+			name:             "old operation in progress conflict uses unknown conflict policy",
+			status:           http.StatusConflict,
+			body:             `{"code":"operation_in_progress","details":{"retryable":true}}`,
+			failOpen:         true,
+			wantPublicStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:             "unknown rate limit fails closed as rate limit",
+			status:           http.StatusTooManyRequests,
+			body:             `{"code":"future_rate_limit","details":{"retryable":true}}`,
+			retryAfter:       "2",
+			wantPublicStatus: http.StatusTooManyRequests,
+		},
+		{
+			name:         "unknown rate limit preserves fail open",
+			status:       http.StatusTooManyRequests,
+			body:         `{"code":"future_rate_limit","details":{"retryable":true}}`,
+			retryAfter:   "2",
+			failOpen:     true,
+			wantFailOpen: true,
+		},
+	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			quota := &fakeQuotaClient{reserveErr: newReservationError(reservationErrorCodeUnavailable, true, 0)}
-			runtimeManager := NewManager(Config{Enabled: true, FailOpen: tt.failOpen}, quota, &captureWriter{}, nil)
-			concrete := runtimeManager.(*manager)
-			var delays []time.Duration
-			concrete.wait = func(_ context.Context, delay time.Duration) error {
-				delays = append(delays, delay)
+			attempts := 0
+			client := NewHTTPClient("https://runtime-usage.example.com", "secret", time.Second)
+			client.client = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				attempts++
+				header := make(http.Header)
+				if tt.retryAfter != "" {
+					header.Set("Retry-After", tt.retryAfter)
+				}
+				return statusJSONResponse(tt.status, tt.body, header), nil
+			})}
+			concrete := NewManager(Config{Enabled: true, FailOpen: tt.failOpen}, client, &captureWriter{}, nil).(*manager)
+			concrete.wait = func(context.Context, time.Duration) error {
+				t.Fatal("unknown Reservation response entered retry delay")
 				return nil
 			}
 
-			lease, err := runtimeManager.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
-			if tt.failOpen {
-				if err != nil {
-					t.Fatalf("BeforeRecall: %v", err)
-				}
-				if lease == nil || lease.Reserved {
-					t.Fatal("retry exhaustion returned an unexpected fail-open lease state")
-				}
-			} else {
-				var reservationErr *reservationError
-				if !errors.As(err, &reservationErr) {
-					t.Fatalf("BeforeRecall error = %T, want structured reservation error", err)
-				}
-				if lease != nil {
-					t.Fatal("fail-closed retry exhaustion returned a lease")
-				}
+			lease, err := concrete.BeforeRecall(context.Background(), Subject{APIKeySubject: "api-key-subject"})
+			if attempts != 1 {
+				t.Fatalf("Reserve attempts = %d, want 1", attempts)
 			}
-			if len(quota.reserveOps) != reservationMaxAttempts {
-				t.Fatalf("Reserve attempts = %d, want %d", len(quota.reserveOps), reservationMaxAttempts)
+			if tt.wantFailOpen {
+				if err != nil || lease == nil || lease.Reserved {
+					t.Fatalf("fail-open result = (%v, %v), want unreserved lease", lease, err)
+				}
+				return
 			}
-			if len(delays) != reservationMaxAttempts-1 {
-				t.Fatalf("retry delays = %d, want %d", len(delays), reservationMaxAttempts-1)
+			if err == nil || lease != nil {
+				t.Fatalf("fail-closed result = (%v, %v), want error", lease, err)
+			}
+			if got := HTTPStatus(err); got != tt.wantPublicStatus {
+				t.Fatalf("HTTPStatus = %d, want %d", got, tt.wantPublicStatus)
+			}
+			details, ok := ReservationFailureDetails(err)
+			if !ok || details.Code != "unknown" || details.AttemptCount != 1 || details.RetryDecision != "terminal" || details.ExhaustionReason != "unrecognized_contract" {
+				t.Fatalf("ReservationFailureDetails = %+v, %v", details, ok)
 			}
 		})
 	}

--- a/server/internal/runtimeusage/reservation_error.go
+++ b/server/internal/runtimeusage/reservation_error.go
@@ -1,19 +1,39 @@
 package runtimeusage
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 )
 
 type reservationErrorCode string
 
 const (
+	reservationErrorCodeUnknown             reservationErrorCode = "unknown"
 	reservationErrorCodeRegistryConflict    reservationErrorCode = "registry_conflict"
 	reservationErrorCodeOperationInProgress reservationErrorCode = "operation_in_progress"
+	reservationErrorCodeRegistryBusy        reservationErrorCode = "registry_busy"
 	reservationErrorCodeConcurrencyLimited  reservationErrorCode = "reservation_concurrency_limited"
 	reservationErrorCodeUnavailable         reservationErrorCode = "unavailable"
 	reservationErrorCodeOperationConflict   reservationErrorCode = "operation_conflict"
+)
+
+type reservationRetryDecision string
+
+const (
+	reservationRetryDecisionRetryable reservationRetryDecision = "retryable"
+	reservationRetryDecisionTerminal  reservationRetryDecision = "terminal"
+	reservationRetryDecisionExhausted reservationRetryDecision = "exhausted"
+)
+
+type reservationExhaustionReason string
+
+const (
+	reservationExhaustionContractNotRetryable reservationExhaustionReason = "contract_not_retryable"
+	reservationExhaustionMaxAttempts          reservationExhaustionReason = "max_attempts"
+	reservationExhaustionUnrecognizedContract reservationExhaustionReason = "unrecognized_contract"
 )
 
 type reservationErrorPolicy struct {
@@ -23,9 +43,9 @@ type reservationErrorPolicy struct {
 
 func (c reservationErrorCode) policy() (reservationErrorPolicy, bool) {
 	switch c {
-	case reservationErrorCodeRegistryConflict, reservationErrorCodeOperationInProgress:
+	case reservationErrorCodeRegistryConflict:
 		return reservationErrorPolicy{statusCode: http.StatusConflict, retryable: true}, true
-	case reservationErrorCodeConcurrencyLimited:
+	case reservationErrorCodeOperationInProgress, reservationErrorCodeRegistryBusy, reservationErrorCodeConcurrencyLimited:
 		return reservationErrorPolicy{statusCode: http.StatusTooManyRequests, retryable: true}, true
 	case reservationErrorCodeUnavailable:
 		return reservationErrorPolicy{statusCode: http.StatusServiceUnavailable, retryable: true}, true
@@ -36,24 +56,59 @@ func (c reservationErrorCode) policy() (reservationErrorPolicy, bool) {
 	}
 }
 
+type reservationFailureState struct {
+	code           reservationErrorCode
+	upstreamStatus int
+	retryable      bool
+	retryAfter     time.Duration
+	terminalReason reservationExhaustionReason
+}
+
+func (s reservationFailureState) publicHTTPStatus() int {
+	if s.upstreamStatus == http.StatusTooManyRequests {
+		return http.StatusTooManyRequests
+	}
+	return http.StatusServiceUnavailable
+}
+
+func (s reservationFailureState) details() ReservationFailure {
+	decision := reservationRetryDecisionRetryable
+	exhaustion := reservationExhaustionReason("")
+	if !s.retryable {
+		decision = reservationRetryDecisionTerminal
+		exhaustion = s.terminalReason
+	}
+	return ReservationFailure{
+		UpstreamStatus:   s.upstreamStatus,
+		Code:             string(s.code),
+		Retryable:        s.retryable,
+		RetryAfter:       retryAfterSeconds(s.retryAfter),
+		AttemptCount:     1,
+		RetryDecision:    string(decision),
+		ExhaustionReason: string(exhaustion),
+	}
+}
+
 type reservationError struct {
-	code       reservationErrorCode
-	retryable  bool
-	retryAfter time.Duration
-	cause      error
+	reservationFailureState
+	cause error
 }
 
 func newReservationError(code reservationErrorCode, retryable bool, retryAfter time.Duration) *reservationError {
+	policy, known := code.policy()
 	var cause error = &UnavailableError{}
 	if code == reservationErrorCodeOperationConflict {
-		policy, _ := code.policy()
 		cause = &ConflictError{StatusCode: policy.statusCode}
 	}
 	return &reservationError{
-		code:       code,
-		retryable:  retryable,
-		retryAfter: retryAfter,
-		cause:      cause,
+		reservationFailureState: reservationFailureState{
+			code:           code,
+			upstreamStatus: policy.statusCode,
+			retryable:      retryable && known && policy.retryable,
+			retryAfter:     retryAfter,
+			terminalReason: reservationExhaustionContractNotRetryable,
+		},
+		cause: cause,
 	}
 }
 
@@ -72,9 +127,119 @@ func (e *reservationError) Unwrap() error {
 }
 
 func (e *reservationError) ReservationRetryable() bool {
-	if e == nil || !e.retryable {
-		return false
+	return e != nil && e.retryable
+}
+
+func (e *reservationError) publicHTTPStatus() int {
+	if e == nil {
+		return http.StatusServiceUnavailable
 	}
-	policy, known := e.code.policy()
-	return known && policy.retryable
+	return e.reservationFailureState.publicHTTPStatus()
+}
+
+func (e *reservationError) reservationFailureDetails() ReservationFailure {
+	if e == nil {
+		return ReservationFailure{}
+	}
+	return e.reservationFailureState.details()
+}
+
+type reservationStatusError struct {
+	reservationFailureState
+	cause error
+}
+
+func newReservationStatusError(status int, retryAfter time.Duration, cause error) *reservationStatusError {
+	return &reservationStatusError{
+		reservationFailureState: reservationFailureState{
+			code:           reservationErrorCodeUnknown,
+			upstreamStatus: status,
+			retryAfter:     retryAfter,
+			terminalReason: reservationExhaustionUnrecognizedContract,
+		},
+		cause: cause,
+	}
+}
+
+func (e *reservationStatusError) Error() string {
+	if e == nil {
+		return "runtime usage reservation failed"
+	}
+	return fmt.Sprintf("runtime usage reservation failed: upstream status %d", e.upstreamStatus)
+}
+
+func (e *reservationStatusError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *reservationStatusError) publicHTTPStatus() int {
+	if e == nil {
+		return http.StatusServiceUnavailable
+	}
+	return e.reservationFailureState.publicHTTPStatus()
+}
+
+func (e *reservationStatusError) reservationFailureDetails() ReservationFailure {
+	if e == nil {
+		return ReservationFailure{}
+	}
+	return e.reservationFailureState.details()
+}
+
+// ReservationFailure describes the bounded provider-contract outcome exposed to handlers and metrics.
+type ReservationFailure struct {
+	UpstreamStatus   int
+	Code             string
+	Retryable        bool
+	RetryAfter       string
+	AttemptCount     int
+	RetryDecision    string
+	ExhaustionReason string
+}
+
+// ReservationFailureDetails returns bounded Reservation metadata when err came from the Reserve path.
+func ReservationFailureDetails(err error) (ReservationFailure, bool) {
+	var failure interface {
+		reservationFailureDetails() ReservationFailure
+	}
+	if !errors.As(err, &failure) {
+		return ReservationFailure{}, false
+	}
+	return failure.reservationFailureDetails(), true
+}
+
+type finalReservationFailure struct {
+	cause   error
+	details ReservationFailure
+}
+
+func (e *finalReservationFailure) Error() string { return e.cause.Error() }
+func (e *finalReservationFailure) Unwrap() error { return e.cause }
+func (e *finalReservationFailure) reservationFailureDetails() ReservationFailure {
+	return e.details
+}
+
+func withFinalReservationDecision(err error, attemptCount int, decision reservationRetryDecision, exhaustion reservationExhaustionReason) error {
+	details, ok := ReservationFailureDetails(err)
+	if !ok {
+		return err
+	}
+	details.AttemptCount = attemptCount
+	details.RetryDecision = string(decision)
+	details.ExhaustionReason = string(exhaustion)
+	return &finalReservationFailure{cause: err, details: details}
+}
+
+func retryAfterSeconds(delay time.Duration) string {
+	if delay <= 0 {
+		return ""
+	}
+	seconds := int64(delay / time.Second)
+	if seconds <= 0 {
+		return ""
+	}
+	return strconv.FormatInt(seconds, 10)
 }

--- a/server/internal/runtimeusage/reservation_error.go
+++ b/server/internal/runtimeusage/reservation_error.go
@@ -189,7 +189,7 @@ func (e *reservationStatusError) reservationFailureDetails() ReservationFailure 
 	return e.reservationFailureState.details()
 }
 
-// ReservationFailure describes the bounded provider-contract outcome exposed to handlers and metrics.
+// ReservationFailure describes the bounded provider-contract outcome exposed to handlers and structured logs.
 type ReservationFailure struct {
 	UpstreamStatus   int
 	Code             string

--- a/server/internal/runtimeusage/types.go
+++ b/server/internal/runtimeusage/types.go
@@ -426,6 +426,12 @@ func HTTPStatus(err error) int {
 	if errors.As(err, &denied) {
 		return denied.Status()
 	}
+	var reservationFailure interface {
+		publicHTTPStatus() int
+	}
+	if errors.As(err, &reservationFailure) {
+		return reservationFailure.publicHTTPStatus()
+	}
 	var conflict *ConflictError
 	if errors.As(err, &conflict) {
 		return http.StatusBadGateway


### PR DESCRIPTION
## Summary

- recognize the revised retryable Reservation status/code pairs and require valid retry metadata
- preserve public 429 throttling and normalize Reservation 409 outcomes to public 503 in fail-closed mode
- preserve quota-shaped product-denial precedence when Reservation metadata overlaps
- add bounded Reservation structured logs plus real provider-wire tests for retry, exhaustion, fail-open, Recall, and Write boundaries

## Scope and impact

- applies only to synchronous Reserve handling before Recall or Write tenant work starts
- preserves quota-shaped 402/429 denials, caller cancellation, stable retry identity, Finalize, Metering, outbox, and manual reconciliation behavior
- keeps existing HTTP request metrics authoritative for final consumer impact; Runtime Usage provider health and contention metrics remain provider-owned
- introduces no schema, migration, required configuration, retry-count, or timeout change
- rollout remains gated on the configured Runtime Usage provider supporting the revised contract

## Verification

- `go test -race -count=1 ./internal/runtimeusage ./internal/handler`
- `make vet`
- `make test`
- Standards review: PASS, 0 findings
- Spec review against #448: PASS, 0 findings
- Integration blast-radius review: PASS, 0 findings
- Test-adequacy review: PASS, 0 findings

Closes #448
