### PR TITLE
Add configurable assistant fact extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Minimal runtime config is `MNEMO_DSN`. Everything else is optional or only appli
 | `MNEMO_LLM_MODEL` | No | `gpt-4o-mini` | LLM model for smart ingest |
 | `MNEMO_LLM_TEMPERATURE` | No | `0.1` | LLM temperature for smart ingest |
 | `MNEMO_INGEST_MODE` | No | `smart` | Ingest mode: `smart` or `raw` |
+| `MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT` | No | `false` | Include durable facts asserted in assistant turns during smart ingest; system and tool turns remain excluded |
 | `MNEMO_DISABLE_SESSION_SAVE` | No | `false` | Disable raw session row persistence for message ingest while still extracting and reconciling facts |
 | `MNEMO_FTS_ENABLED` | No | `false` | Enable TiDB full-text search path. Only set this on clusters that support TiDB FTS |
 

--- a/docs/design/smart-memory-pipeline-proposal.md
+++ b/docs/design/smart-memory-pipeline-proposal.md
@@ -492,6 +492,10 @@ Phase 2 prompt uses integer IDs (0, 1, 2...) mapped to real UUIDs server-side. I
 
 ### 11.1 Phase 1a: Fact Extraction Prompt
 
+Runtime defaults to extracting facts only from user turns. Set
+`MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT=true` to also admit concrete, durable
+facts asserted in assistant turns; system and tool turns remain excluded.
+
 **System prompt:**
 
 ```
@@ -909,6 +913,7 @@ New server environment variables:
 | `MNEMO_LLM_BASE_URL` | No | `https://api.openai.com/v1` | LLM endpoint |
 | `MNEMO_LLM_MODEL` | No | `gpt-4o-mini` | Model for extraction/reconciliation |
 | `MNEMO_INGEST_MODE` | No | `smart` | Default ingest mode |
+| `MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT` | No | `false` | Include durable assistant-turn facts during smart ingest |
 | `MNEMO_DIGEST_TTL_DAYS` | No | `30` | Days before digests auto-archive |
 
 **LLM is optional**: Without `MNEMO_LLM_API_KEY`, ingest falls back to `raw` mode (current behavior). This preserves backward compatibility.

