### PR TITLE
docs: add Chinese algorithm architecture guides

### DIFF
--- a/docs/architecture/mem9-algorithms/README.zh-CN.md
+++ b/docs/architecture/mem9-algorithms/README.zh-CN.md
@@ -1,0 +1,45 @@
+# MEM9 记忆算法中文导读
+
+本文档集解释 MEM9 当前实现中的四条核心链路：Recall、Facts 抽取、Reconcile 和记忆持久化。它们共同组成“把一次对话变成可长期检索的记忆，再在未来召回”的闭环。
+
+## 阅读顺序
+
+1. [Facts 抽取流程](facts-extraction.zh-CN.md)：先理解系统如何从消息中识别可长期保存的原子事实。
+2. [Reconcile 流程](reconciliation.zh-CN.md)：再理解新事实如何与已有记忆比较，并被判定为 ADD、UPDATE、DELETE 或 NOOP。
+3. [记忆存入流程](memory-storage.zh-CN.md)：接着理解 session、pinned、insight 三类记录最终如何写入 TiDB。
+4. [Recall Algorithms](recall.zh-CN.md)：最后理解查询如何从 pinned、insight、session 三个候选池中召回、融合、评分和截断。
+
+## 一眼看懂四条链路
+
+```mermaid
+flowchart LR
+    A[客户端提交 messages 或 content] --> B[可选保存原始 session turns]
+    A --> C[Facts 抽取]
+    C --> D[长期事实过滤、时间归一化、来源标注]
+    D --> E[Reconcile 检索相关旧记忆]
+    E --> F{决策}
+    F -->|ADD| G[新增 active insight]
+    F -->|UPDATE| H[归档旧 insight + 新建 active insight]
+    F -->|DELETE| I[旧 insight 标为 deleted]
+    F -->|NOOP| J[不写入]
+    G --> K[未来 Recall]
+    H --> K
+    B --> K
+    L[显式 pinned 内容] --> M[直接写 active pinned]
+    M --> K
+    K --> N[三池候选 + RRF + confidence + 选择器]
+```
+
+## 三种记忆的职责
+
+| 类型 | 含义 | 主要写入路径 | Recall 中的角色 |
+| --- | --- | --- | --- |
+| `session` | 原始对话 turn，保留上下文与相邻消息 | `SessionService.BulkCreate` | 回答事件、原话、时间和上下文问题 |
+| `insight` | 从对话或 content 中提炼出的长期事实 | Facts 抽取 + Reconcile | 回答稳定事实、偏好、关系、项目和配置问题 |
+| `pinned` | 用户显式要求固定保存的内容 | `MemoryService.CreatePinned` | 高优先级但仍受置信度与数量上限约束 |
+
+## 文档依据与边界
+
+本文档依据本机 MEM9 仓库 `8a6d5c236b121283ea48de783bcb1b0e31e24638` 源码快照编写，主要覆盖 `server/internal/handler`、`server/internal/service` 和 `server/internal/repository/tidb`。源码仓库仍是算法事实的权威来源；本文档是面向理解和运维排障的解释层，不替代 API 契约或源码测试。
+
+本文档描述的是应用算法与数据库语义，不代表某一时刻生产环境的配置、特性开关或实时健康状态。

