### PR TITLE
fix(dsh-plugin): restore @deepseek-ai/dsh import in pack-check

### DIFF
--- a/dsh-plugin/scripts/pack-check.mjs
+++ b/dsh-plugin/scripts/pack-check.mjs
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 const root = dirname(dirname(new URL(import.meta.url).pathname));
 const temp = mkdtempSync(join(tmpdir(), "mem9-dsh-pack-"));
 const require = createRequire(import.meta.url);
-const dshBin = join(dirname(require.resolve("@dsh-ai/dsh/package.json")), "lib", "bin.js");
+const dshBin = join(dirname(require.resolve("@deepseek-ai/dsh/package.json")), "lib", "bin.js");
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {


### PR DESCRIPTION
sed 全局替换 `s|deepseek|dsh|g` 时误伤了 `@deepseek-ai/dsh` → `@dsh-ai/dsh`，导致 `pack:check` 步骤 resolve 失败。