--- a/server/cmd/mnemo-server/main.go
+++ b/server/cmd/mnemo-server/main.go
@@ -286,6 +286,7 @@ func main() {
 		WithWebhookService(webhookSvc).
 		WithActivityTracker(activityTracker).
 		WithDisableSessionSave(cfg.DisableSessionSave).
+		WithAssistantFactExtraction(cfg.FactExtractionIncludeAssistant).
 		WithRecallRequestBudget(cfg.RecallRequestTimeout, cfg.RecallResponseReserve)
 	router := srv.Router(tenantMW, rateMW, apiKeyMW, middleware.CORS(cfg.CORSAllowedOrigins))
 
@@ -315,6 +316,7 @@ func main() {
 		cfg.WorkerConcurrency,
 		encryptor,
 		activityTracker,
+		service.WithAssistantFactExtraction(cfg.FactExtractionIncludeAssistant),
 	)
 	go func() {
 		if err := uploadWorker.Run(workerCtx); err != nil {

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -40,6 +40,10 @@ type Config struct {
 	LLMTemperature float64
 	IngestMode     string
 
+	// FactExtractionIncludeAssistant allows smart ingest to extract durable facts
+	// from assistant turns in addition to user turns. Disabled by default.
+	FactExtractionIncludeAssistant bool
+
 	// DisableSessionSave skips raw session row persistence for message ingest.
 	// Smart ingest still extracts and reconciles facts into insight memories.
 	DisableSessionSave bool
@@ -214,6 +218,7 @@ func Load() (*Config, error) {
 		LLMModel:                         envOr("MNEMO_LLM_MODEL", "gpt-4o-mini"),
 		LLMTemperature:                   envFloat("MNEMO_LLM_TEMPERATURE", 0.1),
 		IngestMode:                       envOr("MNEMO_INGEST_MODE", "smart"),
+		FactExtractionIncludeAssistant:   envBool("MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT", false),
 		DisableSessionSave:               envBool("MNEMO_DISABLE_SESSION_SAVE", false),
 		TiDBZeroEnabled:                  envBool("MNEMO_TIDB_ZERO_ENABLED", true),
 		TiDBZeroAPIURL:                   envOr("MNEMO_TIDB_ZERO_API_URL", "https://zero.tidbapi.com/v1alpha1"),

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -118,6 +118,19 @@ func TestLoad_DisableSessionSave(t *testing.T) {
 	}
 }
 
+func TestLoad_FactExtractionIncludesAssistant(t *testing.T) {
+	t.Setenv("MNEMO_DSN", "test-dsn")
+	t.Setenv("MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT", "true")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.FactExtractionIncludeAssistant {
+		t.Fatal("FactExtractionIncludeAssistant = false, want true")
+	}
+}
+
 func TestLoad_TiDBCloudPrivateLinkConfig(t *testing.T) {
 	t.Setenv("MNEMO_DSN", "test-dsn")
 	t.Setenv("MNEMO_TIDBCLOUD_PREFER_PRIVATELINK", "true")

--- a/server/internal/handler/handler.go
+++ b/server/internal/handler/handler.go
@@ -49,6 +49,7 @@ type Server struct {
 	svcCache              sync.Map
 	chainRecallStopScore  float64
 	disableSessionSave    bool
+	includeAssistantFacts bool
 	recallRequestTimeout  time.Duration
 	recallResponseReserve time.Duration
 }
@@ -117,6 +118,11 @@ func (s *Server) WithDisableSessionSave(disabled bool) *Server {
 	return s
 }
 
+func (s *Server) WithAssistantFactExtraction(enabled bool) *Server {
+	s.includeAssistantFacts = enabled
+	return s
+}
+
 func (s *Server) WithRecallRequestBudget(timeout, responseReserve time.Duration) *Server {
 	s.recallRequestTimeout = timeout
 	s.recallResponseReserve = responseReserve
@@ -143,9 +149,10 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 		schemaReady := s.ensureTenantRuntimeSchema(auth)
 		memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 		sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
+		ingestOption := service.WithAssistantFactExtraction(s.includeAssistantFacts)
 		svc := resolvedSvc{
-			memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-			ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+			memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode, ingestOption),
+			ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode, ingestOption),
 			session: service.NewSessionService(sessRepo, s.embedder, s.autoModel),
 		}
 		if !schemaReady {
@@ -161,9 +168,10 @@ func (s *Server) resolveServices(auth *domain.AuthInfo) resolvedSvc {
 	schemaReady := s.ensureTenantRuntimeSchema(auth)
 	memRepo := repository.NewMemoryRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
 	sessRepo := repository.NewSessionRepo(s.dbBackend, auth.TenantDB, s.autoModel, s.ftsEnabled, auth.ClusterID)
+	ingestOption := service.WithAssistantFactExtraction(s.includeAssistantFacts)
 	svc := resolvedSvc{
-		memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
-		ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode),
+		memory:  service.NewMemoryService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode, ingestOption),
+		ingest:  service.NewIngestService(memRepo, s.llmClient, s.embedder, s.autoModel, s.ingestMode, ingestOption),
 		session: service.NewSessionService(sessRepo, s.embedder, s.autoModel),
 	}
 	if !schemaReady {

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -112,11 +112,23 @@ type MemoryChange struct {
 
 // IngestService orchestrates the two-phase smart memory pipeline.
 type IngestService struct {
-	memories  repository.MemoryRepo
-	llm       *llm.Client
-	embedder  *embed.Embedder
-	autoModel string
-	mode      IngestMode
+	memories              repository.MemoryRepo
+	llm                   *llm.Client
+	embedder              *embed.Embedder
+	autoModel             string
+	mode                  IngestMode
+	includeAssistantFacts bool
+}
+
+// IngestOption configures smart ingest behavior.
+type IngestOption func(*IngestService)
+
+// WithAssistantFactExtraction includes assistant turns as eligible fact sources.
+// User turns remain eligible in both modes; system and tool turns never are.
+func WithAssistantFactExtraction(enabled bool) IngestOption {
+	return func(service *IngestService) {
+		service.includeAssistantFacts = enabled
+	}
 }
 
 // NewIngestService creates a new IngestService.
@@ -126,17 +138,24 @@ func NewIngestService(
 	embedder *embed.Embedder,
 	autoModel string,
 	defaultMode IngestMode,
+	options ...IngestOption,
 ) *IngestService {
 	if defaultMode == "" {
 		defaultMode = ModeSmart
 	}
-	return &IngestService{
+	service := &IngestService{
 		memories:  memories,
 		llm:       llmClient,
 		embedder:  embedder,
 		autoModel: autoModel,
 		mode:      defaultMode,
 	}
+	for _, option := range options {
+		if option != nil {
+			option(service)
+		}
+	}
+	return service
 }
 
 // Ingest runs the pipeline: extract facts from conversation, reconcile with existing memories.
@@ -200,7 +219,7 @@ func (s *IngestService) HasLLM() bool {
 
 // Phase1Result holds the output of ExtractPhase1.
 type Phase1Result struct {
-	Facts       []ExtractedFact // atomic facts extracted from user messages, each with LLM-assigned tags
+	Facts       []ExtractedFact // atomic facts extracted from eligible source messages, each with LLM-assigned tags
 	MessageTags [][]string      // per-message tags parallel to input messages; missing entries = []
 }
 
@@ -309,13 +328,18 @@ func hasSocialNarrativeCue(text string) bool {
 }
 
 type preparedExtractionInput struct {
-	messages        []IngestMessage
-	originalIndices []int
-	formatted       string
+	messages              []IngestMessage
+	originalIndices       []int
+	formatted             string
+	includeAssistantFacts bool
 }
 
 func prepareExtractionInput(messages []IngestMessage, maxConversationRunes int) preparedExtractionInput {
-	input := preparedExtractionInput{}
+	return prepareExtractionInputWithPolicy(messages, maxConversationRunes, false)
+}
+
+func prepareExtractionInputWithPolicy(messages []IngestMessage, maxConversationRunes int, includeAssistantFacts bool) preparedExtractionInput {
+	input := preparedExtractionInput{includeAssistantFacts: includeAssistantFacts}
 	for idx, msg := range messages {
 		content := strings.TrimSpace(msg.Content)
 		if content == "" {
@@ -336,7 +360,22 @@ func prepareExtractionInput(messages []IngestMessage, maxConversationRunes int) 
 }
 
 func prepareExtractionInputFromConversation(conversation string, maxConversationRunes int) preparedExtractionInput {
-	return prepareExtractionInput(parseConversationMessages(conversation), maxConversationRunes)
+	return prepareExtractionInputFromConversationWithPolicy(conversation, maxConversationRunes, false)
+}
+
+func prepareExtractionInputFromConversationWithPolicy(conversation string, maxConversationRunes int, includeAssistantFacts bool) preparedExtractionInput {
+	return prepareExtractionInputWithPolicy(parseConversationMessages(conversation), maxConversationRunes, includeAssistantFacts)
+}
+
+func factSourceRoleAllowed(role string, includeAssistantFacts bool) bool {
+	switch strings.ToLower(strings.TrimSpace(role)) {
+	case "user":
+		return true
+	case "assistant":
+		return includeAssistantFacts
+	default:
+		return false
+	}
 }
 
 func parseConversationMessages(conversation string) []IngestMessage {
@@ -472,6 +511,17 @@ This extends the surrounding output schema only by adding optional "route_target
 If the surrounding output schema includes "message_tags", keep returning it unchanged.`, string(targetsJSON))
 }
 
+func factExtractionSourceRule(includeAssistantFacts bool) string {
+	if !includeAssistantFacts {
+		return "1. Extract facts ONLY from the user's messages. Ignore assistant, system, and tool messages entirely."
+	}
+	return `1. Extract durable facts from both user and assistant messages. Ignore system and tool messages entirely.
+   Assistant messages are eligible only for concrete, durable assertions about the user's world,
+   ongoing projects, systems, decisions, or confirmed outcomes.
+   Do not extract assistant speculation, proposals, generic advice, questions, acknowledgements,
+   or self-referential chatter. Never infer personal facts about the user from an assistant statement alone.`
+}
+
 func normalizeReconciledTemporalContent(content string) (string, *TemporalMetadata) {
 	content = StripTemporalProjection(content)
 	return NormalizeStandaloneTemporalContent(content, time.Now())
@@ -488,7 +538,7 @@ func (s *IngestService) ExtractPhase1WithRouting(ctx context.Context, messages [
 		return &Phase1Result{}, nil
 	}
 
-	input := prepareExtractionInput(messages, maxExtractionConversationRunes)
+	input := prepareExtractionInputWithPolicy(messages, maxExtractionConversationRunes, s.includeAssistantFacts)
 	if input.formatted == "" {
 		return &Phase1Result{}, nil
 	}
@@ -781,7 +831,7 @@ func (s *IngestService) extractFactsWithRouting(ctx context.Context, conversatio
 	if s.llm == nil || conversation == "" {
 		return nil, nil
 	}
-	input := prepareExtractionInputFromConversation(conversation, maxExtractionConversationRunes)
+	input := prepareExtractionInputFromConversationWithPolicy(conversation, maxExtractionConversationRunes, s.includeAssistantFacts)
 	if input.formatted == "" {
 		return nil, nil
 	}
@@ -791,7 +841,7 @@ atomic facts from a conversation.
 
 ## Rules
 
-1. Extract facts ONLY from the user's messages. Ignore assistant and system messages entirely.
+` + factExtractionSourceRule(s.includeAssistantFacts) + `
 2. Each fact must be a single, self-contained statement (one idea per fact).
    Exception: when facts are semantically dependent (cause-effect, event-reason,
    condition-outcome, temporal dependency), keep them as ONE fact preserving the
@@ -805,13 +855,14 @@ atomic facts from a conversation.
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
    - Bad: "Knows some programming languages"
-4. Preserve the user's original language.
+4. Preserve the original language of the source message.
 5. Omit pure greetings, filler, and debugging chatter with no lasting value.
 6. Do NOT extract search queries or lookup questions as facts.
    If the user is asking the assistant to find, explain, or look something up
    ("who is X", "how do I Y", "what does Z mean", "X是谁", "如何做Y", "Z是什么意思"), omit it from the facts array entirely.
-   Only store what the user STATED about themselves, their work, or their world.
-   Heuristic: if the fact can only be known because the user asked, it is query_intent.
+   Only store what an eligible source message STATED about the user, their work, or their world.
+   Heuristic: the user's question itself is query_intent. Evaluate an eligible assistant answer
+   independently under Rule 1 instead of turning the question into a fact.
    If it reveals something stable about the user independently, it is a fact.
    Examples to skip (query_intent):
      - "User asked about the history of the Ming dynasty"
@@ -844,8 +895,8 @@ atomic facts from a conversation.
    because they contain today/yesterday/tomorrow, ate/had/went, or plans/will. If the
    statement describes a person, place, relationship, project, trip, event, or commitment
    that may be useful later, keep it as fact.
-9. Keep concerns, risks, and worries the user expresses about their work, systems, platforms, or ongoing operations,
-	 when they describe an ongoing condition rather than a one-off log line. These signals can have lasting value.
+9. Keep concrete concerns, risks, and worries stated in eligible messages about ongoing work,
+   systems, platforms, or operations when they describe a durable condition rather than a one-off log line.
    Examples to keep:
       - "小红书账号最近数据不好，担心可能被封号"
      - "The API keeps returning 500s, something might be broken upstream"
@@ -873,8 +924,8 @@ atomic facts from a conversation.
    - Good: "小强今天去彩排了"
    - Bad: "他今天去彩排了"
 13. Prefer returning a faithful, minimally rewritten fact over returning an empty array
-   when the user stated durable information.
-14. Return an empty facts array when the user's messages contain no retrievable durable
+   when an eligible source message stated durable information.
+14. Return an empty facts array when eligible source messages contain no retrievable durable
    information, such as pure greetings, acknowledgements, filler, short-lived state, or one-off logs.
 15. Assign 1-3 short lowercase tags to each extracted fact describing its topic or
    category. Examples: "tech", "personal", "preference", "work", "location", "habit",
@@ -963,7 +1014,7 @@ func (s *IngestService) extractFactsAndTags(ctx context.Context, conversation st
 }
 
 func (s *IngestService) extractFactsAndTagsWithRouting(ctx context.Context, conversation string, messageCount int, routingTargets []RoutingTarget) ([]ExtractedFact, [][]string, error) {
-	input := prepareExtractionInputFromConversation(conversation, maxExtractionConversationRunes)
+	input := prepareExtractionInputFromConversationWithPolicy(conversation, maxExtractionConversationRunes, s.includeAssistantFacts)
 	if input.formatted == "" {
 		return nil, normalizeMessageTags(nil, messageCount), nil
 	}
@@ -973,7 +1024,7 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
 
 ## Rules — facts
 
-1. Extract facts ONLY from the user's messages. Ignore assistant and system messages entirely.
+` + factExtractionSourceRule(s.includeAssistantFacts) + `
 2. Each fact must be a single, self-contained statement (one idea per fact).
    Exception: when facts are semantically dependent (cause-effect, event-reason,
    condition-outcome, temporal dependency), keep them as ONE fact preserving the
@@ -987,13 +1038,14 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
 3. Prefer specific details over vague summaries.
    - Good: "Uses Go 1.22 for backend services"
    - Bad: "Knows some programming languages"
-4. Preserve the user's original language.
+4. Preserve the original language of the source message.
 5. Omit pure greetings, filler, and debugging chatter with no lasting value.
 6. Do NOT extract search queries or lookup questions as facts.
    If the user is asking the assistant to find, explain, or look something up
    ("who is X", "how do I Y", "what does Z mean", "X是谁", "如何做Y", "Z是什么意思"), omit it from the facts array entirely.
-   Only store what the user STATED about themselves, their work, or their world.
-   Heuristic: if the fact can only be known because the user asked, it is query_intent.
+   Only store what an eligible source message STATED about the user, their work, or their world.
+   Heuristic: the user's question itself is query_intent. Evaluate an eligible assistant answer
+   independently under Rule 1 instead of turning the question into a fact.
    If it reveals something stable about the user independently, it is a fact.
    Examples to skip (query_intent):
      - "User asked about the history of the Ming dynasty"
@@ -1026,8 +1078,8 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
    because they contain today/yesterday/tomorrow, ate/had/went, or plans/will. If the
    statement describes a person, place, relationship, project, trip, event, or commitment
    that may be useful later, keep it as fact.
-9. Keep concerns, risks, and worries the user expresses about their work, systems, platforms, or ongoing operations,
-	 when they describe an ongoing condition rather than a one-off log line. These signals can have lasting value.
+9. Keep concrete concerns, risks, and worries stated in eligible messages about ongoing work,
+   systems, platforms, or operations when they describe a durable condition rather than a one-off log line.
    Examples to keep:
      - "小红书账号最近数据不好，担心可能被封号"
      - "The API keeps returning 500s, something might be broken upstream"
@@ -1055,8 +1107,8 @@ atomic facts from a conversation AND assign short descriptive tags to each messa
    - Good: "小强今天去彩排了"
    - Bad: "他今天去彩排了"
 13. Prefer returning a faithful, minimally rewritten fact over returning an empty array
-   when the user stated durable information.
-14. Return an empty facts array when the user's messages contain no retrievable durable
+   when an eligible source message stated durable information.
+14. Return an empty facts array when eligible source messages contain no retrievable durable
    information, such as pure greetings, acknowledgements, filler, short-lived state, or one-off logs.
 15. Assign 1-3 short lowercase tags to each extracted fact describing its topic or
    category. Examples: "tech", "personal", "preference", "work", "location", "habit",
@@ -1116,7 +1168,7 @@ Output: {"facts": [], "message_tags": [["fitness", "diet", "timeline"], ["answer
 Return ONLY valid JSON. No markdown fences, no explanation.
 
 The "facts" array must contain durable facts only. Return an empty array when all
-user content is non-durable, while still returning message_tags for every message.
+eligible source content is non-durable, while still returning message_tags for every message.
 
 {"facts": [{"text": "fact one", "tags": ["tag1", "tag2"], "fact_type": "fact"}], "message_tags": [["tag1", "tag2"], ["tag3"]]}`
 	systemPrompt += routingPromptSection(routingTargets)

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -145,6 +145,25 @@ func TestNormalizeTemporalFacts_ResolvesNextMonthAgainstTimestamp(t *testing.T) 
 	}
 }
 
+func TestNormalizeTemporalFacts_UsesAssistantTimestampWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInputWithPolicy([]IngestMessage{
+		{Role: "user", Content: "When is the mem9 migration scheduled?"},
+		{Role: "assistant", Content: "[1:14 pm on 25 May, 2023] The mem9 migration is scheduled next month."},
+	}, maxExtractionConversationRunes, true)
+
+	got := normalizeTemporalFacts(input, []ExtractedFact{
+		{Text: "The mem9 migration is scheduled next month", Tags: []string{"work", "timeline"}},
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 fact, got %d", len(got))
+	}
+	if got[0].Text != "The mem9 migration is scheduled in June 2023" {
+		t.Fatalf("normalized fact = %q, want %q", got[0].Text, "The mem9 migration is scheduled in June 2023")
+	}
+}
+
 func TestNormalizeTemporalFacts_ResolvesLastYearAgainstTimestamp(t *testing.T) {
 	t.Parallel()
 
@@ -385,6 +404,69 @@ func TestExtractPhase1FactTagsPopulated(t *testing.T) {
 	}
 }
 
+func TestExtractPhase1IncludesAssistantFactsWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	var systemPrompt string
+	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Messages []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode llm request: %v", err)
+		}
+		if len(req.Messages) > 0 {
+			systemPrompt = req.Messages[0].Content
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{"message": map[string]string{"content": `{"facts": [{"text": "The mem9 Go API is the source of truth for memory data", "tags": ["architecture"]}], "message_tags": [["question"], ["architecture"]]}`}},
+			},
+		})
+	}))
+	defer mockLLM.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: mockLLM.URL, Model: "test-model"})
+	svc := NewIngestService(
+		&memoryRepoMock{},
+		llmClient,
+		nil,
+		"auto-model",
+		ModeSmart,
+		WithAssistantFactExtraction(true),
+	)
+
+	result, err := svc.ExtractPhase1(context.Background(), []IngestMessage{
+		{Role: "user", Content: "Which component is authoritative?", Seq: intPtr(10)},
+		{Role: "assistant", Content: "The mem9 Go API is the source of truth for memory data.", Seq: intPtr(11)},
+	})
+	if err != nil {
+		t.Fatalf("ExtractPhase1() error = %v", err)
+	}
+	if !strings.Contains(systemPrompt, "Extract durable facts from both user and assistant messages") {
+		t.Fatalf("assistant extraction rule missing from prompt:\n%s", systemPrompt)
+	}
+	if strings.Contains(systemPrompt, "Extract facts ONLY from the user's messages") {
+		t.Fatalf("user-only extraction rule should be disabled:\n%s", systemPrompt)
+	}
+	if len(result.Facts) != 1 {
+		t.Fatalf("expected 1 fact, got %d", len(result.Facts))
+	}
+	if !reflect.DeepEqual(result.Facts[0].SourceSeqs, []int{11}) {
+		t.Fatalf("source seqs = %v, want [11]", result.Facts[0].SourceSeqs)
+	}
+	if len(result.Facts[0].SourceTurns) != 1 {
+		t.Fatalf("source turns = %+v, want one assistant turn", result.Facts[0].SourceTurns)
+	}
+	turn := result.Facts[0].SourceTurns[0]
+	if turn.Seq != 11 || turn.Role != "assistant" || turn.Content != "The mem9 Go API is the source of truth for memory data." {
+		t.Fatalf("source turn = %+v, want assistant seq 11", turn)
+	}
+}
+
 func TestExtractPhase1WithoutRoutingOmitsRoutingPrompt(t *testing.T) {
 	var systemPrompt string
 	mockLLM := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -420,6 +502,12 @@ func TestExtractPhase1WithoutRoutingOmitsRoutingPrompt(t *testing.T) {
 	}
 	if strings.Contains(systemPrompt, "route_targets") {
 		t.Fatalf("route_targets should be omitted without routing targets")
+	}
+	if !strings.Contains(systemPrompt, "Extract facts ONLY from the user's messages") {
+		t.Fatalf("default extraction prompt must remain user-only:\n%s", systemPrompt)
+	}
+	if strings.Contains(systemPrompt, "Extract durable facts from both user and assistant messages") {
+		t.Fatalf("assistant extraction must remain opt-in:\n%s", systemPrompt)
 	}
 }
 

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -52,12 +52,12 @@ type memoryEmbeddingLookup interface {
 	GetEmbeddingsByID(ctx context.Context, ids []string) (map[string][]float32, error)
 }
 