--- a/docs/architecture/mem9-algorithms/facts-extraction.zh-CN.md
+++ b/docs/architecture/mem9-algorithms/facts-extraction.zh-CN.md
@@ -1,0 +1,130 @@
+# MEM9 Facts 抽取流程
+
+Facts 抽取的目标不是总结整段对话，而是从允许的消息角色中生成可独立检索、适合长期保存的原子事实，并为每个事实附加 tags、时间语义、来源 turn 和可选的 Space Chain 路由目标。
+
+## 详细流程图
+
+```mermaid
+flowchart TD
+    A[输入 messages 或单条 content] --> B[StripInjectedContext]
+    B --> C[去除空消息并保留原始索引]
+    C --> D{是否有 LLM 且输入非空?}
+    D -->|否| Z[返回空 Phase1Result；上层可走 raw 写入]
+    D -->|是| E[按 rune 上限截断并 formatConversation]
+    E --> F[确定事实来源角色]
+    F --> F1[默认仅 user]
+    F --> F2[开关启用时 user + 合格 assistant]
+    F1 --> G[构造 extraction prompt]
+    F2 --> G
+    G --> H[LLM 输出 JSON: facts + 可选 message_tags/route_targets]
+    H --> I{JSON 首次解析成功?}
+    I -->|否| J[要求 LLM 修复 JSON，重试一次]
+    J --> K{重试解析成功?}
+    K -->|否| L[尝试 legacy string-array 或 flattened-fact 恢复]
+    K -->|是| M[normalizeParsedFacts]
+    I -->|是| M
+    L --> M
+    M --> N[trim 空文本、保留原语言、原子化事实]
+    N --> O[filterLongTermFacts]
+    O --> P{fact_type 或确定性 guard 命中?}
+    P -->|query_intent| X[丢弃]
+    P -->|transient_status| X
+    P -->|ephemeral_intent| X
+    P -->|activity_log| X
+    P -->|operational_log| X
+    P -->|durable fact| Q[normalizeTemporalFacts]
+    Q --> R[解析绝对时间、相对时间和消息头锚点]
+    R --> S[annotateFactsWithSourceSeqs]
+    S --> T[推断 source_seqs，最多 6 个]
+    T --> U[保存 source_turns 摘要]
+    U --> V[展开 message_tags 到原始消息索引]
+    V --> W[输出 Phase1Result]
+    W --> W1[Facts: Text/Tags/FactType/RouteTargets/Temporal/SourceSeqs]
+    W --> W2[MessageTags: 与原始 messages 等长]
+    X --> Y{还有 durable facts?}
+    Y -->|有| Q
+    Y -->|无| Z2[返回空 facts；原始 session 仍可独立保存]
+```
+
+## 1. 输入预处理
+
+Handler 驱动的消息管线首先调用 `StripInjectedContext`，移除插件注入的 `<relevant-memories>...</relevant-memories>` 内容，避免把上一次召回结果再次写回数据库而形成反馈环。
+
+`prepareExtractionInputWithPolicy` 会跳过空消息、规范化 role 和 content，并记录清洗后消息对应的原始索引。格式化后的对话最多保留 1,000,000 个 rune；单条 `content` 入口在包成 `User:` 消息前最多保留 32,000 个 rune。
+
+## 2. 哪些消息可以成为事实来源
+
+默认策略只从 `user` 消息抽取事实，`system` 和 `tool` 永远不参与事实抽取。启用 `includeAssistantFacts` 后，`assistant` 只允许贡献关于用户世界、项目、系统、决策或已确认结果的具体长期断言，不能把建议、猜测、提问或自我描述当作用户事实。
+
+这一规则只约束 facts；`message_tags` 仍然会为 user、assistant、tool、system 的每条消息生成对应位置的标签。
+
+## 3. LLM 抽取契约
+
+每个事实应是单一、自包含、可独立检索的陈述。因果、条件、先后等语义强依赖的内容允许保留为一个事实，避免拆开后丢失关系。
+
+抽取器要求保留原始语言、具体名称和时间表达，尽量把明确指代替换为实体名，但不得猜测不清楚的指代。每个事实可带 1–3 个短 lowercase tags；启用 Space Chain 时还可带零个或多个 `route_targets`，但路由信息不能混入 tags。
+
+LLM 必须返回 JSON。首次解析失败时会发起一次 JSON 修复重试；仍失败后，服务会尝试兼容旧的 `{"facts":["..."]}` 格式，以及把事实字段错误展开到顶层的 flattened-fact 格式。无法恢复时，Phase 1 返回错误。
+
+## 4. 长期事实过滤
+
+系统使用两层门禁。第一层是 prompt，让模型只产生 durable facts；第二层是服务端 `filterLongTermFacts`，对输出做确定性兜底。
+
+以下类型会被丢弃，不进入 Reconcile：
+
+- `query_intent`：用户只是提问、搜索或要求解释。
+- `transient_status`：当前短暂状态，例如“现在正在健身”。
+- `ephemeral_intent`：一次性意图或请求，例如临时监控、记录一顿饭。
+- `activity_log`：单次饮食、体重、训练、睡眠等自我记录。
+- `operational_log`：调试、任务、导入、运行状态、临时工作区等日志。
+
+服务端还用中英文正则检测部分短期意图和日志。普通人物、地点、关系、项目、旅行、事件或承诺，不应仅因为包含“今天/明天/吃过/计划”等词就被过滤；带同伴或社会关系线索的叙事事件也会避免被简单当作 activity log。
+
+## 5. 时间归一化
+
+抽取文本保持自然语言时间，不把 `[time: ...]` 直接写进正文。后处理将时间解析为 metadata 中的 `TemporalMetadata`：`kind`、`anchor_source`、`granularity`、`resolved_start`、`resolved_end` 和 `display`。
+
+归一化会区分显式绝对时间、本句锚定的相对时间、消息头锚定的相对时间，以及以当前时间为锚的指示性相对时间。Recall 或 Reconcile 需要匹配时，`TemporalRecallProjection` 才临时把 `display` 投影成只读的 `[time: ...]` 后缀。
+
+## 6. 来源追踪
+
+每个事实会获得 `source_seqs` 和 `source_turns`。若 LLM 没有直接返回来源序号，服务会根据事实文本与允许来源消息之间的 token 重合度推断，最多保留 6 个来源序号，再把对应 role/content 写入 metadata。
+
+这一设计让最终 insight 能够追溯到原始对话，同时让 Reconcile 改写后的文本仍可通过相似 token 重新关联到最可能的来源 facts。
+
+## 7. 空结果与失败语义
+
+“没有 durable facts”是正常结果，不是错误。原始 session turns 仍可能已被保存，长期 insight 则不会创建。
+
+LLM 不可用时，`ExtractPhase1` 返回空结果；`IngestService.Ingest` 的 raw 模式或无 LLM 模式会改走整段原文直接写 insight 的路径。对于明确要求 Reconcile 的 `ReconcileContent`，无 LLM 会返回校验错误，不会悄悄降级成 raw 写入。
+
+## 8. 核心伪代码
+
+```text
+cleaned = stripInjectedContext(messages)
+input = prepare(cleaned, allowed_roles, rune_limit)
+if llm == nil or input.empty: return empty
+
+raw = llm.extract(input, routing_targets)
+parsed = parse_or_retry_or_recover(raw)
+facts = trim_and_normalize(parsed.facts)
+facts = keep_only_durable_facts(facts)
+facts = normalize_temporal_metadata(facts)
+facts = attach_source_seqs_and_turns(facts, input.messages)
+message_tags = expand_to_original_indices(parsed.message_tags)
+return facts, message_tags
+```
+
+## 9. 源码定位
+
+- `server/internal/handler/memory.go`: `ingestMessages`，消息入口、session 保存、Phase 1 与 Phase 2 编排。
+- `server/internal/service/ingest.go`: `ExtractPhase1WithRouting`、`extractFactsWithRouting`、`extractFactsAndTagsWithRouting`、`finalizeExtractedFacts`、`filterLongTermFacts`。
+- `server/internal/service/temporal_fact.go`: 时间归一化与 Recall 投影。
+- `server/internal/service/source_provenance.go`: `source_seqs`、`source_turns` 的推断和 metadata 写入。
+
+## 10. 排障检查点
+
+- facts 为空时，先区分“源角色不允许”“LLM 输出为空”“全部被长期事实门禁过滤”与“JSON 无法恢复”。
+- session 中有原话但 insight 中没有，并不必然是故障；这可能是过滤器按设计丢弃了短期内容。
+- 检查 `fact_type` 与 server guard 的过滤指标，避免仅根据最终数据库行数判断抽取失败。
+- 时间问题应同时查看正文、temporal metadata 与 Recall 时的投影，不能只搜索正文中的绝对日期。

