### PR TITLE
Document full Space Chain node response fields

### DIFF
--- a/site/src/content/site.ts
+++ b/site/src/content/site.ts
@@ -1269,10 +1269,6 @@ const spaceChainNodesBodyFields: SiteApiFieldCopy[] = [
   { name: 'nodes[].display_name', description: 'Optional display name for the node.' },
 ];
 
-const spaceChainNodesResponseFields: SiteApiFieldCopy[] = [
-  { name: 'nodes', description: 'Ordered node list. Positions are zero-based.', required: true },
-];
-
 const spaceChainRoutingPolicyPathFields: SiteApiFieldCopy[] = [
   { name: 'chain_id', description: 'Space Chain id.', required: true },
   { name: 'node_id', description: 'Target node id. The first node cannot have a routing policy.', required: true },
@@ -1307,6 +1303,11 @@ const spaceChainNodeResponseFields: SiteApiFieldCopy[] = [
   },
   { name: 'created_at', description: 'Creation timestamp.', required: true },
   { name: 'updated_at', description: 'Last update timestamp.', required: true },
+];
+
+const spaceChainNodesResponseFields: SiteApiFieldCopy[] = [
+  { name: 'nodes', description: 'Ordered node list. Positions are zero-based.', required: true },
+  ...spaceChainNodeResponseFields.map((field) => ({ ...field, name: `nodes[].${field.name}` })),
 ];
 
 const spaceChainBindingsResponseFields: SiteApiFieldCopy[] = [


### PR DESCRIPTION
## What changed

- expand the public API reference response body for `GET /v1alpha2/space-chains/{chain_id}/nodes`
- show every `nodes[]` field, including `routing_policy_enabled`, `routing_policy_prompt`, and `routing_policy_webhook_only`
- reuse the single-node response field definition so list and routing-policy documentation stay in sync
- apply the same complete response contract to `PUT /v1alpha2/space-chains/{chain_id}/nodes`

## Why

The API reference previously showed only the top-level `nodes` array, so readers could not discover the knowledge extraction policy fields returned for each node.

## Validation

- `cd site && npx tsc --noEmit`
- `cd site && npm run build`
- verified generated `dist/api/index.html` contains all three `nodes[].routing_policy_*` fields