### PR TITLE
fix(server): preserve client-side embedding on tag/metadata-only updates

### DIFF
--- a/server/internal/repository/postgres/memory.go
+++ b/server/internal/repository/postgres/memory.go
@@ -576,6 +576,7 @@ func scanMemory(row *sql.Row) (*domain.Memory, error) {
 	m.SupersededBy = supersededBy.String
 	m.Tags = unmarshalTags(tagsJSON)
 	m.Metadata = unmarshalRawJSON(metadataJSON)
+	m.Embedding = parseVec(embeddingStr)
 	return &m, nil
 }
 
@@ -723,6 +724,19 @@ func nullJSON(data json.RawMessage) any {
 }
 
 // vecToParam converts a float32 slice to a pgvector.Vector for use as a query parameter.
+// parseVec decodes a pgvector text value (e.g. "[0.1,0.2,0.3]") into []float32.
+// NULL or malformed values yield nil.
+func parseVec(s sql.NullString) []float32 {
+	if !s.Valid || len(s.String) < 2 {
+		return nil
+	}
+	var v pgvector.Vector
+	if err := v.Parse(s.String); err != nil {
+		return nil
+	}
+	return v.Slice()
+}
+
 func vecToParam(embedding []float32) any {
 	if len(embedding) == 0 {
 		return nil

--- a/server/internal/repository/postgres/memory_test.go
+++ b/server/internal/repository/postgres/memory_test.go
@@ -1,0 +1,32 @@
+package postgres
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestParseVec(t *testing.T) {
+	tests := []struct {
+		name string
+		in   sql.NullString
+		want []float32
+	}{
+		{name: "null", in: sql.NullString{}, want: nil},
+		{name: "empty", in: sql.NullString{String: "", Valid: true}, want: nil},
+		{name: "vector", in: sql.NullString{String: "[0.25,-0.5,1]", Valid: true}, want: []float32{0.25, -0.5, 1}},
+		{name: "malformed", in: sql.NullString{String: "[0.25,x]", Valid: true}, want: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseVec(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseVec(%q) = %v, want %v", tt.in.String, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseVec(%q)[%d] = %v, want %v", tt.in.String, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/server/internal/repository/tidb/memory.go
+++ b/server/internal/repository/tidb/memory.go
@@ -1022,6 +1022,7 @@ func scanMemory(row *sql.Row) (*domain.Memory, error) {
 	m.SupersededBy = supersededBy.String
 	m.Tags = unmarshalTags(tagsJSON)
 	m.Metadata = unmarshalRawJSON(metadataJSON)
+	m.Embedding = parseVecString(embeddingStr)
 	return &m, nil
 }
 

--- a/server/internal/repository/tidb/memory_integration_test.go
+++ b/server/internal/repository/tidb/memory_integration_test.go
@@ -600,3 +600,41 @@ func TestListBootstrap(t *testing.T) {
 // These require TiDB-specific features (VECTOR column type, VEC_COSINE_DISTANCE,
 // VEC_EMBED_COSINE_DISTANCE, fts_match_word) that are not available in plain MySQL.
 // To test these, use a real TiDB Serverless instance.
+
+// GetByID must hydrate Embedding: service read-modify-write paths (tag or
+// metadata patches after create, Update without content change) hand the
+// struct back to UpdateOptimistic, which writes the embedding column
+// unconditionally. A nil Embedding there would wipe the stored vector.
+func TestGetByIDHydratesEmbeddingForUpdate(t *testing.T) {
+	truncateMemories(t)
+	repo := newMemoryRepo()
+	ctx := context.Background()
+
+	m := newTestMemory(func(m *domain.Memory) {
+		m.Embedding = []float32{0.25, -0.5, 1}
+	})
+	if err := repo.Create(ctx, m); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.GetByID(ctx, m.ID)
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if len(got.Embedding) != len(m.Embedding) {
+		t.Fatalf("GetByID embedding: got %v want %v", got.Embedding, m.Embedding)
+	}
+
+	got.Tags = []string{"patched"}
+	if err := repo.UpdateOptimistic(ctx, got, 0); err != nil {
+		t.Fatalf("UpdateOptimistic: %v", err)
+	}
+
+	embeddings, err := repo.GetEmbeddingsByID(ctx, []string{m.ID})
+	if err != nil {
+		t.Fatalf("GetEmbeddingsByID: %v", err)
+	}
+	if len(embeddings[m.ID]) != len(m.Embedding) {
+		t.Fatalf("embedding lost after UpdateOptimistic: got %v want %v", embeddings[m.ID], m.Embedding)
+	}
+}

--- a/server/internal/service/memory.go
+++ b/server/internal/service/memory.go
@@ -1078,12 +1078,18 @@ func (s *MemoryService) Update(ctx context.Context, agentName, id, content strin
 	}
 	current.UpdatedBy = agentName
 
-	if contentChanged && s.autoModel == "" && s.embedder != nil {
-		embedding, err := s.embedder.Embed(ctx, current.Content)
-		if err != nil {
-			return nil, err
+	if contentChanged && s.autoModel == "" {
+		if s.embedder != nil {
+			embedding, err := s.embedder.Embed(ctx, current.Content)
+			if err != nil {
+				return nil, err
+			}
+			current.Embedding = embedding
+		} else {
+			// No embedder: the stored vector describes the old content. Clear it
+			// rather than carrying a stale vector onto the new content.
+			current.Embedding = nil
 		}
-		current.Embedding = embedding
 	}
 
 	writeStart := time.Now()

--- a/server/internal/service/memory_update_embedding_test.go
+++ b/server/internal/service/memory_update_embedding_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qiffang/mnemos/server/internal/domain"
+	"github.com/qiffang/mnemos/server/internal/embed"
+)
+
+// updateCaptureRepo records the memory handed to UpdateOptimistic so tests can
+// assert what embedding the service intends to persist.
+type updateCaptureRepo struct {
+	memoryRepoMock
+	updated *domain.Memory
+}
+
+func (m *updateCaptureRepo) UpdateOptimistic(_ context.Context, mem *domain.Memory, _ int) error {
+	cp := *mem
+	m.updated = &cp
+	return nil
+}
+
+func newUpdateCaptureRepo(stored *domain.Memory) *updateCaptureRepo {
+	repo := &updateCaptureRepo{}
+	repo.getByID = map[string]*domain.Memory{stored.ID: stored}
+	return repo
+}
+
+func storedEmbeddedMemory() *domain.Memory {
+	return &domain.Memory{
+		ID:         "mem-1",
+		Content:    "old content",
+		Tags:       []string{"old"},
+		Embedding:  []float32{0.1, 0.2, 0.3},
+		MemoryType: domain.TypeInsight,
+		State:      domain.StateActive,
+		Version:    1,
+	}
+}
+
+func TestUpdateTagsOnlyPreservesEmbedding(t *testing.T) {
+	repo := newUpdateCaptureRepo(storedEmbeddedMemory())
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	if _, err := svc.Update(context.Background(), "agent", "mem-1", "", []string{"new"}, nil, 0); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if repo.updated == nil {
+		t.Fatal("UpdateOptimistic was not called")
+	}
+	if got, want := repo.updated.Embedding, []float32{0.1, 0.2, 0.3}; !equalVec(got, want) {
+		t.Fatalf("embedding: got %v want %v", got, want)
+	}
+	if got := repo.updated.Tags; len(got) != 1 || got[0] != "new" {
+		t.Fatalf("tags: got %v want [new]", got)
+	}
+}
+
+func TestUpdateContentWithoutEmbedderClearsEmbedding(t *testing.T) {
+	repo := newUpdateCaptureRepo(storedEmbeddedMemory())
+	// No embedder, no autoModel — FTS/keyword-only deployment.
+	svc := NewMemoryService(repo, nil, nil, "", ModeSmart)
+
+	if _, err := svc.Update(context.Background(), "agent", "mem-1", "new content", nil, nil, 0); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if repo.updated == nil {
+		t.Fatal("UpdateOptimistic was not called")
+	}
+	if len(repo.updated.Embedding) != 0 {
+		t.Fatalf("embedding should be cleared when content changes without an embedder, got %v", repo.updated.Embedding)
+	}
+}
+
+func TestUpdateContentWithEmbedderReembeds(t *testing.T) {
+	embedSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"embedding": []float32{0.9, 0.8, 0.7}}},
+		})
+	}))
+	defer embedSrv.Close()
+	embedder := embed.New(embed.Config{BaseURL: embedSrv.URL, Model: "test", Dims: 3})
+
+	repo := newUpdateCaptureRepo(storedEmbeddedMemory())
+	svc := NewMemoryService(repo, nil, embedder, "", ModeSmart)
+
+	if _, err := svc.Update(context.Background(), "agent", "mem-1", "new content", nil, nil, 0); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if repo.updated == nil {
+		t.Fatal("UpdateOptimistic was not called")
+	}
+	if got, want := repo.updated.Embedding, []float32{0.9, 0.8, 0.7}; !equalVec(got, want) {
+		t.Fatalf("embedding: got %v want %v", got, want)
+	}
+}
+
+func TestUpdateContentWithAutoModelLeavesEmbeddingToDatabase(t *testing.T) {
+	repo := newUpdateCaptureRepo(storedEmbeddedMemory())
+	svc := NewMemoryService(repo, nil, nil, "tidbcloud_free/test-model", ModeSmart)
+
+	if _, err := svc.Update(context.Background(), "agent", "mem-1", "new content", nil, nil, 0); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if repo.updated == nil {
+		t.Fatal("UpdateOptimistic was not called")
+	}
+	// With auto-embedding the repository never writes the column; the service
+	// must not touch the in-memory value either.
+	if got, want := repo.updated.Embedding, []float32{0.1, 0.2, 0.3}; !equalVec(got, want) {
+		t.Fatalf("embedding: got %v want %v", got, want)
+	}
+}
+
+func equalVec(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- hydrate `Memory.Embedding` in `scanMemory` (TiDB and PostgreSQL/db9) so `GetByID` returns the stored vector
- keep the embedding intact when a memory is updated with tags/metadata only (`PUT /memories/{id}`), and when smart ingest patches user-provided tags onto a freshly created insight (`POST /memories` with `content` + `tags`)
- clear the embedding when `content` changes on a server running without an embedder (FTS/keyword-only), so a stale vector is never carried onto new content
- add an integration regression test covering the `Create` → `GetByID` → `UpdateOptimistic` round trip, plus service-level tests for the `Update` embedding matrix

Fixes #469

## Root Cause

`scanMemory` (`server/internal/repository/tidb/memory.go`, used by `GetByID`) scanned the `embedding` column into `embeddingStr` but never assigned it to `m.Embedding`. In client-embedding mode (`MNEMO_EMBED_AUTO_MODEL` unset) `UpdateOptimistic` writes `embedding = ?` unconditionally, so every read-modify-write caller persisted `NULL`:

- `MemoryService.Update` re-embeds only when `content` changed; a tags/metadata-only `PUT` passed the un-hydrated struct straight through.
- `MemoryService.Create` (LLM configured) inserts the insight with an embedding via `addInsight`, then applies user-provided tags/metadata with `GetByID` + `UpdateOptimistic`, wiping the vector it had just written.

The memory kept answering keyword/`GET` requests, so nothing surfaced in API responses; it just dropped out of vector search.

History: the omission dates from `f28753e` (hybrid vector search). `2cd49b0` (#175) introduced `parseVecString` but only wired it into `scanMemoryRowsWithDistance`; `scanMemory` was left as-is. Deployments using TiDB auto-embedding (`MNEMO_EMBED_AUTO_MODEL`) never hit this because the `autoModel != ""` branch of `UpdateOptimistic` does not touch the column, which is why it went unnoticed.

## Changes

- `server/internal/repository/tidb/memory.go`: set `m.Embedding = parseVecString(embeddingStr)` in `scanMemory`. `Embedding` is `json:"-"`, so API responses are unchanged.
- `server/internal/repository/tidb/memory_integration_test.go`: add `TestGetByIDHydratesEmbeddingForUpdate` — `Create` with an embedding, `GetByID`, `UpdateOptimistic` with new tags, then assert `GetEmbeddingsByID` still returns the vector. Fails on `main` (`GetByID embedding: got [] want [0.25 -0.5 1]`), passes with this change.

- `server/internal/service/memory.go`: in `Update`, when `content` changed and no auto model is configured, re-embed if an embedder exists, otherwise set `Embedding = nil`. Without this, hydration would let an FTS-only server (`embedder == nil`, `autoModel == ""`) write the old content's vector back under the new content; clearing matches what `updateInsight` already does in that mode (review feedback).
- `server/internal/service/memory_update_embedding_test.go`: `Update` tags-only preserves the embedding; content change without an embedder clears it (fails before the service change); content change with an embedder re-embeds; auto-embedding leaves the value untouched.

- `server/internal/repository/postgres/memory.go`: same hydration in the PostgreSQL `scanMemory` via a new `parseVec` helper (pgvector text → `[]float32`). db9 embeds `postgres.MemoryRepo`, so its `GetByID` is covered too; with a db9 auto model the column is never written anyway (review feedback).
- `server/internal/repository/postgres/memory_test.go`: `parseVec` unit test (NULL, empty, valid, malformed).

`scanMemoryRows` (List/KeywordSearch) is intentionally left alone: its results are never written back, and parsing vectors for every list row would add cost without fixing anything.

## Validation

- `make vet`
- `make test` (`go test -race -count=1 ./...`)
- `go test -tags=integration -run 'TestGetByID|TestCreate$|TestUpdateOptimistic' ./internal/repository/tidb/` against a TiDB Cloud Zero database (`8.0.11-TiDB-v8.5.3-serverless`) — new test verified failing before the fix and passing after
- Manual reproduction from #469 on a Zero tenant (`VECTOR(768)` + HNSW) via `v1alpha2`, LM Studio `text-embedding-nomic-embed-text-v1.5`:
  - before: `POST /memories` → `version=1, embedding present`; `PUT /memories/{id}` with `{"tags":["ops"]}` → `version=2, embedding NULL`
  - after: same sequence → `version=2, embedding present (768 dims)`; the memory is returned by a semantic query (`confidence 88`)
- Same reproduction with `MNEMO_DB_BACKEND=postgres` against `pgvector/pgvector:pg17` (manual-bootstrap tenant, `vector(768)`):
  - before: tag-only `PUT` → `version=2, embedding NULL`
  - after: `version=2`, `md5(embedding::text)` identical before and after the `PUT`, and the memory is returned by a semantic query (`confidence 89`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kf2Rbtey1jrA4vH7jd1qHG