-func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, embedder *embed.Embedder, autoModel string, ingestMode IngestMode) *MemoryService {
+func NewMemoryService(memories repository.MemoryRepo, llmClient *llm.Client, embedder *embed.Embedder, autoModel string, ingestMode IngestMode, ingestOptions ...IngestOption) *MemoryService {
 	return &MemoryService{
 		memories:  memories,
 		embedder:  embedder,
 		autoModel: autoModel,
-		ingest:    NewIngestService(memories, llmClient, embedder, autoModel, ingestMode),
+		ingest:    NewIngestService(memories, llmClient, embedder, autoModel, ingestMode, ingestOptions...),
 	}
 }
 

--- a/server/internal/service/search_source_turns.go
+++ b/server/internal/service/search_source_turns.go
@@ -186,7 +186,11 @@ func formatSearchMemoryWithSourceTurns(content string, turns []sourceTurnMetadat
 	}
 	parts := make([]string, 0, len(turns))
 	for _, turn := range turns {
-		parts = append(parts, turn.Content)
+		content := turn.Content
+		if turn.Role == "assistant" {
+			content = "Assistant: " + content
+		}
+		parts = append(parts, content)
 	}
 	return content + "\n[source-turns]\n" + strings.Join(parts, "\n")
 }

--- a/server/internal/service/search_source_turns_test.go
+++ b/server/internal/service/search_source_turns_test.go
@@ -9,6 +9,18 @@ import (
 	"github.com/qiffang/mnemos/server/internal/domain"
 )
 