--- a/docs/architecture/mem9-algorithms/memory-storage.zh-CN.md
+++ b/docs/architecture/mem9-algorithms/memory-storage.zh-CN.md
@@ -1,0 +1,159 @@
+# MEM9 记忆存入流程
+
+MEM9 的“存入”不是单一路径。客户端可以提交 `messages`、普通 `content` 或显式 `pinned content`；系统会分别保存原始 session、经过 Reconcile 的 insight，或用户固定的 pinned，并根据嵌入模式决定由应用生成向量还是交给 TiDB 自动嵌入。
+
+## 详细流程图
+
+```mermaid
+flowchart TD
+    A[POST memory create] --> B{输入类型}
+    B -->|messages| C[构造 IngestRequest]
+    B -->|content + memory_type=pinned| P[CreatePinned]
+    B -->|普通 content| Q{sync?}
+    C --> D{sync?}
+    D -->|是| E[在请求超时预算内 ingestMessages]
+    D -->|否| F[后台 goroutine ingestMessages，立即 202]
+    E --> G[StripInjectedContext]
+    F --> G
+    G --> H{disableSessionSave?}
+    H -->|否| I[SessionService.BulkCreate，best-effort]
+    H -->|是| J[跳过 session rows]
+    I --> K[ExtractPhase1]
+    J --> K
+    K --> L[并行：PatchTags 到 session]
+    K --> M[并行：ReconcilePhase2]
+    M --> N[ADD/UPDATE/DELETE/NOOP]
+    N --> O[合并用户 metadata；可选 Chain routing]
+    L --> O
+    P --> P1[BulkCreate 构造 TypePinned/version=1/active]
+    Q -->|是| Q1{有 routing targets 且有 LLM?}
+    Q -->|否| Q2[后台执行相同 content 路径，立即 202]
+    Q1 -->|是| Q3[抽取 + Reconcile + Chain routing]
+    Q1 -->|否| Q4[MemoryService.Create]
+    Q4 --> Q5{有 LLM?}
+    Q5 -->|是| Q6[ReconcileContent，产生 insight actions]
+    Q5 -->|否| Q7[单次 raw insight 写入]
+    N --> R{写动作类型}
+    Q6 --> R
+    R -->|ADD| S[MemoryRepo.Create]
+    R -->|UPDATE| T[MemoryRepo.ArchiveAndCreate 事务]
+    R -->|DELETE| U[MemoryRepo.SetState deleted]
+    P1 --> V[MemoryRepo.BulkCreate 事务]
+    Q7 --> S
+    S --> W{Embedding 模式}
+    T --> W
+    V --> W
+    W -->|autoModel 非空| X[INSERT 不带 embedding，由 TiDB 自动模型处理]
+    W -->|外部 embedder| Y[应用先 Embed，再 INSERT embedding]
+    W -->|均无| Z[INSERT embedding=NULL]
+    X --> AA[active memory 可被 Recall]
+    Y --> AA
+    Z --> AA
+    U --> AB[deleted，不再进入 active 查询]
+```
+
+## 1. 消息入口：同时形成 session 与 insight
+
+`messages` 路径由 Handler 的 `ingestMessages` 编排。第一步先清除注入的 relevant memories；随后若未设置 `disableSessionSave`，调用 `SessionService.BulkCreate` 保存每一个原始 turn。
+
+Session 保存是 best-effort。即使 session bulk insert 失败，Facts 抽取与 Reconcile 仍会继续；因此 `sync=true` 只保证抽取/Reconcile 已完成，不保证 `/session-messages` 中一定存在所有原始行。当前 `BulkCreate`、PatchTags 和 Reconcile 也没有被一个总事务包住。
+
+Phase 1 返回后，系统并行执行两件事：把 `message_tags` patch 回对应 session rows；把 facts 交给 `ReconcilePhase2` 产生 insight 变化。两者完成后，可选执行 Space Chain 路由，并把用户 metadata 合并到新创建的 insights。
+
+需要特别注意当前入口差异：Handler 的 `messages` 路径直接调用 `ExtractPhase1WithRouting`，不会根据请求中的 `mode` 切换到 `IngestService.Ingest`。因此在该路径没有 LLM 时，Phase 1 返回空 facts，通常只留下 session rows；`ModeRaw` 或无 LLM 时把整段对话直接写成 raw insight 的行为属于 `IngestService.Ingest` 自身的另一条调用路径。
+
+## 2. 普通 content 入口
+
+普通 `content` 不允许携带 ingest `mode`。有 LLM 时，`MemoryService.Create` 调用 `ReconcileContent`，把 content 包成单条 user 消息进行 Facts 抽取和 Reconcile；同一 content 可能生成零条、一条或多条 insight。
+
+无 LLM 时，普通 content 走可预测的单写路径：校验输入、可选生成外部 embedding、构造一条 `TypeInsight`、`active`、`version=1` 的记录并调用 `MemoryRepo.Create`。它不会先写入再 patch tags/metadata，避免第二次写失败后 API 报错但内容已经落库。
+
+如果 content 位于带路由规则的 Space Chain 且 LLM 可用，Handler 会先抽取带 `route_targets` 的 facts，再对源 Space 和目标 Spaces 分别 Reconcile。用户 tags/metadata 在这些动作完成后再合并到创建出的 insights。
+
+## 3. 显式 pinned 入口
+
+显式 `memory_type` 当前只接受 `pinned`。`CreatePinned` 调用 `BulkCreate`，直接构造 `TypePinned`、`active`、`version=1` 的记录，不经过 Facts 抽取或 Reconcile。
+
+Pinned bulk create 在一个数据库事务内执行，任意一条 insert 失败会回滚整批。单次 CreatePinned 目前也是复用这个批量事务，只是 items 数量为 1。
+
+## 4. Insight 的三种写动作
+
+ADD 调用 `MemoryRepo.Create`，新记录使用 UUID、`TypeInsight`、`active`、`version=1`，并保存 source、agent、app、session、tags、temporal/source/external provenance metadata。
+
+UPDATE 使用 append-new + archive-old：先生成新 UUID，在 `ArchiveAndCreate` 单事务内将旧 active 记录改为 `archived`、写入 `superseded_by`，再 insert 新 active insight。它不是原地覆盖，也不继承旧行的 version 序列；新行从 version 1 开始。
+
+DELETE 将目标 active insight 的 state 改为 `deleted`，属于软删除。Pinned 不允许被自动 Reconcile 删除；显式 API 删除则由 `SoftDelete` 加行锁后幂等更新。
+
+## 5. 嵌入向量的三种模式
+
+| 模式 | 写入行为 | Recall 行为 |
+| --- | --- | --- |
+| `autoModel != ""` | INSERT 省略 `embedding` 列 | 使用 TiDB `AutoVectorSearch(queryText)` |
+| 外部 `embedder != nil` | 应用先生成 `[]float32` 并写入 embedding | 查询也先 Embed，再 `VectorSearch` |
+| 两者都没有 | embedding 为空 | 降级为 FTS 或 LIKE keyword |
+
+在 autoModel 模式下，应用层不应自行写 embedding；在外部 embedder 模式下，content 发生变化时必须重新生成向量。数据库向量搜索只考虑 `embedding IS NOT NULL` 的 active 记录。
+
+## 6. 普通 API Update 与 Reconcile UPDATE 的区别
+
+普通 `MemoryService.Update` 是原地更新同一 ID：读取当前 active 记录、修改 content/tags/metadata、必要时重算 embedding，再调用 `UpdateOptimistic`，SQL 将 `version = version + 1`。虽然接口接受 `If-Match`，当前服务检测到版本不一致时记录 LWW warning，但实际调用 repository 时传入 expectedVersion=0，因此不会用 SQL 条件拒绝这次写入。
+
+Reconcile UPDATE 则使用版本链：旧 ID 归档，新 ID 创建。排障时必须先确认是哪一种 UPDATE，否则会误判 ID 变化或 version 变化。
+
+## 7. 同步、异步与副作用
+
+`sync=true` 在请求上下文和较长超时预算内完成 ingest，并返回最终状态；异步路径先完成配额预留，启动后台 goroutine 后返回 HTTP 202。后台失败只记录日志并执行失败计量，客户端不能从初始 202 判断最终是否产生 insight。
+
+成功写入后还会执行 runtime usage finalize、webhook enqueue 和后续成功处理。应用写入已经成功但计量 finalize 失败时，HTTP 层可能返回错误；排障必须同时检查数据库、usage operation 和 webhook，而不能仅以响应码推断是否落库。
+
+## 8. 原子性边界
+
+| 边界 | 是否原子 | 说明 |
+| --- | --- | --- |
+| 一批 pinned `BulkCreate` | 是 | 单 TiDB 事务 |
+| 一次 insight UPDATE | 是 | archive old + create new 单事务 |
+| 一次显式 soft delete | 是 | 行锁 + update + commit |
+| 整个 messages ingest | 否 | session save、tag patch、多个 Reconcile actions 分开 |
+| 一批 Reconcile actions | 否 | 每个 ADD/UPDATE/DELETE 独立执行，允许 partial |
+| 写入与 runtime usage/webhook | 否 | 属于后置协调，不和 memory SQL 共事务 |
+
+## 9. 核心伪代码
+
+```text
+if request.messages:
+  clean(messages)
+  best_effort_save_session_turns()
+  facts, message_tags = extract_phase1()
+  parallel(
+    patch_session_tags(message_tags),
+    reconcile_phase2(facts)
+  )
+  route_chain_and_merge_metadata()
+
+else if request.memory_type == pinned:
+  bulk_create_transaction(type=pinned)
+
+else if request.content:
+  if llm: extract_and_reconcile_as_insight()
+  else: create_one_raw_insight()
+
+write(ADD)    = insert_active()
+write(UPDATE) = transaction(archive_old(), insert_new_active())
+write(DELETE) = set_state_deleted()
+```
+
+## 10. 源码定位
+
+- `server/internal/handler/memory.go`: create handler、同步/异步路径、`ingestMessages`、Chain routing 和 post-success 操作。
+- `server/internal/service/session.go`: 原始 session turns 的 `BulkCreate` 与 tags patch。
+- `server/internal/service/memory.go`: `Create`、`CreatePinned`、`Update`、`Delete`、`BulkCreate`。
+- `server/internal/service/ingest.go`: insight 的 `addInsight`、`updateInsight` 与 Reconcile delete。
+- `server/internal/repository/tidb/memory.go`: SQL insert、optimistic update、soft delete、bulk transaction、`ArchiveAndCreate`。
+
+## 11. 排障检查点
+
+- 收到 202 只说明异步任务已接受，必须继续验证最终数据库行、日志和计量 finalize。
+- session 缺行但 insight 存在，可能是 best-effort session bulk save 失败；反过来 session 存在但 insight 没有，可能是无 durable facts 或 Reconcile warning。
+- UPDATE 后要沿 `superseded_by` 检查新旧链，不要只查旧 active ID。
+- embedding 为空时先确认部署使用 autoModel、外部 embedder 还是 keyword-only 模式；autoModel 下 INSERT 不带 embedding 是预期实现。
+- 多条事实部分成功时，检查 `Changes` 和 `Warnings`，不要假设整个 ingest 事务回滚。

