### PR TITLE
server: forward image and video message inputs to models that accept them

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3276,6 +3276,30 @@
           "content": {
             "type": "string"
           },
+          "media": {
+            "type": "array",
+            "description": "Optional non-text inputs for this message. Parts are forwarded to the configured model only when it accepts that input modality; otherwise they are ignored.",
+            "items": {
+              "type": "object",
+              "required": [
+                "kind",
+                "url"
+              ],
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "image",
+                    "video"
+                  ]
+                },
+                "url": {
+                  "type": "string",
+                  "description": "Reachable link or provider file reference."
+                }
+              }
+            }
+          },
           "seq": {
             "type": "integer",
             "nullable": true,

--- a/server/internal/llm/client.go
+++ b/server/internal/llm/client.go
@@ -97,12 +97,34 @@ func (m *messageContent) UnmarshalJSON(data []byte) error {
 
 type contentBlock struct {
 	Type         string        `json:"type"`
-	Text         string        `json:"text"`
+	Text         string        `json:"text,omitempty"`
+	ImageURL     *mediaURL     `json:"image_url,omitempty"`
+	VideoURL     *mediaURL     `json:"video_url,omitempty"`
 	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
+type mediaURL struct {
+	URL string `json:"url"`
 }
 
 type cacheControl struct {
 	Type string `json:"type"`
+}
+
+// MediaKind identifies a non-text input modality that can be attached to a
+// user message.
+type MediaKind string
+
+const (
+	MediaKindImage MediaKind = "image"
+	MediaKindVideo MediaKind = "video"
+)
+
+// MediaPart is a single non-text input referenced by URL. URL accepts either a
+// reachable link or a provider file reference.
+type MediaPart struct {
+	Kind MediaKind `json:"kind"`
+	URL  string    `json:"url"`
 }
 
 func plainContent(s string) messageContent {
@@ -117,6 +139,37 @@ func cachedContent(s string) messageContent {
 			CacheControl: &cacheControl{Type: "ephemeral"},
 		}},
 	}
+}
+
+// mediaContent builds the content of a user message. When the model accepts at
+// least one of the attached media modalities the content is sent in the block
+// form so the media reaches the model; otherwise it falls back to the plain
+// string form used for text-only models. The second result reports how many
+// media blocks were attached.
+func mediaContent(model, text string, media []MediaPart) (messageContent, int) {
+	blocks := make([]contentBlock, 0, len(media)+1)
+	if text != "" {
+		blocks = append(blocks, contentBlock{Type: "text", Text: text})
+	}
+	attached := 0
+	for _, part := range media {
+		if part.URL == "" || !supportsInputModality(model, part.Kind) {
+			continue
+		}
+		switch part.Kind {
+		case MediaKindImage:
+			blocks = append(blocks, contentBlock{Type: "image_url", ImageURL: &mediaURL{URL: part.URL}})
+		case MediaKindVideo:
+			blocks = append(blocks, contentBlock{Type: "video_url", VideoURL: &mediaURL{URL: part.URL}})
+		default:
+			continue
+		}
+		attached++
+	}
+	if attached == 0 {
+		return plainContent(text), 0
+	}
+	return messageContent{blocks: blocks}, attached
 }
 
 type responseFormat struct {
@@ -167,11 +220,11 @@ func (e *HTTPStatusError) Error() string {
 
 // Complete sends a chat completion request to the LLM.
 func (c *Client) Complete(ctx context.Context, system, user string) (string, error) {
-	return c.complete(ctx, system, user, nil, CallScope{})
+	return c.complete(ctx, system, user, nil, nil, CallScope{})
 }
 
 func (c *Client) CompleteWithScope(ctx context.Context, system, user string, scope CallScope) (string, error) {
-	return c.complete(ctx, system, user, nil, scope)
+	return c.complete(ctx, system, user, nil, nil, scope)
 }
 
 // CompleteJSON sends a chat completion request with response_format: json_object.
@@ -179,40 +232,49 @@ func (c *Client) CompleteWithScope(ctx context.Context, system, user string, sco
 // If the provider returns HTTP 400 (e.g., Ollama, some vLLM builds that don't support
 // response_format), it automatically retries without the parameter.
 func (c *Client) CompleteJSON(ctx context.Context, system, user string) (string, error) {
-	result, err := c.complete(ctx, system, user, &responseFormat{Type: "json_object"}, CallScope{})
+	result, err := c.complete(ctx, system, user, nil, &responseFormat{Type: "json_object"}, CallScope{})
 	if err != nil {
 		var httpErr *HTTPStatusError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusBadRequest {
 			slog.Warn("LLM rejected response_format:json_object (HTTP 400), retrying without it")
-			return c.complete(ctx, system, user, nil, CallScope{})
+			return c.complete(ctx, system, user, nil, nil, CallScope{})
 		}
 	}
 	return result, err
 }
 
 func (c *Client) CompleteJSONWithScope(ctx context.Context, system, user string, scope CallScope) (string, error) {
-	result, err := c.complete(ctx, system, user, &responseFormat{Type: "json_object"}, scope)
+	return c.CompleteJSONWithMedia(ctx, system, user, nil, scope)
+}
+
+// CompleteJSONWithMedia behaves like CompleteJSONWithScope and additionally
+// attaches non-text inputs to the user message when the configured model
+// accepts those input modalities. Media the model cannot accept is left out, so
+// text-only models keep their current request shape.
+func (c *Client) CompleteJSONWithMedia(ctx context.Context, system, user string, media []MediaPart, scope CallScope) (string, error) {
+	result, err := c.complete(ctx, system, user, media, &responseFormat{Type: "json_object"}, scope)
 	if err != nil {
 		var httpErr *HTTPStatusError
 		if errors.As(err, &httpErr) && httpErr.Code == http.StatusBadRequest {
 			recordRetryMetric(scope, "response_format_400_fallback")
 			slog.Warn("LLM rejected response_format:json_object (HTTP 400), retrying without it")
-			return c.complete(ctx, system, user, nil, scope)
+			return c.complete(ctx, system, user, media, nil, scope)
 		}
 	}
 	return result, err
 }
 
-func (c *Client) complete(ctx context.Context, system, user string, respFmt *responseFormat, scope CallScope) (string, error) {
+func (c *Client) complete(ctx context.Context, system, user string, media []MediaPart, respFmt *responseFormat, scope CallScope) (string, error) {
 	useExplicitCache := supportsExplicitCache(c.model)
 
 	sysContent := plainContent(system)
 	if useExplicitCache {
 		sysContent = cachedContent(system)
 	}
+	userContent, mediaBlocks := mediaContent(c.model, user, media)
 	messages := []Message{
 		{Role: "system", Content: sysContent},
-		{Role: "user", Content: plainContent(user)},
+		{Role: "user", Content: userContent},
 	}
 
 	enableThinking := disableThinkingOptions(c.model)
@@ -227,18 +289,23 @@ func (c *Client) complete(ctx context.Context, system, user string, respFmt *res
 		ReasoningSplit: reasoningSplit,
 	}, scope)
 	if err != nil {
-		// If 400 and any provider-specific extras were applied (thinking flags or
-		// content-block cache markers), retry once with everything stripped.
+		// If 400 and any provider-specific extras were applied (thinking flags,
+		// media content blocks or content-block cache markers), retry once with
+		// everything stripped.
 		var httpErr *HTTPStatusError
-		if errors.As(err, &httpErr) && httpErr.Code == http.StatusBadRequest && (enableThinking != nil || reasoningSplit != nil || useExplicitCache) {
-			if useExplicitCache {
+		if errors.As(err, &httpErr) && httpErr.Code == http.StatusBadRequest && (enableThinking != nil || reasoningSplit != nil || useExplicitCache || mediaBlocks > 0) {
+			switch {
+			case mediaBlocks > 0:
+				recordRetryMetric(scope, "media_block_400_fallback")
+			case useExplicitCache:
 				recordRetryMetric(scope, "cache_control_400_fallback")
-			} else {
+			default:
 				recordRetryMetric(scope, "thinking_param_400_fallback")
 			}
 			slog.Warn("LLM rejected provider-specific parameters (HTTP 400), retrying without them",
 				"model", c.model,
 				"had_cache_control", useExplicitCache,
+				"had_media_blocks", mediaBlocks > 0,
 				"had_thinking_flags", enableThinking != nil || reasoningSplit != nil)
 			plainMessages := []Message{
 				{Role: "system", Content: plainContent(system)},
@@ -391,6 +458,33 @@ func supportsReasoningSplit(model string) *bool {
 // per Aliyun Bailian docs (qwen3-max, qwen3-coder-plus, qwen3-vl-plus, ...).
 func supportsExplicitCache(model string) bool {
 	return strings.HasPrefix(strings.ToLower(model), "qwen")
+}
+
+// modelInputModalities maps a lowercase model-id prefix to the non-text input
+// modalities that model accepts. Models missing from this table are treated as
+// text-only, which keeps their requests in the plain string content form.
+var modelInputModalities = map[string][]MediaKind{
+	"minimax-m3": {MediaKindImage, MediaKindVideo},
+}
+
+// supportsInputModality reports whether the model accepts the given non-text
+// input modality. The longest matching prefix wins so a specific model id can
+// override a broader model-family entry.
+func supportsInputModality(model string, kind MediaKind) bool {
+	lower := strings.ToLower(strings.TrimSpace(model))
+	matched := ""
+	var modalities []MediaKind
+	for prefix, kinds := range modelInputModalities {
+		if strings.HasPrefix(lower, prefix) && len(prefix) > len(matched) {
+			matched, modalities = prefix, kinds
+		}
+	}
+	for _, k := range modalities {
+		if k == kind {
+			return true
+		}
+	}
+	return false
 }
 
 func StripMarkdownFences(s string) string {

--- a/server/internal/llm/client_test.go
+++ b/server/internal/llm/client_test.go
@@ -511,3 +511,253 @@ type roundTripFunc func(*http.Request) (*http.Response, error)
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
+
+// mediaBlock mirrors the wire shape of a single content block so tests can
+// assert the raw JSON rather than the decoded form.
+type mediaBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text"`
+	ImageURL *struct {
+		URL string `json:"url"`
+	} `json:"image_url"`
+	VideoURL *struct {
+		URL string `json:"url"`
+	} `json:"video_url"`
+}
+
+func userContentBlocks(t *testing.T, rawBody []byte) []mediaBlock {
+	t.Helper()
+	var wire struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(rawBody, &wire); err != nil {
+		t.Fatalf("decode raw body: %v", err)
+	}
+	if len(wire.Messages) != 2 {
+		t.Fatalf("messages len = %d, want 2", len(wire.Messages))
+	}
+	if wire.Messages[1].Role != "user" {
+		t.Fatalf("messages[1].role = %q, want user", wire.Messages[1].Role)
+	}
+	var blocks []mediaBlock
+	if err := json.Unmarshal(wire.Messages[1].Content, &blocks); err != nil {
+		t.Fatalf("user content is not an array of blocks: %v\nraw: %s", err, string(wire.Messages[1].Content))
+	}
+	return blocks
+}
+
+func userContentString(t *testing.T, rawBody []byte) string {
+	t.Helper()
+	var wire struct {
+		Messages []struct {
+			Role    string          `json:"role"`
+			Content json.RawMessage `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(rawBody, &wire); err != nil {
+		t.Fatalf("decode raw body: %v", err)
+	}
+	if len(wire.Messages) != 2 {
+		t.Fatalf("messages len = %d, want 2", len(wire.Messages))
+	}
+	var text string
+	if err := json.Unmarshal(wire.Messages[1].Content, &text); err != nil {
+		t.Fatalf("user content is not a plain string: %v\nraw: %s", err, string(wire.Messages[1].Content))
+	}
+	return text
+}
+
+func TestSupportsInputModality(t *testing.T) {
+	cases := []struct {
+		model string
+		kind  MediaKind
+		want  bool
+	}{
+		{model: "MiniMax-M3", kind: MediaKindImage, want: true},
+		{model: "MiniMax-M3", kind: MediaKindVideo, want: true},
+		{model: "minimax-m3", kind: MediaKindImage, want: true},
+		{model: " MiniMax-M3 ", kind: MediaKindVideo, want: true},
+		{model: "MiniMax-M2.7", kind: MediaKindImage, want: false},
+		{model: "MiniMax-M2.7", kind: MediaKindVideo, want: false},
+		{model: "gpt-4o-mini", kind: MediaKindImage, want: false},
+	}
+	for _, tc := range cases {
+		if got := supportsInputModality(tc.model, tc.kind); got != tc.want {
+			t.Fatalf("supportsInputModality(%q, %q) = %v, want %v", tc.model, tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestCompleteJSONWithMedia(t *testing.T) {
+	imagePart := MediaPart{Kind: MediaKindImage, URL: "https://example.com/frame.png"}
+	videoPart := MediaPart{Kind: MediaKindVideo, URL: "mm_file://file-id"}
+
+	t.Run("model accepting image and video sends media blocks", func(t *testing.T) {
+		var rawBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			rawBody = b
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{}"}}]}`))
+		}))
+		defer server.Close()
+
+		client := New(Config{APIKey: "key", BaseURL: server.URL, Model: "MiniMax-M3"})
+		if client == nil {
+			t.Fatal("expected client, got nil")
+		}
+
+		got, err := client.CompleteJSONWithMedia(context.Background(), "system-prompt", "user-prompt",
+			[]MediaPart{imagePart, videoPart}, CallScope{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "{}" {
+			t.Fatalf("content = %q, want %q", got, "{}")
+		}
+
+		blocks := userContentBlocks(t, rawBody)
+		if len(blocks) != 3 {
+			t.Fatalf("user blocks len = %d, want 3", len(blocks))
+		}
+		if blocks[0].Type != "text" || blocks[0].Text != "user-prompt" {
+			t.Fatalf("blocks[0] = %#v, want text block with user-prompt", blocks[0])
+		}
+		if blocks[1].Type != "image_url" {
+			t.Fatalf("blocks[1].type = %q, want image_url", blocks[1].Type)
+		}
+		if blocks[1].ImageURL == nil || blocks[1].ImageURL.URL != imagePart.URL {
+			t.Fatalf("blocks[1].image_url = %#v, want url %q", blocks[1].ImageURL, imagePart.URL)
+		}
+		if blocks[2].Type != "video_url" {
+			t.Fatalf("blocks[2].type = %q, want video_url", blocks[2].Type)
+		}
+		if blocks[2].VideoURL == nil || blocks[2].VideoURL.URL != videoPart.URL {
+			t.Fatalf("blocks[2].video_url = %#v, want url %q", blocks[2].VideoURL, videoPart.URL)
+		}
+		// A media block must not carry an empty text field.
+		if strings.Contains(string(rawBody), `"text":""`) {
+			t.Fatalf("media blocks must omit empty text, body: %s", string(rawBody))
+		}
+	})
+
+	t.Run("text only model drops media and keeps string content", func(t *testing.T) {
+		var rawBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			rawBody = b
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{}"}}]}`))
+		}))
+		defer server.Close()
+
+		client := New(Config{APIKey: "key", BaseURL: server.URL, Model: "MiniMax-M2.7"})
+		if client == nil {
+			t.Fatal("expected client, got nil")
+		}
+
+		if _, err := client.CompleteJSONWithMedia(context.Background(), "system-prompt", "user-prompt",
+			[]MediaPart{imagePart, videoPart}, CallScope{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got := userContentString(t, rawBody); got != "user-prompt" {
+			t.Fatalf("user content = %q, want %q", got, "user-prompt")
+		}
+		if strings.Contains(string(rawBody), "image_url") || strings.Contains(string(rawBody), "video_url") {
+			t.Fatalf("text-only model must not receive media blocks, body: %s", string(rawBody))
+		}
+	})
+
+	t.Run("media without url is skipped", func(t *testing.T) {
+		var rawBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			rawBody = b
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{}"}}]}`))
+		}))
+		defer server.Close()
+
+		client := New(Config{APIKey: "key", BaseURL: server.URL, Model: "MiniMax-M3"})
+		if _, err := client.CompleteJSONWithMedia(context.Background(), "system-prompt", "user-prompt",
+			[]MediaPart{{Kind: MediaKindImage}}, CallScope{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := userContentString(t, rawBody); got != "user-prompt" {
+			t.Fatalf("user content = %q, want %q", got, "user-prompt")
+		}
+	})
+
+	t.Run("400 on media blocks retries without them", func(t *testing.T) {
+		var bodies [][]byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			bodies = append(bodies, b)
+			if len(bodies) == 1 {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"message":"unsupported content block"}}`))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{}"}}]}`))
+		}))
+		defer server.Close()
+
+		client := New(Config{APIKey: "key", BaseURL: server.URL, Model: "MiniMax-M3"})
+		if client == nil {
+			t.Fatal("expected client, got nil")
+		}
+
+		got, err := client.CompleteJSONWithMedia(context.Background(), "system-prompt", "user-prompt",
+			[]MediaPart{imagePart}, CallScope{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != "{}" {
+			t.Fatalf("content = %q, want %q", got, "{}")
+		}
+		if len(bodies) < 2 {
+			t.Fatalf("requests = %d, want at least 2", len(bodies))
+		}
+		// The first attempt carries the media block, the retry falls back to text.
+		if !strings.Contains(string(bodies[0]), "image_url") {
+			t.Fatalf("first request should carry media block, body: %s", string(bodies[0]))
+		}
+		if got := userContentString(t, bodies[len(bodies)-1]); got != "user-prompt" {
+			t.Fatalf("retry user content = %q, want %q", got, "user-prompt")
+		}
+	})
+
+	t.Run("nil media keeps the existing string content shape", func(t *testing.T) {
+		var rawBody []byte
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			rawBody = b
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{}"}}]}`))
+		}))
+		defer server.Close()
+
+		client := New(Config{APIKey: "key", BaseURL: server.URL, Model: "MiniMax-M3"})
+		if _, err := client.CompleteJSONWithScope(context.Background(), "system-prompt", "user-prompt",
+			CallScope{}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := userContentString(t, rawBody); got != "user-prompt" {
+			t.Fatalf("user content = %q, want %q", got, "user-prompt")
+		}
+	})
+}