+func TestFormatSearchMemoryWithSourceTurnsLabelsAssistant(t *testing.T) {
+	t.Parallel()
+
+	got := formatSearchMemoryWithSourceTurns("The API is authoritative", []sourceTurnMetadata{
+		{Seq: 2, Role: "assistant", Content: "The mem9 Go API is authoritative."},
+	})
+	want := "The API is authoritative\n[source-turns]\nAssistant: The mem9 Go API is authoritative."
+	if got != want {
+		t.Fatalf("formatted source turns = %q, want %q", got, want)
+	}
+}
+
 func withSearchEnv(t *testing.T, values map[string]string, fn func()) {
 	t.Helper()
 	previous := make(map[string]string, len(values))

--- a/server/internal/service/source_provenance.go
+++ b/server/internal/service/source_provenance.go
@@ -29,6 +29,7 @@ var sourceProvenanceStopwords = map[string]struct{}{
 
 type sourceTurnMetadata struct {
 	Seq     int    `json:"seq"`
+	Role    string `json:"role,omitempty"`
 	Content string `json:"content"`
 }
 
@@ -42,11 +43,11 @@ func annotateFactsWithSourceSeqs(input preparedExtractionInput, facts []Extracte
 		if len(out[i].SourceSeqs) > 0 {
 			out[i].SourceSeqs = normalizeSourceSeqs(out[i].SourceSeqs)
 		} else if strings.EqualFold(out[i].FactType, factTypeRawFallback) {
-			out[i].SourceSeqs = messageSourceSeqs(input.messages)
+			out[i].SourceSeqs = messageSourceSeqs(input.messages, input.includeAssistantFacts)
 		} else {
-			out[i].SourceSeqs = inferSourceSeqs(out[i].Text, input.messages)
+			out[i].SourceSeqs = inferSourceSeqs(out[i].Text, input.messages, input.includeAssistantFacts)
 		}
-		out[i].SourceTurns = sourceTurnsFromMessages(input.messages, out[i].SourceSeqs)
+		out[i].SourceTurns = sourceTurnsFromMessages(input.messages, out[i].SourceSeqs, input.includeAssistantFacts)
 	}
 	return out
 }
@@ -287,7 +288,7 @@ func sourceTurnsForReconcileText(text string, facts []ExtractedFact) []sourceTur
 	return normalizeSourceTurns(nil, turns)
 }
 