--- a/docs/architecture/mem9-algorithms/recall.zh-CN.md
+++ b/docs/architecture/mem9-algorithms/recall.zh-CN.md
@@ -1,0 +1,205 @@
+# MEM9 Recall Algorithms
+
+MEM9 Recall 不是简单的向量 Top-K。默认查询会同时从 pinned、insight、session 三个池构造候选，通过 FTS/keyword 与 vector 的 RRF 融合、查询形状特征、答案证据、来源先验和覆盖策略计算置信度，再选择最终结果。
+
+## 详细流程图
+
+```mermaid
+flowchart TD
+    A["GET memories，携带查询参数 q"] --> B["解析 auth、app、tags、type、limit、offset"]
+    B --> C{"是否为 content keyword 或 scanAll"}
+    C -->|content keyword| C1["直接执行 LIKE substring list filter"]
+    C -->|scanAll| C2["进入显式全量扫描路径"]
+    C -->|否| D["规范化相对时间 query"]
+    D --> E["建立总请求预算和 response reserve"]
+    E --> F["Runtime Usage BeforeRecall"]
+    F --> G{"memory_type 是否指定"}
+    G -->|空| H["默认三池 Recall"]
+    G -->|pinned、insight 或 session| I["单池 Recall"]
+    H --> J["buildRecallQueryProfile"]
+    I --> J
+    J --> K["分类 general、entity、count、time、location、enumeration、exact"]
+    K --> L["按 shape 调整 effective budget 和 candidate options"]
+    L --> M["三池并发；单池只执行目标分支"]
+    M --> M1["pinned：默认取 5，不启用 second hop"]
+    M --> M2["insight：默认取 10，可启用 second hop"]
+    M --> M3["session：默认取 10，可加入邻接 turn"]
+    M1 --> N["SearchCandidates"]
+    M2 --> N
+    M3 --> N
+    N --> O{"当前搜索能力"}
+    O -->|autoModel| O1["AutoVectorSearch 加 FTS 或 keyword"]
+    O -->|external embedder| O2["Embed 和 VectorSearch 加 FTS 或 keyword"]
+    O -->|仅 FTS| O3["FTS"]
+    O -->|无 FTS 和向量| O4["LIKE keyword"]
+    O1 --> P["若两路均空且条件允许，执行 loose token fallback"]
+    O2 --> P
+    O3 --> P
+    O4 --> P
+    P --> Q["RRF：每一路贡献 1 除以 60 加 rank"]
+    Q --> R["执行可选上下文扩展"]
+    R --> R1["insight second hop：最佳向量相似度至少 0.5，权重 0.3"]
+    R --> R2["session adjacent turns：radius 为 1，权重 0.8"]
+    R --> S["按 content 去重并保留候选证据"]
+    S --> T["计算 0 到 100 的 confidence"]
+    T --> U["RRF、vector、bonuses 和 source prior 加权"]
+    U --> V{"按 query shape 选择结果"}
+    V -->|pinned| V1["阈值 70，默认最多 2；enumeration 最多 1"]
+    V -->|enumeration| V2["阈值 55，覆盖优先、分池轮转、再 backfill"]
+    V -->|general 或 exact| V3["阈值 65，两轮跨池平衡、再 backfill"]
+    V -->|其他 shape| V4["阈值 65，按 Top 排序"]
+    V3 --> W["默认按 18 分 confidence gap 截断"]
+    V4 --> W
+    V1 --> X["合并最终结果"]
+    V2 --> X
+    W --> X
+    X --> Y["应用 session edit overlay 和 temporal display projection"]
+    Y --> Z["Usage finalize、warnings、HTTP response"]
+    M --> ER{"是否发生分支失败"}
+    ER -->|真实错误| ER1["取消其他分支并返回错误"]
+    ER -->|服务端 deadline 且至少一池成功| ER2["返回 partial 和 warning"]
+    ER2 --> T
+```
+
+## 1. Handler 分流
+
+`listMemories` 首先规范化 limit 和 offset，解析 app、tags、source、state、memory type、agent、session、排序和时间范围。默认 limit 为 10，最大 200；`created_after/created_before` 只允许用于 `memory_type=session`，避免混合查询中只有 session 被时间过滤。
+
+只有非空 `q` 且不是 content keyword list filter 时才进入 Recall 预算、计量和置信度算法。显式 content keyword 路径故意绕开向量、FTS 和 Recall 排名，用 LIKE 作为 UI 内容过滤；`scanAll` 也走独立路径。
+
+未指定 `memory_type` 时进入默认三池 Recall；指定 `pinned`、`insight` 或 `session` 时进入单池置信度 Recall。没有 query 时只是普通 list，不运行下述算法。
+
+## 2. Query Profile 与查询形状
+
+系统先构造 `recallQueryProfile`，识别中英文查询中的时间、地点、数量、人物、列举、精确问句、目标 speaker、时态、持续时间、频率、视觉内容和引号文本等信号。
+
+主 shape 有七类：
+
+| Shape | 典型问题 | 选择重点 |
+| --- | --- | --- |
+| `general` | “关于我的部署偏好” | insight/session 平衡，允许关键词证据加成 |
+| `entity` | “谁负责 X？” | 候选中实体证据 |
+| `count` | “有多少个？” | 数值和计数证据 |
+| `time` | “什么时候发生？” | 时间 token、过去/未来一致性 |
+| `location` | “在哪里？” | 地点实体和位置表达 |
+| `enumeration` | “有哪些项目？” | 覆盖不同答案，不只追逐最高分 |
+| `exact` | “什么是 X？” | 文字、标识符和直接答案证据 |
+
+Enumeration 会把有效返回预算扩大为 `min(requested_limit * 2, 20)`，并增加 insight/session 候选数、fetch multiplier、second-hop seeds 和相邻 session turns，以提高列举完整性。
+
+## 3. 三个候选池
+
+默认三池并发执行：pinned 默认候选 5 条、insight 10 条、session 10 条。Pinned 不启用 second hop；insight 可启用 second hop；session 可加入相邻 turn。
+
+三池使用独立 branch context。任何“真实错误”会取消其他分支并让请求失败；如果只是服务端 Recall deadline，且至少一个分支已成功，系统可以返回已有分支结果并附 partial warning。客户端取消等非服务端原因仍会终止请求。
+
+## 4. 每个池内部如何搜候选
+
+`SearchCandidates` 按能力选择四种策略：
+
+1. 配置 TiDB auto embedding 时，使用 `AutoVectorSearch(query text)` 加 FTS/keyword。
+2. 配置外部 embedder 时，先对 query 生成 embedding，再执行 `VectorSearch` 加 FTS/keyword。
+3. 无向量能力但 FTS 可用时，只执行 FTS。
+4. 两者都不可用时，降级为 LIKE keyword。
+
+默认 fetch limit 是最终池 limit 的 3 倍；rich-top 和 enumeration 使用 4 倍。向量结果应用最低相似度过滤。向量与关键词都为空且 query 适合拆词时，会对去停用词后的 loose tokens 做逐词 keyword fallback，再按 token 命中数和更新时间排序。
+
+TiDB 向量查询只检索 embedding 非空的 active 记录。`VEC_COSINE_DISTANCE` 或 auto 版本的距离表达式必须在 SELECT 与 ORDER BY 中保持字节一致，才能利用 TiDB VECTOR INDEX。
+
+## 5. RRF 融合
+
+关键词/FTS 列表和向量列表使用 Reciprocal Rank Fusion 合并：
+
+```text
+RRF(id) = Σ 1 / (60 + rank_leg(id))
+```
+
+这里 `rank` 从 1 开始。一个候选同时在 keyword 和 vector 两路出现时，两项相加；单路第一名约为 `1/61`，两路第一名的理论基准上限为 `2/61`。候选会保留 `InVector`、`InKeyword`、`VectorSimilarity`、`RRFScore`、`RRFRank` 和来源池，供后续置信度计算。
+
+## 6. 二跳与相邻 turn 扩展
+
+Insight 的 second hop 只在 autoModel 候选路径且显式启用时运行。第一跳最佳向量相似度必须至少 0.5，否则认为没有足够强的语义锚点，避免扩展噪声。默认取前 3 个 seed；rich-top/enumeration 可取 5 个。二跳结果排除 seeds、按最佳相似度去重，并以 0.3 权重加入 RRF。
+
+Session 的 adjacent turns 从高排名 seed 出发，在相同 app/session 中按 seq 取半径 1 的上下文，默认最多围绕 4 个 seed；列举查询可以扩大到 12 个。相邻结果以 0.8 权重加入融合，让回答不仅看到命中的一句，还能看到它前后的对话语境。
+
+## 7. Confidence 评分
+
+每个候选最终得到 0–100 的整数 confidence。核心结构为：
+
+```text
+confidenceRaw =
+  0.55 * clamp(RRF / (2/61))
+  + 0.20 * clamp((vectorSimilarity - 0.30) / 0.70)
+  + agreementBonus
+  + literalContentEvidenceBonus
+  + keywordContentEvidenceBonus
+  + recencyBonus
+  + answerEvidenceBonus
+  + sourcePrior
+
+confidence = round(clamp(confidenceRaw, 0, 1) * 100)
+```
+
+其中 vector 与 keyword 同时命中加 0.10；长标识符原文命中可加 0.35，一般长 literal 可加 0.22；更新时间 7 天内可加 0.05、30 天内可加 0.02。`answerEvidenceBonus` 根据 shape 检查实体、时间、地点、数字、speaker、视觉描述等答案证据；`sourcePrior` 让 session 更适合 exact/事件语境，让 insight 更适合稳定的一般事实。
+
+Confidence 不是纯余弦相似度，也不是 LLM 评分；它是确定性特征组合。排障时必须同时看 RRF、vector、keyword、答案证据和来源池。
+
+## 8. 最终选择策略
+
+Pinned 先选，默认 confidence 至少 70 且最多保留 2 条；enumeration 最多保留 1 条。强 identifier literal 命中可能直接占用全部预算。
+
+General/exact 使用跨 insight/session 的平衡选择：先做两轮覆盖不同来源池，再按分数 backfill；如果后续候选比当前最佳候选低 18 分以上，会触发 confidence gap 截断。
+
+Entity/count/time/location 等其他非列举 shape 使用 confidence 至少 65 的 Top 排序，并应用默认 18 分 gap 截断。
+
+Enumeration 使用更低的 55 阈值和 coverage-first 策略，根据答案 focus/coverage token 与来源桶轮转选择，再 backfill。它优化的是“覆盖更多不同答案”，因此返回数量可能超过调用者原始 limit，但不超过扩展后的最大预算 20。
+
+所有路径最后按 content 去重；content 为空时退回 ID。冲突候选优先保留 confidence 更高者，再用来源偏好、更新时间和 ID 稳定决胜。
+
+## 9. 响应前处理与观测
+
+召回完成后，session 结果会应用 edit overlay，时间型 query 会把结构化 temporal metadata 投影成可读显示。随后 runtime usage finalize、计量和 HTTP 写响应在预留的 response budget 中执行。
+
+日志会记录 query shape、selection mode、requested/effective budget、各池候选与选中数量、coverage/backfill、cutoff reason、三分支耗时和 outcome、partial 状态以及总耗时。这些字段比单一 HTTP 状态更适合定位“慢在候选检索还是慢在选择/响应”。
+
+## 10. 核心伪代码
+
+```text
+profile = classify_and_profile(query)
+budget = effective_budget(profile.shape, requested_limit)
+
+parallel:
+  pinned  = search_candidates(type=pinned, second_hop=false)
+  insight = search_candidates(type=insight, second_hop=true)
+  session = search_candidates(type=session, adjacent_turns=true)
+
+for pool in [pinned, insight, session]:
+  candidates = keyword_or_fts + vector
+  candidates = rrf_merge(k=60)
+  candidates += optional_second_hop_or_adjacent_context
+  candidates = dedupe_by_content(candidates)
+  candidates = deterministic_confidence(candidates, profile)
+
+selected_pinned = select_pinned(confidence>=70, max=2)
+selected_mixed = profile.enumeration
+  ? select_for_coverage(confidence>=55)
+  : select_balanced_or_top(confidence>=65, gap_stop=18)
+return selected_pinned + selected_mixed
+```
+
+## 11. 源码定位
+
+- `server/internal/handler/memory.go`: `listMemories` 的参数校验、分流、预算、usage 和响应处理。
+- `server/internal/handler/recall.go`: query shape、三池并发、confidence、pinned/mixed/enumeration 选择和 partial deadline。
+- `server/internal/service/recall.go`: `RecallCandidate`、RRF 候选合并与 content 去重。
+- `server/internal/service/memory.go`: insight/pinned 的 auto hybrid、external hybrid、FTS/keyword fallback 和 second hop。
+- `server/internal/service/session.go`: session hybrid search 与 adjacent turns。
+- `server/internal/repository/tidb/memory.go`、`sessions.go`: TiDB FTS、LIKE 和向量查询。
+
+## 12. 排障检查点
+
+- 先确认请求走的是 Recall、content keyword、scanAll 还是普通 list；这些路径的排序语义完全不同。
+- “向量相似度很高但没返回”可能是 confidence 阈值、pinned 上限、来源平衡、gap cutoff 或 content 去重导致，不能只看 ANN Top-K。
+- 列举问题结果不全时，检查 query 是否被正确分类为 enumeration，以及 effective budget、coverage tokens、second hop 和 adjacent turns 是否启用。
+- HTTP 超时但已有部分结果时，查看三个 branch outcome 和 partial warnings；真实分支错误与服务器预算到期的恢复语义不同。
+- keyword/FTS 与 vector 两路同时为空时，确认 query 是否满足 loose token fallback 条件，并检查 FTS 可用状态与 embedding 是否非空。