--- a/server/internal/service/ingest.go
+++ b/server/internal/service/ingest.go
@@ -83,9 +83,10 @@ type IngestRequest struct {
 
 // IngestMessage represents a single conversation message.
 type IngestMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-	Seq     *int   `json:"seq,omitempty"`
+	Role    string          `json:"role"`
+	Content string          `json:"content"`
+	Media   []llm.MediaPart `json:"media,omitempty"`
+	Seq     *int            `json:"seq,omitempty"`
 }
 
 // IngestResult is the output of the ingest pipeline.
@@ -191,7 +192,7 @@ func (s *IngestService) Ingest(ctx context.Context, agentName string, req Ingest
 	// Cap conversation size to avoid blowing LLM token limits.
 	formatted = truncateRunes(formatted, maxExtractionConversationRunes)
 
-	changes, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted, req.ExternalProvenance)
+	changes, warnings, err := s.extractAndReconcile(ctx, agentName, req.AgentID, req.AppID, req.SessionID, formatted, collectMessageMedia(req.Messages), req.ExternalProvenance)
 	if err != nil {
 		slog.Error("insight extraction failed", "err", err)
 		return &IngestResult{Status: "failed", Warnings: warnings}, nil
@@ -331,6 +332,7 @@ type preparedExtractionInput struct {
 	messages              []IngestMessage
 	originalIndices       []int
 	formatted             string
+	media                 []llm.MediaPart
 	includeAssistantFacts bool
 }
 
@@ -342,15 +344,17 @@ func prepareExtractionInputWithPolicy(messages []IngestMessage, maxConversationR
 	input := preparedExtractionInput{includeAssistantFacts: includeAssistantFacts}
 	for idx, msg := range messages {
 		content := strings.TrimSpace(msg.Content)
-		if content == "" {
+		if content == "" && len(msg.Media) == 0 {
 			continue
 		}
 		input.messages = append(input.messages, IngestMessage{
 			Role:    strings.TrimSpace(msg.Role),
 			Content: content,
+			Media:   msg.Media,
 			Seq:     msg.Seq,
 		})
 		input.originalIndices = append(input.originalIndices, idx)
+		input.media = append(input.media, msg.Media...)
 	}
 	if len(input.messages) == 0 {
 		return input
@@ -543,7 +547,7 @@ func (s *IngestService) ExtractPhase1WithRouting(ctx context.Context, messages [
 		return &Phase1Result{}, nil
 	}
 
-	facts, messageTags, err := s.extractFactsAndTagsWithRouting(ctx, input.formatted, len(input.messages), routingTargets)
+	facts, messageTags, err := s.extractFactsAndTagsWithRouting(ctx, input.formatted, len(input.messages), input.media, routingTargets)
 	if err != nil {
 		return nil, err
 	}
@@ -673,7 +677,7 @@ func (s *IngestService) ExtractContentWithRouting(ctx context.Context, content s
 	}
 	const maxContentRunes = 32000
 	formatted := truncateRunes(content, maxContentRunes)
-	return s.extractFactsWithRouting(ctx, "User: "+formatted, routingTargets)
+	return s.extractFactsWithRouting(ctx, "User: "+formatted, nil, routingTargets)
 }
 
 // ingestRaw stores messages as a single raw memory (legacy behavior).
@@ -729,12 +733,12 @@ func (s *IngestService) ingestRaw(ctx context.Context, agentName string, req Ing
 }
 
 // extractAndReconcile runs Phase 1a (extraction) + Phase 2 (reconciliation).
-func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string, externalProvenance *ExternalProvenance) ([]MemoryChange, int, error) {
+func (s *IngestService) extractAndReconcile(ctx context.Context, agentName, agentID, appID, sessionID, conversation string, media []llm.MediaPart, externalProvenance *ExternalProvenance) ([]MemoryChange, int, error) {
 	const maxFacts = 50 // Cap extracted facts to bound reconciliation prompt size
 
 	// Phase 1a: Extract facts only — no message_tags needed here (smart-ingest / raw-ingest path).
 	// Use extractFacts instead of extractFactsAndTags to avoid wasting tokens on tag generation.
-	facts, err := s.extractFacts(ctx, conversation)
+	facts, err := s.extractFactsWithRouting(ctx, conversation, media, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("extract facts: %w", err)
 	}
@@ -824,10 +828,10 @@ func normalizeParsedFacts(raw string, parsed []ExtractedFact) []ExtractedFact {
 // extractFacts calls the LLM to extract atomic facts only, without per-message tag generation.
 // Used by extractAndReconcile (ReconcileContent path) where message_tags are not needed.
 func (s *IngestService) extractFacts(ctx context.Context, conversation string) ([]ExtractedFact, error) {
-	return s.extractFactsWithRouting(ctx, conversation, nil)
+	return s.extractFactsWithRouting(ctx, conversation, nil, nil)
 }
 
-func (s *IngestService) extractFactsWithRouting(ctx context.Context, conversation string, routingTargets []RoutingTarget) ([]ExtractedFact, error) {
+func (s *IngestService) extractFactsWithRouting(ctx context.Context, conversation string, media []llm.MediaPart, routingTargets []RoutingTarget) ([]ExtractedFact, error) {
 	if s.llm == nil || conversation == "" {
 		return nil, nil
 	}
@@ -835,6 +839,9 @@ func (s *IngestService) extractFactsWithRouting(ctx context.Context, conversatio
 	if input.formatted == "" {
 		return nil, nil
 	}
+	// The conversation reaches this point as formatted text, so the non-text
+	// inputs are carried separately by the caller.
+	input.media = media
 
 	systemPrompt := `You are an information extraction engine. Your task is to identify distinct,
 atomic facts from a conversation.
@@ -968,7 +975,7 @@ candidate is a query, transient status, one-off intent, activity log, or operati
 	}
 
 	scope := llm.CallScope{Step: "extraction"}
-	raw, err := s.llm.CompleteJSONWithScope(ctx, systemPrompt, userPrompt, scope)
+	raw, err := s.llm.CompleteJSONWithMedia(ctx, systemPrompt, userPrompt, input.media, scope)
 	if err != nil {
 		slog.Warn("extraction LLM call failed", "err", err)
 		return nil, fmt.Errorf("extraction llm call: %w", err)
@@ -978,9 +985,9 @@ candidate is a query, transient status, one-off intent, activity log, or operati
 	lastRaw := raw
 	if err != nil {
 		metrics.LLMRetryTotal.WithLabelValues("extraction", "json_parse_retry").Inc()
-		raw2, retryErr := s.llm.CompleteJSONWithScope(ctx, systemPrompt,
+		raw2, retryErr := s.llm.CompleteJSONWithMedia(ctx, systemPrompt,
 			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt,
-			scope)
+			input.media, scope)
 		if retryErr != nil {
 			slog.Warn("extraction retry failed", "err", retryErr)
 			return nil, fmt.Errorf("extraction retry: %w", retryErr)
@@ -1010,14 +1017,17 @@ candidate is a query, transient status, one-off intent, activity log, or operati
 // extractFactsAndTags calls the LLM to extract atomic facts and per-message tags
 // from the conversation in a single call.
 func (s *IngestService) extractFactsAndTags(ctx context.Context, conversation string, messageCount int) ([]ExtractedFact, [][]string, error) {
-	return s.extractFactsAndTagsWithRouting(ctx, conversation, messageCount, nil)
+	return s.extractFactsAndTagsWithRouting(ctx, conversation, messageCount, nil, nil)
 }
 
-func (s *IngestService) extractFactsAndTagsWithRouting(ctx context.Context, conversation string, messageCount int, routingTargets []RoutingTarget) ([]ExtractedFact, [][]string, error) {
+func (s *IngestService) extractFactsAndTagsWithRouting(ctx context.Context, conversation string, messageCount int, media []llm.MediaPart, routingTargets []RoutingTarget) ([]ExtractedFact, [][]string, error) {
 	input := prepareExtractionInputFromConversationWithPolicy(conversation, maxExtractionConversationRunes, s.includeAssistantFacts)
 	if input.formatted == "" {
 		return nil, normalizeMessageTags(nil, messageCount), nil
 	}
+	// The conversation reaches this point as formatted text, so the non-text
+	// inputs are carried separately by the caller.
+	input.media = media
 
 	systemPrompt := `You are an information extraction engine. Your task is to identify distinct,
 atomic facts from a conversation AND assign short descriptive tags to each message.
@@ -1181,7 +1191,7 @@ eligible source content is non-durable, while still returning message_tags for e
 	}
 
 	scope := llm.CallScope{Step: "extraction_and_classification"}
-	raw, err := s.llm.CompleteJSONWithScope(ctx, systemPrompt, userPrompt, scope)
+	raw, err := s.llm.CompleteJSONWithMedia(ctx, systemPrompt, userPrompt, input.media, scope)
 	if err != nil {
 		slog.Warn("extraction LLM call failed", "err", err)
 		return nil, normalizeMessageTags(nil, messageCount), fmt.Errorf("extraction llm call: %w", err)
@@ -1191,9 +1201,9 @@ eligible source content is non-durable, while still returning message_tags for e
 	lastRaw := raw
 	if err != nil {
 		metrics.LLMRetryTotal.WithLabelValues("extraction_and_classification", "json_parse_retry").Inc()
-		raw2, retryErr := s.llm.CompleteJSONWithScope(ctx, systemPrompt,
+		raw2, retryErr := s.llm.CompleteJSONWithMedia(ctx, systemPrompt,
 			"Your previous response was invalid JSON:\n"+raw+"\n\nFix it and return ONLY the corrected JSON object.\n\n"+userPrompt,
-			scope)
+			input.media, scope)
 		if retryErr != nil {
 			slog.Warn("extraction retry failed", "err", retryErr)
 			return nil, normalizeMessageTags(nil, messageCount), fmt.Errorf("extraction retry: %w", retryErr)
@@ -1904,8 +1914,8 @@ func stripInjectedContext(messages []IngestMessage) []IngestMessage {
 	for _, msg := range messages {
 		cleaned := stripMemoryTags(msg.Content)
 		cleaned = strings.TrimSpace(cleaned)
-		if cleaned != "" {
-			result = append(result, IngestMessage{Role: msg.Role, Content: cleaned, Seq: msg.Seq})
+		if cleaned != "" || len(msg.Media) > 0 {
+			result = append(result, IngestMessage{Role: msg.Role, Content: cleaned, Media: msg.Media, Seq: msg.Seq})
 		}
 	}
 	return result
@@ -1927,6 +1937,16 @@ func stripMemoryTags(s string) string {
 		s = s[:start] + s[end+len("</relevant-memories>"):]
 	}
 	return s
+}
+
+// collectMessageMedia gathers the non-text inputs attached to messages so they
+// can be sent alongside the formatted conversation text.
+func collectMessageMedia(messages []IngestMessage) []llm.MediaPart {
+	var media []llm.MediaPart
+	for _, msg := range messages {
+		media = append(media, msg.Media...)
+	}
+	return media
 }
 
 // formatConversation formats messages into a conversation string for LLM.

--- a/server/internal/service/ingest_test.go
+++ b/server/internal/service/ingest_test.go
@@ -3795,3 +3795,139 @@ func TestReconcileTagsClampedViaReconcilePath(t *testing.T) {
 		t.Fatalf("expected event.Tags clamped to %d via reconcile ADD path, got %d", maxTags, len(memRepo.createCalls[0].Tags))
 	}
 }
+
+func TestCollectMessageMedia(t *testing.T) {
+	t.Parallel()
+
+	got := collectMessageMedia([]IngestMessage{
+		{Role: "user", Content: "look at this", Media: []llm.MediaPart{{Kind: llm.MediaKindImage, URL: "https://example.com/a.png"}}},
+		{Role: "assistant", Content: "no media"},
+		{Role: "user", Media: []llm.MediaPart{{Kind: llm.MediaKindVideo, URL: "mm_file://vid"}}},
+	})
+	want := []llm.MediaPart{
+		{Kind: llm.MediaKindImage, URL: "https://example.com/a.png"},
+		{Kind: llm.MediaKindVideo, URL: "mm_file://vid"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collectMessageMedia() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPrepareExtractionInputKeepsMediaOnlyMessage(t *testing.T) {
+	t.Parallel()
+
+	input := prepareExtractionInput([]IngestMessage{
+		{Role: "user", Media: []llm.MediaPart{{Kind: llm.MediaKindImage, URL: "https://example.com/a.png"}}},
+	}, maxExtractionConversationRunes)
+
+	if len(input.messages) != 1 {
+		t.Fatalf("messages len = %d, want 1", len(input.messages))
+	}
+	if len(input.media) != 1 || input.media[0].Kind != llm.MediaKindImage {
+		t.Fatalf("input.media = %#v, want a single image part", input.media)
+	}
+}
+
+func TestStripInjectedContextKeepsMediaOnlyMessage(t *testing.T) {
+	t.Parallel()
+
+	got := StripInjectedContext([]IngestMessage{
+		{Role: "user", Content: "<relevant-memories>noise</relevant-memories>",
+			Media: []llm.MediaPart{{Kind: llm.MediaKindVideo, URL: "mm_file://vid"}}},
+	})
+	if len(got) != 1 {
+		t.Fatalf("messages len = %d, want 1", len(got))
+	}
+	if got[0].Content != "" {
+		t.Fatalf("content = %q, want empty", got[0].Content)
+	}
+	if len(got[0].Media) != 1 {
+		t.Fatalf("media = %#v, want a single part", got[0].Media)
+	}
+}
+
+// TestIngestSendsMessageMediaToLLM covers the smart-ingest path end to end: an
+// imported message carrying image and video inputs must reach the model as
+// content blocks rather than being dropped during conversation formatting.
+func TestIngestSendsMessageMediaToLLM(t *testing.T) {
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		bodies = append(bodies, b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{\"facts\":[]}"}}]}`))
+	}))
+	defer srv.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: srv.URL, Model: "MiniMax-M3"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	if _, err := svc.Ingest(context.Background(), "agent", IngestRequest{
+		AgentID: "agent-1",
+		Messages: []IngestMessage{{
+			Role:    "user",
+			Content: "what is in this clip?",
+			Media: []llm.MediaPart{
+				{Kind: llm.MediaKindImage, URL: "https://example.com/frame.png"},
+				{Kind: llm.MediaKindVideo, URL: "mm_file://vid"},
+			},
+		}},
+		Mode: ModeSmart,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(bodies) == 0 {
+		t.Fatal("expected at least one LLM request")
+	}
+	body := string(bodies[0])
+	if !strings.Contains(body, `"image_url"`) || !strings.Contains(body, "https://example.com/frame.png") {
+		t.Fatalf("extraction request is missing the image input, body: %s", body)
+	}
+	if !strings.Contains(body, `"video_url"`) || !strings.Contains(body, "mm_file://vid") {
+		t.Fatalf("extraction request is missing the video input, body: %s", body)
+	}
+}
+
+// TestIngestKeepsStringContentForTextOnlyModel guards the existing request
+// shape: a model without image or video input support must keep receiving the
+// plain string content form.
+func TestIngestKeepsStringContentForTextOnlyModel(t *testing.T) {
+	var bodies [][]byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		bodies = append(bodies, b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"{\"facts\":[]}"}}]}`))
+	}))
+	defer srv.Close()
+
+	llmClient := llm.New(llm.Config{APIKey: "test-key", BaseURL: srv.URL, Model: "MiniMax-M2.7"})
+	svc := NewIngestService(&memoryRepoMock{}, llmClient, nil, "auto-model", ModeSmart)
+
+	if _, err := svc.Ingest(context.Background(), "agent", IngestRequest{
+		AgentID: "agent-1",
+		Messages: []IngestMessage{{
+			Role:    "user",
+			Content: "what is in this clip?",
+			Media:   []llm.MediaPart{{Kind: llm.MediaKindImage, URL: "https://example.com/frame.png"}},
+		}},
+		Mode: ModeSmart,
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(bodies) == 0 {
+		t.Fatal("expected at least one LLM request")
+	}
+	body := string(bodies[0])
+	if strings.Contains(body, "image_url") || strings.Contains(body, "https://example.com/frame.png") {
+		t.Fatalf("text-only model must not receive media blocks, body: %s", body)
+	}
+}

--- a/server/internal/service/upload.go
+++ b/server/internal/service/upload.go
@@ -673,7 +673,7 @@ func parseSessionFile(data []byte) (SessionFile, error) {
 			// Skip lines that aren't valid JSON (metadata, etc.)
 			continue
 		}
-		if simple.Role != "" && simple.Content != "" {
+		if simple.Role != "" && (simple.Content != "" || len(simple.Media) > 0) {
 			messages = append(messages, simple)
 			continue
 		}
@@ -712,46 +712,85 @@ func parseOpenClawLine(line []byte) *IngestMessage {
 	}
 	role := entry.Message.Role
 
-	content := flattenContentBlocks(entry.Message.Content)
-	if content == "" {
+	content, media := flattenContentBlocks(entry.Message.Content)
+	if content == "" && len(media) == 0 {
 		return nil
 	}
-	return &IngestMessage{Role: role, Content: content}
+	return &IngestMessage{Role: role, Content: content, Media: media}
 }
 
-// flattenContentBlocks converts a content field to a plain string.
+// contentBlockURL is the nested URL wrapper used by media content blocks.
+type contentBlockURL struct {
+	URL string `json:"url"`
+}
+
+// flattenContentBlocks converts a content field to a plain string and collects
+// the non-text inputs the block form carries.
 // Handles both string content and array-of-blocks content
 // (e.g. [{"type":"text","text":"..."},{"type":"thinking","thinking":"..."}]).
-func flattenContentBlocks(raw json.RawMessage) string {
+// Image and video blocks are returned as media parts rather than discarded, so
+// they can still reach models that accept those input modalities.
+func flattenContentBlocks(raw json.RawMessage) (string, []llm.MediaPart) {
 	if len(raw) == 0 {
-		return ""
+		return "", nil
 	}
 
 	// Try plain string first.
 	var s string
 	if json.Unmarshal(raw, &s) == nil {
-		return s
+		return s, nil
 	}
 
 	// Try array of content blocks.
 	var blocks []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
+		Type     string           `json:"type"`
+		Text     string           `json:"text"`
+		URL      string           `json:"url"`
+		ImageURL *contentBlockURL `json:"image_url"`
+		VideoURL *contentBlockURL `json:"video_url"`
+		Source   *contentBlockURL `json:"source"`
 	}
 	if json.Unmarshal(raw, &blocks) != nil {
-		return ""
+		return "", nil
 	}
 
 	var sb strings.Builder
+	var media []llm.MediaPart
 	for _, b := range blocks {
-		if b.Type == "text" && b.Text != "" {
+		switch b.Type {
+		case "text":
+			if b.Text == "" {
+				continue
+			}
 			if sb.Len() > 0 {
 				sb.WriteString("\n\n")
 			}
 			sb.WriteString(b.Text)
+		case "image", "image_url":
+			if url := firstBlockURL(b.URL, b.ImageURL, b.Source); url != "" {
+				media = append(media, llm.MediaPart{Kind: llm.MediaKindImage, URL: url})
+			}
+		case "video", "video_url":
+			if url := firstBlockURL(b.URL, b.VideoURL, b.Source); url != "" {
+				media = append(media, llm.MediaPart{Kind: llm.MediaKindVideo, URL: url})
+			}
 		}
 	}
-	return sb.String()
+	return sb.String(), media
+}
+
+// firstBlockURL returns the first non-empty URL among a block's direct url
+// field and its nested URL wrappers.
+func firstBlockURL(direct string, refs ...*contentBlockURL) string {
+	if direct != "" {
+		return direct
+	}
+	for _, ref := range refs {
+		if ref != nil && ref.URL != "" {
+			return ref.URL
+		}
+	}
+	return ""
 }
 
 func chunkMessages(msgs []IngestMessage, size int) [][]IngestMessage {

--- a/server/internal/service/upload_test.go
+++ b/server/internal/service/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/llm"
 )
 
 func TestChunkMessages(t *testing.T) {
@@ -556,4 +557,104 @@ func makeMessages(n int) []IngestMessage {
 		msgs[i] = IngestMessage{Role: "user", Content: "msg"}
 	}
 	return msgs
+}
+
+func TestFlattenContentBlocks(t *testing.T) {
+	t.Run("plain string content carries no media", func(t *testing.T) {
+		text, media := flattenContentBlocks(json.RawMessage(`"hello"`))
+		if text != "hello" {
+			t.Fatalf("text = %q, want %q", text, "hello")
+		}
+		if len(media) != 0 {
+			t.Fatalf("media len = %d, want 0", len(media))
+		}
+	})
+
+	t.Run("text blocks are joined and image and video blocks are kept", func(t *testing.T) {
+		raw := json.RawMessage(`[
+			{"type":"text","text":"first"},
+			{"type":"image_url","image_url":{"url":"https://example.com/a.png"}},
+			{"type":"text","text":"second"},
+			{"type":"video_url","video_url":{"url":"mm_file://vid"}},
+			{"type":"thinking","thinking":"ignored"}
+		]`)
+		text, media := flattenContentBlocks(raw)
+		if text != "first\n\nsecond" {
+			t.Fatalf("text = %q, want %q", text, "first\n\nsecond")
+		}
+		want := []llm.MediaPart{
+			{Kind: llm.MediaKindImage, URL: "https://example.com/a.png"},
+			{Kind: llm.MediaKindVideo, URL: "mm_file://vid"},
+		}
+		if len(media) != len(want) {
+			t.Fatalf("media = %#v, want %#v", media, want)
+		}
+		for i := range want {
+			if media[i] != want[i] {
+				t.Fatalf("media[%d] = %#v, want %#v", i, media[i], want[i])
+			}
+		}
+	})
+
+	t.Run("source and direct url forms are accepted", func(t *testing.T) {
+		raw := json.RawMessage(`[
+			{"type":"image","source":{"url":"https://example.com/b.png"}},
+			{"type":"video","url":"https://example.com/c.mp4"}
+		]`)
+		text, media := flattenContentBlocks(raw)
+		if text != "" {
+			t.Fatalf("text = %q, want empty", text)
+		}
+		if len(media) != 2 {
+			t.Fatalf("media len = %d, want 2", len(media))
+		}
+		if media[0] != (llm.MediaPart{Kind: llm.MediaKindImage, URL: "https://example.com/b.png"}) {
+			t.Fatalf("media[0] = %#v", media[0])
+		}
+		if media[1] != (llm.MediaPart{Kind: llm.MediaKindVideo, URL: "https://example.com/c.mp4"}) {
+			t.Fatalf("media[1] = %#v", media[1])
+		}
+	})
+
+	t.Run("media blocks without a url are skipped", func(t *testing.T) {
+		raw := json.RawMessage(`[{"type":"text","text":"only text"},{"type":"image_url"}]`)
+		text, media := flattenContentBlocks(raw)
+		if text != "only text" {
+			t.Fatalf("text = %q, want %q", text, "only text")
+		}
+		if len(media) != 0 {
+			t.Fatalf("media len = %d, want 0", len(media))
+		}
+	})
+}
+
+func TestParseOpenClawLineKeepsMediaOnlyMessage(t *testing.T) {
+	line := []byte(`{"type":"message","message":{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.com/a.png"}}]}}`)
+	msg := parseOpenClawLine(line)
+	if msg == nil {
+		t.Fatal("expected a message for media-only content, got nil")
+	}
+	if msg.Content != "" {
+		t.Fatalf("content = %q, want empty", msg.Content)
+	}
+	if len(msg.Media) != 1 || msg.Media[0].Kind != llm.MediaKindImage {
+		t.Fatalf("media = %#v, want a single image part", msg.Media)
+	}
+}
+
+func TestParseSessionFileKeepsMediaOnlyJSONLMessage(t *testing.T) {
+	data := []byte(`{"role":"user","media":[{"kind":"video","url":"mm_file://vid"}]}`)
+	file, err := parseSessionFile(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(file.Messages) != 1 {
+		t.Fatalf("messages len = %d, want 1", len(file.Messages))
+	}
+	if len(file.Messages[0].Media) != 1 {
+		t.Fatalf("media = %#v, want a single part", file.Messages[0].Media)
+	}
+	if file.Messages[0].Media[0] != (llm.MediaPart{Kind: llm.MediaKindVideo, URL: "mm_file://vid"}) {
+		t.Fatalf("media[0] = %#v", file.Messages[0].Media[0])
+	}
 }


### PR DESCRIPTION
Reason: MiniMax-M3 accepts image and video inputs, but smart ingest sent string-only messages and dropped imported image/video content blocks, so that content could never reach the model.

## Problem

`flattenContentBlocks` kept only `type: "text"` blocks when parsing imported session
transcripts, so any image or video block was silently discarded. Even when such content
survived parsing, the LLM client only ever sent user content as a JSON string, so there
was no way to pass a non-text input through the extraction pipeline.

## Changes

`server/internal/llm/client.go`

- Add `MediaPart` (`kind` + `url`) with `MediaKindImage` / `MediaKindVideo`, and extend
  `contentBlock` with `image_url` / `video_url` wrappers. `text` is now `omitempty` so
  media blocks do not carry an empty text field.
- Add `modelInputModalities` plus `supportsInputModality`, following the existing
  per-model capability helpers in this file. Models absent from the table are treated as
  text-only, so their requests keep the current plain-string content shape.
- Add `CompleteJSONWithMedia`. It emits the block content form only when the configured
  model accepts the attached modality, and drops parts the model cannot accept.
  `CompleteJSONWithScope` now delegates to it with no media, so existing callers are
  unchanged.
- Extend the existing HTTP 400 fallback: if a request carrying media blocks is rejected,
  it retries once with plain string content and records a `media_block_400_fallback`
  retry metric.

`server/internal/service/upload.go`

- `flattenContentBlocks` now returns the flattened text plus the media parts it found,
  instead of discarding image and video blocks. It accepts the `image_url` / `video_url`
  wrapper form, a direct `url` field, and a nested `source.url`.
- A message that carries only media is no longer dropped by `parseOpenClawLine` or by the
  JSONL branch of `parseSessionFile`.

`server/internal/service/ingest.go`

- `IngestMessage` gains an optional `media` array, and it is preserved through
  `prepareExtractionInput` and `StripInjectedContext`.
- Because the conversation is formatted into text before extraction, media is threaded
  separately from `Ingest` through `extractAndReconcile` into `extractFactsWithRouting`,
  and from `ExtractPhase1WithRouting` into `extractFactsAndTagsWithRouting`, so both
  extraction paths forward it to the model.

`docs/api/openapi.json`

- Document the new optional `media` field on `IngestMessage`.

Behaviour for text-only models and for messages without media is unchanged: the request
still sends user content as a plain string.

## Checks

Run from `server/`:

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`

All pass. New coverage: `TestSupportsInputModality` and `TestCompleteJSONWithMedia`
(block shape, text-only drop, missing-URL skip, and the 400 fallback) in
`internal/llm`; `TestFlattenContentBlocks`, `TestParseOpenClawLineKeepsMediaOnlyMessage`,
`TestParseSessionFileKeepsMediaOnlyJSONLMessage`, `TestCollectMessageMedia`,
`TestPrepareExtractionInputKeepsMediaOnlyMessage`,
`TestStripInjectedContextKeepsMediaOnlyMessage`, plus the end-to-end
`TestIngestSendsMessageMediaToLLM` and `TestIngestKeepsStringContentForTextOnlyModel`
in `internal/service`.

`gofmt -l` reports no drift on the touched files. `internal/service/temporal_fact.go` is
already unformatted on the base branch and is left untouched.