-func inferSourceSeqs(text string, messages []IngestMessage) []int {
+func inferSourceSeqs(text string, messages []IngestMessage, includeAssistantFacts bool) []int {
 	query := sourceTokenSet(text)
 	if len(query) == 0 {
 		return nil
@@ -300,7 +301,7 @@ func inferSourceSeqs(text string, messages []IngestMessage) []int {
 	var candidates []candidate
 	maxHits := 0
 	for _, msg := range messages {
-		if msg.Seq == nil || !strings.EqualFold(msg.Role, "user") {
+		if msg.Seq == nil || !factSourceRoleAllowed(msg.Role, includeAssistantFacts) {
 			continue
 		}
 		hits := countTokenOverlap(query, sourceTokenSet(msg.Content))
@@ -382,10 +383,10 @@ func countTokenOverlap(left, right map[string]struct{}) int {
 	return hits
 }
 
-func messageSourceSeqs(messages []IngestMessage) []int {
+func messageSourceSeqs(messages []IngestMessage, includeAssistantFacts bool) []int {
 	seqs := make([]int, 0, len(messages))
 	for _, msg := range messages {
-		if msg.Seq == nil || !strings.EqualFold(msg.Role, "user") {
+		if msg.Seq == nil || !factSourceRoleAllowed(msg.Role, includeAssistantFacts) {
 			continue
 		}
 		seqs = append(seqs, *msg.Seq)
@@ -396,33 +397,37 @@ func messageSourceSeqs(messages []IngestMessage) []int {
 	return normalizeSourceSeqs(seqs)
 }
 
-func sourceTurnsFromMessages(messages []IngestMessage, seqs []int) []sourceTurnMetadata {
+func sourceTurnsFromMessages(messages []IngestMessage, seqs []int, includeAssistantFacts bool) []sourceTurnMetadata {
 	seqs = normalizeSourceSeqs(seqs)
 	if len(seqs) == 0 {
 		return nil
 	}
-	contentsBySeq := make(map[int]string, len(messages))
+	turnsBySeq := make(map[int]sourceTurnMetadata, len(messages))
 	for _, msg := range messages {
-		if msg.Seq == nil || !strings.EqualFold(msg.Role, "user") {
+		if msg.Seq == nil || !factSourceRoleAllowed(msg.Role, includeAssistantFacts) {
 			continue
 		}
 		content := strings.TrimSpace(msg.Content)
 		if content == "" {
 			continue
 		}
-		if _, exists := contentsBySeq[*msg.Seq]; exists {
+		if _, exists := turnsBySeq[*msg.Seq]; exists {
 			continue
 		}
-		contentsBySeq[*msg.Seq] = content
+		role := ""
+		if strings.EqualFold(strings.TrimSpace(msg.Role), "assistant") {
+			role = "assistant"
+		}
+		turnsBySeq[*msg.Seq] = sourceTurnMetadata{Seq: *msg.Seq, Role: role, Content: content}
 	}
 
 	turns := make([]sourceTurnMetadata, 0, len(seqs))
 	for _, seq := range seqs {
-		content, ok := contentsBySeq[seq]
+		turn, ok := turnsBySeq[seq]
 		if !ok {
 			continue
 		}
-		turns = append(turns, sourceTurnMetadata{Seq: seq, Content: content})
+		turns = append(turns, turn)
 	}
 	return normalizeSourceTurns(seqs, turns)
 }
@@ -514,6 +519,11 @@ func normalizeSourceTurns(seqs []int, turns []sourceTurnMetadata) []sourceTurnMe
 		turn.Content = strings.TrimSpace(turn.Content)
 		if turn.Content == "" {
 			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(turn.Role), "assistant") {
+			turn.Role = "assistant"
+		} else {
+			turn.Role = ""
 		}
 		if _, ok := seen[turn.Seq]; ok {
 			continue

--- a/server/internal/service/temporal_fact.go
+++ b/server/internal/service/temporal_fact.go
@@ -221,7 +221,7 @@ func normalizeTemporalFacts(input preparedExtractionInput, facts []ExtractedFact
 }
 
 func normalizeTemporalFactsAt(input preparedExtractionInput, facts []ExtractedFact, now time.Time) []ExtractedFact {
-	anchors := buildTemporalAnchorCandidates(input.messages)
+	anchors := buildTemporalAnchorCandidates(input.messages, input.includeAssistantFacts)
 	out := make([]ExtractedFact, 0, len(facts))
 	for _, fact := range facts {
 		if strings.EqualFold(fact.FactType, factTypeQueryIntent) {
@@ -243,7 +243,7 @@ func normalizeRawFallbackFacts(input preparedExtractionInput, facts []ExtractedF
 }
 
 func normalizeRawFallbackFactsAt(input preparedExtractionInput, facts []ExtractedFact, now time.Time) []ExtractedFact {
-	anchors := buildTemporalAnchorCandidates(input.messages)
+	anchors := buildTemporalAnchorCandidates(input.messages, input.includeAssistantFacts)
 	out := make([]ExtractedFact, 0, len(facts))
 	for _, fact := range facts {
 		out = append(out, normalizeRawFallbackFact(fact, anchors, now))
@@ -298,10 +298,10 @@ func normalizeTemporalFactContent(text string, anchors []temporalAnchorCandidate
 	return cleaned, nil
 }
 
-func buildTemporalAnchorCandidates(messages []IngestMessage) []temporalAnchorCandidate {
+func buildTemporalAnchorCandidates(messages []IngestMessage, includeAssistantFacts bool) []temporalAnchorCandidate {
 	anchors := make([]temporalAnchorCandidate, 0, len(messages))
 	for _, msg := range messages {
-		if !strings.EqualFold(strings.TrimSpace(msg.Role), "user") {
+		if !factSourceRoleAllowed(msg.Role, includeAssistantFacts) {
 			continue
 		}
 		anchor, body, ok := extractTemporalAnchor(msg.Content)

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -114,6 +114,7 @@ type UploadWorker struct {
 	concurrency  int
 	encryptor    encrypt.Encryptor
 	activity     *ActivityTracker
+	ingestOpts   []IngestOption
 }
 
 // NewUploadWorker creates a new UploadWorker.
@@ -132,6 +133,7 @@ func NewUploadWorker(
 	concurrency int,
 	encryptor encrypt.Encryptor,
 	activity *ActivityTracker,
+	ingestOptions ...IngestOption,
 ) *UploadWorker {
 	if logger == nil {
 		logger = slog.Default()
@@ -155,6 +157,7 @@ func NewUploadWorker(
 		concurrency:  concurrency,
 		encryptor:    encryptor,
 		activity:     activity,
+		ingestOpts:   append([]IngestOption(nil), ingestOptions...),
 	}
 }
 
@@ -246,7 +249,7 @@ func (w *UploadWorker) processTask(ctx context.Context, task domain.UploadTask) 
 	}
 
 	memRepo := repository.NewMemoryRepo(w.pool.Backend(), db, w.autoModel, w.ftsEnabled, tenantInfo.ClusterID)
-	ingestSvc := NewIngestService(memRepo, w.llmClient, w.embedder, w.autoModel, w.mode)
+	ingestSvc := NewIngestService(memRepo, w.llmClient, w.embedder, w.autoModel, w.mode, w.ingestOpts...)
 
 	data, err := os.ReadFile(task.FilePath)
 	if err != nil {


### PR DESCRIPTION
## What changed

- Added the startup setting `MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT`, defaulting to `false`.
- Threaded the setting through HTTP smart ingest and asynchronous upload ingest.
- Updated both fact-extraction prompts so enabled instances admit concrete, durable assistant assertions while continuing to exclude system/tool turns, speculation, generic advice, questions, acknowledgements, and operational chatter.
- Extended source provenance and temporal-anchor handling for assistant turns, including an explicit assistant role in source-turn metadata and recall decorations.
- Documented the setting and added focused regression coverage.

## Why

Fact extraction previously hard-coded user-only behavior in both LLM prompts and in downstream source/temporal attribution. That is a safe default for personal memory, but it drops durable project decisions, confirmed outcomes, architecture facts, and other useful information that may appear only in an assistant response.

The new setting makes assistant extraction opt-in, preserving existing behavior for all current deployments.

## Impact

There is no API or database schema change. Existing deployments remain user-only. To enable assistant-turn fact extraction for an instance, start it with:

```bash
MNEMO_FACT_EXTRACTION_INCLUDE_ASSISTANT=true
```

## Validation

- `go test -race -count=1 ./internal/config ./internal/service ./internal/handler`
- `go test -race -count=1 -run 'TestExtractPhase1IncludesAssistantFactsWhenEnabled|TestExtractPhase1WithoutRoutingOmitsRoutingPrompt' ./internal/service`
- `make vet`
- `git diff --check`
