### PR TITLE
fix(runtime-usage): map reserve cancellations to 499

### DIFF
--- a/server/internal/handler/memory_test.go
+++ b/server/internal/handler/memory_test.go
@@ -2338,6 +2338,127 @@ func TestListMemories_RuntimeUsageReserveConflictStopsTenantRecall(t *testing.T)
 	}
 }
 
+func TestRuntimeUsageReserveCallerCancellationReturns499(t *testing.T) {
+	tests := []struct {
+		name              string
+		request           func(*testing.T) *http.Request
+		run               func(*Server, http.ResponseWriter, *http.Request)
+		assertTenantFence func(*testing.T, *testMemoryRepo)
+	}{
+		{
+			name: "recall",
+			request: func(t *testing.T) *http.Request {
+				return makeTenantRequest(t, http.MethodGet, "/memories?q=must-not-run", nil)
+			},
+			run: func(srv *Server, w http.ResponseWriter, r *http.Request) {
+				srv.listMemories(w, r)
+			},
+			assertTenantFence: func(t *testing.T, repo *testMemoryRepo) {
+				if repo.searchCalls != 0 || repo.listCalls != 0 || repo.allTypeListCalls != 0 {
+					t.Fatalf("tenant recall calls = search:%d list:%d all:%d, want 0", repo.searchCalls, repo.listCalls, repo.allTypeListCalls)
+				}
+			},
+		},
+		{
+			name: "write",
+			request: func(t *testing.T) *http.Request {
+				return makeTenantRequest(t, http.MethodPost, "/memories", map[string]any{
+					"content":     "must not be written",
+					"memory_type": "pinned",
+				})
+			},
+			run: func(srv *Server, w http.ResponseWriter, r *http.Request) {
+				srv.createMemory(w, r)
+			},
+			assertTenantFence: func(t *testing.T, repo *testMemoryRepo) {
+				if repo.bulkCreateCalls != 0 || len(repo.createCalls) != 0 {
+					t.Fatalf("tenant writes = bulk:%d create:%d, want 0", repo.bulkCreateCalls, len(repo.createCalls))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&logBuf, nil))
+			reserveStarted := make(chan struct{}, 1)
+			releaseProvider := make(chan struct{})
+			var providerRequests atomic.Int32
+			provider := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				providerRequests.Add(1)
+				select {
+				case reserveStarted <- struct{}{}:
+				default:
+				}
+				select {
+				case <-r.Context().Done():
+				case <-releaseProvider:
+				}
+			}))
+			defer provider.Close()
+			defer close(releaseProvider)
+
+			meteringWriter := &captureMeteringWriter{}
+			runtimeUsage := runtimeusage.NewManager(
+				runtimeusage.Config{Enabled: true},
+				runtimeusage.NewHTTPClient(provider.URL, "test-secret", time.Second),
+				meteringWriter,
+				logger,
+			)
+			memRepo := &testMemoryRepo{}
+			srv := newTestServer(memRepo, &testSessionRepo{}).WithRuntimeUsage(runtimeUsage)
+			srv.logger = logger
+			req := tt.request(t)
+			ctx, cancel := context.WithCancel(req.Context())
+			defer cancel()
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+			done := make(chan struct{})
+
+			go func() {
+				defer close(done)
+				tt.run(srv, rr, req)
+			}()
+
+			select {
+			case <-reserveStarted:
+			case <-time.After(time.Second):
+				t.Fatal("Runtime Usage Reserve did not start")
+			}
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("handler did not return after caller cancellation")
+			}
+
+			if rr.Code != statusClientClosedRequest {
+				t.Fatalf("status = %d, want 499: %s", rr.Code, rr.Body.String())
+			}
+			if got := rr.Body.String(); got != "{\"error\":\"client closed request\"}\n" {
+				t.Fatalf("body = %q, want client closed request response", got)
+			}
+			tt.assertTenantFence(t, memRepo)
+			if got := providerRequests.Load(); got != 1 {
+				t.Fatalf("Runtime Usage provider requests = %d, want 1 Reserve and no Finalize", got)
+			}
+			if got := len(meteringWriter.snapshot()); got != 0 {
+				t.Fatalf("Runtime Usage metering events = %d, want 0", got)
+			}
+
+			entry := findHandlerLogEntry(t, decodeHandlerLogs(t, &logBuf), "runtime usage request failed")
+			assertHandlerLogField(t, entry, "level", "INFO")
+			assertHandlerLogField(t, entry, "error_class", "client_canceled")
+			assertHandlerLogField(t, entry, "error_source", "request_context")
+			assertHandlerLogField(t, entry, "error_role", runtimeUsageRoleClientResponse)
+			assertHandlerLogField(t, entry, "stage", runtimeUsageStageReserve)
+			assertHandlerLogField(t, entry, "http_status", float64(statusClientClosedRequest))
+			assertHandlerLogField(t, entry, "retryable", false)
+		})
+	}
+}
+
 func TestCreateMemory_RuntimeUsageNoticeAddsTopLevelFieldsToCreatedMemory(t *testing.T) {
 	memRepo := &testMemoryRepo{}
 	runtimeUsage := &captureRuntimeUsageManager{

--- a/server/internal/handler/runtime_usage.go
+++ b/server/internal/handler/runtime_usage.go
@@ -195,6 +195,9 @@ func (s *Server) handleRuntimeUsageError(
 	details runtimeUsageErrorDetails,
 ) error {
 	s.logRuntimeUsageError(ctx, err, details, runtimeUsageRoleClientResponse)
+	if isRuntimeUsageReserveClientCanceled(ctx, err, details) {
+		return respondError(w, statusClientClosedRequest, "client closed request")
+	}
 
 	var denied *runtimeusage.QuotaDeniedError
 	if errors.As(err, &denied) {
@@ -227,6 +230,11 @@ func (s *Server) logRuntimeUsageBackgroundFinalizeError(ctx context.Context, err
 
 func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details runtimeUsageErrorDetails, errorRole string) {
 	errorClass, status, retryable := classifyRuntimeUsageError(err)
+	errorSource := "runtime_usage"
+	if errorRole == runtimeUsageRoleClientResponse && isRuntimeUsageReserveClientCanceled(ctx, err, details) {
+		errorClass, errorSource, retryable = clientCanceledClassification()
+		status = statusClientClosedRequest
+	}
 	statusField := "http_status"
 	message := "runtime usage request failed"
 	if errorRole == runtimeUsageRoleBackground {
@@ -235,7 +243,7 @@ func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details ru
 	}
 	attrs := []any{
 		"error_class", errorClass,
-		"error_source", "runtime_usage",
+		"error_source", errorSource,
 		"error_role", errorRole,
 		"stage", details.stage,
 		statusField, status,
@@ -268,10 +276,16 @@ func (s *Server) logRuntimeUsageError(ctx context.Context, err error, details ru
 		logger = slog.Default()
 	}
 	level := slog.LevelError
-	if errorClass == "quota_denied" {
+	if errorClass == "client_canceled" {
+		level = slog.LevelInfo
+	} else if errorClass == "quota_denied" {
 		level = slog.LevelWarn
 	}
 	logger.Log(ctx, level, message, attrs...)
+}
+
+func isRuntimeUsageReserveClientCanceled(ctx context.Context, err error, details runtimeUsageErrorDetails) bool {
+	return details.stage == runtimeUsageStageReserve && isClientCanceledRequest(ctx, err)
 }
 
 func classifyRuntimeUsageError(err error) (string, int, bool) {

--- a/server/internal/handler/runtime_usage_test.go
+++ b/server/internal/handler/runtime_usage_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -239,7 +240,79 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 		wantAttemptCount     int
 		wantRetryDecision    string
 		wantExhaustionReason string
+		cancelContext        bool
+		wantSource           string
 	}{
+		{
+			name:          "caller cancellation during reserve",
+			err:           &runtimeusage.UnavailableError{Err: fmt.Errorf("reserve request: %w", context.Canceled)},
+			details:       runtimeUsageErrorDetails{stage: runtimeUsageStageReserve, clusterID: "cluster-canceled", meter: runtimeusage.MeterMemoryRecallRequests},
+			wantStatus:    statusClientClosedRequest,
+			wantClass:     "client_canceled",
+			wantRetryable: false,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-canceled",
+			wantMeter:     runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:   "client closed request",
+			cancelContext: true,
+			wantSource:    "request_context",
+		},
+		{
+			name: "caller cancellation takes precedence over quota denial",
+			err: errors.Join(
+				fmt.Errorf("reserve request: %w", context.Canceled),
+				&runtimeusage.QuotaDeniedError{StatusCode: http.StatusTooManyRequests, RetryAfter: "20"},
+			),
+			details:       runtimeUsageErrorDetails{stage: runtimeUsageStageReserve, clusterID: "cluster-canceled-quota", meter: runtimeusage.MeterMemoryRecallRequests},
+			wantStatus:    statusClientClosedRequest,
+			wantClass:     "client_canceled",
+			wantRetryable: false,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-canceled-quota",
+			wantMeter:     runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:   "client closed request",
+			cancelContext: true,
+			wantSource:    "request_context",
+		},
+		{
+			name:          "canceled request with independent provider failure",
+			err:           &runtimeusage.UnavailableError{Err: errors.New("provider timeout")},
+			details:       runtimeUsageErrorDetails{stage: runtimeUsageStageReserve, clusterID: "cluster-independent", meter: runtimeusage.MeterMemoryRecallRequests},
+			wantStatus:    http.StatusServiceUnavailable,
+			wantClass:     "unavailable",
+			wantRetryable: true,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-independent",
+			wantMeter:     runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:   "runtime usage unavailable",
+			cancelContext: true,
+		},
+		{
+			name:          "active request with wrapped cancellation",
+			err:           &runtimeusage.UnavailableError{Err: fmt.Errorf("provider request: %w", context.Canceled)},
+			details:       runtimeUsageErrorDetails{stage: runtimeUsageStageReserve, clusterID: "cluster-active", meter: runtimeusage.MeterMemoryRecallRequests},
+			wantStatus:    http.StatusServiceUnavailable,
+			wantClass:     "unavailable",
+			wantRetryable: true,
+			wantStage:     runtimeUsageStageReserve,
+			wantClusterID: "cluster-active",
+			wantMeter:     runtimeusage.MeterMemoryRecallRequests,
+			wantMessage:   "runtime usage unavailable",
+		},
+		{
+			name:          "caller cancellation-shaped finalization failure",
+			err:           &runtimeusage.UnavailableError{Err: fmt.Errorf("finalize request: %w", context.Canceled)},
+			details:       runtimeUsageErrorDetails{stage: runtimeUsageStageFinalize, clusterID: "cluster-finalize-canceled", meter: runtimeusage.MeterMemoryWriteRequests, operationID: "operation-finalize-canceled"},
+			wantStatus:    http.StatusServiceUnavailable,
+			wantClass:     "unavailable",
+			wantRetryable: true,
+			wantStage:     runtimeUsageStageFinalize,
+			wantClusterID: "cluster-finalize-canceled",
+			wantMeter:     runtimeusage.MeterMemoryWriteRequests,
+			wantOperation: "operation-finalize-canceled",
+			wantMessage:   "runtime usage unavailable",
+			cancelContext: true,
+		},
 		{
 			name: "quota rate limit during reserve",
 			err: &runtimeusage.QuotaDeniedError{
@@ -486,7 +559,12 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			logger := slog.New(reqid.NewHandler(slog.NewJSONHandler(&logBuf, nil)))
 			server := &Server{logger: logger}
 			recorder := httptest.NewRecorder()
-			ctx := reqid.NewContext(context.Background(), "request-runtime-usage")
+			ctx := context.Context(reqid.NewContext(context.Background(), "request-runtime-usage"))
+			if tt.cancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
 
 			server.handleRuntimeUsageError(ctx, recorder, tt.err, tt.details)
 
@@ -505,7 +583,11 @@ func TestHandleRuntimeUsageErrorLogsStableClassification(t *testing.T) {
 			assertRuntimeUsageLogField(t, entry, "msg", "runtime usage request failed")
 			assertRuntimeUsageLogField(t, entry, "request_id", "request-runtime-usage")
 			assertRuntimeUsageLogField(t, entry, "error_class", tt.wantClass)
-			assertRuntimeUsageLogField(t, entry, "error_source", "runtime_usage")
+			wantSource := tt.wantSource
+			if wantSource == "" {
+				wantSource = "runtime_usage"
+			}
+			assertRuntimeUsageLogField(t, entry, "error_source", wantSource)
 			assertRuntimeUsageLogField(t, entry, "error_role", runtimeUsageRoleClientResponse)
 			assertRuntimeUsageLogField(t, entry, "stage", tt.wantStage)
 			assertRuntimeUsageLogField(t, entry, "http_status", float64(tt.wantStatus))
@@ -549,7 +631,15 @@ func TestRuntimeUsageFailuresRecordFinalHTTPStatusMetrics(t *testing.T) {
 		err            error
 		wantStatus     int
 		wantRetryAfter string
+		cancelContext  bool
 	}{
+		{
+			name:          "caller canceled",
+			route:         "/test/runtime-usage/client-canceled",
+			err:           &runtimeusage.UnavailableError{Err: fmt.Errorf("reserve request: %w", context.Canceled)},
+			wantStatus:    statusClientClosedRequest,
+			cancelContext: true,
+		},
 		{
 			name:  "rate limited",
 			route: "/test/runtime-usage/rate-limited",
@@ -585,7 +675,13 @@ func TestRuntimeUsageFailuresRecordFinalHTTPStatusMetrics(t *testing.T) {
 			})
 
 			recorder := httptest.NewRecorder()
-			router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, tt.route, nil))
+			request := httptest.NewRequest(http.MethodGet, tt.route, nil)
+			if tt.cancelContext {
+				ctx, cancel := context.WithCancel(request.Context())
+				cancel()
+				request = request.WithContext(ctx)
+			}
+			router.ServeHTTP(recorder, request)
 
 			if recorder.Code != tt.wantStatus {
 				t.Fatalf("status = %d, want %d", recorder.Code, tt.wantStatus)


### PR DESCRIPTION
## Summary

- map caller-canceled synchronous Runtime Usage Reserve failures to HTTP 499 with the existing client closed request envelope
- classify the response as client_canceled from request_context while preserving provider, timeout, server-budget, quota, Reservation, and Finalize behavior
- cover Recall and Write through the real Runtime Usage HTTP transport and manager, including tenant-work fences and multi-identity precedence

## Testing

- focused Runtime Usage handler regression tests
- make vet
- make test (go test -race -count=1 ./...)
- Standards, Spec, Integration Blast Radius, and Test Adequacy reviews passed

Closes #454