### PR TITLE
fix(site): proxy Console Markdown documents

### DIFF
--- a/site/scripts/netlify-build.sh
+++ b/site/scripts/netlify-build.sh
@@ -63,6 +63,8 @@ cat > "${site_dist_dir}/_redirects" <<REDIRECTS
 # Configure CONSOLE_FE_ORIGIN and CONSOLE_API_ORIGIN per deploy context.
 /console/api/*     ${console_api_origin}/api/:splat             200!
 /console/auth/*    ${console_api_origin}/auth/:splat            200!
+/console/admin-api.md  ${console_fe_origin}/console/admin-api.md  200
+/console/spaces/api-guide/import-api-keys.md  ${console_fe_origin}/console/spaces/api-guide/import-api-keys.md  200
 /console/assets/*  ${console_fe_origin}/console/assets/:splat   200
 /console/favicon.svg  ${console_fe_origin}/console/favicon.svg  200
 /console           ${console_fe_origin}/console/index.html      200


### PR DESCRIPTION
## What Changed
- Route the Admin API Markdown document through the Console frontend origin.
- Route the Space API import guide through the same origin before the SPA fallback.

## Why
- The existing `/console/*` fallback serves `index.html` for these Markdown URLs on `mem9.ai`.
- The Console frontend already publishes both documents as `text/markdown`.

## Review Path
1. Inspect the two exact document routes in `site/scripts/netlify-build.sh`.
2. Confirm both rules appear before the `/console/*` SPA fallback.

## Validation
- `bash -n site/scripts/netlify-build.sh`
- `CONSOLE_FE_ORIGIN=https://mem9-console-fe-dev.netlify.app CONSOLE_API_ORIGIN=https://console-api.mem9.ai bash site/scripts/netlify-build.sh`
- Confirmed generated `site/dist/_redirects` contains both exact routes before `/console/*`.