--- a/docs/architecture/mem9-algorithms/reconciliation.zh-CN.md
+++ b/docs/architecture/mem9-algorithms/reconciliation.zh-CN.md
@@ -1,0 +1,149 @@
+# MEM9 Reconcile 流程
+
+Reconcile 的职责是把“新抽取的长期事实”与“当前已有的 active insight/pinned 记忆”放到同一个决策上下文中，决定每条事实应当 ADD、UPDATE、DELETE 还是 NOOP，并以防重复、可追溯、可恢复的方式执行结果。
+
+## 详细流程图
+
+```mermaid
+flowchart TD
+    A[输入 ExtractedFacts] --> B[再次 filterLongTermFacts]
+    B --> C{facts 是否为空?}
+    C -->|是| Z[complete，0 changes]
+    C -->|否| D[最多保留 50 条]
+    D --> E[NearDupSearch shadow metric]
+    E --> F[为每条 fact 构造时间投影文本]
+    F --> G[最多 4 workers 并发查已有记忆]
+    G --> H{有 embedding/auto model?}
+    H -->|是| I[向量检索 + FTS/keyword，两条 leg]
+    H -->|否| J[FTS 或 keyword 单 leg]
+    I --> K[向量相似度低于 0.3 的结果丢弃]
+    J --> L[汇总候选]
+    K --> L
+    L --> M[按 UUID 去重，正文截到 150 rune，最多 60 条]
+    M --> N{所有搜索都失败?}
+    N -->|是| N1[返回错误，阻止静默重复写入]
+    N -->|否| O{候选为空?}
+    O -->|是| P[addAllFacts：每条事实直接 ADD]
+    O -->|否| Q[UUID 映射为 0..N 整数 ID]
+    Q --> R[附加 memory age 与 temporal projection]
+    R --> S[一次 LLM 批量判断所有 facts + candidates]
+    S --> T{LLM/JSON 成功?}
+    T -->|调用失败| T1[warning，跳过全部动作以避免重复]
+    T -->|JSON 失败| T2[修复重试一次]
+    T2 -->|仍失败| T1
+    T -->|成功| U[遍历 actions]
+    T2 -->|成功| U
+    U --> V{event}
+    V -->|ADD| A1[规范化时间、合并来源和外部 provenance]
+    A1 --> A2[创建新 active insight]
+    V -->|UPDATE| B1[校验整数 ID、正文和 tags]
+    B1 --> B2{目标是 pinned?}
+    B2 -->|是| B3[禁止覆盖 pinned，退化为 ADD insight]
+    B2 -->|否| B4[ArchiveAndCreate 原子事务]
+    V -->|DELETE| C1[校验整数 ID]
+    C1 --> C2{目标是 pinned?}
+    C2 -->|是| C3[跳过并 warning]
+    C2 -->|否| C4[active -> deleted]
+    V -->|NOOP/NONE| D1[不写入]
+    A2 --> Y[汇总 Changes/Warnings/InsightIDs]
+    B3 --> Y
+    B4 --> Y
+    C3 --> Y
+    C4 --> Y
+    D1 --> Y
+    P --> Y
+```
+
+## 1. 为什么 Reconcile 先检索
+
+如果每个新事实都直接 ADD，重复表达会不断产生近似 insight，冲突事实也无法替换旧状态。因此系统先针对每条 fact 检索相关的 active `insight,pinned`，再把新旧信息交给一次批量 LLM 判断。
+
+`NearDupSearch` 当前只记录最近邻余弦分数作为 shadow metric，不会据此直接删除或抑制事实。真正的动作仍由后续检索与 Reconcile 决策完成。
+
+## 2. 已有记忆候选召回
+
+每条事实最多取 5 个候选，最多 4 个 worker 并发执行。存在自动嵌入模型时使用 `AutoVectorSearch`；存在外部 embedder 时先生成向量再执行 `VectorSearch`；两者都没有时只走 FTS 或 LIKE keyword。
+
+有向量能力时，向量 leg 和 FTS/keyword leg 都会尝试。向量结果低于 0.3 相似度会被丢弃，keyword 结果不应用这个阈值。所有 facts 的候选随后按 UUID 去重，传给 LLM 的正文最多 150 rune，总候选最多 60 条。
+
+单个 fact 的一条检索 leg 失败可以容忍，另一条成功仍可继续。若所有检索尝试都失败，系统返回错误并停止写入，避免把本应 UPDATE/NOOP 的事实静默 ADD 成重复记忆。FTS 候选窗口被截断也被视为不完整检索并阻止继续。
+
+如果检索成功但确实没有任何候选，系统不再调用 Reconcile LLM，而是执行 `addAllFacts`，逐条新增 insight。
+
+## 3. LLM 决策模型
+
+真实 UUID 不直接暴露给 LLM。服务先把候选映射成从 0 开始的整数 ID，并保存整数到 UUID 的本地映射，以阻止模型编造可写目标。每条候选还带有相对 age；age 只能在同一实体、同一属性槽发生冲突时作为辅助判断，不能单独触发 UPDATE 或 DELETE。
+
+四个动作的语义如下：
+
+| 动作 | 条件 | 数据库结果 |
+| --- | --- | --- |
+| `ADD` | 新信息不存在，或同一实体的新属性 | 新建 active insight |
+| `UPDATE` | 同一实体的同一属性槽被新信息取代 | 旧 insight archived，新 insight active |
+| `DELETE` | 新事实明确否定旧记忆 | 旧 insight state 变为 deleted |
+| `NOOP` | 已有记忆已经覆盖等价信息 | 不写入；正常输出中通常省略该项 |
+
+例如，已有“Sarah 是我的姐姐”，新事实“Sarah 住在大阪”是同一实体的新属性，应 ADD；已有“住在北京”，新事实“住在上海”命中同一实体的同一 location 槽，才适合 UPDATE。
+
+## 4. 决策输出的保护措施
+
+LLM 调用失败、修复重试失败或 JSON 最终无法解析时，系统返回 warning 并跳过全部动作。这里选择“宁可暂时不写，也不盲目写重复或错误记忆”。
+
+所有 UPDATE/DELETE 都必须引用范围内的整数 ID，服务再通过 `idMap` 解析真实 UUID。ID 越界、正文为空或映射不存在时，该动作会被跳过。
+
+Pinned 记忆受额外保护：Reconcile 不会自动删除 pinned；针对 pinned 的 UPDATE 会退化成新增一个 insight，而不是修改用户显式固定的内容。
+
+未知 event 只记录 warning 日志，不执行写入。`NOOP` 和 `NONE` 都明确不产生数据库动作。
+
+## 5. UPDATE 为什么采用版本链
+
+Reconcile 的 UPDATE 不会原地改写旧 insight。`updateInsight` 生成新 UUID，在同一个数据库事务中把旧记录设为 `archived` 并写入 `superseded_by=newID`，随后创建 version=1 的新 active insight。
+
+这种 append-new + archive-old 模型保留了变化历史，也避免读取方在更新中途看到“旧记录已归档但新记录尚未创建”的不完整状态。事务任一步失败都会回滚。
+
+## 6. Provenance 与时间 metadata
+
+ADD/UPDATE 前会移除只读的 `[time: ...]` 投影，并重新生成结构化 temporal metadata。随后把与该 Reconcile 文本最匹配的 `source_seqs`、`source_turns` 和外部 provenance 合并到 metadata 中。
+
+UPDATE 默认沿用旧记忆 tags；只有 LLM 明确返回 tags 时才替换。旧 metadata 会作为时间与来源合并的基础，避免丢失必要的追踪信息。
+
+## 7. 结果状态
+
+`Changes` 记录实际执行成功的 add/update/delete；`InsightIDs` 只包含 ADD 和 UPDATE 产生的新 active ID。`MemoriesChanged` 按 `InsightIDs` 计数，因此 DELETE 不增加这个字段。
+
+存在 warning 且没有任何新 insight ID 时，结果为 `partial`；Reconcile 发生不可恢复错误时为 `failed`；否则为 `complete`。某些动作失败不会回滚已经成功的其他动作，因为动作遍历目前不是一个跨事件总事务。
+
+## 8. 核心伪代码
+
+```text
+facts = keep_only_durable(facts)[:50]
+for fact in facts: observe_near_duplicate_score(fact)
+
+existing = parallel_search(facts, pools=[insight, pinned])
+if every_search_attempt_failed: abort
+if existing.empty: return add_all(facts)
+
+refs, id_map = map_uuids_to_integer_ids(existing)
+events = llm.reconcile(refs_with_age, facts_with_temporal_projection)
+events = parse_or_retry(events)
+if parse_failed: return warning_without_writes
+
+for event in events:
+  ADD    -> create_active_insight()
+  UPDATE -> pinned ? create_active_insight() : archive_old_and_create_new_tx()
+  DELETE -> pinned ? skip_with_warning : set_state_deleted()
+  NOOP   -> do_nothing()
+```
+
+## 9. 源码定位
+
+- `server/internal/service/ingest.go`: `ReconcilePhase2`、`reconcile`、`gatherExistingMemories`、`searchExistingMemoriesForFact`、`addAllFacts`、`addInsight`、`updateInsight`。
+- `server/internal/repository/tidb/memory.go`: `ArchiveAndCreate`、`SetState`、向量/FTS/keyword 查询。
+- `server/internal/service/source_provenance.go`: Reconcile 输出文本到来源 facts 的重新关联。
+
+## 10. 排障检查点
+
+- 重复记忆增加时，先确认是“搜索成功但零候选”还是“检索结果漏召回”，不要只检查 LLM 输出。
+- Reconcile 没有写入时，区分全部 NOOP、LLM/JSON warning、动作 ID 无效、pinned 保护和单动作数据库失败。
+- UPDATE 后查询不到旧 ID 是预期行为，因为 `GetByID` 只读取 active；应检查旧行是否 archived 且 `superseded_by` 指向新 ID。
+- `MemoriesChanged=0` 不代表完全没有状态变化，DELETE 可能已成功但不会进入 `InsightIDs` 计数。


### PR DESCRIPTION
## Summary

- add a Chinese architecture overview for the core mem9 algorithms
- document fact extraction, memory storage, recall, and reconciliation flows

## Validation

- `git diff --cached --check`

Docs-only change; no runtime behavior changed.